### PR TITLE
fix: team header Avatar scaling

### DIFF
--- a/apps/storybook/src/Avatar.stories.tsx
+++ b/apps/storybook/src/Avatar.stories.tsx
@@ -9,7 +9,6 @@ export default {
 export const Normal = () => (
   <Avatar
     border={boolean('Border', false)}
-    small={boolean('Small', false)}
     imageUrl={text(
       'Image URL',
       'https://www.hhmi.org/sites/default/files/styles/epsa_250_250/public/Programs/Investigator/Randy-Schekman-400x400.jpg',
@@ -19,8 +18,13 @@ export const Normal = () => (
 export const InitialsFallback = () => (
   <Avatar
     border={boolean('Border', false)}
-    small={boolean('Small', false)}
     firstName={text('First Name', 'John')}
     lastName={text('Last Name', 'Doe')}
+  />
+);
+export const Placeholder = () => (
+  <Avatar
+    border={boolean('Border', false)}
+    placeholder={text('Placeholder', '+5')}
   />
 );

--- a/packages/react-components/src/atoms/Avatar.tsx
+++ b/packages/react-components/src/atoms/Avatar.tsx
@@ -15,9 +15,11 @@ import {
   berry,
   lavender,
   mauve,
+  charcoal,
+  paper,
 } from '../colors';
 import { perRem } from '../pixels';
-import { headlineStyles } from '../text';
+import { headlineStyles, fontStyles } from '../text';
 
 const hash = (str: string) => {
   let h = 0;
@@ -30,18 +32,15 @@ const hash = (str: string) => {
   return h;
 };
 
+const minWidth = 36;
+const maxWidth = 90;
 const ringStyle = css({
   boxSizing: 'border-box',
-  height: `${90 / perRem}em`,
-  width: `${90 / perRem}em`,
+  minWidth: `${minWidth / perRem}em`,
+  width: `min(100%, ${maxWidth / perRem}em)`,
 
-  margin: `${12 / perRem}em 0`,
-});
-
-const smallRingStyle = css({
-  boxSizing: 'border-box',
-  height: `${48 / perRem}em`,
-  width: `${48 / perRem}em`,
+  // margin only for Avatars that get all the space (max) they want
+  margin: `clamp(0px, calc(100% - ${maxWidth - 12}px), 12px) 0`,
 });
 
 const ringBorderStyle = css({
@@ -51,6 +50,12 @@ const ringBorderStyle = css({
   borderStyle: 'solid',
   borderRadius: '50%',
   borderColor: silver.rgb,
+});
+const placeholderBorderStyle = css({
+  borderWidth: '1px',
+  borderStyle: 'solid',
+  borderRadius: '50%',
+  borderColor: charcoal.rgb,
 });
 
 const circleStyle = css({
@@ -67,43 +72,69 @@ const imageStyle = css({
   objectFit: 'cover',
 });
 
-const initialsStyle = css(headlineStyles[3]);
-const smallInitialsStyle = css({
-  fontWeight: 'bold',
+const initialsStyle = css({
+  display: 'grid',
+  justifyContent: 'stretch',
+  alignContent: 'stretch',
 });
-
-type AvatarProps = {
+const textStyle = css(fontStyles, headlineStyles[3], {
+  dominantBaseline: 'central',
+  textAnchor: 'middle',
+});
+type RegularAvatarProps = {
   readonly imageUrl?: string;
   readonly firstName?: string;
   readonly lastName?: string;
-  readonly small?: boolean;
+
+  readonly placeholder?: undefined;
+};
+type PlaceholderAvatarProps = {
+  readonly imageUrl?: undefined;
+  readonly firstName?: undefined;
+  readonly lastName?: undefined;
+
+  readonly placeholder?: string;
+};
+type AvatarProps = (RegularAvatarProps | PlaceholderAvatarProps) & {
   readonly border?: boolean;
 };
 
-const colors = [
-  css({ backgroundColor: mint.rgb, color: pine.rgb }),
-  css({ backgroundColor: apricot.rgb, color: clay.rgb }),
-  css({ backgroundColor: sky.rgb, color: denim.rgb }),
-  css({ backgroundColor: azure.rgb, color: space.rgb }),
-  css({ backgroundColor: lilac.rgb, color: berry.rgb }),
-  css({ backgroundColor: lavender.rgb, color: mauve.rgb }),
+const placeholderColorStyle = css({
+  backgroundColor: paper.rgb,
+  fill: charcoal.rgb,
+});
+const colorStyles = [
+  css({ backgroundColor: mint.rgb, fill: pine.rgb }),
+  css({ backgroundColor: apricot.rgb, fill: clay.rgb }),
+  css({ backgroundColor: sky.rgb, fill: denim.rgb }),
+  css({ backgroundColor: azure.rgb, fill: space.rgb }),
+  css({ backgroundColor: lilac.rgb, fill: berry.rgb }),
+  css({ backgroundColor: lavender.rgb, fill: mauve.rgb }),
 ];
 
 const Avatar: React.FC<AvatarProps> = ({
   imageUrl,
   firstName = '',
   lastName = '',
-  small = false,
+  placeholder = '',
   border = false,
 }) => {
   const name = `${firstName}${firstName && lastName ? ' ' : ''}${lastName}`;
   const initials = (firstName?.[0] ?? '') + (lastName?.[0] ?? '');
 
   return (
-    <div css={[small ? smallRingStyle : ringStyle, border && ringBorderStyle]}>
+    <div
+      css={[
+        ringStyle,
+        border && ringBorderStyle,
+        placeholder && placeholderBorderStyle,
+      ]}
+    >
       {imageUrl ? (
         // eslint-disable-next-line jsx-a11y/img-redundant-alt
         <img
+          width={maxWidth}
+          height={maxWidth}
           alt={`Profile picture${name ? ` of ${name}` : ''}`}
           src={imageUrl}
           css={[circleStyle, imageStyle]}
@@ -112,11 +143,17 @@ const Avatar: React.FC<AvatarProps> = ({
         <p
           css={[
             circleStyle,
-            small ? smallInitialsStyle : initialsStyle,
-            colors[hash(initials) % colors.length],
+            initialsStyle,
+            placeholder
+              ? placeholderColorStyle
+              : colorStyles[hash(initials) % colorStyles.length],
           ]}
         >
-          {initials}
+          <svg viewBox="0 0 90 90">
+            <text x="50%" y="50%" css={textStyle}>
+              {placeholder || initials}
+            </text>
+          </svg>
         </p>
       )}
     </div>

--- a/packages/react-components/src/atoms/__tests__/Avatar.test.tsx
+++ b/packages/react-components/src/atoms/__tests__/Avatar.test.tsx
@@ -3,7 +3,7 @@ import { render } from '@testing-library/react';
 import { findParentWithStyle } from '@asap-hub/dom-test-utils';
 
 import Avatar from '../Avatar';
-import { viewportCalc } from '../../test-utils';
+import { paper } from '../../colors';
 
 it('renders the profile picture', () => {
   const { getByRole } = render(<Avatar imageUrl="/avatar.png" />);
@@ -24,9 +24,32 @@ it('generates an alt text when no name is available', () => {
   );
 });
 
+it('shows a placeholder on white background', () => {
+  const { getByText } = render(<Avatar placeholder="+1" />);
+
+  expect(getByText('+1')).toBeVisible();
+
+  const { backgroundColor } = findParentWithStyle(
+    getByText('+1'),
+    'backgroundColor',
+  )!;
+  expect(backgroundColor).toBe(paper.rgb);
+});
+
+it("shows the initials 'JD' on colored background", () => {
+  const { getByText } = render(<Avatar firstName="John" lastName="Doe" />);
+
+  expect(getByText('JD')).toBeVisible();
+
+  const { backgroundColor } = findParentWithStyle(
+    getByText('JD'),
+    'backgroundColor',
+  )!;
+  expect(backgroundColor).not.toBe(paper.rgb);
+});
+
 it.each`
   firstName    | lastName     | initials
-  ${'John'}    | ${'Doe'}     | ${'JD'}
   ${'John'}    | ${undefined} | ${'J'}
   ${undefined} | ${'Doe'}     | ${'D'}
   ${undefined} | ${undefined} | ${''}
@@ -48,20 +71,4 @@ it('respects the border prop', () => {
   expect(
     findParentWithStyle(getByRole('img'), 'borderStyle')?.borderStyle,
   ).toMatchInlineSnapshot(`"solid"`);
-});
-
-it('respects the small prop', () => {
-  const { getByText, rerender } = render(<Avatar firstName="J" lastName="D" />);
-  const normalFontSize = Number(
-    viewportCalc(
-      findParentWithStyle(getByText(/[A-Z]/), 'fontSize')!.fontSize,
-    ).replace(/px$/, ''),
-  );
-
-  rerender(<Avatar firstName="J" lastName="D" small />);
-  const smallFontSize = Number(
-    getComputedStyle(getByText(/[A-Z]/)).fontSize.replace(/em$/, ''),
-  );
-
-  expect(smallFontSize).toBeLessThan(normalFontSize);
 });

--- a/packages/react-components/src/molecules/UserMenuButton.tsx
+++ b/packages/react-components/src/molecules/UserMenuButton.tsx
@@ -17,7 +17,8 @@ const styles = css({
   padding: `${12 / perRem}em ${24 / perRem}em`,
   cursor: 'pointer',
 
-  display: 'flex',
+  display: 'grid',
+  gridTemplateColumns: `auto ${48 / perRem}em auto auto`,
   alignItems: 'center',
 });
 
@@ -50,12 +51,7 @@ const UserMenuButton: React.FC<UserMenuButtonProps> = ({
           {displayName}
         </strong>
       </Paragraph>
-      <Avatar
-        small
-        imageUrl={avatarUrl}
-        firstName={firstName}
-        lastName={lastName}
-      />
+      <Avatar imageUrl={avatarUrl} firstName={firstName} lastName={lastName} />
       <div
         css={{
           paddingLeft: `${12 / perRem}em`,

--- a/packages/react-components/src/organisms/MembersSection.tsx
+++ b/packages/react-components/src/organisms/MembersSection.tsx
@@ -12,9 +12,9 @@ const containerStyles = css({
   display: 'grid',
 
   gridColumnGap: `${18 / perRem}em`,
-  gridTemplateColumns: 'min-content 1fr',
+  gridTemplateColumns: `${48 / perRem}em 1fr`,
   [`@media (min-width: ${tabletScreen.min}px)`]: {
-    gridTemplateColumns: 'min-content 1fr min-content 1fr',
+    gridTemplateColumns: `${48 / perRem}em 1fr ${48 / perRem}em 1fr`,
   },
 
   alignItems: 'center',
@@ -70,7 +70,6 @@ const MembersSection: React.FC<MembersSectionProps> = ({
                 <div css={avatarStyles}>
                   <Avatar
                     imageUrl={avatarUrl}
-                    small
                     border
                     firstName={firstName}
                     lastName={lastName}

--- a/packages/react-components/src/organisms/PeopleCard.tsx
+++ b/packages/react-components/src/organisms/PeopleCard.tsx
@@ -12,7 +12,7 @@ const containerStyles = css({
   columnGap: '25px',
   rowGap: '12px',
   [`@media (min-width: ${tabletScreen.min}px)`]: {
-    gridTemplateColumns: 'min-content auto',
+    gridTemplateColumns: '90px auto',
   },
 });
 

--- a/packages/react-components/src/templates/TeamHeader.tsx
+++ b/packages/react-components/src/templates/TeamHeader.tsx
@@ -8,29 +8,14 @@ import { TabNav } from '../molecules';
 import { contentSidePaddingWithNavigation } from '../layout';
 import { createMailTo } from '../utils';
 import { perRem, mobileScreen } from '../pixels';
-import { paper, lead } from '../colors';
+import { paper } from '../colors';
+
+const MAX_MEMBER_AVATARS = 5;
 
 const containerStyles = css({
   alignSelf: 'stretch',
   backgroundColor: paper.rgb,
-  padding: `${36 / perRem}em ${contentSidePaddingWithNavigation(8)} 0`,
-});
-
-type TeamProps = TeamResponse & {
-  readonly aboutHref: string;
-  readonly outputsHref: string;
-};
-
-const memberStyle = css({});
-const membersContainerStyle = css({
-  padding: 0,
-  listStyle: 'none',
-
-  display: 'flex',
-  flexDirection: 'row',
-  alignItems: 'center',
-
-  gridArea: 'members',
+  padding: `${36 / perRem}em ${contentSidePaddingWithNavigation(10)} 0`,
 });
 
 const sectionStyles = css({
@@ -47,7 +32,7 @@ const sectionStyles = css({
 
   [`@media (min-width: ${mobileScreen.max}px)`]: {
     grid: `
-      "contact members update" auto / auto 1fr auto
+      "contact members update" / max-content 1fr max-content
     `,
   },
 });
@@ -65,18 +50,28 @@ const pointOfContactStyles = css({
   },
 });
 
-const extraUsersStyles = css({
+const membersContainerStyles = css({
+  gridArea: 'members',
+
   display: 'grid',
-  height: `${48 / perRem}em`,
-  width: `${48 / perRem}em`,
-  justifyContent: 'center',
-  alignItems: 'center',
-  borderRadius: '50%',
-  border: `1px solid ${lead.rgb}`,
-  fontWeight: 'bold',
-  marginLeft: `${6 / perRem}em`,
+  gridAutoFlow: 'column',
+  gridTemplateColumns: `repeat(${MAX_MEMBER_AVATARS}, minmax(auto, 60px)) ${
+    6 / perRem
+  }em minmax(auto, 60px)`,
+});
+const membersListStyles = css({
+  display: 'contents',
+  listStyle: 'none',
+});
+const extraUsersStyles = css({
+  display: 'block',
+  gridColumnEnd: '-1',
 });
 
+type TeamProps = TeamResponse & {
+  readonly aboutHref: string;
+  readonly outputsHref: string;
+};
 const TeamHeader: React.FC<TeamProps> = ({
   displayName,
   lastModifiedDate,
@@ -90,25 +85,32 @@ const TeamHeader: React.FC<TeamProps> = ({
     <header css={containerStyles}>
       <Display styleAsHeading={2}>Team {displayName}</Display>
       <section css={sectionStyles}>
-        <ul css={membersContainerStyle}>
-          {members.slice(0, 5).map(({ id, avatarUrl, firstName, lastName }) => {
-            return (
-              <li key={id} css={memberStyle}>
-                <Link href={`/network/users/${id}`} theme={null}>
-                  <Avatar
-                    small
-                    firstName={firstName}
-                    lastName={lastName}
-                    imageUrl={avatarUrl}
-                  />
-                </Link>
-              </li>
-            );
-          })}
-          {members.length > 5 ? (
-            <li css={extraUsersStyles}>{`+${members.length - 5}`}</li>
-          ) : null}
-        </ul>
+        <div css={membersContainerStyles}>
+          <ul css={membersListStyles}>
+            {members
+              .slice(0, MAX_MEMBER_AVATARS)
+              .map(({ id, avatarUrl, firstName, lastName }) => {
+                return (
+                  <li key={id}>
+                    <Link href={`/network/users/${id}`} theme={null}>
+                      <Avatar
+                        firstName={firstName}
+                        lastName={lastName}
+                        imageUrl={avatarUrl}
+                      />
+                    </Link>
+                  </li>
+                );
+              })}
+            <li css={extraUsersStyles}>
+              {members.length > MAX_MEMBER_AVATARS && (
+                <Avatar
+                  placeholder={`+${members.length - MAX_MEMBER_AVATARS}`}
+                />
+              )}
+            </li>
+          </ul>
+        </div>
         {pointOfContact && (
           <div css={pointOfContactStyles}>
             <Link

--- a/packages/react-components/src/templates/TeamPage.tsx
+++ b/packages/react-components/src/templates/TeamPage.tsx
@@ -11,7 +11,7 @@ const styles = css({
 });
 const contentStyles = css({
   borderTop: `1px solid ${steel.rgb}`,
-  padding: `${36 / perRem}em ${contentSidePaddingWithNavigation(8)}`,
+  padding: `${36 / perRem}em ${contentSidePaddingWithNavigation(10)}`,
 });
 
 type TeamPageProps = ComponentProps<typeof TeamHeader> & {


### PR DESCRIPTION
I've changed the team page to have enough space available.

Avatars can now scale according to the available space.

I hadn't considered the difficulty scaling the initials,
but with a simple SVG it's reasonably easy,
and the autoscaling has e.g. the advantage of being able to
fill exactly one row with Avatars, as is done in the new team header.

I've also refactored the team header's extra users bubble
into the Avatar component to share styling with the real Avatar bubbles.
