### PR TITLE
refactor(react-components): do not use Link where we really just want the HashLink/anchor behavior

### DIFF
--- a/packages/react-components/src/atoms/Anchor.tsx
+++ b/packages/react-components/src/atoms/Anchor.tsx
@@ -1,0 +1,46 @@
+import React, { AnchorHTMLAttributes, ComponentProps } from 'react';
+import { HashLink } from 'react-router-hash-link';
+import css from '@emotion/css';
+
+import { isInternalLink } from '../utils';
+import { useHasRouter } from '../routing';
+
+const resetStyles = css({
+  outline: 'none',
+  textDecoration: 'none',
+  ':hover, :focus': {
+    textDecoration: 'none',
+  },
+  color: 'unset',
+  ':active': {
+    color: 'unset',
+  },
+});
+
+// Lint rules don't understand abstractions ...
+/* eslint-disable jsx-a11y/anchor-has-content */
+/* eslint-disable react/jsx-no-target-blank */
+
+type AnchorProps = {
+  // hrefs may conditionally be undefined, but the prop is mandatory so it cannot be forgotten
+  href: string | undefined;
+  enabled?: boolean;
+} & Omit<ComponentProps<typeof HashLink>, 'to' | 'smooth'> &
+  Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'href' | 'target' | 'rel'>;
+const Anchor: React.FC<AnchorProps> = ({ href, enabled = true, ...props }) => {
+  const internal = enabled && href ? isInternalLink(href) : false;
+  if (useHasRouter() && href && internal) {
+    return <HashLink {...props} to={href} smooth css={resetStyles} />;
+  }
+  return (
+    <a
+      {...props}
+      href={(enabled && href) || undefined}
+      target={internal ? undefined : '_blank'}
+      rel={internal ? undefined : 'noreferrer noopener'}
+      css={resetStyles}
+    />
+  );
+};
+
+export default Anchor;

--- a/packages/react-components/src/atoms/Link.tsx
+++ b/packages/react-components/src/atoms/Link.tsx
@@ -1,37 +1,22 @@
 import React, { ReactNode } from 'react';
-import css, { CSSObject, SerializedStyles } from '@emotion/css';
-import { HashLink } from 'react-router-hash-link';
+import css, { SerializedStyles } from '@emotion/css';
 
 import { fern, paper, pine } from '../colors';
-import { useHasRouter } from '../routing';
 import { ThemeVariant, defaultThemeVariant } from '../theme';
 import { getButtonStyles, getButtonChildren } from '../button';
-import { isInternalLink } from '../utils';
+import { Anchor } from '.';
 
 const styles = css({
-  outline: 'none',
-  textDecoration: 'none',
-  ':hover, :focus': {
-    textDecoration: 'none',
-  },
-  color: 'unset',
-  ':active': {
-    color: 'unset',
-  },
+  textDecoration: 'underline',
 });
-
 export const themeStyles: Record<ThemeVariant, SerializedStyles> = {
   light: css({ color: fern.rgb, ':active': { color: pine.rgb } }),
   grey: css({ color: fern.rgb, ':active': { color: pine.rgb } }),
   dark: css({ color: paper.rgb, ':active': { color: paper.rgb } }),
 };
-const underlineStyles = css({
-  textDecoration: 'underline',
-});
 
 interface NormalLinkProps {
-  readonly theme?: ThemeVariant | null;
-  readonly display?: CSSObject['display'];
+  readonly theme?: ThemeVariant;
 
   readonly buttonStyle?: undefined;
 
@@ -41,7 +26,6 @@ interface NormalLinkProps {
 }
 interface ButtonStyleLinkProps {
   readonly theme?: undefined;
-  readonly display?: undefined;
 
   readonly buttonStyle: true;
 
@@ -51,7 +35,6 @@ interface ButtonStyleLinkProps {
 }
 type LinkProps = {
   readonly children: ReactNode;
-  // hrefs may conditionally be undefined, but the prop is mandatory so it cannot be forgotton
   readonly href: string | undefined;
   readonly label?: string;
 } & (NormalLinkProps | ButtonStyleLinkProps);
@@ -61,7 +44,6 @@ const Link: React.FC<LinkProps> = ({
   label,
 
   theme = defaultThemeVariant,
-  display,
 
   buttonStyle = false,
   primary = false,
@@ -69,34 +51,13 @@ const Link: React.FC<LinkProps> = ({
   enabled = true,
 }) => {
   const linkStyles = buttonStyle
-    ? [styles, getButtonStyles({ primary, small, enabled, children })]
-    : [
-        styles,
-        theme && themeStyles[theme],
-        theme && underlineStyles,
-        { display },
-      ];
+    ? [getButtonStyles({ primary, small, enabled, children })]
+    : [styles, themeStyles[theme]];
   const linkChildren = buttonStyle ? getButtonChildren(children) : children;
-  const internal = enabled && href ? isInternalLink(href) : false;
-  if (useHasRouter() && href && internal) {
-    return (
-      <HashLink to={href} aria-label={label} css={linkStyles} smooth>
-        {linkChildren}
-      </HashLink>
-    );
-  }
   return (
-    // lint rule does not understand the conditionals
-    // eslint-disable-next-line react/jsx-no-target-blank
-    <a
-      href={(enabled && href) || undefined}
-      aria-label={label}
-      css={linkStyles}
-      target={internal ? undefined : '_blank'}
-      rel={internal ? undefined : 'noreferrer noopener'}
-    >
+    <Anchor href={href} enabled={enabled} aria-label={label} css={linkStyles}>
       {linkChildren}
-    </a>
+    </Anchor>
   );
 };
 

--- a/packages/react-components/src/atoms/__tests__/Anchor.test.tsx
+++ b/packages/react-components/src/atoms/__tests__/Anchor.test.tsx
@@ -1,0 +1,125 @@
+import React from 'react';
+import { StaticRouter } from 'react-router-dom';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import Anchor from '../Anchor';
+
+it('renders the text in an anchor', () => {
+  const { getByText } = render(<Anchor href="/">text</Anchor>);
+  expect(getByText('text').tagName).toBe('A');
+});
+
+describe.each`
+  contextDescription    | wrapper
+  ${'with a router'}    | ${StaticRouter}
+  ${'without a router'} | ${undefined}
+`('$contextDescription', ({ wrapper }) => {
+  describe.each`
+    linkDescription    | href
+    ${'external link'} | ${'https://parkinsonsroadmap.org/'}
+    ${'internal link'} | ${'/'}
+  `("for an $linkDescription to '$href'", ({ href }) => {
+    it('applies the href to the anchor', () => {
+      const { getByRole } = render(<Anchor href={href}>text</Anchor>, {
+        wrapper,
+      });
+      const anchor = getByRole('link') as HTMLAnchorElement;
+      expect(new URL(anchor.href, window.location.href).href).toBe(
+        new URL(href, window.location.href).href,
+      );
+    });
+  });
+
+  it('renders an inactive link without an href', () => {
+    const { getByText } = render(<Anchor href={undefined}>text</Anchor>, {
+      wrapper,
+    });
+    expect(getByText('text', { selector: 'a' })).not.toHaveAttribute('href');
+  });
+
+  it('renders an inactive link with an empty href', () => {
+    const { getByText } = render(<Anchor href="">text</Anchor>, {
+      wrapper,
+    });
+    expect(getByText('text', { selector: 'a' })).not.toHaveAttribute('href');
+  });
+});
+
+describe('for an external link', () => {
+  it('sets the anchor target to open in a new page', () => {
+    const { getByRole } = render(
+      <Anchor href="https://parkinsonsroadmap.org/">text</Anchor>,
+    );
+    const { target } = getByRole('link') as HTMLAnchorElement;
+    expect(target).toBe('_blank');
+  });
+
+  it('secures the link against third parties', () => {
+    const { getByRole } = render(
+      <Anchor href="https://parkinsonsroadmap.org/">text</Anchor>,
+    );
+    const { relList } = getByRole('link') as HTMLAnchorElement;
+    expect(relList).toContain('noreferrer');
+    expect(relList).toContain('noopener');
+  });
+
+  it('triggers a full page navigation on click', () => {
+    const { getByRole } = render(
+      <Anchor href="https://parkinsonsroadmap.org/">text</Anchor>,
+    );
+    const anchor = getByRole('link') as HTMLAnchorElement;
+    expect(fireEvent.click(anchor)).toBe(true);
+  });
+});
+
+describe.each`
+  description           | wrapper
+  ${'with a router'}    | ${StaticRouter}
+  ${'without a router'} | ${undefined}
+`('for an internal link $description to /', ({ wrapper }) => {
+  it('does not set the anchor target', () => {
+    const { getByRole } = render(<Anchor href="/">text</Anchor>, { wrapper });
+    const { target } = getByRole('link') as HTMLAnchorElement;
+    expect(target).toBe('');
+  });
+
+  it('does not secure the link against third parties', () => {
+    const { getByRole } = render(<Anchor href="/">text</Anchor>, { wrapper });
+    const { relList } = getByRole('link') as HTMLAnchorElement;
+    expect(relList).not.toContain('noreferrer');
+    expect(relList).not.toContain('noopener');
+  });
+});
+
+describe('for an internal link with a router', () => {
+  it('does not trigger a full page navigation on click', () => {
+    const { getByRole } = render(
+      <Anchor
+        href={`${window.location.protocol}//${window.location.host}/page?query#fragment`}
+      >
+        text
+      </Anchor>,
+      { wrapper: StaticRouter },
+    );
+    const anchor = getByRole('link') as HTMLAnchorElement;
+    expect(fireEvent.click(anchor)).toBe(false);
+  });
+
+  it('smoothly scrolls the anchor referenced by the fragment into view', async () => {
+    const { getByRole } = render(
+      <>
+        <Anchor href={`#fragment`}>text</Anchor>
+        <main id="fragment">text</main>
+      </>,
+      { wrapper: StaticRouter },
+    );
+    const main = getByRole('main');
+    const spyScrollIntoView = jest.spyOn(main, 'scrollIntoView');
+
+    userEvent.click(getByRole('link'));
+    await waitFor(() =>
+      expect(spyScrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth' }),
+    );
+  });
+});

--- a/packages/react-components/src/atoms/__tests__/Link.test.tsx
+++ b/packages/react-components/src/atoms/__tests__/Link.test.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
-import { StaticRouter } from 'react-router-dom';
-import { render, fireEvent, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render } from '@testing-library/react';
 import { findParentWithStyle } from '@asap-hub/dom-test-utils';
 
 import Link from '../Link';
@@ -45,28 +43,6 @@ describe('the dark theme', () => {
     );
     const { textDecoration } = getComputedStyle(getByRole('link'));
     expect(textDecoration).toBe('underline');
-  });
-});
-
-describe('no theme', () => {
-  it('applies no color', () => {
-    const { getByRole } = render(
-      <Link href="/" theme={null}>
-        text
-      </Link>,
-    );
-    const { color } = getComputedStyle(getByRole('link'));
-    expect(color).toBe('');
-  });
-
-  it('does not apply an underline', () => {
-    const { getByRole } = render(
-      <Link href="/" theme={null}>
-        text
-      </Link>,
-    );
-    const { textDecoration } = getComputedStyle(getByRole('link'));
-    expect(textDecoration).toBe('none');
   });
 });
 
@@ -150,125 +126,17 @@ describe('when button-styled', () => {
   });
 
   it('removes the href when disabled', () => {
-    const { getByText } = render(
+    const { getByText, rerender } = render(
+      <Link href="/" buttonStyle>
+        text
+      </Link>,
+    );
+    expect(getByText('text').closest('a')).toHaveAttribute('href');
+    rerender(
       <Link href="/" buttonStyle enabled={false}>
         text
       </Link>,
     );
-    expect(getByText('text')).not.toHaveAttribute('href');
-  });
-});
-
-describe.each`
-  contextDescription    | wrapper
-  ${'with a router'}    | ${StaticRouter}
-  ${'without a router'} | ${undefined}
-`('$contextDescription', ({ wrapper }) => {
-  describe.each`
-    linkDescription    | href
-    ${'external link'} | ${'https://parkinsonsroadmap.org/'}
-    ${'internal link'} | ${'/'}
-  `("for an $linkDescription to '$href'", ({ href }) => {
-    it('applies the href to the anchor', () => {
-      const { getByRole } = render(<Link href={href}>text</Link>, {
-        wrapper,
-      });
-      const anchor = getByRole('link') as HTMLAnchorElement;
-      expect(new URL(anchor.href, window.location.href).href).toBe(
-        new URL(href, window.location.href).href,
-      );
-    });
-  });
-
-  it('renders an inactive link without an href', () => {
-    const { getByText } = render(<Link href={undefined}>text</Link>, {
-      wrapper,
-    });
-    expect(getByText('text', { selector: 'a' })).not.toHaveAttribute('href');
-  });
-
-  it('renders an inactive link with an empty href', () => {
-    const { getByText } = render(<Link href="">text</Link>, {
-      wrapper,
-    });
-    expect(getByText('text', { selector: 'a' })).not.toHaveAttribute('href');
-  });
-});
-
-describe('for an external link', () => {
-  it('sets the anchor target to open in a new page', () => {
-    const { getByRole } = render(
-      <Link href="https://parkinsonsroadmap.org/">text</Link>,
-    );
-    const { target } = getByRole('link') as HTMLAnchorElement;
-    expect(target).toBe('_blank');
-  });
-
-  it('secures the link against third parties', () => {
-    const { getByRole } = render(
-      <Link href="https://parkinsonsroadmap.org/">text</Link>,
-    );
-    const { relList } = getByRole('link') as HTMLAnchorElement;
-    expect(relList).toContain('noreferrer');
-    expect(relList).toContain('noopener');
-  });
-
-  it('triggers a full page navigation on click', () => {
-    const { getByRole } = render(
-      <Link href="https://parkinsonsroadmap.org/">text</Link>,
-    );
-    const anchor = getByRole('link') as HTMLAnchorElement;
-    expect(fireEvent.click(anchor)).toBe(true);
-  });
-});
-
-describe.each`
-  description           | wrapper
-  ${'with a router'}    | ${StaticRouter}
-  ${'without a router'} | ${undefined}
-`('for an internal link $description to /', ({ wrapper }) => {
-  it('does not set the anchor target', () => {
-    const { getByRole } = render(<Link href="/">text</Link>, { wrapper });
-    const { target } = getByRole('link') as HTMLAnchorElement;
-    expect(target).toBe('');
-  });
-
-  it('does not secure the link against third parties', () => {
-    const { getByRole } = render(<Link href="/">text</Link>, { wrapper });
-    const { relList } = getByRole('link') as HTMLAnchorElement;
-    expect(relList).not.toContain('noreferrer');
-    expect(relList).not.toContain('noopener');
-  });
-});
-
-describe('for an internal link with a router', () => {
-  it('does not trigger a full page navigation on click', () => {
-    const { getByRole } = render(
-      <Link
-        href={`${window.location.protocol}//${window.location.host}/page?query#fragment`}
-      >
-        text
-      </Link>,
-      { wrapper: StaticRouter },
-    );
-    const anchor = getByRole('link') as HTMLAnchorElement;
-    expect(fireEvent.click(anchor)).toBe(false);
-  });
-
-  it('smoothly scrolls the anchor referenced by the fragment into view', async () => {
-    const { getByRole } = render(
-      <>
-        <Link href={`#fragment`}>text</Link>
-        <main id="fragment">text</main>
-      </>,
-      { wrapper: StaticRouter },
-    );
-    const main = getByRole('main');
-    const spyScrollIntoView = jest.spyOn(main, 'scrollIntoView');
-
-    userEvent.click(getByRole('link'));
-    await waitFor(() =>
-      expect(spyScrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth' }),
-    );
+    expect(getByText('text').closest('a')).not.toHaveAttribute('href');
   });
 });

--- a/packages/react-components/src/atoms/index.ts
+++ b/packages/react-components/src/atoms/index.ts
@@ -1,3 +1,4 @@
+export { default as Anchor } from './Anchor';
 export { default as Avatar } from './Avatar';
 export { default as Button } from './Button';
 export { default as Caption } from './Caption';

--- a/packages/react-components/src/molecules/ErrorCard.tsx
+++ b/packages/react-components/src/molecules/ErrorCard.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import css from '@emotion/css';
 import { serializeError } from 'serialize-error';
 
-import { Card, Link, Button } from '../atoms';
+import { Card, Anchor, Button } from '../atoms';
 import { alertIcon } from '../icons';
 import { perRem } from '../pixels';
 import { mailToSupport } from '../mail';
@@ -76,9 +76,9 @@ const ErrorCard: React.FC<ErrorCardProps> = ({
         {error && (
           <span>
             <br /> If the issue persists, you can{' '}
-            <Link theme={null} href={mailto(error)}>
+            <Anchor href={mailto(error)}>
               <span css={underlineStyles}>contact support</span>
-            </Link>
+            </Anchor>
             .
           </span>
         )}

--- a/packages/react-components/src/molecules/ExternalLink.tsx
+++ b/packages/react-components/src/molecules/ExternalLink.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import css from '@emotion/css';
-import { Link } from '../atoms';
+
+import { Anchor } from '../atoms';
 import { externalLinkIcon } from '../icons';
 import { fern, pine } from '../colors';
 import { perRem } from '../pixels';
@@ -45,12 +46,12 @@ const ExternalLink: React.FC<ExternalLinkProps> = ({
   label = 'External Link',
 }) => (
   <div css={containerStyles}>
-    <Link theme={null} href={href}>
+    <Anchor href={href}>
       <div css={styles}>
         {icon}
         <div css={textStyles}>{label}</div>
       </div>
-    </Link>
+    </Anchor>
   </div>
 );
 

--- a/packages/react-components/src/molecules/MembersList.tsx
+++ b/packages/react-components/src/molecules/MembersList.tsx
@@ -4,7 +4,7 @@ import { UserResponse, UserTeam } from '@asap-hub/model';
 
 import { perRem, tabletScreen } from '../pixels';
 import { lead } from '../colors';
-import { Link, Avatar } from '../atoms';
+import { Link, Avatar, Anchor } from '../atoms';
 
 const containerStyles = css({
   margin: 0,
@@ -72,7 +72,7 @@ const MembersList: React.FC<MembersListProps> = ({
   <ul css={[containerStyles, singleColumn || multiColumnContainerStyles]}>
     {members.map(({ id, href, displayName, role, teams, ...member }) => (
       <li key={id} css={{ display: 'contents' }}>
-        <Link href={href} theme={null} display="contents">
+        <Anchor href={href} css={{ display: 'contents' }}>
           <div css={avatarStyles}>
             <Avatar
               firstName={member.firstName}
@@ -80,11 +80,11 @@ const MembersList: React.FC<MembersListProps> = ({
               imageUrl={member.avatarUrl}
             />
           </div>
-        </Link>
-        <Link href={href} theme={null} display="contents">
+        </Anchor>
+        <Anchor href={href} css={{ display: 'contents' }}>
           <div css={nameStyles}>{displayName}</div>
-        </Link>
-        <Link href={href} theme={null} display="contents">
+        </Anchor>
+        <Anchor href={href} css={{ display: 'contents' }}>
           <div
             css={[
               addToColumnStyles,
@@ -94,7 +94,7 @@ const MembersList: React.FC<MembersListProps> = ({
           >
             {role}
           </div>
-        </Link>
+        </Anchor>
         <ul
           css={[
             addToColumnStyles,

--- a/packages/react-components/src/molecules/PageControls.tsx
+++ b/packages/react-components/src/molecules/PageControls.tsx
@@ -16,7 +16,7 @@ import {
   previousPageIcon,
   lastPageIcon,
 } from '../icons';
-import { Link } from '../atoms';
+import { Anchor } from '../atoms';
 
 const containerStyles = css({
   display: 'flex',
@@ -194,18 +194,18 @@ const PageControls: React.FC<PageControlsProps> = ({
     <nav css={containerStyles}>
       <ol css={listStyles}>
         <li css={itemStyles}>
-          <Link theme={null} href={firstPageHref}>
+          <Anchor href={firstPageHref}>
             <span css={[textStyles, firstPageHref ?? disabledTextStyles]}>
               {firstPageIcon}
             </span>
-          </Link>
+          </Anchor>
         </li>
         <li css={itemStyles}>
-          <Link theme={null} href={previousPageHref}>
+          <Anchor href={previousPageHref}>
             <span css={[textStyles, previousPageHref ?? disabledTextStyles]}>
               {previousPageIcon}
             </span>
-          </Link>
+          </Anchor>
         </li>
         {shownPages.map(({ index, followsGap, wideScreenOnly }) => {
           const active = index === currentPageIndex;
@@ -218,27 +218,27 @@ const PageControls: React.FC<PageControlsProps> = ({
                 wideScreenOnly ? 'wide-screen-only' : '',
               ].join(' ')}
             >
-              <Link theme={null} href={renderPageHref(index)}>
+              <Anchor href={renderPageHref(index)}>
                 <span css={[textStyles, active && activeTextStyles]}>
                   {index + 1}
                 </span>
-              </Link>
+              </Anchor>
             </li>
           );
         })}
         <li css={itemStyles}>
-          <Link theme={null} href={nextPageHref}>
+          <Anchor href={nextPageHref}>
             <span css={[textStyles, nextPageHref ?? disabledTextStyles]}>
               {nextPageIcon}
             </span>
-          </Link>
+          </Anchor>
         </li>
         <li css={itemStyles}>
-          <Link theme={null} href={lastPageHref}>
+          <Anchor href={lastPageHref}>
             <span css={[textStyles, lastPageHref ?? disabledTextStyles]}>
               {lastPageIcon}
             </span>
-          </Link>
+          </Anchor>
         </li>
       </ol>
     </nav>

--- a/packages/react-components/src/organisms/GroupCard.tsx
+++ b/packages/react-components/src/organisms/GroupCard.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import css from '@emotion/css';
-import { Card, Headline2, Paragraph, Link } from '../atoms';
+import { Card, Headline2, Paragraph, Anchor } from '../atoms';
 import { TagList } from '../molecules';
 import { teamIcon } from '../icons';
 import { perRem } from '../pixels';
@@ -26,10 +26,10 @@ const GroupCard: React.FC<GroupCardProps> = ({
   numberOfTeams,
 }) => (
   <Card>
-    <Link theme={null} href={href}>
+    <Anchor href={href}>
       <Headline2 styleAsHeading={4}>{name}</Headline2>
       <Paragraph accent="lead">{description}</Paragraph>
-    </Link>
+    </Anchor>
     <TagList min={2} max={3} tags={tags} />
     <Paragraph>
       <span css={iconStyles}>{teamIcon} </span>

--- a/packages/react-components/src/organisms/NewsAndEventsCard.tsx
+++ b/packages/react-components/src/organisms/NewsAndEventsCard.tsx
@@ -1,7 +1,14 @@
 import React from 'react';
 import css from '@emotion/css';
 import { NewsOrEventResponse, NewsAndEventsType } from '@asap-hub/model';
-import { Card, Paragraph, Headline2, TagLabel, Caption, Link } from '../atoms';
+import {
+  Card,
+  Paragraph,
+  Headline2,
+  TagLabel,
+  Caption,
+  Anchor,
+} from '../atoms';
 import { perRem, smallDesktopScreen } from '../pixels';
 import { formatDate } from '../utils';
 import {
@@ -71,9 +78,9 @@ const NewsAndEventsCard: React.FC<NewsAndEventsCardProps> = ({
   href,
 }) => {
   const titleComponent = text ? (
-    <Link theme={null} href={href}>
+    <Anchor href={href}>
       <Headline2 styleAsHeading={4}>{title}</Headline2>
-    </Link>
+    </Anchor>
   ) : (
     <Headline2 styleAsHeading={4}>{title}</Headline2>
   );

--- a/packages/react-components/src/organisms/PeopleCard.tsx
+++ b/packages/react-components/src/organisms/PeopleCard.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import css from '@emotion/css';
 import { UserResponse, UserTeam } from '@asap-hub/model';
 
-import { Card, Link, Headline2, Avatar, Caption } from '../atoms';
+import { Card, Anchor, Headline2, Avatar, Caption } from '../atoms';
 import { UserProfilePersonalText } from '../molecules';
 import { tabletScreen } from '../pixels';
 import { formatDate } from '../utils';
@@ -65,18 +65,18 @@ const PeopleCard: React.FC<PeopleCardProps> = ({
 }) => (
   <Card>
     <div css={[containerStyles]}>
-      <Link theme={null} href={href}>
+      <Anchor href={href}>
         <Avatar
           imageUrl={avatarUrl}
           firstName={firstName}
           lastName={lastName}
         />
-      </Link>
+      </Anchor>
       <div css={textContainerStyles}>
         <div css={moveStyles}>
-          <Link theme={null} href={href}>
+          <Anchor href={href}>
             <Headline2 styleAsHeading={4}>{displayName}</Headline2>
-          </Link>
+          </Anchor>
         </div>
         <div css={profileTextStyles}>
           <UserProfilePersonalText

--- a/packages/react-components/src/organisms/SharedResearchCard.tsx
+++ b/packages/react-components/src/organisms/SharedResearchCard.tsx
@@ -3,7 +3,7 @@ import css from '@emotion/css';
 import format from 'date-fns/format';
 import { ResearchOutputResponse, ResearchOutputType } from '@asap-hub/model';
 
-import { Card, Link, Headline2, Caption, TagLabel } from '../atoms';
+import { Card, Anchor, Headline2, Caption, TagLabel } from '../atoms';
 import { perRem } from '../pixels';
 import { lead } from '../colors';
 import { teamIcon } from '../icons';
@@ -80,9 +80,9 @@ const SharedResearchCard: React.FC<SharedResearchCardProps> = ({
   const titleComponent = link ? (
     <Headline2 styleAsHeading={4}>{title}</Headline2>
   ) : (
-    <Link theme={null} href={href}>
+    <Anchor href={href}>
       <Headline2 styleAsHeading={4}>{title}</Headline2>
-    </Link>
+    </Anchor>
   );
 
   return (
@@ -99,7 +99,7 @@ const SharedResearchCard: React.FC<SharedResearchCardProps> = ({
           {team && (
             <span css={teamMemberStyles}>
               <span css={iconStyles}>{teamIcon}</span>
-              <Link href={team.href}>Team {team.displayName}</Link>
+              <Anchor href={team.href}>Team {team.displayName}</Anchor>
             </span>
           )}
         </div>

--- a/packages/react-components/src/organisms/TeamCard.tsx
+++ b/packages/react-components/src/organisms/TeamCard.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import css from '@emotion/css';
 import { TeamMember } from '@asap-hub/model';
 
-import { Card, Link, Paragraph, Headline2 } from '../atoms';
+import { Card, Anchor, Paragraph, Headline2 } from '../atoms';
 import { perRem } from '../pixels';
 import { teamIcon } from '../icons';
 import { TagList } from '../molecules';
@@ -35,10 +35,10 @@ const TeamCard: React.FC<TeamCardProps> = ({
   href,
 }) => (
   <Card>
-    <Link theme={null} href={href}>
+    <Anchor href={href}>
       <Headline2 styleAsHeading={4}>Team {displayName}</Headline2>
       <Paragraph accent="lead">{projectTitle}</Paragraph>
-    </Link>
+    </Anchor>
     <TagList min={5} max={5} tags={skills} />
     <span css={teamMemberStyles}>
       <span css={iconStyles}>{teamIcon} </span>

--- a/packages/react-components/src/organisms/ToolCard.tsx
+++ b/packages/react-components/src/organisms/ToolCard.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css } from '@emotion/core';
 import { TeamTool } from '@asap-hub/model';
 
-import { Card, Headline3, Paragraph, Link } from '../atoms';
+import { Card, Headline3, Paragraph, Anchor } from '../atoms';
 import { placeholderIcon } from '../icons';
 import { perRem, tabletScreen } from '../pixels';
 import { getIconFromUrl } from '../utils';
@@ -39,11 +39,11 @@ const ToolCard: React.FC<ToolCardProps> = ({
     <div css={containerStyle}>
       <div css={logoIconStyle}>{getIconFromUrl(url) ?? placeholderIcon}</div>
       <div css={{ flex: 1 }}>
-        <Link href={url} theme={null}>
+        <Anchor href={url}>
           <Headline3 styleAsHeading={4}>{name}</Headline3>
           <Paragraph accent="lead">{description}</Paragraph>
-        </Link>
-        <Link href={editHref}>Edit Link</Link>
+        </Anchor>
+        <Anchor href={editHref}>Edit Link</Anchor>
       </div>
     </div>
   </Card>

--- a/packages/react-components/src/organisms/UserNavigation.tsx
+++ b/packages/react-components/src/organisms/UserNavigation.tsx
@@ -7,7 +7,7 @@ import {
   mobileScreen,
   largeDesktopScreen,
 } from '../pixels';
-import { Divider, NavigationLink, Caption, Link } from '../atoms';
+import { Divider, NavigationLink, Caption, Anchor } from '../atoms';
 import { teamIcon, userIcon, feedbackIcon, logoutIcon } from '../icons';
 
 const containerStyles = css({
@@ -95,17 +95,11 @@ const UserNavigation: React.FC<UserNavigationProps> = ({
     </ul>
     <div css={bottomLinksStyles}>
       <Caption accent="lead" asParagraph>
-        <Link theme={null} href={termsHref}>
-          Terms of Use
-        </Link>
+        <Anchor href={termsHref}>Terms of Use</Anchor>
         {'  ·  '}
-        <Link theme={null} href={privacyPolicyHref}>
-          Privacy Policy
-        </Link>
+        <Anchor href={privacyPolicyHref}>Privacy Policy</Anchor>
         {'  ·  '}
-        <Link theme={null} href={aboutHref}>
-          About ASAP
-        </Link>
+        <Anchor href={aboutHref}>About ASAP</Anchor>
       </Caption>
     </div>
   </nav>

--- a/packages/react-components/src/organisms/UserProfileRecentWorks.tsx
+++ b/packages/react-components/src/organisms/UserProfileRecentWorks.tsx
@@ -9,7 +9,7 @@ import {
   TagLabel,
   Divider,
   Paragraph,
-  Link,
+  Anchor,
 } from '../atoms';
 import { perRem, tabletScreen } from '../pixels';
 import { orcidIcon } from '../icons';
@@ -125,17 +125,7 @@ const UserProfileRecentWork: React.FC<UserProfileRecentWorkProps> = ({
     </div>
   );
 
-  return (
-    <li>
-      {doi ? (
-        <Link theme={null} href={doi}>
-          {elements}
-        </Link>
-      ) : (
-        elements
-      )}
-    </li>
-  );
+  return <li>{doi ? <Anchor href={doi}>{elements}</Anchor> : elements}</li>;
 };
 
 const UserProfileRecentWorks: React.FC<UserProfileRecentWorksProps> = ({

--- a/packages/react-components/src/templates/TeamProfileHeader.tsx
+++ b/packages/react-components/src/templates/TeamProfileHeader.tsx
@@ -3,7 +3,7 @@ import css from '@emotion/css';
 import { formatDistance } from 'date-fns';
 import { TeamResponse, TeamTool } from '@asap-hub/model';
 
-import { Link, TabLink, Display, Paragraph, Avatar } from '../atoms';
+import { Anchor, Link, TabLink, Display, Paragraph, Avatar } from '../atoms';
 import { TabNav } from '../molecules';
 import { contentSidePaddingWithNavigation } from '../layout';
 import { createMailTo } from '../mail';
@@ -93,13 +93,13 @@ const TeamProfileHeader: React.FC<TeamProfileHeaderProps> = ({
             .slice(0, MAX_MEMBER_AVATARS)
             .map(({ id, avatarUrl, firstName, lastName }) => (
               <li key={id}>
-                <Link href={`/network/users/${id}`} theme={null}>
+                <Anchor href={`/network/users/${id}`}>
                   <Avatar
                     firstName={firstName}
                     lastName={lastName}
                     imageUrl={avatarUrl}
                   />
-                </Link>
+                </Anchor>
               </li>
             ))}
           <li css={extraUsersStyles}>

--- a/packages/react-components/src/templates/WelcomePage.tsx
+++ b/packages/react-components/src/templates/WelcomePage.tsx
@@ -3,7 +3,7 @@ import React, { ComponentProps } from 'react';
 
 import WelcomeCard from './WelcomeCard';
 import { Header } from '../molecules';
-import { Link, Paragraph } from '../atoms';
+import { Anchor, Link, Paragraph } from '../atoms';
 import { perRem, tabletScreen } from '../pixels';
 import { backgroundNeuronsImage } from '../images';
 import { themes } from '../theme';
@@ -127,9 +127,9 @@ const WelcomePage: React.FC<WelcomePageProps> = ({
         <Toast onClose={onCloseAuthFailedToast}>
           There was a problem with your account. If this issue persists, please
           contact{' '}
-          <Link theme={null} href={mailToSupport()}>
+          <Anchor href={mailToSupport()}>
             <span css={{ textDecoration: 'underline' }}>ASAP Support</span>
-          </Link>
+          </Anchor>
           .
         </Toast>
       )}


### PR DESCRIPTION
As discussed. I've tried extracting it into just a hook but returning an element type and props there is just stupid, so it's a component after all, but one that with its props interface and everything is kind of a transparent anchor and can be passed all anchor attributes.
