### PR TITLE
build(ts): require project references to all dependencies

### DIFF
--- a/apps/orcid-user-profile-script/tsconfig.json
+++ b/apps/orcid-user-profile-script/tsconfig.json
@@ -4,5 +4,6 @@
     "rootDir": "src",
     "outDir": "build"
   },
-  "include": ["src"]
+  "include": ["src"],
+  "references": [{ "path": "../../packages/auth" }]
 }


### PR DESCRIPTION
Turns out not specifying them is not an option, even when we include all projects in the build anyway. They are still required for TypeScript to understand the dependency graph and build in the correct order. This was surfaced by https://github.com/yldio/asap-hub/pull/22.

So we do have to specify them all, but I extended our script to automatically check and enforce that they are present.