### PR TITLE
fix(text-field): avoid showing valid indicator below custom indicator

### DIFF
--- a/packages/react-components/src/atoms/TextField.tsx
+++ b/packages/react-components/src/atoms/TextField.tsx
@@ -143,13 +143,14 @@ const TextField: React.FC<TextFieldProps> = ({
   pattern,
 
   customValidationMessage = '',
-  indicateValid = required !== undefined ||
-    minLength !== undefined ||
-    maxLength !== undefined ||
-    pattern !== undefined,
 
-  loading = false,
   customIndicator,
+  loading = false,
+  indicateValid = customIndicator === undefined &&
+    (required !== undefined ||
+      minLength !== undefined ||
+      maxLength !== undefined ||
+      pattern !== undefined),
 
   value,
   onChange = noop,

--- a/packages/react-components/src/atoms/__tests__/TextField.test.tsx
+++ b/packages/react-components/src/atoms/__tests__/TextField.test.tsx
@@ -104,6 +104,19 @@ describe('when valid', () => {
       );
     });
 
+    describe('but also a custom indicator', () => {
+      it('does not show a valid indicator', () => {
+        const { getByRole } = render(
+          <TextField
+            value=""
+            pattern=".*"
+            customIndicator={<svg role="img" viewBox="0 0 2 1" />}
+          />,
+        );
+        expect(getComputedStyle(getByRole('textbox')).backgroundImage).toBe('');
+      });
+    });
+
     it('removes the indicator while the value is changing', () => {
       const { getByRole, rerender } = render(
         <TextField value="val" pattern=".*" />,


### PR DESCRIPTION
aka
fix(password-field): do not show valid indicator below show/hide button