### PR TITLE
fix(layout): prevent side menu from causing scrollbar on low heights

### DIFF
--- a/packages/react-components/src/templates/Layout.tsx
+++ b/packages/react-components/src/templates/Layout.tsx
@@ -175,7 +175,7 @@ const Layout: React.FC<LayoutProps> = ({
   }, [location]);
 
   return (
-    <article css={[styles]}>
+    <article css={[styles, menuShown || { overflow: 'hidden' }]}>
       {/* order relevant for overlap */}
       <div css={[headerStyles, menuShown && headerMenuShownStyles]}>
         <MenuHeader


### PR DESCRIPTION
Works pretty nicely even when scrolling down in the side menu and then clicking the overlay to hide it. Can try it out in Storybook on mobile landscape.
