### PR TITLE
fix(welcome): use dark theme except on card

### DIFF
--- a/packages/react-components/src/atoms/Card.tsx
+++ b/packages/react-components/src/atoms/Card.tsx
@@ -8,6 +8,7 @@ import {
   mobileScreen,
   largeDesktopScreen,
 } from '../pixels';
+import { themes } from '../theme';
 
 const containerStyles = css({
   padding: `24px ${vminLinearCalc(
@@ -18,7 +19,6 @@ const containerStyles = css({
     'px',
   )}`,
 
-  backgroundColor: colors.paper.rgb,
   borderRadius: `${10 / perRem}em`,
   border: `1px solid ${colors.silver.rgb}`,
 });
@@ -27,7 +27,7 @@ interface CardProps {
   readonly children: React.ReactNode;
 }
 const Card: React.FC<CardProps> = ({ children }) => (
-  <section css={[containerStyles]}>{children}</section>
+  <section css={[themes.light, containerStyles]}>{children}</section>
 );
 
 export default Card;

--- a/packages/react-components/src/atoms/GlobalStyles.tsx
+++ b/packages/react-components/src/atoms/GlobalStyles.tsx
@@ -4,11 +4,13 @@ import css from '@emotion/css';
 import emotionNormalize from 'emotion-normalize';
 
 import { fontStyles } from '../text';
+import { themes } from '../theme';
 
 const styles = css`
   ${emotionNormalize}
   html {
     ${fontStyles}
+    ${themes.light}
   }
   html,
   body,

--- a/packages/react-components/src/templates/WelcomePage.tsx
+++ b/packages/react-components/src/templates/WelcomePage.tsx
@@ -6,6 +6,7 @@ import { Header } from '../molecules';
 import { Link, Paragraph } from '../atoms';
 import { perRem, tabletScreen } from '../pixels';
 import { backgroundBrains } from '../images';
+import { themes } from '../theme';
 
 const values = {
   signup: {
@@ -94,7 +95,7 @@ const WelcomePage: React.FC<WelcomePageProps> = ({
   const copy = signup ? values.signup : values.welcome;
 
   return (
-    <div css={containerStyles}>
+    <div css={[themes.dark, containerStyles]}>
       <div css={headerStyles}>
         <Header transparent />
       </div>

--- a/packages/react-components/src/text.ts
+++ b/packages/react-components/src/text.ts
@@ -1,6 +1,5 @@
 import type { Interpolation } from '@emotion/css';
 
-import { charcoal, paper } from './colors';
 import {
   perRem,
   vminLinearCalc,
@@ -39,9 +38,6 @@ export const fontStyles = {
 
   fontSize: `${perRem}px`,
   lineHeight: `${lineHeight / perRem}em`,
-
-  backgroundColor: paper.rgb,
-  color: charcoal.rgb,
 } as const;
 export const layoutStyles = {
   marginTop: '12px',


### PR DESCRIPTION
The dark background is closer to the background image,
so the image loading top-to-bottom will be less visible.