### PR TITLE
fix(link): consistent behavior with href=""

### DIFF
--- a/packages/react-components/src/atoms/Link.tsx
+++ b/packages/react-components/src/atoms/Link.tsx
@@ -74,7 +74,7 @@ const Link: React.FC<LinkProps> = ({
 
   const internal =
     new URL(href ?? '', window.location.href).origin === window.location.origin;
-  if (useHasRouter() && href !== undefined && internal) {
+  if (useHasRouter() && href && internal) {
     return (
       <ReactRouterLink css={linkStyles} to={href}>
         {linkChildren}
@@ -83,7 +83,7 @@ const Link: React.FC<LinkProps> = ({
   }
   return (
     <a
-      href={href}
+      href={href || undefined}
       css={linkStyles}
       target={internal ? undefined : '_blank'}
       rel={internal ? undefined : 'noreferrer noopener'}

--- a/packages/react-components/src/atoms/__tests__/Link.test.tsx
+++ b/packages/react-components/src/atoms/__tests__/Link.test.tsx
@@ -135,7 +135,6 @@ describe.each`
     linkDescription    | href
     ${'external link'} | ${'https://parkinsonsroadmap.org/'}
     ${'internal link'} | ${'/'}
-    ${'internal link'} | ${''}
   `("for an $linkDescription to '$href'", ({ href }) => {
     it('applies the href to the anchor', () => {
       const { getByRole } = render(<Link href={href}>text</Link>, {
@@ -150,6 +149,13 @@ describe.each`
 
   it('renders an inactive link without an href', () => {
     const { getByText } = render(<Link href={undefined}>text</Link>, {
+      wrapper,
+    });
+    expect(getByText('text', { selector: 'a' })).not.toHaveAttribute('href');
+  });
+
+  it('renders an inactive link with an empty href', () => {
+    const { getByText } = render(<Link href="">text</Link>, {
       wrapper,
     });
     expect(getByText('text', { selector: 'a' })).not.toHaveAttribute('href');


### PR DESCRIPTION
Previously, react-router links would treat "" like "/",
while normal anchors would treat ""
like the URL constructor (no URL change).
Now, we avoid react-router for empty hrefs so that
the behavior is always the latter.
