### PR TITLE
fix: infinite loading when session so old that refresh token expired

### DIFF
--- a/apps/frontend/src/auth/react-auth0-spa.tsx
+++ b/apps/frontend/src/auth/react-auth0-spa.tsx
@@ -5,7 +5,7 @@
 import React, { useState, useEffect } from 'react';
 import { Auth0User, Auth0 } from '@asap-hub/auth';
 import { Auth0Context } from '@asap-hub/react-context';
-import createAuth0Client, {
+import {
   Auth0ClientOptions,
   Auth0Client,
   RedirectLoginResult,
@@ -31,7 +31,7 @@ export const Auth0Provider: React.FC<Auth0ProviderProps> = ({
 
   useEffect(() => {
     const initAuth0 = async () => {
-      const auth0FromHook = await createAuth0Client(initOptions);
+      const auth0FromHook = new Auth0Client(initOptions);
       setAuth0Client(auth0FromHook);
 
       if (

--- a/apps/frontend/src/auth/react-auth0-spa.tsx
+++ b/apps/frontend/src/auth/react-auth0-spa.tsx
@@ -1,4 +1,6 @@
-// Copied from the Auth0 React quickstart, added some types and checks
+// Copied from the Auth0 React quickstart.
+// Added some typings and guards.
+// Refactored to use constructor instead of createAuth0Client factory.
 /* istanbul ignore file */
 /* eslint-disable no-shadow */
 


### PR DESCRIPTION
This is a bit of a weird one. 

See: https://github.com/auth0/auth0-spa-js/issues/449

I have been able to test this with my own expired refresh token and @fampinheiro's. If you have an expired refresh token you will be sent to the login page and signin as usual.

What i have been unable to test is when the access token has expired (after 24 hours) and the refresh token is still valid because it is signed.

I have saved my current session to test this tomorrow but I think this should go in as this will allow people who are currently locked out to access the hub.
