### PR TITLE
fix(avatar): overflow on small avatars

### DIFF
--- a/apps/storybook/src/MembersSection.stories.tsx
+++ b/apps/storybook/src/MembersSection.stories.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { MembersSection } from '@asap-hub/react-components';
+import { text } from '@storybook/addon-knobs';
 
 export default {
   title: 'Organisms / Team / Members',
@@ -26,6 +27,10 @@ export const Normal = () => (
         lastName: 'Venkman',
         email: 'peter@venk.com',
         role: 'Project Manager',
+        avatarUrl: text(
+          'Member 2 Avatar URL',
+          'https://www.hhmi.org/sites/default/files/styles/epsa_250_250/public/Programs/Investigator/Randy-Schekman-400x400.jpg',
+        ),
       },
       {
         id: '3',

--- a/apps/storybook/src/TeamPage.stories.tsx
+++ b/apps/storybook/src/TeamPage.stories.tsx
@@ -1,5 +1,6 @@
 import React, { ComponentProps } from 'react';
 import { formatISO, subDays } from 'date-fns';
+import { text } from '@storybook/addon-knobs';
 import { TeamPage, TeamAbout, TeamOutputs } from '@asap-hub/react-components';
 
 import { LayoutDecorator } from './decorators';
@@ -9,7 +10,7 @@ export default {
   decorators: [LayoutDecorator],
 };
 
-const commonProps: Omit<ComponentProps<typeof TeamPage>, 'children'> = {
+const commonProps = (): Omit<ComponentProps<typeof TeamPage>, 'children'> => ({
   id: '42',
   displayName: 'Ramirez, T',
   projectTitle:
@@ -36,6 +37,10 @@ const commonProps: Omit<ComponentProps<typeof TeamPage>, 'children'> = {
       lastName: 'Venkman',
       email: 'peter@ven.com',
       role: 'Project Manager',
+      avatarUrl: text(
+        'Member 2 Avatar URL',
+        'https://www.hhmi.org/sites/default/files/styles/epsa_250_250/public/Programs/Investigator/Randy-Schekman-400x400.jpg',
+      ),
     },
     {
       id: '3',
@@ -80,16 +85,16 @@ const commonProps: Omit<ComponentProps<typeof TeamPage>, 'children'> = {
   ],
   aboutHref: '/wrong',
   outputsHref: '/wrong',
-};
+});
 
 export const AboutTab = () => (
-  <TeamPage {...commonProps} aboutHref="#">
-    <TeamAbout {...commonProps}></TeamAbout>
+  <TeamPage {...commonProps()} aboutHref="#">
+    <TeamAbout {...commonProps()}></TeamAbout>
   </TeamPage>
 );
 
 export const OutputsTab = () => (
-  <TeamPage {...commonProps} outputsHref="#">
+  <TeamPage {...commonProps()} outputsHref="#">
     <TeamOutputs />
   </TeamPage>
 );

--- a/packages/fixtures/src/teams.ts
+++ b/packages/fixtures/src/teams.ts
@@ -1,4 +1,4 @@
-import { ListTeamResponse } from '@asap-hub/model';
+import { ListTeamResponse, TeamMember } from '@asap-hub/model';
 
 const listTeamMember: Omit<ListTeamResponse['items'][0]['members'][0], 'id'> = {
   firstName: 'Mason',
@@ -18,6 +18,12 @@ const listTeamResponseItem: Omit<ListTeamResponse['items'][0], 'id'> = {
   lastModifiedDate: '2020-09-07T17:36:54Z',
 };
 
+export const createTeamResponseMembers = (teamMembers: number): TeamMember[] =>
+  Array.from({ length: teamMembers }, (__, memberIndex) => ({
+    ...listTeamMember,
+    id: `tm${memberIndex}`,
+  }));
+
 export const createListTeamResponse = (
   items: number,
   { teamMembers = 0 } = {},
@@ -27,10 +33,7 @@ export const createListTeamResponse = (
     ...listTeamResponseItem,
     id: `t${itemIndex}`,
     displayName: `${listTeamResponseItem.displayName} ${itemIndex + 1}`,
-    members: Array.from({ length: teamMembers }, (__, memberIndex) => ({
-      ...listTeamMember,
-      id: `t${itemIndex}-m${memberIndex}`,
-    })),
+    members: createTeamResponseMembers(teamMembers),
   })),
 });
 

--- a/packages/react-components/src/atoms/Avatar.tsx
+++ b/packages/react-components/src/atoms/Avatar.tsx
@@ -38,15 +38,6 @@ const maxWidth = 90;
 const borderPadding = 4;
 const borderWidth = 1;
 
-const borderMaxWidth = maxWidth - 2 * borderPadding - 2 * borderWidth;
-
-const squareStyle = css({
-  '::after': {
-    height: 0,
-    paddingBottom: '100%',
-  },
-});
-
 const ringStyle = css({
   boxSizing: 'border-box',
   minWidth: `${minWidth / perRem}em`,
@@ -73,15 +64,15 @@ const placeholderStyle = css({
 
 const circleStyle = css({
   margin: 0,
-  display: 'flex',
-  justifyContent: 'center',
-  alignItems: 'center',
   borderRadius: '50%',
 });
 
-const imageStyle = css({
-  objectFit: 'cover',
-});
+const imageStyle = (imageUrl: string) =>
+  css({
+    backgroundImage: `url(${JSON.stringify(imageUrl)})`,
+    backgroundSize: 'cover',
+    backgroundPosition: 'center',
+  });
 
 const initialsStyle = css({
   display: 'grid',
@@ -92,6 +83,20 @@ const textStyle = css(fontStyles, headlineStyles[3], {
   dominantBaseline: 'central',
   textAnchor: 'middle',
 });
+
+const placeholderColorStyle = css({
+  backgroundColor: paper.rgb,
+  fill: charcoal.rgb,
+});
+const colorStyles = [
+  css({ backgroundColor: mint.rgb, fill: pine.rgb }),
+  css({ backgroundColor: apricot.rgb, fill: clay.rgb }),
+  css({ backgroundColor: sky.rgb, fill: denim.rgb }),
+  css({ backgroundColor: azure.rgb, fill: space.rgb }),
+  css({ backgroundColor: lilac.rgb, fill: berry.rgb }),
+  css({ backgroundColor: lavender.rgb, fill: mauve.rgb }),
+];
+
 type RegularAvatarProps = {
   readonly imageUrl?: string;
   readonly firstName?: string;
@@ -110,19 +115,6 @@ type AvatarProps = (RegularAvatarProps | PlaceholderAvatarProps) & {
   readonly border?: boolean;
 };
 
-const placeholderColorStyle = css({
-  backgroundColor: paper.rgb,
-  fill: charcoal.rgb,
-});
-const colorStyles = [
-  css({ backgroundColor: mint.rgb, fill: pine.rgb }),
-  css({ backgroundColor: apricot.rgb, fill: clay.rgb }),
-  css({ backgroundColor: sky.rgb, fill: denim.rgb }),
-  css({ backgroundColor: azure.rgb, fill: space.rgb }),
-  css({ backgroundColor: lilac.rgb, fill: berry.rgb }),
-  css({ backgroundColor: lavender.rgb, fill: mauve.rgb }),
-];
-
 const Avatar: React.FC<AvatarProps> = ({
   imageUrl,
   firstName = '',
@@ -136,38 +128,37 @@ const Avatar: React.FC<AvatarProps> = ({
   return (
     <div
       css={[
-        squareStyle,
         ringStyle,
         border && ringBorderStyle,
         placeholder && placeholderStyle,
       ]}
     >
-      {imageUrl ? (
-        // eslint-disable-next-line jsx-a11y/img-redundant-alt
-        <img
-          width={border ? borderMaxWidth : maxWidth}
-          height={border ? borderMaxWidth : maxWidth}
-          alt={`Profile picture${name ? ` of ${name}` : ''}`}
-          src={imageUrl}
-          css={[squareStyle, circleStyle, imageStyle]}
-        />
-      ) : (
-        <p
-          css={[
-            circleStyle,
-            initialsStyle,
-            placeholder
-              ? placeholderColorStyle
-              : colorStyles[hash(initials) % colorStyles.length],
-          ]}
-        >
-          <svg viewBox="0 0 90 90">
-            <text x="50%" y="50%" css={textStyle}>
-              {placeholder || initials}
-            </text>
-          </svg>
-        </p>
-      )}
+      <p
+        role="img"
+        aria-label={`Profile picture${
+          placeholder
+            ? ` placeholder: ${placeholder}`
+            : name
+            ? ` of ${name}`
+            : ''
+        }`}
+        css={[
+          circleStyle,
+          initialsStyle,
+          placeholder
+            ? placeholderColorStyle
+            : imageUrl
+            ? null
+            : colorStyles[hash(initials) % colorStyles.length],
+          imageUrl && imageStyle(imageUrl),
+        ]}
+      >
+        <svg viewBox="0 0 90 90" css={imageUrl && { visibility: 'hidden' }}>
+          <text x="50%" y="50%" css={textStyle}>
+            {placeholder || initials}
+          </text>
+        </svg>
+      </p>
     </div>
   );
 };

--- a/packages/react-components/src/atoms/__tests__/Avatar.test.tsx
+++ b/packages/react-components/src/atoms/__tests__/Avatar.test.tsx
@@ -7,21 +7,25 @@ import { paper } from '../../colors';
 
 it('renders the profile picture', () => {
   const { getByRole } = render(<Avatar imageUrl="/avatar.png" />);
-  expect(getByRole('img')).toHaveAttribute('src', '/avatar.png');
+  const { backgroundImage } = getComputedStyle(getByRole('img'));
+  expect(backgroundImage).toContain('/avatar.png');
 });
 
-it('generates an alt text based on the name', () => {
-  const { getByAltText } = render(
+it('generates a label text based on the name', () => {
+  const { getByLabelText } = render(
     <Avatar imageUrl="/avatar.png" firstName="John" lastName="Doe" />,
   );
-  expect(getByAltText(/pic.+John Doe/i)).toBeVisible();
+  expect(getByLabelText(/pic.+John Doe/i)).toBeVisible();
 });
 
-it('generates an alt text when no name is available', () => {
-  const { getByRole } = render(<Avatar imageUrl="/avatar.png" />);
-  expect((getByRole('img') as HTMLImageElement).alt).toMatchInlineSnapshot(
-    `"Profile picture"`,
-  );
+it('generates a label text when no name is available', () => {
+  const { getByLabelText } = render(<Avatar imageUrl="/avatar.png" />);
+  expect(getByLabelText(/pic/)).toBeVisible();
+});
+
+it('generates a label text for a placeholder', () => {
+  const { getByLabelText } = render(<Avatar placeholder="+1" />);
+  expect(getByLabelText(/placeholder.+\+1/)).toBeVisible();
 });
 
 it('shows a placeholder on white background', () => {
@@ -46,6 +50,14 @@ it("shows the initials 'JD' on colored background", () => {
     'backgroundColor',
   )!;
   expect(backgroundColor).not.toBe(paper.rgb);
+});
+
+it('does not show the initials if there is an image', () => {
+  const { getByText } = render(
+    <Avatar firstName="John" lastName="Doe" imageUrl="/avatar.png" />,
+  );
+
+  expect(getByText('JD')).not.toBeVisible();
 });
 
 it.each`

--- a/packages/react-components/src/molecules/__tests__/UserMenuButton.test.tsx
+++ b/packages/react-components/src/molecules/__tests__/UserMenuButton.test.tsx
@@ -26,7 +26,7 @@ it('renders a fallback instead of the display name', async () => {
 });
 
 it('renders the user avatar', async () => {
-  const { findByAltText } = render(
+  const { findByLabelText } = render(
     <authTestUtils.Auth0Provider>
       <authTestUtils.LoggedIn
         user={{ avatarUrl: '/pic.jpg', firstName: 'John', lastName: 'Doe' }}
@@ -35,7 +35,7 @@ it('renders the user avatar', async () => {
       </authTestUtils.LoggedIn>
     </authTestUtils.Auth0Provider>,
   );
-  expect(await findByAltText(/pic.+John Doe/i)).toBeVisible();
+  expect(await findByLabelText(/pic.+John Doe/i)).toBeVisible();
 });
 it('renders a fallback for the user avatar', async () => {
   const { findByText } = render(<UserMenuButton />);

--- a/packages/react-components/src/templates/__tests__/TeamHeader.test.tsx
+++ b/packages/react-components/src/templates/__tests__/TeamHeader.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { subYears, formatISO } from 'date-fns';
+import { createTeamResponseMembers } from '@asap-hub/fixtures';
 
 import TeamHeader from '../TeamHeader';
 
@@ -54,56 +55,11 @@ it('renders a list of members', () => {
 });
 
 it('renders no more than 5 members', () => {
-  const { getAllByRole } = render(
-    <TeamHeader
-      {...boilerplateProps}
-      members={[
-        {
-          id: '1',
-          displayName: 'Unknown',
-          email: 'foo1@bar.com',
-          avatarUrl: 'https://example.com',
-          role: 'Collaborator',
-        },
-        {
-          id: '2',
-          displayName: 'Unknown',
-          email: 'foo2@bar.com',
-          avatarUrl: 'https://example.com',
-          role: 'Collaborator',
-        },
-        {
-          id: '3',
-          displayName: 'Unknown',
-          email: 'foo3@bar.com',
-          avatarUrl: 'https://example.com',
-          role: 'Collaborator',
-        },
-        {
-          id: '4',
-          displayName: 'Unknown',
-          email: 'foo4@bar.com',
-          avatarUrl: 'https://example.com',
-          role: 'Collaborator',
-        },
-        {
-          id: '5',
-          displayName: 'Unknown',
-          email: 'foo5@bar.com',
-          avatarUrl: 'https://example.com',
-          role: 'Collaborator',
-        },
-        {
-          id: '6',
-          displayName: 'Unknown',
-          email: 'foo6@bar.com',
-          avatarUrl: 'https://example.com',
-          role: 'Collaborator',
-        },
-      ]}
-    />,
+  const { getByLabelText, getAllByLabelText } = render(
+    <TeamHeader {...boilerplateProps} members={createTeamResponseMembers(6)} />,
   );
-  expect(getAllByRole('img')).toHaveLength(5);
+  expect(getAllByLabelText(/pic.+ of .+/)).toHaveLength(5);
+  expect(getByLabelText(/\+1/)).toBeVisible();
 });
 
 it('renders a contact button when there is a pointOfContact', () => {


### PR DESCRIPTION
Background images are just so much easier to deal with,
and now images are pretty much guaranteed to
behave like the fallback initials, since it's the same element...
