### PR TITLE
Fix: Change link

### DIFF
--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -55,7 +55,7 @@ const ConfiguredLayout: React.FC = ({ children }) => {
     <Layout
       discoverAsapHref="/discover"
       sharedResearchHref="/shared-research"
-      networkHref="/network"
+      networkHref="/network/teams"
       newsAndEventsHref="/news-and-events"
       profileHref={`/network/users/${user.id}`}
       teams={user.teams.map(({ id, displayName = '' }) => ({


### PR DESCRIPTION
This is a fix for Network not being highlighted. I spoke with James and their ideal would be network highlighted for all pages under network except team internal and user internal pages. This sounds like it needs specced out to understand how hilighting of navigation links will work on all pages post MVP so I will bring this up in standup on Monday