### PR TITLE
chore: create build dev by default

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,6 @@
 # https://gitlab.com/yldio/asap-hub/-/ci/lint
 include:
-  - 'apps/react-templates/.gitlab-ci.yml'
+  - 'ci/.gitlab-ci.ses.yml'
   - 'ci/.gitlab-ci.squidex.yml'
 
 .tmpl:master: &tmpl_master
@@ -14,6 +14,16 @@ include:
     - if: $CI_EXTERNAL_PULL_REQUEST_IID
   variables: &tmpl_branch_variables
     SLS_STAGE: $CI_EXTERNAL_PULL_REQUEST_IID
+
+.tmpl:deploy: &tmpl_deploy
+  script:
+    - yarn sls deploy --verbose
+  stage: deploy
+  variables: &tmpl_deploy_variables
+    NODE_ENV: production
+  dependencies:
+    - build:ts
+    - build:native
 
 .tmpl:branch_remove: &tmpl_branch_remove
   rules:
@@ -32,7 +42,7 @@ workflow:
     - if: $CI_EXTERNAL_PULL_REQUEST_IID
 
 variables:
-  BASE_HOSTNAME: hub.asap.science
+  ASAP_HOSTNAME: hub.asap.science
 
 stages:
   - build
@@ -42,26 +52,27 @@ stages:
 
 # stage build
 
-build:
-  before_script:
-    - source ci/env-setup.sh
-  script:
-    - yarn run build
+build:ts:
   artifacts:
+    expire_in: 1 day
     paths:
       - 'packages/*/build'
       - 'apps/*/build'
+  script:
+    - source ci/env-create.sh
+    - export REACT_APP_API_BASE_URL=$ASAP_API_URL
+    - yarn run build
+  needs:
+    - []
   stage: build
-  variables:
-    AUTH_FRONTEND_BASE_URL: $ASAP_APP_URL/.auth/
-    REACT_APP_API_BASE_URL: $ASAP_API_URL
 
-build:native-deps:
+build:native:
+  artifacts:
+    expire_in: 1 day
+    paths:
+      - '.yarn/unplugged'
   script:
     - yarn rebuild
-  artifacts:
-    paths:
-      - .yarn/unplugged
   needs:
     - []
   stage: build
@@ -89,34 +100,23 @@ test:format:
   script:
     - yarn run lint:format
 
-test:
+test:jest:
   <<: *tmpl_test
+  artifacts:
+    expire_in: 1 day
+    paths:
+      - coverage
   script:
-    - export SQUIDEX_APP_NAME=$SQUIDEX_TEST_APP_NAME
-    - export SQUIDEX_CLIENT_ID=$SQUIDEX_TEST_CLIENT_ID
-    - export SQUIDEX_CLIENT_SECRET=$SQUIDEX_TEST_CLIENT_SECRET
+    - SQUIDEX_APP_NAME=$SQUIDEX_TEST_APP_NAME
+    - SQUIDEX_CLIENT_ID=$SQUIDEX_TEST_CLIENT_ID
+    - SQUIDEX_CLIENT_SECRET=$SQUIDEX_TEST_CLIENT_SECRET
     - yarn run test --coverage
   after_script:
     - yarn dlx codecov@3.7.2
-  artifacts:
-    paths:
-      - coverage
   needs:
-    - build
+    - build:ts
   variables:
     <<: *tmpl_branch_variables
-
-# stage deploy
-
-.tmpl:deploy: &tmpl_deploy
-  script:
-    - yarn sls deploy --verbose
-  stage: deploy
-  variables: &tmpl_deploy_variables
-    NODE_ENV: production
-  needs:
-    - build
-    - build:native-deps
 
 deploy:sls:branch:
   <<: *tmpl_branch
@@ -132,35 +132,35 @@ deploy:sls:branch:
     <<: *tmpl_branch_variables
     <<: *tmpl_deploy_variables
   needs:
-    - build
-    - build:native-deps
+    - build:ts
+    - build:native
 
 deploy:sls:branch_remove:
+  <<: *tmpl_branch
   <<: *tmpl_branch_remove
-  needs:
-    - build:native-deps
   environment:
     name: review/$CI_EXTERNAL_PULL_REQUEST_IID
     action: stop
   script:
     - git checkout $CI_COMMIT_SHA # the branch may not exist
     - yarn sls remove --verbose
+  needs:
+    - build:native
   stage: deploy
 
-deploy:sls:dev:
+deploy:sls:development:
   <<: *tmpl_master
   <<: *tmpl_deploy
   environment:
-    name: dev
+    name: development
     url: $ASAP_APP_URL
   variables:
     <<: *tmpl_master_variables
     <<: *tmpl_deploy_variables
     SLS_STAGE: 'dev'
   needs:
-    - build
-    - build:native-deps
-    - test
+    - build:ts
+    - build:native
 
 deploy:sls:production:
   <<: *tmpl_master
@@ -172,16 +172,10 @@ deploy:sls:production:
   before_script:
     - export AUTH_FRONTEND_BASE_URL=$ASAP_APP_URL/.auth/
     - export REACT_APP_API_BASE_URL=$ASAP_API_URL
-    - yarn build
+    - yarn run build # create production build
   environment:
     name: production
     url: $ASAP_APP_URL
   variables:
     <<: *tmpl_master_variables
     <<: *tmpl_deploy_variables
-  dependencies:
-    - build
-    - build:native-deps
-  rules:
-    - if: $CI_COMMIT_BRANCH == 'master'
-      when: manual

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -59,7 +59,7 @@ build:ts:
       - 'packages/*/build'
       - 'apps/*/build'
   script:
-    - source ci/env-create.sh
+    - source ci/env-setup.sh
     - export REACT_APP_API_BASE_URL=$ASAP_API_URL
     - yarn run build
   needs:
@@ -107,9 +107,9 @@ test:jest:
     paths:
       - coverage
   script:
-    - SQUIDEX_APP_NAME=$SQUIDEX_TEST_APP_NAME
-    - SQUIDEX_CLIENT_ID=$SQUIDEX_TEST_CLIENT_ID
-    - SQUIDEX_CLIENT_SECRET=$SQUIDEX_TEST_CLIENT_SECRET
+    - export SQUIDEX_APP_NAME=$SQUIDEX_TEST_APP_NAME
+    - export SQUIDEX_CLIENT_ID=$SQUIDEX_TEST_CLIENT_ID
+    - export SQUIDEX_CLIENT_SECRET=$SQUIDEX_TEST_CLIENT_SECRET
     - yarn run test --coverage
   after_script:
     - yarn dlx codecov@3.7.2
@@ -125,7 +125,7 @@ deploy:sls:branch:
     - source ci/env-setup.sh
   environment:
     name: review/$CI_EXTERNAL_PULL_REQUEST_IID
-    url: https://$CI_EXTERNAL_PULL_REQUEST_IID.$BASE_HOSTNAME
+    url: https://$CI_EXTERNAL_PULL_REQUEST_IID.$ASAP_HOSTNAME
     on_stop: deploy:sls:branch_remove
     auto_stop_in: 3 days
   variables:

--- a/ci/.gitlab-ci.ses.yml
+++ b/ci/.gitlab-ci.ses.yml
@@ -5,7 +5,7 @@ deploy:ses:master:
     - yarn node apps/react-templates/lib/deploy.js
   stage: deploy
   dependencies:
-    - build
+    - build:ts
   variables:
     SLS_STAGE: production
     APP_ORIGIN: $ASAP_APP_URL

--- a/ci/README.md
+++ b/ci/README.md
@@ -1,17 +1,23 @@
-| NAME                                 | test   | dev                      | production               | default   | description |
-| ------------------------------------ | ------ | ------------------------ | ------------------------ | --------- | ----------- |
-| API_HOSTNAME                         |        | dev-api.hub.asap.science | api.hub.asap.science     |           |             |
-| APP_HOSTNAME                         |        | dev.hub.asap.science     | hub.asap.science         |           |             |
-| AUTH0_CLIENT_ID                      |        |                          | \*\*\*                   | \*\*\*    |             |
-| AUTH0_SHARED_SECRET                  |        |                          | \*\*\*                   | \*\*\*    |             |
-| AWS_ACCESS_KEY_ID                    |        |                          |                          | \*\*\*    |             |
-| AWS_ACM_ASAP_SCIENCE_CERTIFICATE_ARN |        |                          |                          | \*\*\*    |             |
-| AWS_DEFAULT_REGION                   |        |                          |                          | us-east-1 |             |
-| AWS_REGION                           |        |                          |                          | us-east-1 |             |
-| AWS_SECRET_ACCESS_KEY                |        |                          |                          | \*\*\*    |             |
-| CODECOV_TOKEN                        |        |                          |                          | \*\*\*    |             |
-| GLOBAL_TOKEN                         |        |                          |                          | \*\*\*    |             |
-| SQUIDEX_BASE_URL                     | \*\*\* |                          | https://cloud.squidex.io | \*\*\*    |             |
-| SQUIDEX_APP_NAME                     | \*\*\* | \*\*\*                   | \*\*\*                   | \*\*\*    |             |
-| SQUIDEX_CLIENT_ID                    | \*\*\* |                          | \*\*\*                   | \*\*\*    |             |
-| SQUIDEX_CLIENT_SECRET                | \*\*\* |                          | \*\*\*                   | \*\*\*    |             |
+| NAME                       | feature\*                        | production                   | default                          |
+| -------------------------- | -------------------------------- | ---------------------------- | -------------------------------- |
+| ASAP_API_URL               | https://#mr-api.hub.asap.science | https://api.hub.asap.science | https://dev-api.hub.asap.science |
+| ASAP_APP_URL               | https://#mr.hub.asap.science     | https://hub.asap.science     | https://dev.hub.asap.science     |
+| AUTH0_CLIENT_ID            |                                  | \*                           | \*                               |
+| AUTH0_DOMAIN               |                                  | dev-asap-hub.us.auth0.com    | asap-hub.us.auth0.com            |
+| AUTH0_SHARED_SECRET        |                                  | \*                           | \*                               |
+| AWS_ACCESS_KEY_ID          |                                  |                              | \*                               |
+| AWS_ACM_CERTIFICATE_ARN    |                                  |                              | \*                               |
+| AWS_DEFAULT_REGION         |                                  |                              | us-east-1                        |
+| AWS_REGION                 |                                  |                              | us-east-1                        |
+| AWS_SECRET_ACCESS_KEY      |                                  |                              | \*                               |
+| CODECOV_TOKEN              |                                  |                              | \*                               |
+| GLOBAL_TOKEN               |                                  |                              | \*                               |
+| SQUIDEX_BASE_URL           |                                  | https://cloud.squidex.io     | \*                               |
+| SQUIDEX_APP_NAME           |                                  | \*                           | \*                               |
+| SQUIDEX_CLIENT_ID          |                                  | \*                           | \*                               |
+| SQUIDEX_CLIENT_SECRET      |                                  | \*                           | \*                               |
+| SQUIDEX_TEST_APP_NAME      |                                  |                              | \*                               |
+| SQUIDEX_TEST_CLIENT_ID     |                                  |                              | \*                               |
+| SQUIDEX_TEST_CLIENT_SECRET |                                  |                              | \*                               |
+
+\* Variables set by `ci/env-create.sh` script.

--- a/ci/config-squidex-rules.sh
+++ b/ci/config-squidex-rules.sh
@@ -2,4 +2,4 @@ find dev/squidex/rules -type f \( -name "*.json" -not -name "__rule.json" \) -pr
   sed -i '/sharedSecret/c\    \"sharedSecret\" : \"'$SQUIDEX_SHARED_SECRET'\",' @file
 
 find dev/squidex/rules -type f \( -name "*.json" -not -name "__rule.json" \) -print0 | xargs -t -0 -I @file \
-  sed -i -E 's#https?\:\/\/(www\.)?[[:alpha:]|.]+#https://$API_HOSTNAME#' @file
+  sed -i -E 's#https?\:\/\/(www\.)?[[:alpha:]|.]+#ASAP_API_URL#' @file

--- a/ci/env-create.sh
+++ b/ci/env-create.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env sh
-
-HOSTNAME=${BASE_HOSTNAME:-"hub.asap.science"}
-if [ ! -z $CI_EXTERNAL_PULL_REQUEST_IID ]; then
-    echo ASAP_API_URL="api-${CI_EXTERNAL_PULL_REQUEST_IID}.${BASE_HOSTNAME}"
-    echo ASAP_APP_URL="${CI_EXTERNAL_PULL_REQUEST_IID}.${BASE_HOSTNAME}"
-fi

--- a/ci/env-setup.sh
+++ b/ci/env-setup.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 
-HOSTNAME=${BASE_HOSTNAME:-"hub.asap.science"}
+ASAP_HOSTNAME=${ASAP_HOSTNAME:-"hub.asap.science"}
 if [ ! -z $CI_EXTERNAL_PULL_REQUEST_IID ]; then
-    export ASAP_API_URL="https://api-${CI_EXTERNAL_PULL_REQUEST_IID}.${BASE_HOSTNAME}"
-    export ASAP_APP_URL="https://${CI_EXTERNAL_PULL_REQUEST_IID}.${BASE_HOSTNAME}"
+    export ASAP_API_URL="https://api-${CI_EXTERNAL_PULL_REQUEST_IID}.${ASAP_HOSTNAME}"
+    export ASAP_APP_URL="https://${CI_EXTERNAL_PULL_REQUEST_IID}.${ASAP_HOSTNAME}"
 fi

--- a/packages/auth/src/config.ts
+++ b/packages/auth/src/config.ts
@@ -1,4 +1,4 @@
 export const domain: string =
-  process.env.AUTH0_DOMAIN || 'dev.asap-hub.us.auth0.com';
+  process.env.AUTH0_DOMAIN || 'dev-asap-hub.us.auth0.com';
 export const clientID: string =
   process.env.AUTH0_CLIENT_ID || 'xRDvgZe3Ql3LSZDs2dWQYzcohFnLyeL2';

--- a/serverless.js
+++ b/serverless.js
@@ -93,7 +93,7 @@ module.exports = {
     },
   },
   functions: {
-    'create-user': {
+    createUser: {
       handler: 'apps/asap-server/build/handlers/users/create.handler',
       events: [
         {
@@ -115,7 +115,7 @@ module.exports = {
         GLOBAL_TOKEN: `\${env:GLOBAL_TOKEN}`,
       },
     },
-    'fetch-users': {
+    fetchUsers: {
       handler: 'apps/asap-server/build/handlers/users/fetch.handler',
       events: [
         {
@@ -127,7 +127,7 @@ module.exports = {
         },
       ],
     },
-    'fetch-user-by-id': {
+    fetchUserById: {
       handler: 'apps/asap-server/build/handlers/users/fetch-by-id.handler',
       events: [
         {
@@ -139,43 +139,43 @@ module.exports = {
         },
       ],
     },
-    'fetch-user-by-code': {
-      handler: 'apps/asap-server/build/handlers/users/fetch-by-code.handler',
-      events: [
-        {
-          // https://www.serverless.com/framework/docs/providers/aws/events/http-api/
-          httpApi: {
-            method: 'GET',
-            path: `/users/invites/{code}`,
-          },
-        },
-      ],
-    },
-    'fetch-me': {
-      handler: 'apps/asap-server/build/handlers/users/fetch-me.handler',
-      events: [
-        {
-          // https://www.serverless.com/framework/docs/providers/aws/events/http-api/
-          httpApi: {
-            method: 'GET',
-            path: `/users/me`,
-          },
-        },
-      ],
-    },
-    'connect-by-code': {
-      handler: 'apps/asap-server/build/handlers/users/connect-by-code.handler',
-      events: [
-        {
-          // https://www.serverless.com/framework/docs/providers/aws/events/http-api/
-          httpApi: {
-            method: 'POST',
-            path: `/users/connections`,
-          },
-        },
-      ],
-    },
-    'webhook-fetch-by-code': {
+    // 'fetch-user-by-code': {
+    //   handler: 'apps/asap-server/build/handlers/users/fetch-by-code.handler',
+    //   events: [
+    //     {
+    //       // https://www.serverless.com/framework/docs/providers/aws/events/http-api/
+    //       httpApi: {
+    //         method: 'GET',
+    //         path: `/users/invites/{code}`,
+    //       },
+    //     },
+    //   ],
+    // },
+    // 'fetch-me': {
+    //   handler: 'apps/asap-server/build/handlers/users/fetch-me.handler',
+    //   events: [
+    //     {
+    //       // https://www.serverless.com/framework/docs/providers/aws/events/http-api/
+    //       httpApi: {
+    //         method: 'GET',
+    //         path: `/users/me`,
+    //       },
+    //     },
+    //   ],
+    // },
+    // 'connect-by-code': {
+    //   handler: 'apps/asap-server/build/handlers/users/connect-by-code.handler',
+    //   events: [
+    //     {
+    //       // https://www.serverless.com/framework/docs/providers/aws/events/http-api/
+    //       httpApi: {
+    //         method: 'POST',
+    //         path: `/users/connections`,
+    //       },
+    //     },
+    //   ],
+    // },
+    auth0FetchByCode: {
       handler:
         'apps/asap-server/build/handlers/users/webhook-fetch-by-code.handler',
       events: [
@@ -188,7 +188,7 @@ module.exports = {
         },
       ],
     },
-    'webhook-connect-by-code': {
+    auth0ConnectByCode: {
       handler:
         'apps/asap-server/build/handlers/users/webhook-connect-by-code.handler',
       events: [
@@ -201,7 +201,7 @@ module.exports = {
         },
       ],
     },
-    'sync-user-orcid': {
+    syncUserOrcid: {
       handler:
         'apps/asap-server/build/handlers/users/webhook-sync-orcid.handler',
       events: [
@@ -214,33 +214,33 @@ module.exports = {
         },
       ],
     },
-    'create-research-output': {
-      handler:
-        'apps/asap-server/build/handlers/research-outputs/create.handler',
-      events: [
-        {
-          // https://www.serverless.com/framework/docs/providers/aws/events/http-api/
-          httpApi: {
-            method: 'POST',
-            path: `/users/{id}/research-outputs`,
-          },
-        },
-      ],
-    },
-    'fetch-research-outputs': {
-      handler:
-        'apps/asap-server/build/handlers/research-outputs/fetch-by-id.handler',
-      events: [
-        {
-          // https://www.serverless.com/framework/docs/providers/aws/events/http-api/
-          httpApi: {
-            method: 'GET',
-            path: `/users/{id}/research-outputs`,
-          },
-        },
-      ],
-    },
-    'fetch-page': {
+    // 'create-research-output': {
+    //   handler:
+    //     'apps/asap-server/build/handlers/research-outputs/create.handler',
+    //   events: [
+    //     {
+    //       // https://www.serverless.com/framework/docs/providers/aws/events/http-api/
+    //       httpApi: {
+    //         method: 'POST',
+    //         path: `/users/{id}/research-outputs`,
+    //       },
+    //     },
+    //   ],
+    // },
+    // 'fetch-research-outputs': {
+    //   handler:
+    //     'apps/asap-server/build/handlers/research-outputs/fetch-by-id.handler',
+    //   events: [
+    //     {
+    //       // https://www.serverless.com/framework/docs/providers/aws/events/http-api/
+    //       httpApi: {
+    //         method: 'GET',
+    //         path: `/users/{id}/research-outputs`,
+    //       },
+    //     },
+    //   ],
+    // },
+    fetchPage: {
       handler: 'apps/asap-server/build/handlers/pages/fetch.handler',
       events: [
         {
@@ -252,7 +252,7 @@ module.exports = {
         },
       ],
     },
-    'fetch-content-by-slug': {
+    fetchContentBySlug: {
       handler: 'apps/asap-server/build/handlers/content/fetch-by-slug.handler',
       events: [
         {
@@ -264,7 +264,7 @@ module.exports = {
         },
       ],
     },
-    'fetch-teams': {
+    fetchTeams: {
       handler: 'apps/asap-server/build/handlers/teams/fetch.handler',
       events: [
         {
@@ -276,7 +276,7 @@ module.exports = {
         },
       ],
     },
-    'fetch-team-by-id': {
+    fetchTeamById: {
       handler: 'apps/asap-server/build/handlers/teams/fetch-by-id.handler',
       events: [
         {
@@ -290,7 +290,7 @@ module.exports = {
     },
     ...(NODE_ENV === 'production'
       ? {
-          'cronjob-sync-orcid': {
+          cronjobSyncOrcid: {
             handler:
               'apps/asap-server/build/handlers/users/cronjob-sync-orcid.handler',
             events: [

--- a/serverless.js
+++ b/serverless.js
@@ -9,7 +9,7 @@ if (NODE_ENV === 'production') {
   [
     'ASAP_API_URL',
     'ASAP_APP_URL',
-    'AWS_ACM_ASAP_SCIENCE_CERTIFICATE_ARN',
+    'AWS_ACM_CERTIFICATE_ARN',
     'GLOBAL_TOKEN',
   ].forEach((env) => {
     assert.ok(process.env[env], `${env} not defined`);
@@ -19,9 +19,9 @@ if (NODE_ENV === 'production') {
 const {
   ASAP_APP_URL = 'http://localhost:3000',
   ASAP_API_URL = 'http://localhost:3333',
-  AWS_ACM_ASAP_SCIENCE_CERTIFICATE_ARN,
+  ASAP_HOSTNAME = 'hub.asap.science',
+  AWS_ACM_CERTIFICATE_ARN,
   AWS_REGION = 'us-east-1',
-  BASE_HOSTNAME = 'hub.asap.science',
   SLS_STAGE = 'development',
 } = process.env;
 
@@ -66,8 +66,8 @@ module.exports = {
     excludeDevDependencies: false,
   },
   custom: {
-    appHostname: new URL(ASAP_APP_URL).hostname,
     apiHostname: new URL(ASAP_API_URL).hostname,
+    appHostname: new URL(ASAP_APP_URL).hostname,
     s3Sync: [
       {
         bucketName: `\${self:service}-\${self:provider.stage}-frontend`,
@@ -310,7 +310,7 @@ module.exports = {
           DomainName: `\${self:custom.apiHostname}`,
           DomainNameConfigurations: [
             {
-              CertificateArn: AWS_ACM_ASAP_SCIENCE_CERTIFICATE_ARN,
+              CertificateArn: AWS_ACM_CERTIFICATE_ARN,
               EndpointType: 'REGIONAL',
             },
           ],
@@ -329,7 +329,7 @@ module.exports = {
       HttpApiRecordSetGroup: {
         Type: 'AWS::Route53::RecordSetGroup',
         Properties: {
-          HostedZoneName: `${BASE_HOSTNAME}.`,
+          HostedZoneName: `${ASAP_HOSTNAME}.`,
           RecordSets: [
             {
               Name: `\${self:custom.apiHostname}`,
@@ -625,7 +625,7 @@ module.exports = {
             Enabled: true,
             PriceClass: 'PriceClass_100',
             ViewerCertificate: {
-              AcmCertificateArn: AWS_ACM_ASAP_SCIENCE_CERTIFICATE_ARN,
+              AcmCertificateArn: AWS_ACM_CERTIFICATE_ARN,
               MinimumProtocolVersion: 'TLSv1.2_2018',
               SslSupportMethod: 'sni-only',
             },
@@ -635,7 +635,7 @@ module.exports = {
       CloudFrontRecordSetGroup: {
         Type: 'AWS::Route53::RecordSetGroup',
         Properties: {
-          HostedZoneName: `${BASE_HOSTNAME}.`,
+          HostedZoneName: `${ASAP_HOSTNAME}.`,
           RecordSets: [
             {
               Name: `\${self:custom.appHostname}`,


### PR DESCRIPTION
- Use `ASAP` prefix variables on CI
- Explicit `source ci/env-create.sh` when building and deploying feature branches
- Usage of auxiliary env vars prefixed with `SQUIDEX_TEST` for tests
- Rebuild for production not development or feature branches
