### PR TITLE
feat: change schema to add biography

### DIFF
--- a/apps/asap-server/src/controllers/users.ts
+++ b/apps/asap-server/src/controllers/users.ts
@@ -22,6 +22,7 @@ function transform(user: CMSUser): UserResponse {
     firstName: user.data.firstName?.iv,
     middleName: user.data.middleName?.iv,
     lastName: user.data.lastName?.iv,
+    biography: user.data.biography?.iv,
     jobTitle: user.data.jobTitle?.iv,
     institution: user.data.institution?.iv,
     teams: user.data.teams?.iv,

--- a/apps/asap-server/src/entities/user.ts
+++ b/apps/asap-server/src/entities/user.ts
@@ -12,6 +12,7 @@ export interface CMSUser {
     jobTitle?: { iv: string };
     institution?: { iv: string };
     connections: { iv: { code: string }[] };
+    biography?: { iv: string };
     teams?: { iv: TeamMember[] };
     orcid?: { iv: string };
     orcidLastModifiedDate?: { iv: string };
@@ -40,6 +41,7 @@ export const createSchema = Joi.object({
   lastName: Joi.string(),
   title: Joi.string(),
   orcid: Joi.string(),
+  biography: Joi.string(),
   institution: Joi.string(),
   connections: Joi.string(),
 });

--- a/apps/asap-server/test/helpers/create-user.ts
+++ b/apps/asap-server/test/helpers/create-user.ts
@@ -43,6 +43,7 @@ export const createUser = (
     orcid: chance.ssn(),
     institution: chance.company(),
     email: chance.email(),
+    biography: chance.paragraph({ sentence: 3 }),
     ...overwrites,
   };
 

--- a/apps/frontend/src/users/Profile.tsx
+++ b/apps/frontend/src/users/Profile.tsx
@@ -5,6 +5,7 @@ import {
   Container,
   ProfileHeader,
   Paragraph,
+  ProfileBiography,
 } from '@asap-hub/react-components';
 
 import { useUserById } from '../api';
@@ -43,7 +44,16 @@ const ProfilePage: React.FC<{}> = () => {
           outputsHref={join(url, 'outputs')}
         />
         <Switch>
-          <Route path={`${path}/about`} render={() => 'About'} />
+          <Route
+            path={`${path}/about`}
+            render={() => (
+              <>
+                {profile.biography && (
+                  <ProfileBiography biography={profile.biography} />
+                )}
+              </>
+            )}
+          />
           <Route
             path={`${path}/research-interests`}
             render={() => 'Research interests'}

--- a/apps/storybook/src/ProfileHeader.stories.tsx
+++ b/apps/storybook/src/ProfileHeader.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { date, text } from '@storybook/addon-knobs';
-import { ProfileHeader } from '@asap-hub/react-components';
+import { ProfileHeader, ProfileBiography } from '@asap-hub/react-components';
 
 export default {
   title: 'Templates / Profile / Header',
@@ -25,5 +25,14 @@ export const Normal = () => (
     aboutHref="#"
     researchInterestsHref="#"
     outputsHref="#"
+  />
+);
+
+export const Biography = () => (
+  <ProfileBiography
+    biography={text(
+      'Biography',
+      'Dr. Randy Schekman is a Professor in the Department of Molecular and Cell Biology, University of California, and an Investigator of the Howard Hughes Medical Institute. He studied the enzymology of DNA replication as a graduate student with Arthur Kornberg at Stanford University. Among his awards is the Nobel Prize in Physiology or Medicine, which he shared with James Rothman and Thomas Südhof.',
+    )}
   />
 );

--- a/dev/squidex/schemas/teams.json
+++ b/dev/squidex/schemas/teams.json
@@ -94,7 +94,7 @@
       }
     ],
     "previewUrls": {
-      "Web": "http://hub.asap.science/teams/${id}"
+      "Web": "https://hub.asap.science/teams/${id}"
     },
     "category": "Storage",
     "isPublished": true

--- a/dev/squidex/schemas/users.json
+++ b/dev/squidex/schemas/users.json
@@ -167,6 +167,23 @@
         }
       },
       {
+        "name": "biography",
+        "isHidden": false,
+        "isLocked": false,
+        "isDisabled": false,
+        "partitioning": "invariant",
+        "properties": {
+          "fieldType": "String",
+          "isUnique": false,
+          "inlineEditable": false,
+          "editor": "TextArea",
+          "label": "Biography",
+          "hints": "",
+          "placeholder": "",
+          "isRequired": false
+        }
+      },
+      {
         "name": "teams",
         "isHidden": false,
         "isLocked": false,
@@ -410,7 +427,7 @@
       }
     ],
     "previewUrls": {
-      "Web": "http://hub.asap.science/users/${id}"
+      "Web": "https://hub.asap.science/users/${id}"
     },
     "category": "Storage",
     "isPublished": true

--- a/packages/model/src/user.ts
+++ b/packages/model/src/user.ts
@@ -4,6 +4,7 @@ export interface Invitee {
   firstName?: string;
   middleName?: string;
   lastName?: string;
+  biography?: string;
   jobTitle?: string;
   orcid?: string;
   department?: string;

--- a/packages/react-components/src/icons/docs.tsx
+++ b/packages/react-components/src/icons/docs.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+
+/* istanbul ignore file */
+
+const docs = (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    xmlnsXlink="http://www.w3.org/1999/xlink"
+    version="1.1"
+    id="Livello_1"
+    x="0px"
+    y="0px"
+    viewBox="0 0 6994.3 9672.9"
+    style={{ enableBackground: 'new 0 0 6994.3 9672.9' } as React.CSSProperties}
+    xmlSpace="preserve"
+  >
+    <style type="text/css">
+      {`
+        .st0{fill:#4285F4;}
+        .st1{fill:url(#SVGID_1_);}
+        .st2{fill:#F1F1F1;}
+        .st3{fill:#A1C2FA;}
+        .st4{fill:#FFFFFF;fill-opacity:0.2;}
+        .st5{fill:#1A237E;fill-opacity:0.2;}
+        .st6{fill:#1A237E;fill-opacity:0.1;}
+        .st7{display:none;fill:url(#SVGID_2_);}
+        `}
+    </style>
+    <g id="Docs-icon" transform="translate(174.000000, 91.000000)">
+      <g>
+        <path
+          id="Path"
+          className="st0"
+          d="M4201.1-91H480.8C123.6-91-174,206.6-174,563.8v8348.5c0,357.2,297.6,654.8,654.8,654.8h5684.7    c357.2,0,654.8-297.6,654.8-654.8V2543L5287.5,1441.8L4201.1-91z"
+        />
+
+        <linearGradient
+          id="SVGID_1_"
+          gradientUnits="userSpaceOnUse"
+          x1="1911.4532"
+          y1="4540.8711"
+          x2="1911.4532"
+          y2="4676.9185"
+          gradientTransform="matrix(16.3362 0 0 16.4273 -25618.4668 -72031.9375)"
+        >
+          <stop offset="0" style={{ stopColor: '#1A237E', stopOpacity: 0.2 }} />
+          <stop
+            offset="1"
+            style={{ stopColor: '#1A237E', stopOpacity: 2.0e-2 }}
+          />
+        </linearGradient>
+        <polygon
+          className="st1"
+          points="4394.6,2349.5 6820.2,4805 6820.2,2543"
+        />
+        <path
+          id="Shape"
+          className="st2"
+          d="M1582,6947.9h3497.1v-446.4H1582V6947.9z M1582,7825.9h2619.1v-446.4H1582V7825.9z M1582,4745.4    v446.4h3497.1v-446.4H1582z M1582,6069.9h3497.1v-446.4H1582V6069.9z"
+        />
+        <g transform="translate(26.437500, -2.954545)">
+          <path
+            className="st3"
+            d="M4165.4-81.3v1979.2c0,357.2,297.6,654.8,654.8,654.8h1964.3L4165.4-81.3z"
+          />
+        </g>
+        <path
+          className="st4"
+          d="M480.8-91C123.6-91-174,206.6-174,563.8v59.5c0-357.2,297.6-654.8,654.8-654.8h3720.3V-91H480.8z"
+        />
+        <path
+          className="st5"
+          d="M6165.5,9522.4H480.8c-357.2,0-654.8-297.6-654.8-654.8v59.5c0,357.2,297.6,654.8,654.8,654.8h5684.7    c357.2,0,654.8-297.6,654.8-654.8v-59.5C6820.2,9224.7,6522.6,9522.4,6165.5,9522.4z"
+        />
+        <path
+          className="st6"
+          d="M4855.9,2543c-357.2,0-654.8-297.6-654.8-654.8v59.5c0,357.2,297.6,654.8,654.8,654.8h1964.3V2543H4855.9z"
+        />
+      </g>
+    </g>
+  </svg>
+);
+
+export default docs;

--- a/packages/react-components/src/icons/index.ts
+++ b/packages/react-components/src/icons/index.ts
@@ -1,3 +1,4 @@
+export { default as docsIcon } from './docs';
 export { default as dropdownChevronIcon } from './dropdown-chevron';
 export { default as googleIcon } from './google';
 export { default as googleSigninLightNormalIcon } from './google-signin-light-normal';

--- a/packages/react-components/src/index.ts
+++ b/packages/react-components/src/index.ts
@@ -52,6 +52,7 @@ export {
   RecordOutputForm,
   Signin,
   ProfileHeader,
+  ProfileBiography,
   Welcome,
 } from './templates';
 export {

--- a/packages/react-components/src/templates/ProfileBiography.tsx
+++ b/packages/react-components/src/templates/ProfileBiography.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Card, Headline2, Button, Paragraph } from '../atoms';
+import { Container } from '../molecules';
+
+type ProfileProps = {
+  readonly biography: string;
+};
+
+const Profile: React.FC<ProfileProps> = ({ biography }) => {
+  return (
+    <Container>
+      <Card>
+        <Headline2>Biography</Headline2>
+        <Paragraph>{biography}</Paragraph>
+        <Button>View Biosketch</Button>
+      </Card>
+    </Container>
+  );
+};
+
+export default Profile;

--- a/packages/react-components/src/templates/ProfileBiography.tsx
+++ b/packages/react-components/src/templates/ProfileBiography.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Card, Headline2, Button, Paragraph } from '../atoms';
 import { Container } from '../molecules';
+import { docsIcon } from '../icons';
 
 type ProfileProps = {
   readonly biography: string;
@@ -12,7 +13,10 @@ const Profile: React.FC<ProfileProps> = ({ biography }) => {
       <Card>
         <Headline2>Biography</Headline2>
         <Paragraph>{biography}</Paragraph>
-        <Button>View Biosketch</Button>
+        <Button>
+          {docsIcon}
+          View Biosketch
+        </Button>
       </Card>
     </Container>
   );

--- a/packages/react-components/src/templates/index.ts
+++ b/packages/react-components/src/templates/index.ts
@@ -1,5 +1,6 @@
 export { default as InviteUserForm } from './InviteUserForm';
 export { default as ProfileHeader } from './ProfileHeader';
+export { default as ProfileBiography } from './ProfileBiography';
 export { default as RecordOutputForm } from './RecordOutputForm';
 export { default as Signin } from './Signin';
 export { default as Welcome } from './Welcome';


### PR DESCRIPTION
Change the schema to include biography for each user and show it on the profile page.
We need to revisit the design of the page when the header of the page and the other sections are included.