### PR TITLE
feat: add tracing errors

### DIFF
--- a/apps/asap-server/src/utils/instrumented-framework.ts
+++ b/apps/asap-server/src/utils/instrumented-framework.ts
@@ -63,9 +63,11 @@ export const http = (
     span.setTag('statusCode', statusCode);
 
     try {
-      body
-        ? span.log({ event: 'error', ...JSON.parse(body) })
-        : span.log({ event: 'error', error: body });
+      if (body) {
+        span.log({ event: 'error', ...JSON.parse(body) });
+      } else {
+        span.log({ event: 'error', error: body });
+      }
     } catch (e) {
       span.log({ event: 'error', error: body });
     }

--- a/apps/asap-server/src/utils/instrumented-framework.ts
+++ b/apps/asap-server/src/utils/instrumented-framework.ts
@@ -58,9 +58,17 @@ export const http = (
   )) as APIGatewayProxyStructuredResultV2;
 
   if (response.statusCode && response.statusCode >= 400) {
-    const { statusCode, body: error } = response;
+    const { statusCode, body } = response;
     span.setTag(opentracing.Tags.ERROR, true);
-    span.log({ event: 'error', statusCode, error });
+    span.setTag('statusCode', statusCode);
+
+    try {
+      body
+        ? span.log({ event: 'error', ...JSON.parse(body) })
+        : span.log({ event: 'error', error: body });
+    } catch (e) {
+      span.log({ event: 'error', error: body });
+    }
   }
 
   span.finish();


### PR DESCRIPTION
Traces corresponding to faulty requests will be flagged as such, and list the error body in the event
![image](https://user-images.githubusercontent.com/6756384/104030395-3b485200-51c3-11eb-9e21-5a7e4684ee7a.png)
![image](https://user-images.githubusercontent.com/6756384/104030414-4307f680-51c3-11eb-931a-25f7c7221188.png)
