### PR TITLE
fix(auth-frontend): re-add missing layout

### DIFF
--- a/apps/auth-frontend/src/App.tsx
+++ b/apps/auth-frontend/src/App.tsx
@@ -1,14 +1,19 @@
 import React from 'react';
 import { BrowserRouter, Switch, Route } from 'react-router-dom';
+import { Layout } from '@asap-hub/react-components';
 
 import Login from './login/Login';
 
 const App: React.FC<{}> = () => (
   <BrowserRouter>
-    <Switch>
-      <Route path="/login" component={Login} />
-      <Route render={() => 'This route does not exist'} />
-    </Switch>
+    <Layout>
+      <Switch>
+        <Route exact path="/login">
+          <Login />
+        </Route>
+        <Route>Not Found</Route>
+      </Switch>
+    </Layout>
   </BrowserRouter>
 );
 


### PR DESCRIPTION
That app was completely overlooked in 8469ef6,
causing the sign in page to be renderer on its own without a containing layout.