### PR TITLE
build(ts): do not read root tsconfig for projects missing one

### DIFF
--- a/scripts/get-composite-ts-projects.js
+++ b/scripts/get-composite-ts-projects.js
@@ -11,7 +11,6 @@ const { readdirSync } = require('fs');
 const { resolve } = require('path');
 const { stdout, exit } = require('process');
 const {
-  findConfigFile,
   readConfigFile,
   parseJsonConfigFileContent,
   sys: tsSys,
@@ -43,7 +42,7 @@ const configErrors = [];
 
     // read tsconfig.json
     const { error, config } = readConfigFile(
-      findConfigFile(dir, tsSys.fileExists),
+      resolve(dir, 'tsconfig.json'),
       tsSys.readFile,
     );
     if (error) {


### PR DESCRIPTION
This makes the error message in case a project is missing a tsconfig
a lot less confusing