### PR TITLE
build(ts): clean up unnecessary projects references

### DIFF
--- a/apps/orcid-user-profile-script/tsconfig.json
+++ b/apps/orcid-user-profile-script/tsconfig.json
@@ -4,6 +4,5 @@
     "rootDir": "src",
     "outDir": "build"
   },
-  "include": ["src"],
-  "references": [{ "path": "../../packages/auth" }]
+  "include": ["src"]
 }


### PR DESCRIPTION
They are not needed as we give TSC the paths to all our subprojects,
and they are annoying to keep in sync with subproject dependencies.