### PR TITLE
fix: squidex setup image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:latest
+FROM ubuntu:18.04
 
 WORKDIR /src
 
@@ -6,10 +6,10 @@ VOLUME ["/dev/fixtures"]
 VOLUME ["/dev/squidex"]
 
 RUN apt-get update && \
-    apt-get install -y wget unzip libicu63 dirmngr gnupg apt-transport-https software-properties-common ca-certificates curl
+    apt-get install -y wget unzip dirmngr gnupg apt-transport-https software-properties-common ca-certificates curl
 
-RUN curl -fsSL https://www.mongodb.org/static/pgp/server-4.2.asc | apt-key add - && \
-    add-apt-repository 'deb https://repo.mongodb.org/apt/debian buster/mongodb-org/4.2 main' && \
+RUN wget -qO - https://www.mongodb.org/static/pgp/server-4.4.asc | apt-key add - && \
+    echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/4.4 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-4.4.list && \
     apt-get update && \
     apt-get install -y mongodb-org
 


### PR DESCRIPTION
The image was not building (at least not on Ubuntu 17.04 with Docker 18.01) due to some dependency errors for mongodb-org. 

This PR changes the base image to Ubuntu (from Debian) and updates mongodb installation method.