### PR TITLE
refactor(layout): extract some shared layout styling info

### DIFF
--- a/packages/react-components/src/__tests__/layout.test.ts
+++ b/packages/react-components/src/__tests__/layout.test.ts
@@ -1,0 +1,54 @@
+import {
+  contentSidePaddingWithoutNavigation,
+  contentSidePaddingWithNavigation,
+} from '../layout';
+import { viewportCalc } from '../test-utils';
+import { largeDesktopScreen } from '../pixels';
+
+describe('contentSidePaddingWithoutNavigation', () => {
+  it('without arguments returns the minimum side padding', () => {
+    expect(
+      viewportCalc(contentSidePaddingWithoutNavigation(), largeDesktopScreen),
+    ).toMatchInlineSnapshot(`"159px"`);
+  });
+
+  it('increases the padding to account for fewer columns', () => {
+    const normalSidePadding = Number(
+      viewportCalc(
+        contentSidePaddingWithoutNavigation(),
+        largeDesktopScreen,
+      ).replace(/px$/, ''),
+    );
+    const twoColumnSidePadding = Number(
+      viewportCalc(
+        contentSidePaddingWithoutNavigation(2),
+        largeDesktopScreen,
+      ).replace(/px$/, ''),
+    );
+    expect(twoColumnSidePadding).toBeGreaterThan(normalSidePadding);
+  });
+});
+
+describe('contentSidePaddingWithNavigation', () => {
+  it('without arguments returns the minimum side padding', () => {
+    expect(
+      viewportCalc(contentSidePaddingWithNavigation(), largeDesktopScreen),
+    ).toMatchInlineSnapshot(`"30px"`);
+  });
+
+  it('increases the padding to account for fewer columns', () => {
+    const normalSidePadding = Number(
+      viewportCalc(
+        contentSidePaddingWithNavigation(),
+        largeDesktopScreen,
+      ).replace(/px$/, ''),
+    );
+    const twoColumnSidePadding = Number(
+      viewportCalc(
+        contentSidePaddingWithNavigation(2),
+        largeDesktopScreen,
+      ).replace(/px$/, ''),
+    );
+    expect(twoColumnSidePadding).toBeGreaterThan(normalSidePadding);
+  });
+});

--- a/packages/react-components/src/__tests__/pixels.test.ts
+++ b/packages/react-components/src/__tests__/pixels.test.ts
@@ -1,12 +1,4 @@
-import {
-  screen,
-  vminLinearCalc,
-  Screen,
-  contentSidePaddingWithNavigation,
-  contentSidePaddingWithoutNavigation,
-  largeDesktopScreen,
-} from '../pixels';
-import { viewportCalc } from '../test-utils';
+import { screen, vminLinearCalc, Screen } from '../pixels';
 
 describe('screen', () => {
   it('sets the dimensions', () => {
@@ -26,53 +18,5 @@ describe('vminLinearCalc', () => {
     expect(vminLinearCalc(smallScreen, 10, largeScreen, 12, 'px')).toEqual(
       'calc(8px + 2vmin)',
     );
-  });
-});
-
-describe('contentSidePaddingWithoutNavigation', () => {
-  it('without arguments returns the minimum side padding', () => {
-    expect(
-      viewportCalc(contentSidePaddingWithoutNavigation(), largeDesktopScreen),
-    ).toMatchInlineSnapshot(`"159px"`);
-  });
-
-  it('increases the padding to account for fewer columns', () => {
-    const normalSidePadding = Number(
-      viewportCalc(
-        contentSidePaddingWithoutNavigation(),
-        largeDesktopScreen,
-      ).replace(/px$/, ''),
-    );
-    const twoColumnSidePadding = Number(
-      viewportCalc(
-        contentSidePaddingWithoutNavigation(2),
-        largeDesktopScreen,
-      ).replace(/px$/, ''),
-    );
-    expect(twoColumnSidePadding).toBeGreaterThan(normalSidePadding);
-  });
-});
-
-describe('contentSidePaddingWithNavigation', () => {
-  it('without arguments returns the minimum side padding', () => {
-    expect(
-      viewportCalc(contentSidePaddingWithNavigation(), largeDesktopScreen),
-    ).toMatchInlineSnapshot(`"30px"`);
-  });
-
-  it('increases the padding to account for fewer columns', () => {
-    const normalSidePadding = Number(
-      viewportCalc(
-        contentSidePaddingWithNavigation(),
-        largeDesktopScreen,
-      ).replace(/px$/, ''),
-    );
-    const twoColumnSidePadding = Number(
-      viewportCalc(
-        contentSidePaddingWithNavigation(2),
-        largeDesktopScreen,
-      ).replace(/px$/, ''),
-    );
-    expect(twoColumnSidePadding).toBeGreaterThan(normalSidePadding);
   });
 });

--- a/packages/react-components/src/atoms/NavigationLink.tsx
+++ b/packages/react-components/src/atoms/NavigationLink.tsx
@@ -12,9 +12,9 @@ import {
   largeDesktopScreen,
   vminLinearCalc,
 } from '../pixels';
+import { navigationGrey } from '../layout';
 
 const activeClassName = 'active-link';
-const hoverBackgroundColor = color(242, 245, 247);
 const activeBackgroundColor = color(122, 210, 169, 0.18);
 
 const styles = css({
@@ -42,7 +42,7 @@ const styles = css({
 
   borderRadius: `${6 / perRem}em`,
   ':hover, :focus': {
-    backgroundColor: hoverBackgroundColor.rgb,
+    backgroundColor: navigationGrey.rgb,
   },
 });
 const activeStyles = css({

--- a/packages/react-components/src/layout.ts
+++ b/packages/react-components/src/layout.ts
@@ -1,0 +1,38 @@
+import {
+  smallDesktopScreen,
+  vminLinearCalc,
+  mobileScreen,
+  largeDesktopScreen,
+} from './pixels';
+import { color } from './colors';
+
+export const navigationGrey = color(242, 245, 247);
+
+export const drawerQuery = `@media (max-width: ${
+  smallDesktopScreen.width - 1
+}px)`;
+export const crossQuery = `@media (min-width: ${smallDesktopScreen.width}px)`;
+
+const largeDesktopColWidth = 66;
+const largeDesktopColGap = 30;
+export const contentSidePaddingWithoutNavigation = (
+  desktopCols: 2 | 4 | 6 | 8 | 10 | 12 = 12,
+): string =>
+  vminLinearCalc(
+    mobileScreen,
+    24,
+    largeDesktopScreen,
+    159 +
+      ((12 - desktopCols) / 2) * (largeDesktopColWidth + largeDesktopColGap),
+    'px',
+  );
+export const contentSidePaddingWithNavigation = (
+  desktopCols: 2 | 4 | 6 | 8 | 10 | 12 = 12,
+): string =>
+  vminLinearCalc(
+    mobileScreen,
+    24,
+    largeDesktopScreen,
+    30 + ((12 - desktopCols) / 2) * (largeDesktopColWidth + largeDesktopColGap),
+    'px',
+  );

--- a/packages/react-components/src/organisms/MenuHeader.tsx
+++ b/packages/react-components/src/organisms/MenuHeader.tsx
@@ -3,21 +3,21 @@ import css from '@emotion/css';
 
 import { noop } from '../utils';
 import { MenuButton, Header } from '../molecules';
-import { layoutCrossQuery } from '../pixels';
+import { crossQuery } from '../layout';
 import { steel } from '../colors';
 
 const menuButtonWidth = 72;
 
 const styles = css({
   display: 'flex',
-  [layoutCrossQuery]: {
+  [crossQuery]: {
     flexDirection: 'column',
     alignItems: 'flex-start',
   },
 });
 
 const menuButtonStyles = css({
-  [layoutCrossQuery]: {
+  [crossQuery]: {
     display: 'none',
   },
 
@@ -31,7 +31,7 @@ const menuButtonStyles = css({
 });
 const headerSpaceStyles = css({
   width: `${menuButtonWidth}px`,
-  [layoutCrossQuery]: {
+  [crossQuery]: {
     display: 'none',
   },
 });

--- a/packages/react-components/src/pixels.ts
+++ b/packages/react-components/src/pixels.ts
@@ -36,32 +36,3 @@ export const vminLinearCalc = (
 };
 
 export const formTargetWidth = 354;
-
-export const layoutDrawerQuery = `@media (max-width: ${
-  smallDesktopScreen.width - 1
-}px)`;
-export const layoutCrossQuery = `@media (min-width: ${smallDesktopScreen.width}px)`;
-
-const largeDesktopColWidth = 66;
-const largeDesktopColGap = 30;
-export const contentSidePaddingWithoutNavigation = (
-  desktopCols: 2 | 4 | 6 | 8 | 10 | 12 = 12,
-): string =>
-  vminLinearCalc(
-    mobileScreen,
-    24,
-    largeDesktopScreen,
-    159 +
-      ((12 - desktopCols) / 2) * (largeDesktopColWidth + largeDesktopColGap),
-    'px',
-  );
-export const contentSidePaddingWithNavigation = (
-  desktopCols: 2 | 4 | 6 | 8 | 10 | 12 = 12,
-): string =>
-  vminLinearCalc(
-    mobileScreen,
-    24,
-    largeDesktopScreen,
-    30 + ((12 - desktopCols) / 2) * (largeDesktopColWidth + largeDesktopColGap),
-    'px',
-  );

--- a/packages/react-components/src/templates/ContentPage.tsx
+++ b/packages/react-components/src/templates/ContentPage.tsx
@@ -2,8 +2,9 @@ import React from 'react';
 import css from '@emotion/css';
 import { PageResponse } from '@asap-hub/model';
 
-import { perRem, contentSidePaddingWithNavigation } from '../pixels';
+import { perRem } from '../pixels';
 import { Display, RichText } from '../atoms';
+import { contentSidePaddingWithNavigation } from '../layout';
 
 const styles = css({
   alignSelf: 'stretch',

--- a/packages/react-components/src/templates/Layout.tsx
+++ b/packages/react-components/src/templates/Layout.tsx
@@ -7,7 +7,7 @@ import { steel, paper } from '../colors';
 import { MenuHeader, MainNavigation, UserNavigation } from '../organisms';
 import { UserMenuButton } from '../molecules';
 import { Overlay } from '../atoms';
-import { layoutCrossQuery, layoutDrawerQuery } from '../pixels';
+import { navigationGrey, crossQuery, drawerQuery } from '../layout';
 
 const styles = css({
   position: 'relative',
@@ -18,7 +18,7 @@ const styles = css({
     "main-menu  content" max-content
     "user-menu  content" 1fr         / max-content 1fr`,
 
-  [layoutCrossQuery]: {
+  [crossQuery]: {
     grid: `
       "header     user-button" max-content
       "main-menu  content"     1fr         / max-content 1fr`,
@@ -32,7 +32,7 @@ const headerStyles = css({
   borderBottom: `1px solid ${steel.rgb}`,
 });
 const headerMenuShownStyles = css({
-  [layoutDrawerQuery]: {
+  [drawerQuery]: {
     borderBottom: '1px solid transparent', // box shadow only above drawer instead
   },
 });
@@ -40,7 +40,7 @@ const headerMenuShownStyles = css({
 const contentStyles = css({
   gridRow: 'header-end / -1',
   gridColumn: '1 / -1',
-  [layoutCrossQuery]: {
+  [crossQuery]: {
     gridColumn: 'content',
     borderLeft: `1px solid ${steel.rgb}`,
   },
@@ -56,7 +56,7 @@ const overlayStyles = css({
   gridColumn: '1 / -1',
 
   visibility: 'hidden',
-  [layoutCrossQuery]: {
+  [crossQuery]: {
     display: 'none',
   },
 });
@@ -65,7 +65,7 @@ const overlayMenuShownStyles = css({
 });
 
 const userButtonStyles = css({
-  [layoutDrawerQuery]: {
+  [drawerQuery]: {
     display: 'none',
   },
 
@@ -80,14 +80,14 @@ const userButtonStyles = css({
 const menuStyles = css({
   backgroundColor: paper.rgb,
 
-  [layoutDrawerQuery]: {
+  [drawerQuery]: {
     visibility: 'hidden',
     transform: 'translateX(-100%)',
     transition: `transform 250ms ease, visibility 0s 250ms`,
   },
 });
 const menuMenuShownStyles = css({
-  [layoutDrawerQuery]: {
+  [drawerQuery]: {
     visibility: 'visible',
     transform: 'translateX(0)',
     transition: `transform 250ms ease`,
@@ -97,14 +97,14 @@ const menuMenuShownStyles = css({
 const mainMenuStyles = css({
   gridArea: 'main-menu',
 
-  [layoutDrawerQuery]: {
+  [drawerQuery]: {
     boxShadow: `0 -1px 0 ${steel.rgb}`, // instead of header border bottom
   },
 });
 const userMenuStyles = css({
   gridArea: 'user-menu',
 
-  [layoutCrossQuery]: {
+  [crossQuery]: {
     gridArea: 'content',
 
     position: 'absolute',
@@ -115,7 +115,10 @@ const userMenuStyles = css({
   },
 });
 const userMenuShownStyles = css({
-  [layoutCrossQuery]: {
+  [drawerQuery]: {
+    backgroundColor: navigationGrey.rgb,
+  },
+  [crossQuery]: {
     display: 'unset',
   },
 });

--- a/packages/react-components/src/templates/NetworkPage.tsx
+++ b/packages/react-components/src/templates/NetworkPage.tsx
@@ -1,15 +1,10 @@
 import React from 'react';
 import css from '@emotion/css';
 
-import {
-  perRem,
-  contentSidePaddingWithNavigation,
-  tabletScreen,
-  mobileScreen,
-  vminLinearCalc,
-} from '../pixels';
+import { perRem, tabletScreen, mobileScreen, vminLinearCalc } from '../pixels';
 import { pearl } from '../colors';
 import NetworkPageHeader from './NetworkPageHeader';
+import { contentSidePaddingWithNavigation } from '../layout';
 
 const mainStyles = css({
   alignSelf: 'stretch',

--- a/packages/react-components/src/templates/NetworkPageHeader.tsx
+++ b/packages/react-components/src/templates/NetworkPageHeader.tsx
@@ -1,13 +1,10 @@
 import React from 'react';
 import css from '@emotion/css';
 import { Display, Paragraph, Button } from '../atoms';
-import {
-  perRem,
-  contentSidePaddingWithNavigation,
-  tabletScreen,
-} from '../pixels';
+import { perRem, tabletScreen } from '../pixels';
 import { paper, steel } from '../colors';
 import { filterIcon } from '../icons';
+import { contentSidePaddingWithNavigation } from '../layout';
 
 const containerStyles = css({
   alignSelf: 'stretch',

--- a/packages/react-components/src/templates/ProfileAbout.tsx
+++ b/packages/react-components/src/templates/ProfileAbout.tsx
@@ -2,8 +2,9 @@ import React, { ComponentProps } from 'react';
 import css from '@emotion/css';
 
 import { ProfileBiography, ProfileRecentWorks } from '../organisms';
-import { perRem, contentSidePaddingWithNavigation } from '../pixels';
+import { perRem } from '../pixels';
 import { pearl, steel } from '../colors';
+import { contentSidePaddingWithNavigation } from '../layout';
 
 const styles = css({
   backgroundColor: pearl.rgb,

--- a/packages/react-components/src/templates/ProfileHeader.tsx
+++ b/packages/react-components/src/templates/ProfileHeader.tsx
@@ -3,9 +3,10 @@ import css from '@emotion/css';
 import formatDistance from 'date-fns/formatDistance';
 import { UserResponse } from '@asap-hub/model';
 
-import { contentSidePaddingWithNavigation, tabletScreen } from '../pixels';
+import { tabletScreen } from '../pixels';
 import { Avatar, Button, Paragraph, TabLink, Display } from '../atoms';
 import { ProfilePersonalText, TabNav } from '../molecules';
+import { contentSidePaddingWithNavigation } from '../layout';
 
 const containerStyles = css({
   alignSelf: 'stretch',

--- a/packages/react-components/src/templates/ProfileResearch.tsx
+++ b/packages/react-components/src/templates/ProfileResearch.tsx
@@ -1,10 +1,11 @@
 import React, { ComponentProps } from 'react';
 import css from '@emotion/css';
 
-import { perRem, contentSidePaddingWithNavigation } from '../pixels';
+import { perRem } from '../pixels';
 import { pearl, steel } from '../colors';
 import { ProfileBackground, SkillsSection } from '../organisms';
 import { UserResponse } from '../../../model/src';
+import { contentSidePaddingWithNavigation } from '../layout';
 
 const styles = css({
   backgroundColor: pearl.rgb,

--- a/packages/react-components/src/templates/RecordOutputPage.tsx
+++ b/packages/react-components/src/templates/RecordOutputPage.tsx
@@ -3,12 +3,8 @@ import { ResearchOutputFormData } from '@asap-hub/model';
 
 import RecordOutputForm from './RecordOutputForm';
 import { Display, Paragraph } from '../atoms';
-import {
-  vminLinearCalc,
-  mobileScreen,
-  largeDesktopScreen,
-  contentSidePaddingWithNavigation,
-} from '../pixels';
+import { vminLinearCalc, mobileScreen, largeDesktopScreen } from '../pixels';
+import { contentSidePaddingWithNavigation } from '../layout';
 
 interface RecordOutputPageProps {
   onPreview?: (formData: ResearchOutputFormData) => void;

--- a/packages/react-components/src/templates/SigninPage.tsx
+++ b/packages/react-components/src/templates/SigninPage.tsx
@@ -2,12 +2,8 @@ import React, { ComponentProps } from 'react';
 
 import SigninForm from './SigninForm';
 import { AgreeToTerms } from '../molecules';
-import {
-  vminLinearCalc,
-  mobileScreen,
-  largeDesktopScreen,
-  contentSidePaddingWithNavigation,
-} from '../pixels';
+import { vminLinearCalc, mobileScreen, largeDesktopScreen } from '../pixels';
+import { contentSidePaddingWithNavigation } from '../layout';
 
 type SigninPageProps = ComponentProps<typeof SigninForm> &
   ComponentProps<typeof AgreeToTerms>;

--- a/packages/react-components/src/templates/TeamAbout.tsx
+++ b/packages/react-components/src/templates/TeamAbout.tsx
@@ -1,9 +1,10 @@
 import React, { ComponentProps } from 'react';
 import css from '@emotion/css';
 
-import { perRem, contentSidePaddingWithNavigation } from '../pixels';
+import { perRem } from '../pixels';
 import { pearl, steel } from '../colors';
 import { MembersSection, SkillsSection, TeamOverview } from '../organisms';
+import { contentSidePaddingWithNavigation } from '../layout';
 
 const styles = css({
   backgroundColor: pearl.rgb,

--- a/packages/react-components/src/templates/TeamHeader.tsx
+++ b/packages/react-components/src/templates/TeamHeader.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import css from '@emotion/css';
 import { formatDistance } from 'date-fns';
-import { contentSidePaddingWithNavigation } from '../pixels';
 import { Link, TabLink, Display, Button, Paragraph, Avatar } from '../atoms';
 import { TabNav } from '../molecules';
 import { TeamResponse } from '../../../model/src';
+import { contentSidePaddingWithNavigation } from '../layout';
 
 const containerStyles = css({
   alignSelf: 'stretch',


### PR DESCRIPTION
And move some out of `pixels` which has become quite large.
Useful prerequisite to make the upcoming PR for the user menu smaller.