### PR TITLE
fix(link): identify external links even in a router context

### DIFF
--- a/packages/react-components/src/atoms/Link.tsx
+++ b/packages/react-components/src/atoms/Link.tsx
@@ -45,16 +45,16 @@ const Link: React.FC<LinkProps> = ({
     theme && underlineStyles,
     { display },
   ];
-  if (useHasRouter()) {
+
+  const internal =
+    new URL(href, window.location.href).origin === window.location.origin;
+  if (useHasRouter() && internal) {
     return (
       <ReactRouterLink css={linkStyles} to={href}>
         {children}
       </ReactRouterLink>
     );
   }
-
-  const internal =
-    new URL(href, window.location.href).origin === window.location.origin;
   return (
     <a
       href={href}

--- a/packages/react-components/src/atoms/__tests__/Link.test.tsx
+++ b/packages/react-components/src/atoms/__tests__/Link.test.tsx
@@ -70,7 +70,8 @@ describe('no theme', () => {
 
 describe.each`
   description                         | href                                | wrapper
-  ${'external link'}                  | ${'https://parkinsonsroadmap.org/'} | ${undefined}
+  ${'external link with a router'}    | ${'https://parkinsonsroadmap.org/'} | ${StaticRouter}
+  ${'external link without a router'} | ${'https://parkinsonsroadmap.org/'} | ${undefined}
   ${'internal link with a router'}    | ${'/'}                              | ${StaticRouter}
   ${'internal link without a router'} | ${'/'}                              | ${undefined}
 `('for an $description to $href', ({ href, wrapper }) => {


### PR DESCRIPTION
Fixes https://trello.com/c/kgrugxNf/288-website-link-redirects-the-user-to-an-internal-page

First I thought I'd need to write a test that mocks the `location`, actually clicks the link, and then checks where it *really* redirected to (which would still be the safest way to test, but make the test even more complex), but this also catches such an error nicely:
![image](https://user-images.githubusercontent.com/16069751/92237233-49096600-eeb7-11ea-8854-41860bb57d5d.png)
