### PR TITLE
fix(modals): prevent navigation when already elsewhere

### DIFF
--- a/apps/frontend/src/history/__tests__/index.test.tsx
+++ b/apps/frontend/src/history/__tests__/index.test.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { Router } from 'react-router-dom';
+import { renderHook } from '@testing-library/react-hooks';
+import { createMemoryHistory } from 'history';
+
+import { usePushFromHere, usePushFromPathname } from '..';
+
+describe('usePushFromPathname', () => {
+  it('pushes a history entry if currently on given page', () => {
+    const history = createMemoryHistory({ initialEntries: ['/current'] });
+    const wrapper: React.FC = ({ children }) => (
+      <Router history={history}>{children}</Router>
+    );
+    const {
+      result: { current },
+    } = renderHook(() => usePushFromPathname('/current'), {
+      wrapper,
+    });
+
+    current('/new');
+    expect(history.location.pathname).toBe('/new');
+  });
+
+  it('does not push a history entry if currently on a different page', () => {
+    const history = createMemoryHistory({ initialEntries: ['/current'] });
+    const wrapper: React.FC = ({ children }) => (
+      <Router history={history}>{children}</Router>
+    );
+    const {
+      result: { current },
+    } = renderHook(() => usePushFromPathname('/wrong'), {
+      wrapper,
+    });
+
+    current('/new');
+    expect(history.location.pathname).toBe('/current');
+  });
+});
+
+describe('usePushFromHere', () => {
+  it('pushes a history entry if still on the same page', () => {
+    const history = createMemoryHistory({ initialEntries: ['/current'] });
+    const wrapper: React.FC = ({ children }) => (
+      <Router history={history}>{children}</Router>
+    );
+    const {
+      result: { current },
+    } = renderHook(() => usePushFromHere(), {
+      wrapper,
+    });
+
+    current('/new');
+    expect(history.location.pathname).toBe('/new');
+  });
+
+  it('does not push a history entry if no longer on the same page', () => {
+    const history = createMemoryHistory({ initialEntries: ['/current'] });
+    const wrapper: React.FC = ({ children }) => (
+      <Router history={history}>{children}</Router>
+    );
+    const {
+      result: { current },
+    } = renderHook(() => usePushFromHere(), {
+      wrapper,
+    });
+
+    history.push('/elsewhere');
+
+    // Note that `current` is still the hook result from before the push;
+    // now the hook is returning a function "bound" to `/elsewhere`.
+    current('/new');
+    expect(history.location.pathname).toBe('/elsewhere');
+  });
+});

--- a/apps/frontend/src/history/index.ts
+++ b/apps/frontend/src/history/index.ts
@@ -1,3 +1,17 @@
-import { createBrowserHistory } from 'history';
+import { createBrowserHistory, History } from 'history';
+import { useHistory, useLocation } from 'react-router-dom';
+
+export const usePushFromPathname = (
+  pathname: string,
+): History<unknown>['push'] => {
+  const history = useHistory();
+  return (...args: Parameters<History['push']>) => {
+    if (history.location.pathname === pathname) {
+      history.push(...args);
+    }
+  };
+};
+export const usePushFromHere = () =>
+  usePushFromPathname(useLocation().pathname);
 
 export default createBrowserHistory();

--- a/apps/frontend/src/network/teams/Workspace.tsx
+++ b/apps/frontend/src/network/teams/Workspace.tsx
@@ -1,16 +1,17 @@
 import React from 'react';
-import { useRouteMatch, Route, useHistory } from 'react-router-dom';
+import { useRouteMatch, Route } from 'react-router-dom';
 import { join } from 'path';
 import { TeamProfileWorkspace, ToolModal } from '@asap-hub/react-components';
 import { TeamTool, TeamResponse } from '@asap-hub/model';
 import { usePatchTeamById } from './state';
+import { usePushFromHere } from '../../history';
 
 interface WorkspaceProps {
   readonly team: TeamResponse & Required<Pick<TeamResponse, 'tools'>>;
 }
 const Workspace: React.FC<WorkspaceProps> = ({ team }) => {
   const { path, url } = useRouteMatch();
-  const history = useHistory();
+  const historyPush = usePushFromHere();
 
   const patchTeam = usePatchTeamById(team.id);
 
@@ -34,7 +35,7 @@ const Workspace: React.FC<WorkspaceProps> = ({ team }) => {
             await patchTeam({
               tools: [...(team.tools ?? []), data],
             });
-            history.push(url);
+            historyPush(url);
           }}
         />
       </Route>
@@ -48,7 +49,7 @@ const Workspace: React.FC<WorkspaceProps> = ({ team }) => {
               await patchTeam({
                 tools: Object.assign([], team.tools, { [i]: data }),
               });
-              history.push(url);
+              historyPush(url);
             }}
           />
         </Route>

--- a/apps/frontend/src/network/users/About.tsx
+++ b/apps/frontend/src/network/users/About.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { join } from 'path';
-import { useRouteMatch, Route, useHistory } from 'react-router-dom';
+import { useRouteMatch, Route } from 'react-router-dom';
 import { UserProfileAbout, BiographyModal } from '@asap-hub/react-components';
 import { UserResponse } from '@asap-hub/model';
 import { useCurrentUser } from '@asap-hub/react-context';
 import { usePatchUserById } from './state';
+import { usePushFromHere } from '../../history';
 
 type AboutProps = {
   user: UserResponse;
@@ -13,7 +14,7 @@ const About: React.FC<AboutProps> = ({ user }) => {
   const { id } = useCurrentUser() ?? {};
 
   const { path, url } = useRouteMatch();
-  const history = useHistory();
+  const historyPush = usePushFromHere();
 
   const patchUser = usePatchUserById(user.id);
 
@@ -36,7 +37,7 @@ const About: React.FC<AboutProps> = ({ user }) => {
             await patchUser({
               biography: newBiography,
             });
-            history.push(url);
+            historyPush(url);
           }}
         />
       </Route>

--- a/apps/frontend/src/network/users/Editing.tsx
+++ b/apps/frontend/src/network/users/Editing.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route, useHistory, useRouteMatch } from 'react-router-dom';
+import { Route, useRouteMatch } from 'react-router-dom';
 import {
   PersonalInfoModal,
   ContactInfoModal,
@@ -8,13 +8,14 @@ import { UserResponse } from '@asap-hub/model';
 
 import { EDIT_PERSONAL_INFO_PATH, EDIT_CONTACT_INFO_PATH } from './routes';
 import { usePatchUserById } from './state';
+import { usePushFromHere } from '../../history';
 
 interface EditingProps {
   user: UserResponse;
 }
 const Editing: React.FC<EditingProps> = ({ user }) => {
-  const history = useHistory();
   const { path, url } = useRouteMatch();
+  const historyPush = usePushFromHere();
 
   const patchUser = usePatchUserById(user.id);
 
@@ -26,7 +27,7 @@ const Editing: React.FC<EditingProps> = ({ user }) => {
           backHref={url}
           onSave={async (patch) => {
             await patchUser(patch);
-            history.push(url);
+            historyPush(url);
           }}
         />
       </Route>
@@ -39,7 +40,7 @@ const Editing: React.FC<EditingProps> = ({ user }) => {
             await patchUser({
               contactEmail: newContactEmail,
             });
-            history.push(url);
+            historyPush(url);
           }}
         />
       </Route>

--- a/apps/frontend/src/network/users/Research.tsx
+++ b/apps/frontend/src/network/users/Research.tsx
@@ -1,5 +1,5 @@
 import React, { ComponentProps } from 'react';
-import { useRouteMatch, useHistory, Route, Redirect } from 'react-router-dom';
+import { useRouteMatch, Route, Redirect } from 'react-router-dom';
 import { join } from 'path';
 import {
   UserProfileResearch,
@@ -9,6 +9,7 @@ import {
 import { UserResponse } from '@asap-hub/model';
 import { useCurrentUser } from '@asap-hub/react-context';
 import { usePatchUserById } from './state';
+import { usePushFromHere } from '../../history';
 
 type ResearchProps = {
   user: UserResponse;
@@ -18,7 +19,7 @@ const Research: React.FC<ResearchProps> = ({ user, teams }) => {
   const { id } = useCurrentUser() ?? {};
 
   const { url, path } = useRouteMatch();
-  const history = useHistory();
+  const historyPush = usePushFromHere();
 
   const patchUser = usePatchUserById(user.id);
 
@@ -56,7 +57,7 @@ const Research: React.FC<ResearchProps> = ({ user, teams }) => {
                   backHref={url}
                   onSave={async (patch) => {
                     await patchUser(patch);
-                    history.push(url);
+                    historyPush(url);
                   }}
                 />
               ) : (
@@ -70,7 +71,7 @@ const Research: React.FC<ResearchProps> = ({ user, teams }) => {
               backHref={url}
               onSave={async (patch) => {
                 await patchUser(patch);
-                history.push(url);
+                historyPush(url);
               }}
             />
           </Route>


### PR DESCRIPTION
We first tried actually aborting the save requests,
however that would almost 100% of the time not actually prevent the
change being made, meaning now we had to initiate another GET for the
changed value. This wastes resources and increased the code of each
useXById and their tests by a lot.

We decided to instead let the request complete (and update our state
with the change) and only ensure that the Promise resolution does not
trigger a navigation when the user might already be somewhere else
entirely.

There is technically another edge case now when you save-abort-reenter
the modal, but the incoming response closing the modal in that case
actually seems reasonable given that the modal contains stale data.
