### PR TITLE
feat: research output tags

### DIFF
--- a/packages/squidex/schema/schemas/research-outputs.json
+++ b/packages/squidex/schema/schemas/research-outputs.json
@@ -107,6 +107,21 @@
           "label": "Publish Date",
           "isRequired": false
         }
+      },
+      {
+        "name": "tags",
+        "isHidden": false,
+        "isLocked": false,
+        "isDisabled": false,
+        "partitioning": "invariant",
+        "properties": {
+          "fieldType": "Tags",
+          "editor": "Tags",
+          "label": "Tags",
+          "hints": "",
+          "placeholder": "",
+          "isRequired": false
+        }
       }
     ],
     "previewUrls": {


### PR DESCRIPTION
Create a tags property on research output for back office management.