### PR TITLE
build(backend): source maps

### DIFF
--- a/apps/hello-world/package.json
+++ b/apps/hello-world/package.json
@@ -8,7 +8,7 @@
   "main": "build/handler.js",
   "types": "build/handler.d.ts",
   "scripts": {
-    "build:babel": "babel src -Dd build -x .js,.jsx,.ts,.tsx --root-mode upward",
+    "build:babel": "babel src -Dd build -x .js,.jsx,.ts,.tsx --root-mode upward --source-maps inline",
     "watch:babel": "yarn build:babel -w --verbose"
   },
   "devDependencies": {

--- a/apps/orcid-user-profile-script/package.json
+++ b/apps/orcid-user-profile-script/package.json
@@ -6,7 +6,7 @@
     "node": "12.x"
   },
   "scripts": {
-    "build:babel": "babel src -Dd build -x .js,.jsx,.ts,.tsx --root-mode upward"
+    "build:babel": "babel src -Dd build -x .js,.jsx,.ts,.tsx --root-mode upward --source-maps inline"
   },
   "dependencies": {
     "jsonwebtoken": "^8.5.1"

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -8,7 +8,7 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "scripts": {
-    "build:babel": "babel src -Dd build -x .js,.jsx,.ts,.tsx --root-mode upward",
+    "build:babel": "babel src -Dd build -x .js,.jsx,.ts,.tsx --root-mode upward --source-maps inline",
     "watch:babel": "yarn build:babel -w --verbose"
   }
 }

--- a/packages/example-lib/package.json
+++ b/packages/example-lib/package.json
@@ -8,7 +8,7 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "scripts": {
-    "build:babel": "babel src -Dd build -x .js,.jsx,.ts,.tsx --root-mode upward",
+    "build:babel": "babel src -Dd build -x .js,.jsx,.ts,.tsx --root-mode upward --source-maps inline",
     "watch:babel": "yarn build:babel -w --verbose"
   },
   "devDependencies": {


### PR DESCRIPTION
This works for dev:
```
Error: Not implemented
    at error (/home/seckinger/proj/yld/asap-hub/apps/hello-world/build/handler.js:21:9)
```
becomes
```
Error: Not implemented
    at error (/home/seckinger/proj/yld/asap-hub/apps/hello-world/src/handler.ts:14:9)
```

If we want it for prod at some point, it'll need more effort - checking why serverless-plugin-ncc does not do it, or evaluating alternatives to it.