### PR TITLE
fix: Calendar-created webhook notFound error

### DIFF
--- a/apps/asap-server/src/handlers/webhooks/webhook-calendar-created.ts
+++ b/apps/asap-server/src/handlers/webhooks/webhook-calendar-created.ts
@@ -66,6 +66,15 @@ export const webhookCalendarCreatedHandlerFactory = (
         }
       }
 
+      if (payload.data.id.iv === '') {
+        return {
+          statusCode: 200,
+          payload: {
+            message: 'Subscription skipped due to missing Calendar ID',
+          },
+        };
+      }
+
       if (['CalendarsCreated', 'CalendarsUpdated'].includes(event)) {
         try {
           const resourceId = await subscribe(payload.data.id.iv, payload.id);

--- a/apps/asap-server/test/handlers/webhooks/webhook-calendar-created.test.ts
+++ b/apps/asap-server/test/handlers/webhooks/webhook-calendar-created.test.ts
@@ -90,6 +90,27 @@ describe('Calendar Webhook', () => {
       expect(res.statusCode).toStrictEqual(502);
       expect(res.body).toContain(errorMessage);
     });
+
+    test('Should unsubscribe and skip the subscription if the calendar ID was set to an empty string', async () => {
+      const res = (await handler(
+        createSignedPayload({
+          ...updateCalendarEvent,
+          payload: {
+            ...updateCalendarEvent.payload,
+            data: {
+              ...updateCalendarEvent.payload.data,
+              id: {
+                iv: '',
+              },
+            },
+          },
+        }),
+      )) as APIGatewayProxyResult;
+
+      expect(res.statusCode).toStrictEqual(200);
+      expect(unsubscribe).toHaveBeenCalled();
+      expect(subscribe).not.toHaveBeenCalled();
+    });
   });
 
   describe('Calendar Update trigger', () => {
@@ -116,7 +137,7 @@ describe('Calendar Webhook', () => {
       )) as APIGatewayProxyResult;
 
       expect(res.statusCode).toStrictEqual(200);
-      expect(subscribe).not.toHaveBeenCalled();
+      expect(unsubscribe).not.toHaveBeenCalled();
       expect(subscribe).not.toHaveBeenCalled();
     });
 


### PR DESCRIPTION
Fixes the issue whereby the hook, upon receiving a calendar entry with an empty calendar ID, attempts to subscribe and fails.