### PR TITLE
feat: Move groups-by-team-id handler to express

### DIFF
--- a/apps/asap-server/src/app.ts
+++ b/apps/asap-server/src/app.ts
@@ -7,6 +7,7 @@ import { eventRouteFactory } from './routes/events.route';
 import { groupRouteFactory } from './routes/groups.route';
 import Groups, { GroupController } from './controllers/groups';
 import decodeToken from './utils/validate-token';
+import { teamRouteFactory } from './routes/teams.route';
 
 export const appFactory = (libs: Libs = {}): Express => {
   const app = express();
@@ -15,6 +16,7 @@ export const appFactory = (libs: Libs = {}): Express => {
   const authHandler = libs.authHandler || authHandlerFactory(decodeToken);
   const eventRoutes = eventRouteFactory();
   const groupRoutes = groupRouteFactory(groupController);
+  const teamRoutes = teamRouteFactory(groupController);
 
   app.use(cors());
   app.use(authHandler);
@@ -25,6 +27,7 @@ export const appFactory = (libs: Libs = {}): Express => {
 
   app.use(eventRoutes);
   app.use(groupRoutes);
+  app.use(teamRoutes);
 
   app.get('*', async (_req, res) => {
     res.status(404).json('Invalid route');

--- a/apps/asap-server/src/controllers/groups.ts
+++ b/apps/asap-server/src/controllers/groups.ts
@@ -65,6 +65,10 @@ export type FetchOptions = {
 
 export interface GroupController {
   fetch: (options: FetchOptions) => Promise<ListGroupResponse>;
+  fetchByTeamId: (
+    teamId: string | string[],
+    options: FetchOptions,
+  ) => Promise<ListGroupResponse>;
 }
 
 export default class Groups implements GroupController {

--- a/apps/asap-server/src/routes/teams.route.ts
+++ b/apps/asap-server/src/routes/teams.route.ts
@@ -1,0 +1,36 @@
+import { Router } from 'express';
+import { framework } from '@asap-hub/services-common';
+import Joi from '@hapi/joi';
+import { GroupController, FetchOptions } from '../controllers/groups';
+
+export const teamRouteFactory = (groupsController: GroupController): Router => {
+  const groupRoutes = Router();
+
+  groupRoutes.get('/teams/:teamId/groups', async (req, res) => {
+    const { query } = req;
+    const { params } = req;
+
+    const { teamId } = framework.validate('parameters', params, paramSchema);
+    const options = (framework.validate(
+      'query',
+      query,
+      querySchema,
+    ) as unknown) as FetchOptions;
+
+    const result = await groupsController.fetchByTeamId(teamId, options);
+
+    res.json(result);
+  });
+
+  return groupRoutes;
+};
+
+const querySchema = Joi.object({
+  take: Joi.number(),
+  skip: Joi.number(),
+  search: Joi.string(),
+}).required();
+
+const paramSchema = Joi.object({
+  teamId: Joi.string().required(),
+});

--- a/apps/asap-server/test/mocks/group-controller.mock.ts
+++ b/apps/asap-server/test/mocks/group-controller.mock.ts
@@ -1,0 +1,6 @@
+import { GroupController } from '../../src/controllers/groups';
+
+export const groupControllerMock: jest.Mocked<GroupController> = {
+  fetch: jest.fn(),
+  fetchByTeamId: jest.fn(),
+};

--- a/apps/asap-server/test/routes/teams.test.ts
+++ b/apps/asap-server/test/routes/teams.test.ts
@@ -5,24 +5,24 @@ import * as fixtures from '../handlers/groups/fetch.fixtures';
 import { authHandlerMock } from '../mocks/auth-handler.mock';
 import { groupControllerMock } from '../mocks/group-controller.mock';
 
-describe('/groups/ route', () => {
+describe('/teams/ route', () => {
   const app = appFactory({
     groupController: groupControllerMock,
     authHandler: authHandlerMock,
   });
 
   afterEach(() => {
-    groupControllerMock.fetch.mockReset();
+    groupControllerMock.fetchByTeamId.mockReset();
   });
 
-  describe('GET /groups', () => {
+  describe('GET /teams/{team_id}/groups', () => {
     test('Should return 200 when no grups exist', async () => {
-      groupControllerMock.fetch.mockResolvedValueOnce({
+      groupControllerMock.fetchByTeamId.mockResolvedValueOnce({
         items: [],
         total: 0,
       });
 
-      const response = await supertest(app).get('/groups/');
+      const response = await supertest(app).get('/teams/123/groups');
 
       expect(response.status).toBe(200);
       expect(response.body).toEqual({
@@ -32,20 +32,23 @@ describe('/groups/ route', () => {
     });
 
     test('Should return the results correctly', async () => {
-      groupControllerMock.fetch.mockResolvedValueOnce(fixtures.expectation);
+      groupControllerMock.fetchByTeamId.mockResolvedValueOnce(
+        fixtures.expectation,
+      );
 
-      const response = await supertest(app).get('/groups/');
+      const response = await supertest(app).get('/teams/123/groups');
 
       expect(response.body).toEqual(fixtures.expectation);
     });
 
     test('Should call the controller with the right parameters', async () => {
-      groupControllerMock.fetch.mockResolvedValueOnce({
+      groupControllerMock.fetchByTeamId.mockResolvedValueOnce({
         items: [],
         total: 0,
       });
+      const teamId = '123abcd';
 
-      await supertest(app).get('/groups/').query({
+      await supertest(app).get(`/teams/${teamId}/groups`).query({
         take: 15,
         skip: 5,
         search: 'something',
@@ -57,12 +60,15 @@ describe('/groups/ route', () => {
         search: 'something',
       };
 
-      expect(groupControllerMock.fetch).toBeCalledWith(expectedParams);
+      expect(groupControllerMock.fetchByTeamId).toBeCalledWith(
+        teamId,
+        expectedParams,
+      );
     });
 
     describe('Parameter validation', () => {
       test('Should return a validation error when the arguments are not valid', async () => {
-        const response = await supertest(app).get('/groups/').query({
+        const response = await supertest(app).get(`/teams/123/groups`).query({
           take: 'invalid param',
         });
 

--- a/serverless.js
+++ b/serverless.js
@@ -107,6 +107,24 @@ module.exports = {
             path: `/events`,
           },
         },
+        {
+          httpApi: {
+            method: 'GET',
+            path: `/groups/{proxy+}`,
+          },
+        },
+        {
+          httpApi: {
+            method: 'GET',
+            path: `/groups`,
+          },
+        },
+        {
+          httpApi: {
+            method: 'GET',
+            path: `/teams/{id}/groups`,
+          },
+        },
       ],
     },
     uploadUserAvatar: {
@@ -289,34 +307,6 @@ module.exports = {
           httpApi: {
             method: 'GET',
             path: `/news-and-events/{id}`,
-          },
-        },
-      ],
-    },
-    fetchGroups: {
-      handler: 'apps/asap-server/build-cjs/handlers/api-handler.apiHandler',
-      events: [
-        {
-          httpApi: {
-            method: 'GET',
-            path: `/groups/{proxy+}`,
-          },
-        },
-        {
-          httpApi: {
-            method: 'GET',
-            path: `/groups`,
-          },
-        },
-      ],
-    },
-    fetchGroupsByTeamId: {
-      handler: 'apps/asap-server/build-cjs/handlers/api-handler.apiHandler',
-      events: [
-        {
-          httpApi: {
-            method: 'GET',
-            path: `/teams/{id}/groups`,
           },
         },
       ],

--- a/serverless.js
+++ b/serverless.js
@@ -311,8 +311,7 @@ module.exports = {
       ],
     },
     fetchGroupsByTeamId: {
-      handler:
-        'apps/asap-server/build-cjs/handlers/groups/fetch-by-team-id.handler',
+      handler: 'apps/asap-server/build-cjs/handlers/api-handler.apiHandler',
       events: [
         {
           httpApi: {


### PR DESCRIPTION
see: https://trello.com/c/RZp9YZg5/893-update-express-router-to-reply-to-groups-resources-and-endpoints