### PR TITLE
perf: kick recoil out of the React bundle

### DIFF
--- a/apps/frontend/src/GuardedApp.tsx
+++ b/apps/frontend/src/GuardedApp.tsx
@@ -1,0 +1,84 @@
+import React, { useEffect } from 'react';
+import { Switch, Route } from 'react-router-dom';
+import { useSetRecoilState, RecoilRoot, useResetRecoilState } from 'recoil';
+import { NotFoundPage } from '@asap-hub/react-components';
+import { useAuth0 } from '@asap-hub/react-context';
+
+import {
+  DISCOVER_PATH,
+  NETWORK_PATH,
+  LOGOUT_PATH,
+  NEWS_AND_EVENTS_PATH,
+  SHARED_RESEARCH_PATH,
+} from './routes';
+import { auth0State } from './auth/state';
+import Logout from './auth/Logout';
+
+const loadNewsAndEvents = () =>
+  import(/* webpackChunkName: "news-and-events" */ './news/Routes');
+const loadNetwork = () =>
+  import(/* webpackChunkName: "network" */ './network/Network');
+const loadSharedResearch = () =>
+  import(/* webpackChunkName: "shared-research" */ './shared-research/Routes');
+const loadDashboard = () =>
+  import(/* webpackChunkName: "dashboard" */ './dashboard/Dashboard');
+const loadDiscover = () =>
+  import(/* webpackChunkName: "discover" */ './discover/Discover');
+const NewsAndEvents = React.lazy(loadNewsAndEvents);
+const Network = React.lazy(loadNetwork);
+const SharedResearch = React.lazy(loadSharedResearch);
+const Dashboard = React.lazy(loadDashboard);
+const Discover = React.lazy(loadDiscover);
+
+const GuardedApp: React.FC<{}> = () => {
+  const auth0 = useAuth0();
+  const setAuth0 = useSetRecoilState(auth0State);
+  const resetAuth0 = useResetRecoilState(auth0State);
+  useEffect(() => {
+    setAuth0(auth0);
+    return () => resetAuth0();
+  }, [auth0, setAuth0, resetAuth0]);
+
+  useEffect(() => {
+    // order by the likelyhood of user navigating there
+    loadDashboard()
+      .then(loadNewsAndEvents)
+      .then(loadNetwork)
+      .then(loadSharedResearch)
+      .then(loadDiscover);
+  }, []);
+
+  return (
+    <Switch>
+      <Route exact path="/">
+        <Dashboard />
+      </Route>
+      <Route path={LOGOUT_PATH}>
+        <Logout />
+      </Route>
+      <Route path={DISCOVER_PATH}>
+        <Discover />
+      </Route>
+      <Route path={NEWS_AND_EVENTS_PATH}>
+        <NewsAndEvents />
+      </Route>
+      <Route path={NETWORK_PATH}>
+        <Network />
+      </Route>
+      <Route path={SHARED_RESEARCH_PATH}>
+        <SharedResearch />
+      </Route>
+      <Route>
+        <NotFoundPage />
+      </Route>
+    </Switch>
+  );
+};
+
+const GuardedAppWithRecoil: React.FC<{}> = () => (
+  <RecoilRoot>
+    <GuardedApp />
+  </RecoilRoot>
+);
+
+export default GuardedAppWithRecoil;

--- a/apps/frontend/src/__tests__/GuardedApp.test.tsx
+++ b/apps/frontend/src/__tests__/GuardedApp.test.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { useRecoilValue } from 'recoil';
+import { StaticRouter } from 'react-router-dom';
+import { render, waitFor } from '@testing-library/react';
+import { authTestUtils } from '@asap-hub/react-components';
+
+import GuardedApp from '../GuardedApp';
+import { authorizationState } from '../auth/state';
+import Dashboard from '../dashboard/Dashboard';
+
+// We're not actually interested in testing what's rendered since it's all
+// declarative routes at this level - get any backend requests out of the way
+// so that it just easily renders
+jest.mock('../dashboard/Dashboard', () => jest.fn());
+const MockDashboard = Dashboard as jest.MockedFunction<typeof Dashboard>;
+beforeEach(() => {
+  MockDashboard.mockReset().mockReturnValue(null);
+});
+
+const wrapper: React.FC<{}> = ({ children }) => (
+  <authTestUtils.Auth0Provider>
+    <authTestUtils.LoggedIn user={{}}>
+      <StaticRouter>
+        <React.Suspense fallback="loading">{children}</React.Suspense>
+      </StaticRouter>
+    </authTestUtils.LoggedIn>
+  </authTestUtils.Auth0Provider>
+);
+
+it('syncs the auth state to recoil', async () => {
+  MockDashboard.mockImplementation(() => {
+    const authorization = useRecoilValue(authorizationState);
+    return <>{authorization}</>;
+  });
+  const { container } = render(<GuardedApp />, { wrapper });
+  await waitFor(() => expect(container).not.toHaveTextContent(/loading/i));
+  expect(container.textContent).toMatchInlineSnapshot(`"Bearer token"`);
+});

--- a/apps/frontend/src/auth/index.ts
+++ b/apps/frontend/src/auth/index.ts
@@ -1,4 +1,0 @@
-export { default as AuthProvider } from './AuthProvider';
-export { default as Logout } from './Logout';
-export { default as CheckAuth } from './CheckAuth';
-export { authorizationState } from './state';

--- a/apps/frontend/src/auth/react-auth0-spa.tsx
+++ b/apps/frontend/src/auth/react-auth0-spa.tsx
@@ -1,9 +1,8 @@
-// Copied from the Auth0 React quickstart, added some types, checks, and recoil integration
+// Copied from the Auth0 React quickstart, added some types and checks
 /* istanbul ignore file */
 /* eslint-disable no-shadow */
 
 import React, { useState, useEffect } from 'react';
-import { useSetRecoilState, useResetRecoilState } from 'recoil';
 import { Auth0User, Auth0 } from '@asap-hub/auth';
 import { Auth0Context } from '@asap-hub/react-context';
 import createAuth0Client, {
@@ -11,8 +10,6 @@ import createAuth0Client, {
   Auth0Client,
   RedirectLoginResult,
 } from '@auth0/auth0-spa-js';
-
-import { auth0State } from './state';
 
 const DEFAULT_REDIRECT_CALLBACK = () =>
   window.history.replaceState({}, document.title, window.location.pathname);
@@ -31,9 +28,6 @@ export const Auth0Provider: React.FC<Auth0ProviderProps> = ({
   const [auth0Client, setAuth0Client] = useState<Auth0Client>();
   const [loading, setLoading] = useState(true);
   const [popupOpen, setPopupOpen] = useState(false);
-
-  const setAuth0 = useSetRecoilState(auth0State);
-  const resetAuth0 = useResetRecoilState(auth0State);
 
   useEffect(() => {
     const initAuth0 = async () => {
@@ -123,10 +117,6 @@ export const Auth0Provider: React.FC<Auth0ProviderProps> = ({
     ),
     logout: getSafeAuth0ClientProperty('logout').bind(auth0Client),
   };
-  useEffect(() => {
-    setAuth0(auth0);
-    return () => resetAuth0();
-  }, [auth0, setAuth0, resetAuth0]);
 
   return (
     <Auth0Context.Provider value={auth0}>{children}</Auth0Context.Provider>

--- a/apps/frontend/src/network/teams/state.ts
+++ b/apps/frontend/src/network/teams/state.ts
@@ -6,8 +6,8 @@ import {
 } from 'recoil';
 import { TeamResponse, TeamPatchRequest } from '@asap-hub/model';
 
-import { authorizationState } from '../../auth';
 import { getTeam, patchTeam } from './api';
+import { authorizationState } from '../../auth/state';
 
 export const refreshTeamState = atomFamily<number, string>({
   key: 'refreshTeam',

--- a/apps/frontend/src/network/users/state.ts
+++ b/apps/frontend/src/network/users/state.ts
@@ -4,7 +4,7 @@ import {
   useSetRecoilState,
   useRecoilValue,
 } from 'recoil';
-import { authorizationState } from '@asap-hub/frontend/src/auth';
+import { authorizationState } from '@asap-hub/frontend/src/auth/state';
 import { UserResponse, UserPatchRequest } from '@asap-hub/model';
 
 import { getUser, patchUser } from './api';

--- a/apps/frontend/src/routes.ts
+++ b/apps/frontend/src/routes.ts
@@ -1,3 +1,5 @@
 export const DISCOVER_PATH = '/discover';
+export const LOGOUT_PATH = '/logout';
 export const NETWORK_PATH = '/network';
+export const NEWS_AND_EVENTS_PATH = '/news-and-events';
 export const SHARED_RESEARCH_PATH = '/shared-research';

--- a/packages/react-components/src/auth-test-utils.tsx
+++ b/packages/react-components/src/auth-test-utils.tsx
@@ -17,6 +17,10 @@ const notReady = (method: string) => () => {
   throw new Error(`Auth0 test fixture loading, not ready for ${method}`);
 };
 
+/**
+ * You probably don't want to use this in the frontend,
+ * which has its own recoil-integrated auth test utils.
+ */
 export const Auth0Provider: React.FC<{
   readonly children: React.ReactNode;
 }> = ({ children }) => {

--- a/packages/react-components/src/index.ts
+++ b/packages/react-components/src/index.ts
@@ -1,7 +1,6 @@
 import * as messages from './messages';
 import * as pixels from './pixels';
 import * as text from './text';
-// Do not use in the frontend anymore; the frontend now has its own auth test utils. Remove once unused.
 import * as authTestUtils from './auth-test-utils';
 
 export { messages, pixels, text, authTestUtils };


### PR DESCRIPTION
We only need it behind the auth guard.
Also it's nice to split up App at least a bit
