### PR TITLE
feat: add fetch-groups-by-team-id endpoint

### DIFF
--- a/apps/asap-server/src/handlers/groups/fetch-by-team-id.ts
+++ b/apps/asap-server/src/handlers/groups/fetch-by-team-id.ts
@@ -1,0 +1,39 @@
+import Joi from '@hapi/joi';
+import { framework } from '@asap-hub/services-common';
+import { http } from '../../utils/instrumented-framework';
+import { Handler } from '../../utils/types';
+import validateUser from '../../utils/validate-user';
+import Groups from '../../controllers/groups';
+
+const paramsSchema = Joi.object({
+  id: Joi.string().required(),
+}).required();
+
+const querySchema = Joi.object({
+  take: Joi.number(),
+  skip: Joi.number(),
+}).required();
+
+export const handler: Handler = http(async (request) => {
+  await validateUser(request);
+
+  const params = framework.validate('params', request.params, paramsSchema) as {
+    id: string;
+  };
+
+  const options = (framework.validate(
+    'query',
+    request.query,
+    querySchema,
+  ) as unknown) as {
+    take: number;
+    skip: number;
+  };
+
+  const groups = new Groups(request.headers);
+  const res = await groups.fetchByTeamId(params.id, options);
+
+  return {
+    payload: res,
+  };
+});

--- a/apps/asap-server/test/handlers/groups/fetch-by-team-id.test.ts
+++ b/apps/asap-server/test/handlers/groups/fetch-by-team-id.test.ts
@@ -1,0 +1,91 @@
+import nock from 'nock';
+import { config } from '@asap-hub/squidex';
+
+import { buildGraphQLQueryFetchGroups } from '../../../src/controllers/groups';
+import { apiGatewayEvent } from '../../helpers/events';
+import { identity } from '../../helpers/squidex';
+import { handler } from '../../../src/handlers/groups/fetch-by-team-id';
+import { APIGatewayProxyResult } from 'aws-lambda';
+import * as fixtures from './fetch.fixtures';
+
+jest.mock('../../../src/utils/validate-token');
+
+describe('GET /teams/{id}/groups', () => {
+  beforeAll(() => {
+    identity();
+  });
+
+  afterEach(() => {
+    expect(nock.isDone()).toBe(true);
+  });
+
+  test('returns 200 when no groups for the team exist', async () => {
+    const teamUUID = 'eb531b6e-195c-46e2-b347-58fb86715033';
+    const filter = `data/teams/iv eq '${teamUUID}'`;
+
+    nock(config.baseUrl)
+      .post(`/api/content/${config.appName}/graphql`, {
+        query: buildGraphQLQueryFetchGroups(filter),
+      })
+      .reply(200, {
+        data: {
+          queryGroupsContentsWithTotal: {
+            total: 0,
+            items: [],
+          },
+        },
+      });
+
+    const result = (await handler(
+      apiGatewayEvent({
+        httpMethod: 'get',
+        pathParameters: {
+          id: teamUUID,
+        },
+        headers: {
+          Authorization: 'Bearer token',
+        },
+      }),
+    )) as APIGatewayProxyResult;
+
+    const body = JSON.parse(result.body);
+
+    expect(result.statusCode).toStrictEqual(200);
+    expect(result.body).toBeDefined();
+    expect(body).toStrictEqual({
+      items: [],
+      total: 0,
+    });
+  });
+
+  test('returns 200 when fetching team groups', async () => {
+    const teamUUID = 'eb531b6e-195c-46e2-b347-58fb86715033';
+    const filter = `data/teams/iv eq '${teamUUID}'`;
+
+    nock(config.baseUrl)
+      .post(`/api/content/${config.appName}/graphql`, {
+        query: buildGraphQLQueryFetchGroups(filter, 36, 11),
+      })
+      .reply(200, fixtures.response);
+
+    const result = (await handler(
+      apiGatewayEvent({
+        httpMethod: 'get',
+        pathParameters: {
+          id: teamUUID,
+        },
+        queryStringParameters: {
+          take: '36',
+          skip: '11',
+        },
+        headers: {
+          Authorization: `Bearer token`,
+        },
+      }),
+    )) as APIGatewayProxyResult;
+
+    const body = JSON.parse(result.body);
+    expect(result.statusCode).toStrictEqual(200);
+    expect(body).toStrictEqual(fixtures.expectation);
+  });
+});

--- a/serverless.js
+++ b/serverless.js
@@ -287,6 +287,18 @@ module.exports = {
         },
       ],
     },
+    fetchGroupsByTeamId: {
+      handler:
+        'apps/asap-server/build-cjs/handlers/groups/fetch-by-team-id.handler',
+      events: [
+        {
+          httpApi: {
+            method: 'GET',
+            path: `/teams/{id}/groups`,
+          },
+        },
+      ],
+    },
     dashboard: {
       handler: 'apps/asap-server/build-cjs/handlers/dashboard/fetch.handler',
       events: [


### PR DESCRIPTION
See: https://trello.com/c/pIP6RsXT/871-create-api-to-obtain-group-data-for-each-team-team-page-updates