### PR TITLE
fix(auth-frontend): show all error items

### DIFF
--- a/apps/auth-frontend/src/auth0/__tests__/errors.test.ts
+++ b/apps/auth-frontend/src/auth0/__tests__/errors.test.ts
@@ -50,7 +50,7 @@ describe('extractErrorMessage', () => {
         'Unknown',
       ],
       [
-        'includes rule item messages',
+        'includes rule item messages with a tick/cross',
         [
           { message: 'At least 4 characters', verified: true },
           {
@@ -68,7 +68,7 @@ describe('extractErrorMessage', () => {
             ],
           },
         ],
-        'Not too many of the same characters:\n  At least three different characters',
+        'Not too many of the same characters:\n✔ Not more than half of the same character\n✖ At least three different characters',
       ],
       [
         'formats the message',

--- a/apps/auth-frontend/src/auth0/errors.ts
+++ b/apps/auth-frontend/src/auth0/errors.ts
@@ -25,12 +25,10 @@ export const extractRuleErrorMessage = (
     .flatMap(
       ({ message: ruleMessage, format: ruleFormat = [], items = [] }) => [
         format(ruleMessage, ...ruleFormat),
-        ...items
-          .filter(({ verified }) => !verified)
-          .map(
-            ({ message: itemMessage, format: itemFormat = [] }) =>
-              `  ${format(itemMessage, ...itemFormat)}`,
-          ),
+        ...items.map(
+          ({ message: itemMessage, format: itemFormat = [], verified }) =>
+            `${verified ? '✔' : '✖'} ${format(itemMessage, ...itemFormat)}`,
+        ),
       ],
     )
     .join('\n');


### PR DESCRIPTION
Signalize verification success via icons instead.
This avoid confusion in the case of the message
'Must fulfill 3 of 4 criteria'
and only the 2 failed criteria instead of all 4 being shown.
