### PR TITLE
chore: apply squidex changes on every deploy

### DIFF
--- a/ci/.gitlab-ci.squidex.yml
+++ b/ci/.gitlab-ci.squidex.yml
@@ -30,14 +30,14 @@ setup:squidex-image:
   stage: prepare
   rules:
     - if: $CI_COMMIT_BRANCH == 'master'
-      changes:
-        - dev/squidex/**/*
-      when: manual
 
 deploy:sync-squidex:dev:
   <<: *tmpl_sync
   environment:
     name: dev
+  rules:
+    - if: $CI_COMMIT_BRANCH == 'master'
+      when: manual
 
 deploy:sync-squidex:production:
   <<: *tmpl_sync


### PR DESCRIPTION
Due to our continuous deployment pipeline we can have a change to squidex schema to be superseded by a newer deployment.
To avoid it we should apply squidex changes on every production deploy.