### PR TITLE
feat: 404 page for static routes

### DIFF
--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import { Router, Switch, Route } from 'react-router-dom';
-import { Layout, BasicLayout } from '@asap-hub/react-components';
+import { Layout, BasicLayout, NotFoundPage } from '@asap-hub/react-components';
 import { useAuth0, useCurrentUser } from '@asap-hub/react-context';
 
 import history from './history';
@@ -95,7 +95,7 @@ const App: React.FC<{}> = () => {
                       <Route path="/network" component={Network} />
                       <Route path="/library" component={Library} />
 
-                      <Route>Not Found</Route>
+                      <Route component={NotFoundPage} />
                     </Switch>
                   </React.Suspense>
                 </ConfiguredLayout>

--- a/apps/frontend/src/research-outputs/Routes.tsx
+++ b/apps/frontend/src/research-outputs/Routes.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useRouteMatch, Switch, Route } from 'react-router-dom';
+import { NotFoundPage } from '@asap-hub/react-components';
 
 import CreateResearchOutput from './CreateResearchOutput';
 
@@ -9,7 +10,7 @@ const Routes: React.FC<{}> = () => {
   return (
     <Switch>
       <Route exact path={`${path}/create`} component={CreateResearchOutput} />
-      <Route>Not Found</Route>
+      <Route component={NotFoundPage} />
     </Switch>
   );
 };

--- a/apps/frontend/src/welcome/Routes.tsx
+++ b/apps/frontend/src/welcome/Routes.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Switch, Route, useRouteMatch } from 'react-router-dom';
+import { NotFoundPage } from '@asap-hub/react-components';
 
 import Welcome from './Welcome';
 
@@ -9,7 +10,7 @@ const Users: React.FC<{}> = () => {
   return (
     <Switch>
       <Route exact path={`${path}/:code`} component={Welcome} />
-      <Route>Not Found</Route>
+      <Route component={NotFoundPage} />
     </Switch>
   );
 };

--- a/apps/storybook/src/NotFoundPage.stories.tsx
+++ b/apps/storybook/src/NotFoundPage.stories.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { NotFoundPage } from '@asap-hub/react-components';
+
+import { LayoutDecorator } from './decorators';
+
+export default {
+  title: 'Pages / Not Found',
+  decorators: [LayoutDecorator],
+};
+
+export const Normal = () => <NotFoundPage />;

--- a/packages/react-components/src/index.ts
+++ b/packages/react-components/src/index.ts
@@ -84,6 +84,7 @@ export {
   NewsAndEventsPage,
   NewsAndEventsPageHeader,
   NewsAndEventsPageBody,
+  NotFoundPage,
   PasswordResetEmailSentPage,
   ProfileAbout,
   ProfileHeader,

--- a/packages/react-components/src/templates/NotFoundPage.tsx
+++ b/packages/react-components/src/templates/NotFoundPage.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import css from '@emotion/css';
+
+import { Display, Paragraph, Link } from '../atoms';
+import {
+  vminLinearCalc,
+  mobileScreen,
+  largeDesktopScreen,
+  perRem,
+  tabletScreen,
+} from '../pixels';
+import { contentSidePaddingWithNavigation } from '../layout';
+
+const styles = css({
+  padding: `${vminLinearCalc(
+    mobileScreen,
+    36,
+    largeDesktopScreen,
+    72,
+    'px',
+  )} ${contentSidePaddingWithNavigation()}`,
+
+  display: 'grid',
+  gridRowGap: `${12 / perRem}em`,
+  textAlign: 'center',
+
+  [`@media (min-width: ${mobileScreen.width + 1}px)`]: {
+    justifyItems: 'center',
+  },
+});
+
+const tabletAndAbove = css({
+  [`@media (max-width: ${tabletScreen.min - 1}px)`]: {
+    display: 'none',
+  },
+});
+
+const NotFoundPage: React.FC<{}> = () => (
+  <div css={styles}>
+    <div>
+      <Display styleAsHeading={2}>
+        Sorry! We can’t seem to find that page.
+      </Display>
+      <Paragraph>
+        Either something went wrong or that page doesn’t exist anymore.{' '}
+        <br css={tabletAndAbove} />
+        You can always find the latest info on the Dashboard.
+      </Paragraph>
+    </div>
+    <Link buttonStyle primary href="/">
+      Dashboard
+    </Link>
+  </div>
+);
+
+export default NotFoundPage;

--- a/packages/react-components/src/templates/__tests__/NotFoundPage.test.tsx
+++ b/packages/react-components/src/templates/__tests__/NotFoundPage.test.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import NotFoundPage from '../NotFoundPage';
+
+it('renders a level 1 headline', () => {
+  const { getByRole } = render(<NotFoundPage />);
+  expect(getByRole('heading').tagName).toBe('H1');
+});
+
+it('links back to the root', () => {
+  const { getByRole } = render(<NotFoundPage />);
+  expect(getByRole('link')).toHaveAttribute('href', '/');
+});

--- a/packages/react-components/src/templates/index.ts
+++ b/packages/react-components/src/templates/index.ts
@@ -14,6 +14,7 @@ export { default as NetworkTeams } from './NetworkTeams';
 export { default as NewsAndEventsPage } from './NewsAndEventsPage';
 export { default as NewsAndEventsPageBody } from './NewsAndEventsPageBody';
 export { default as NewsAndEventsPageHeader } from './NewsAndEventsPageHeader';
+export { default as NotFoundPage } from './NotFoundPage';
 export { default as PasswordResetEmailSentPage } from './PasswordResetEmailSentPage';
 export { default as ProfileAbout } from './ProfileAbout';
 export { default as ProfileHeader } from './ProfileHeader';


### PR DESCRIPTION
Taking care of 404 pages for missing ids in another PR where I also address handling other kinds of backend errors,
but this can already go in for now and be design reviewed.
