### PR TITLE
chore: use proposal reference

### DIFF
--- a/dev/squidex/schemas/teams.json
+++ b/dev/squidex/schemas/teams.json
@@ -76,12 +76,12 @@
           "placeholder": "",
           "isRequired": false
         }
-      },      
+      },
       {
         "name": "proposalURL",
         "isHidden": false,
         "isLocked": false,
-        "isDisabled": false,
+        "isDisabled": true,
         "partitioning": "invariant",
         "properties": {
           "fieldType": "String",
@@ -89,6 +89,27 @@
           "inlineEditable": false,
           "editor": "Input",
           "label": "Proposal URL",
+          "hints": "",
+          "placeholder": "",
+          "isRequired": false
+        }
+      },
+      {
+        "name": "proposal",
+        "isHidden": false,
+        "isLocked": false,
+        "isDisabled": false,
+        "partitioning": "invariant",
+        "properties": {
+          "fieldType": "References",
+          "maxItems": 1,
+          "allowDuplicates": false,
+          "resolveReference": false,
+          "editor": "Dropdown",
+          "schemaIds": [
+            "research-outputs"
+          ],
+          "label": "Proposal",
           "hints": "",
           "placeholder": "",
           "isRequired": false


### PR DESCRIPTION
* On `research-outputs` title needs to be the first property to show on the proposal selection drop-down
* The team proposal property references a `research-output`