### PR TITLE
refactor(team-card): use CSS to cut off skill tags overflow

### DIFF
--- a/packages/react-components/src/molecules/TeamCard.tsx
+++ b/packages/react-components/src/molecules/TeamCard.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import css from '@emotion/css';
 
 import { Card, Link, Tag, Paragraph, Headline2 } from '../atoms';
-import { perRem } from '../pixels';
+import { perRem, tabletScreen } from '../pixels';
 import { TeamMember } from '../../../model/src';
 import { teamMembersIcon } from '../icons';
 
@@ -13,9 +13,40 @@ const listStyles = css({
   display: 'flex',
   flexDirection: 'row',
   flexWrap: 'wrap',
+  alignItems: 'center',
 
-  '> li:not(:last-of-type)': {
+  '> .overflow': {
+    display: 'none', // can later be activated by previous list items
+  },
+});
+
+const normalListItemStyles = css({
+  counterIncrement: 'skills -1',
+
+  ':not(:nth-last-of-type(2))': {
     paddingRight: `${12 / perRem}em`,
+  },
+
+  ':nth-of-type(n + 4)': {
+    display: 'none',
+    '~ .overflow': {
+      display: 'unset',
+    },
+  },
+
+  [`@media (max-width: ${tabletScreen.min - 1}px)`]: {
+    ':nth-of-type(n + 3)': {
+      display: 'none',
+      '~ .overflow': {
+        display: 'unset',
+      },
+    },
+  },
+});
+
+const overflowContentStyles = css({
+  '::after': {
+    content: '"+" counter(skills)',
   },
 });
 
@@ -44,26 +75,23 @@ const TeamCard: React.FC<TeamCardProps> = ({
   skills,
   members,
 }) => {
-  const shownSkills = skills.slice(0, 2);
-  const hiddenSkillsCount = skills.slice(2).length;
-
   return (
     <Link theme={null} href={`/teams/${id}`}>
       <Card>
         <Headline2 styleAsHeading={4}>{displayName}</Headline2>
         <Paragraph>{projectSummary}</Paragraph>
-        {!!shownSkills.length && (
-          <ul css={listStyles}>
-            {shownSkills.map((skill, index) => (
-              <li key={index}>
+        {!!skills.length && (
+          <ul css={[listStyles, { counterReset: `skills ${skills.length}` }]}>
+            {skills.map((skill, index) => (
+              <li key={index} css={normalListItemStyles}>
                 <Tag>{skill}</Tag>
               </li>
             ))}
-            {!!hiddenSkillsCount && (
-              <li>
-                <Tag>+{hiddenSkillsCount}</Tag>
-              </li>
-            )}
+            <li key="overflow" className="overflow">
+              <Tag>
+                <span css={overflowContentStyles}></span>
+              </Tag>
+            </li>
           </ul>
         )}
         <span css={teamMemberStyles}>

--- a/packages/react-components/src/molecules/__tests__/TeamCard.test.tsx
+++ b/packages/react-components/src/molecules/__tests__/TeamCard.test.tsx
@@ -36,34 +36,52 @@ it('renders the title', () => {
   expect(getByRole('heading').tagName).toEqual('H2');
 });
 
-it('Hides more than two team skills the content', () => {
-  const { getAllByRole } = render(<TeamCard {...teamCardProps} />);
-  expect(
-    getAllByRole('listitem').map(({ textContent }) => textContent),
-  ).toEqual(['Neurological Diseases', 'Clinical Neurology', '+4']);
-});
-
-it('Shows just 2 skills when appropriate', () => {
-  const props = { ...teamCardProps, skills: teamCardProps.skills.slice(0, 2) };
-  const { getAllByRole } = render(<TeamCard {...props} />);
+it('shows all skills when there are few', () => {
+  const { getAllByRole } = render(
+    <TeamCard
+      {...teamCardProps}
+      skills={['Neurological Diseases', 'Clinical Neurology']}
+    />,
+  );
   expect(
     getAllByRole('listitem').map(({ textContent }) => textContent),
   ).toEqual(['Neurological Diseases', 'Clinical Neurology']);
 });
 
-it('Hides skills when there are none', () => {
-  const props = { ...teamCardProps, skills: [] };
-  const { queryAllByRole } = render(<TeamCard {...props} />);
+it('shows only the first skills when there are many', () => {
+  const { getAllByRole } = render(
+    <TeamCard
+      {...teamCardProps}
+      skills={[
+        'Neurological Diseases',
+        'Clinical Neurology',
+        'Adult Neurology',
+        'Neuroimaging',
+      ]}
+    />,
+  );
+  expect(
+    getAllByRole('listitem').map(({ textContent }) => textContent),
+  ).toEqual(['Neurological Diseases', 'Clinical Neurology', 'Adult Neurology']);
+});
+
+it('hides skills when there are none', () => {
+  const { queryAllByRole } = render(
+    <TeamCard {...teamCardProps} skills={[]} />,
+  );
   expect(queryAllByRole('list')).toEqual([]);
 });
 
-it('Singular when more one team member', () => {
-  const { getByText } = render(<TeamCard {...teamCardProps} />);
+it('uses singular for one team member', () => {
+  const { getByText } = render(
+    <TeamCard {...teamCardProps} members={[member]} />,
+  );
   expect(getByText('1 Team Member')).toBeVisible();
 });
 
-it('Pluralises when more than one team member', () => {
-  const props = { ...teamCardProps, members: [...Array(3).fill(member, 0, 3)] };
-  const { getByText } = render(<TeamCard {...props} />);
+it('pluralises when more than one team member', () => {
+  const { getByText } = render(
+    <TeamCard {...teamCardProps} members={Array(3).fill(member)} />,
+  );
   expect(getByText('3 Team Members')).toBeVisible();
 });


### PR DESCRIPTION
This CSS is a bit ... _wild_, but I think it's a good solution for the issue we chatted about @kmaid.
Also don't forget the list of tags should be extracted into a `TagList` molecule that can take a prop for whether it should cut off. That molecule can then be used in `ProfileSkills` as well.