### PR TITLE
docs(license): add MIT license file

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,7 @@
+Copyright 2020 Aligning Science Across Parkinson's
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -37,3 +37,9 @@ Refer to [this Yarn documentation page](https://yarnpkg.com/advanced/editor-sdks
 
 Individual `packages` or `apps` may contain their own readme files as deemed necessary.
 The [`docs`](docs) folder contains overall architecture / decision documentation.
+
+## License
+
+The source code of this project is licensed under the MIT License.
+A copy of it can be found [alongside the repository files](LICENSE.txt).
+This repository contains some externally created content, such as logos, that are not included in this licensing.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "private": true,
   "name": "asap-hub",
+  "license": "MIT",
   "workspaces": [
     "apps/*",
     "packages/*"


### PR DESCRIPTION
The ASAP Hub product concept document mentioned that the hub should be open source and MIT-licensed. So far, it was only open source, but not declared as free and open source, let alone specifically MIT licensed. This should clarify that.