### PR TITLE
refactor(ts): readonly props

### DIFF
--- a/apps/auth-frontend/src/App.tsx
+++ b/apps/auth-frontend/src/App.tsx
@@ -3,15 +3,13 @@ import { BrowserRouter, Switch, Route } from 'react-router-dom';
 
 import Login from './login/Login';
 
-function App() {
-  return (
-    <BrowserRouter>
-      <Switch>
-        <Route path="/login" component={Login} />
-        <Route render={() => 'This route does not exist'} />
-      </Switch>
-    </BrowserRouter>
-  );
-}
+const App: React.FC<{}> = () => (
+  <BrowserRouter>
+    <Switch>
+      <Route path="/login" component={Login} />
+      <Route render={() => 'This route does not exist'} />
+    </Switch>
+  </BrowserRouter>
+);
 
 export default App;

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -6,17 +6,15 @@ import { AuthProvider } from './auth';
 import Admin from './admin/Admin';
 import history from './history';
 
-function App() {
-  return (
-    <AuthProvider>
-      <Router history={history}>
-        <Switch>
-          <Route path="/admin/" component={Admin} />
-          <Route component={Home} />
-        </Switch>
-      </Router>
-    </AuthProvider>
-  );
-}
+const App: React.FC<{}> = () => (
+  <AuthProvider>
+    <Router history={history}>
+      <Switch>
+        <Route path="/admin/" component={Admin} />
+        <Route component={Home} />
+      </Switch>
+    </Router>
+  </AuthProvider>
+);
 
 export default App;

--- a/apps/frontend/src/admin/Admin.tsx
+++ b/apps/frontend/src/admin/Admin.tsx
@@ -4,7 +4,7 @@ import { AdminInviteUserPage } from '@asap-hub/react-components';
 
 import { API_BASE_URL } from '../config';
 
-const Admin = () => {
+const Admin: React.FC<{}> = () => {
   const [invitationState, setInvitationState] = useState<
     ComponentProps<typeof AdminInviteUserPage>['state']
   >('initial');

--- a/apps/frontend/src/auth/AuthProvider.tsx
+++ b/apps/frontend/src/auth/AuthProvider.tsx
@@ -18,7 +18,7 @@ const onRedirectCallback = (appState: RedirectLoginResult['appState']) => {
   );
 };
 
-const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
+const AuthProvider: React.FC<{ readonly children: React.ReactNode }> = ({
   children,
 }) => {
   return (

--- a/apps/frontend/src/home/Home.tsx
+++ b/apps/frontend/src/home/Home.tsx
@@ -9,7 +9,7 @@ import {
 
 import './Home.css';
 
-const Home = () => {
+const Home: React.FC<{}> = () => {
   return (
     <div className="App">
       <Theme variant="dark">

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -5,18 +5,18 @@ import * as config from './config';
 export { config };
 
 export interface User {
-  name?: string;
-  given_name?: string;
-  family_name?: string;
-  orcid?: string;
+  readonly name?: string;
+  readonly given_name?: string;
+  readonly family_name?: string;
+  readonly orcid?: string;
 }
 
 export type Auth0 = {
-  isAuthenticated?: boolean;
-  user?: User;
-  loading: boolean;
-  popupOpen: boolean;
-  handleRedirectCallback: () => Promise<void>;
+  readonly isAuthenticated?: boolean;
+  readonly user?: User;
+  readonly loading: boolean;
+  readonly popupOpen: boolean;
+  readonly handleRedirectCallback: () => Promise<void>;
 } & Pick<
   Auth0Client,
   | 'getIdTokenClaims'

--- a/packages/react-components/src/atoms/Button.tsx
+++ b/packages/react-components/src/atoms/Button.tsx
@@ -161,23 +161,23 @@ const linkStyles = css({
 });
 
 interface NormalButtonProps {
-  enabled?: boolean;
-  primary?: boolean;
-  small?: boolean;
-  linkStyle?: undefined;
+  readonly enabled?: boolean;
+  readonly primary?: boolean;
+  readonly small?: boolean;
+  readonly linkStyle?: undefined;
 }
 interface LinkStyleButtonProps {
-  linkStyle: true;
-  enabled?: undefined;
-  primary?: undefined;
-  small?: undefined;
+  readonly linkStyle: true;
+  readonly enabled?: undefined;
+  readonly primary?: undefined;
+  readonly small?: undefined;
 }
 type ButtonProps = (NormalButtonProps | LinkStyleButtonProps) & {
-  submit?: boolean;
+  readonly submit?: boolean;
 
-  children?: React.ReactNode;
+  readonly children?: React.ReactNode;
 
-  onClick?: () => void;
+  readonly onClick?: () => void;
 };
 const Button: React.FC<ButtonProps> = ({
   enabled = true,

--- a/packages/react-components/src/atoms/Caption.tsx
+++ b/packages/react-components/src/atoms/Caption.tsx
@@ -11,8 +11,8 @@ const styles = css({
 });
 
 interface CaptionProps {
-  children: React.ReactNode;
-  accent?: AccentColorName;
+  readonly children: React.ReactNode;
+  readonly accent?: AccentColorName;
 }
 const Caption: React.FC<CaptionProps> = ({ children, accent }) => (
   <figcaption

--- a/packages/react-components/src/atoms/Display.tsx
+++ b/packages/react-components/src/atoms/Display.tsx
@@ -11,7 +11,7 @@ const styles = css({
 });
 
 interface DisplayProps {
-  children: TextChildren;
+  readonly children: TextChildren;
 }
 const Display: React.FC<DisplayProps> = ({ children }) => (
   <h1 css={[layoutStyles, styles]}>{children}</h1>

--- a/packages/react-components/src/atoms/Divider.tsx
+++ b/packages/react-components/src/atoms/Divider.tsx
@@ -39,7 +39,7 @@ const textStyles = css({
 });
 
 interface DividerProps {
-  children?: ReactText | ReadonlyArray<ReactText>;
+  readonly children?: ReactText | ReadonlyArray<ReactText>;
 }
 const Divider: React.FC<DividerProps> = ({ children }) => (
   <div css={containerStyles}>

--- a/packages/react-components/src/atoms/Gradient.tsx
+++ b/packages/react-components/src/atoms/Gradient.tsx
@@ -7,7 +7,7 @@ const commonStyles = css({
   background: `linear-gradient(90deg, ${cerulean.rgb} 0%,${fern.rgb} 100% )`,
 });
 
-const Display: React.FC<unknown> = () => (
+const Display: React.FC<{}> = () => (
   <div css={[commonStyles]} role="presentation"></div>
 );
 

--- a/packages/react-components/src/atoms/Headline2.tsx
+++ b/packages/react-components/src/atoms/Headline2.tsx
@@ -11,7 +11,7 @@ const styles = css({
 });
 
 interface Headline2Props {
-  children: TextChildren;
+  readonly children: TextChildren;
 }
 const Headline2: React.FC<Headline2Props> = ({ children }) => (
   <h2 css={[layoutStyles, styles]}>{children}</h2>

--- a/packages/react-components/src/atoms/Headline3.tsx
+++ b/packages/react-components/src/atoms/Headline3.tsx
@@ -17,7 +17,7 @@ const styles = css({
 });
 
 interface Headline3Props {
-  children: TextChildren;
+  readonly children: TextChildren;
 }
 const Headline3: React.FC<Headline3Props> = ({ children }) => (
   <h3 css={[layoutStyles, styles]}>{children}</h3>

--- a/packages/react-components/src/atoms/Headline4.tsx
+++ b/packages/react-components/src/atoms/Headline4.tsx
@@ -11,7 +11,7 @@ const styles = css({
 });
 
 interface Headline4Props {
-  children: TextChildren;
+  readonly children: TextChildren;
 }
 const Headline4: React.FC<Headline4Props> = ({ children }) => (
   <h4 css={[layoutStyles, styles]}>{children}</h4>

--- a/packages/react-components/src/atoms/Label.tsx
+++ b/packages/react-components/src/atoms/Label.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { perRem, formTargetWidth } from '../pixels';
 
 interface LabelProps {
-  children?: React.ReactNode;
+  readonly children?: React.ReactNode;
 }
 const Label: React.FC<LabelProps> = ({ children }) => (
   <label

--- a/packages/react-components/src/atoms/Link.tsx
+++ b/packages/react-components/src/atoms/Link.tsx
@@ -18,8 +18,8 @@ const styles = css({
 });
 
 interface LinkProps {
-  children: TextChildren;
-  href: string;
+  readonly children: TextChildren;
+  readonly href: string;
 }
 const Link: React.FC<LinkProps> = ({ children, href }) => (
   <a href={href} css={[styles]} target="_blank" rel="noreferrer noopener">

--- a/packages/react-components/src/atoms/Paragraph.tsx
+++ b/packages/react-components/src/atoms/Paragraph.tsx
@@ -15,9 +15,9 @@ const primaryStyles = css({
 });
 
 interface ParagraphProps {
-  children: React.ReactNode;
-  primary?: boolean;
-  accent?: AccentColorName;
+  readonly children: React.ReactNode;
+  readonly primary?: boolean;
+  readonly accent?: AccentColorName;
 }
 const Paragraph: React.FC<ParagraphProps> = ({
   children,

--- a/packages/react-components/src/atoms/TextField.tsx
+++ b/packages/react-components/src/atoms/TextField.tsx
@@ -112,8 +112,8 @@ const validationMessageStyles = css({
 });
 
 type TextFieldProps = {
-  type?: 'text' | 'search' | 'email' | 'tel' | 'url' | 'password';
-  enabled?: boolean;
+  readonly type?: 'text' | 'search' | 'email' | 'tel' | 'url' | 'password';
+  readonly enabled?: boolean;
 
   /**
    * By default, a valid text field only shows an indicator
@@ -122,14 +122,14 @@ type TextFieldProps = {
    * However, if custom validity checking is used, this can be used
    * to show an indicator despite no validation attributes being set.
    */
-  indicateValid?: boolean;
-  customValidationMessage?: string;
+  readonly indicateValid?: boolean;
+  readonly customValidationMessage?: string;
 
-  loading?: boolean;
-  customIndicator?: React.ReactElement;
+  readonly loading?: boolean;
+  readonly customIndicator?: React.ReactElement;
 
-  value: string;
-  onChange?: (newValue: string) => void;
+  readonly value: string;
+  readonly onChange?: (newValue: string) => void;
 } & Pick<
   InputHTMLAttributes<HTMLInputElement>,
   'placeholder' | 'required' | 'minLength' | 'maxLength' | 'pattern'

--- a/packages/react-components/src/atoms/Theme.tsx
+++ b/packages/react-components/src/atoms/Theme.tsx
@@ -15,8 +15,8 @@ const colors: Record<ThemeVariant, OpaqueColor> = {
 };
 
 interface ThemeProps {
-  children: React.ReactNode;
-  variant?: ThemeVariant;
+  readonly children: React.ReactNode;
+  readonly variant?: ThemeVariant;
 }
 
 const Theme: React.FC<ThemeProps> = ({ children, variant = 'light' }) => (

--- a/packages/react-components/src/molecules/AgreeToTerms.tsx
+++ b/packages/react-components/src/molecules/AgreeToTerms.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { Paragraph, Link } from '../atoms';
 
 interface AgreeToTermsProps {
-  termsHref: string;
-  privacyPolicyHref: string;
+  readonly termsHref: string;
+  readonly privacyPolicyHref: string;
 }
 const AgreeToTerms: React.FC<AgreeToTermsProps> = ({
   termsHref,

--- a/packages/react-components/src/molecules/LabeledPasswordField.tsx
+++ b/packages/react-components/src/molecules/LabeledPasswordField.tsx
@@ -21,9 +21,9 @@ const showPasswordIndicatorStyles = css({
 });
 
 type LabeledPasswordFieldProps = {
-  title?: string;
+  readonly title?: string;
 
-  forgotPasswordHref: string;
+  readonly forgotPasswordHref: string;
 } & Pick<
   ComponentProps<typeof TextField>,
   'value' | 'onChange' | 'required' | 'placeholder' | 'customValidationMessage'

--- a/packages/react-components/src/molecules/LabeledTextField.tsx
+++ b/packages/react-components/src/molecules/LabeledTextField.tsx
@@ -15,9 +15,9 @@ const hintStyles = css({
 });
 
 type LabeledTextFieldProps = {
-  title: React.ReactText | ReadonlyArray<React.ReactText>;
-  subtitle?: React.ReactText | ReadonlyArray<React.ReactText>;
-  hint?: React.ReactText | ReadonlyArray<React.ReactText>;
+  readonly title: React.ReactText | ReadonlyArray<React.ReactText>;
+  readonly subtitle?: React.ReactText | ReadonlyArray<React.ReactText>;
+  readonly hint?: React.ReactText | ReadonlyArray<React.ReactText>;
 } & ComponentProps<typeof TextField>;
 const LabeledTextField: React.FC<LabeledTextFieldProps> = ({
   title,

--- a/packages/react-components/src/organisms/Layout.tsx
+++ b/packages/react-components/src/organisms/Layout.tsx
@@ -29,7 +29,7 @@ const contentStyles = css({
 });
 
 interface LayoutProps {
-  children: React.ReactNode | React.ReactNodeArray;
+  readonly children: React.ReactNode;
 }
 const Layout: React.FC<LayoutProps> = ({ children }) => (
   <article css={containerStyles}>

--- a/packages/react-components/src/organisms/auth/EmailPasswordSignin.tsx
+++ b/packages/react-components/src/organisms/auth/EmailPasswordSignin.tsx
@@ -18,14 +18,14 @@ type EmailPasswordSigninProps = Pick<
   ComponentProps<typeof LabeledPasswordField>,
   'forgotPasswordHref'
 > & {
-  email: string;
-  onChangeEmail?: (newEmail: string) => void;
+  readonly email: string;
+  readonly onChangeEmail?: (newEmail: string) => void;
 
-  password: string;
-  onChangePassword?: (newPassword: string) => void;
+  readonly password: string;
+  readonly onChangePassword?: (newPassword: string) => void;
 
-  customValidationMessage?: string;
-  onSignin?: () => void;
+  readonly customValidationMessage?: string;
+  readonly onSignin?: () => void;
 };
 const EmailPasswordSignin: React.FC<EmailPasswordSigninProps> = ({
   forgotPasswordHref,

--- a/packages/react-components/src/organisms/auth/LoginLogoutButton.tsx
+++ b/packages/react-components/src/organisms/auth/LoginLogoutButton.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { useAuth0 } from '@asap-hub/react-context';
 import { Button } from '../../atoms';
 
-const LoginLogoutButton = () => {
+const LoginLogoutButton: React.FC<{}> = () => {
   const { isAuthenticated, user, loginWithRedirect, logout } = useAuth0();
 
   return (

--- a/packages/react-components/src/organisms/auth/SsoButtons.tsx
+++ b/packages/react-components/src/organisms/auth/SsoButtons.tsx
@@ -9,8 +9,8 @@ const styles = css({
 });
 
 interface SsoButtonsProps {
-  onGoogleSignin?: () => void;
-  onOrcidSignin?: () => void;
+  readonly onGoogleSignin?: () => void;
+  readonly onOrcidSignin?: () => void;
 }
 const SsoButtons: React.FC<SsoButtonsProps> = ({
   onGoogleSignin,

--- a/packages/react-components/src/organisms/auth/test-utils.tsx
+++ b/packages/react-components/src/organisms/auth/test-utils.tsx
@@ -11,9 +11,9 @@ const notReady = (method: string) => () => {
   throw new Error(`Auth0 test fixture loading, not ready for ${method}`);
 };
 
-export const Auth0Provider: React.FC<{ children: React.ReactNode }> = ({
-  children,
-}) => {
+export const Auth0Provider: React.FC<{
+  readonly children: React.ReactNode;
+}> = ({ children }) => {
   const [auth0Client, setAuth0] = useState<Auth0Client>();
   useEffect(() => {
     const initAuth0 = async () => {
@@ -55,10 +55,10 @@ export const Auth0Provider: React.FC<{ children: React.ReactNode }> = ({
 };
 
 export const LoggedIn: React.FC<{
-  children: React.ReactNode;
+  readonly children: React.ReactNode;
   // undefined user should be explicit, this is for the intermediate state
   // where the getUser() promise is pending.
-  user: User | undefined;
+  readonly user: User | undefined;
 }> = ({ children, user }) => {
   const ctx = useAuth0();
   return (

--- a/packages/react-components/src/pages/AdminInviteUserPage.tsx
+++ b/packages/react-components/src/pages/AdminInviteUserPage.tsx
@@ -16,8 +16,8 @@ const centerStyles = css({
 });
 
 interface AdminInviteUserPageProps {
-  state: 'initial' | 'loading' | 'success' | Error;
-  onInviteUser?: ComponentProps<typeof InviteUserForm>['onSubmit'];
+  readonly state: 'initial' | 'loading' | 'success' | Error;
+  readonly onInviteUser?: ComponentProps<typeof InviteUserForm>['onSubmit'];
 }
 const AdminInviteUserPage: React.FC<AdminInviteUserPageProps> = ({
   state,

--- a/packages/react-components/src/templates/InviteUserForm.tsx
+++ b/packages/react-components/src/templates/InviteUserForm.tsx
@@ -5,7 +5,7 @@ import { noop } from '../utils';
 import { LabeledTextField, LabeledPasswordField } from '../molecules';
 
 interface InviteUserFormProps {
-  onSubmit?: (
+  readonly onSubmit?: (
     invitee: { displayName: string; email: string },
     adminPassword: string,
   ) => void;

--- a/packages/react-components/src/templates/messages/Layout.tsx
+++ b/packages/react-components/src/templates/messages/Layout.tsx
@@ -5,7 +5,7 @@ import { silver } from '../../colors';
 import { logo } from '../../images';
 
 interface LayoutProps {
-  children: React.ReactNode;
+  readonly children: React.ReactNode;
 }
 
 const imageContainerStyle = css({

--- a/packages/react-components/src/templates/messages/Welcome.tsx
+++ b/packages/react-components/src/templates/messages/Welcome.tsx
@@ -4,8 +4,8 @@ import Layout from './Layout';
 import { Headline3, Paragraph, Button } from '../../atoms';
 
 interface WelcomeProps {
-  firstName: string;
-  link: string;
+  readonly firstName: string;
+  readonly link: string;
 }
 
 const listStyle = css({


### PR DESCRIPTION
I've seen this catch mistakes, especially by React beginners,
like setting props or pushing to prop arrays.