### PR TITLE
build(sls): decrease timeout below AWS Lambda limit

### DIFF
--- a/serverless.js
+++ b/serverless.js
@@ -17,7 +17,7 @@ module.exports = {
   provider: {
     name: 'aws',
     runtime: 'nodejs12.x',
-    timeout: 128,
+    timeout: 16,
     memorySize: 512,
     region: `\${env:AWS_REGION, "us-east-1"}`,
     stage: `\${env:SLS_STAGE, "development"}`,


### PR DESCRIPTION
should remove the warnings from the CI deploy job