### PR TITLE
perf(frontend): prefetch more sections

### DIFF
--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -37,9 +37,11 @@ const Discover = React.lazy(loadDiscover);
 
 const Prefetch: React.FC<{}> = () => {
   useEffect(() => {
-    loadNetwork();
-    loadLibrary();
-    loadNewsAndEvents();
+    loadHome()
+      .then(loadNewsAndEvents)
+      .then(loadNetwork)
+      .then(loadLibrary)
+      .then(loadDiscover);
   }, []);
   return null;
 };


### PR DESCRIPTION
And prefetch sequentially. This means that on slower networks (where
prefetching matters most, and the bandwidth is so constrained that
fetching more bundles at once does not increase overall throughput), the
first sections will complete prefetching earlier because they do not
share bandwidth with other bundles being prefetched. The order should
reflect how likely we think users are to navigate to each section.