### PR TITLE
Fix: Use refresh token to get new access token after 24 hours

### DIFF
--- a/apps/frontend/src/auth/react-auth0-spa.tsx
+++ b/apps/frontend/src/auth/react-auth0-spa.tsx
@@ -35,6 +35,10 @@ export const Auth0Provider: React.FC<Auth0ProviderProps> = ({
     const initAuth0 = async () => {
       const auth0FromHook = new Auth0Client(initOptions);
       setAuth0Client(auth0FromHook);
+      try {
+        await auth0FromHook.checkSession(); // use refresh token to get new access token if required
+        // eslint-disable-next-line
+      } catch (error) {} // Invalid refresh token proceed as if user isn't logged in
 
       if (
         window.location.search.includes('code=') &&


### PR DESCRIPTION
See: https://auth0.github.io/auth0-spa-js/classes/auth0client.html#checksession

Currently if an access token expires a user will be sent to the login page. This means unnecessary logins. This call will check if a session is valid and if not try and get a new access token using the refresh token. If this fails we proceed with normal signin process