### PR TITLE
fix(page-controls): '1 ...' on mobile

### DIFF
--- a/packages/react-components/src/organisms/PageControls.tsx
+++ b/packages/react-components/src/organisms/PageControls.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { aperture, filter, uniqBy, sortWith, pipe } from 'ramda';
+import { aperture, filter, uniqBy, sortWith, pipe, ascend } from 'ramda';
 import css from '@emotion/css';
 
 import {
@@ -177,9 +177,9 @@ const PageControls: React.FC<PageControlsProps> = ({
     ],
     filter<PageNumber>(({ index }) => index >= 0 && index < numPages),
     sortWith([
-      ({ index }) => index,
+      ascend(({ index }) => index),
       // sort wideScreenOnly to the back so that uniq does not lose mandatory pages
-      ({ wideScreenOnly }) => (wideScreenOnly ? 1 : 0),
+      ascend(({ wideScreenOnly }) => (wideScreenOnly ? 1 : 0)),
     ]),
     uniqBy(({ index }) => index),
   )();


### PR DESCRIPTION
If there are two pages, and the current page is the first,
'1 ...' was shown on mobile, while on the second page '1 2' was shown
correctly. This fixes it so that both pages show '1 2' correctly.

Unfortunately, this cannot be tested yet, because JSDOM doesn't let us
check how things look on mobile. I may have something in the pipeline
for that...