### PR TITLE
feat: Add API token to google event subscription

### DIFF
--- a/apps/asap-server/src/config.ts
+++ b/apps/asap-server/src/config.ts
@@ -11,6 +11,7 @@ const {
   REGION,
   GOOGLE_API_CREDENTIALS_SECRET_ID,
   ASAP_API_URL,
+  GOOGLE_API_TOKEN,
 } = process.env;
 
 export const globalToken = GLOBAL_TOKEN || 'change_me_when_we_have_admins';
@@ -27,4 +28,5 @@ export const googleApiUrl = 'https://www.googleapis.com/';
 export const region = REGION || 'us-east-1';
 export const googleApiCredentialsSecretId =
   GOOGLE_API_CREDENTIALS_SECRET_ID || 'google-api-credentials-dev';
+export const googleApiToken = GOOGLE_API_TOKEN || 'asap-google-api-token';
 export const asapApiUrl = ASAP_API_URL || 'http://localhost:3333';

--- a/apps/asap-server/src/handlers/webhooks/webhook-calendar-created.ts
+++ b/apps/asap-server/src/handlers/webhooks/webhook-calendar-created.ts
@@ -61,6 +61,10 @@ export const webhookCalendarCreatedHandlerFactory = (
         if (payload.dataOld.resourceId) {
           try {
             await unsubscribe(payload.dataOld.resourceId?.iv, payload.id);
+
+            await calendarController.update(payload.id, {
+              resourceId: null,
+            });
           } catch (error) {
             logger('Error during unsubscribing from the calendar', error);
           }

--- a/apps/asap-server/src/handlers/webhooks/webhook-calendar-created.ts
+++ b/apps/asap-server/src/handlers/webhooks/webhook-calendar-created.ts
@@ -9,6 +9,7 @@ import {
   googleApiCredentialsSecretId,
   googleApiUrl,
   asapApiUrl,
+  googleApiToken,
 } from '../../config';
 import { http } from '../../utils/instrumented-framework';
 import { Handler } from '../../utils/types';
@@ -114,6 +115,7 @@ export const subscribeToEventChangesFactory = (
   const url = `${googleApiUrl}calendar/v3/calendars/${calendarId}/events/watch`;
   const data = {
     id: subscriptionId,
+    token: googleApiToken,
     type: 'web_hook',
     address: `${asapApiUrl}/webhook/events`,
     params: {

--- a/apps/asap-server/test/handlers/webhooks/webhook-calendar-created.test.ts
+++ b/apps/asap-server/test/handlers/webhooks/webhook-calendar-created.test.ts
@@ -16,7 +16,7 @@ import {
   createCalendarEvent,
   updateCalendarEvent,
 } from './webhook-sync-calendar.fixtures';
-import { googleApiUrl, asapApiUrl } from '../../../src/config';
+import { googleApiUrl, asapApiUrl, googleApiToken } from '../../../src/config';
 import { googleApiAuthJWTCredentials } from '../../mocks/google-api.mock';
 import { calendarControllerMock } from '../../mocks/calendar-controller.mock';
 
@@ -206,6 +206,7 @@ describe('Subscription', () => {
       })
       .post(`/calendar/v3/calendars/${calendarId}/events/watch`, {
         id: createCalendarEvent.payload.id,
+        token: googleApiToken,
         type: 'web_hook',
         address: `${asapApiUrl}/webhook/events`,
         params: {

--- a/apps/asap-server/test/handlers/webhooks/webhook-calendar-created.test.ts
+++ b/apps/asap-server/test/handlers/webhooks/webhook-calendar-created.test.ts
@@ -141,7 +141,7 @@ describe('Calendar Webhook', () => {
       expect(subscribe).not.toHaveBeenCalled();
     });
 
-    test('Should unsubscribe first and then resubscribe if the calendar ID changed', async () => {
+    test('Should unsubscribe and remove the resourceId then resubscribe if the calendar ID changed', async () => {
       const res = (await handler(
         createSignedPayload(updateCalendarEvent),
       )) as APIGatewayProxyResult;
@@ -150,6 +150,12 @@ describe('Calendar Webhook', () => {
       expect(unsubscribe).toHaveBeenCalledWith(
         updateCalendarEvent.payload.dataOld!.resourceId!.iv,
         updateCalendarEvent.payload.id,
+      );
+      expect(calendarControllerMock.update).toHaveBeenCalledWith(
+        createCalendarEvent.payload.id,
+        {
+          resourceId: null,
+        },
       );
       expect(subscribe).toHaveBeenCalled();
     });

--- a/packages/squidex/src/entities/calendar.ts
+++ b/packages/squidex/src/entities/calendar.ts
@@ -6,7 +6,7 @@ export interface Calendar {
   color: GoogleLegacyCalendarColor;
   name: string;
   syncToken?: string;
-  resourceId?: string;
+  resourceId?: string | null;
   expirationDate?: string;
 }
 

--- a/serverless.js
+++ b/serverless.js
@@ -177,6 +177,9 @@ module.exports = {
         GOOGLE_API_CREDENTIALS_SECRET_ID: `google-api-credentials-${
           SLS_STAGE === 'production' ? 'prod' : 'dev'
         }`,
+        GOOGLE_API_TOKEN: `\${ssm:google-api-token-${
+          SLS_STAGE === 'production' ? 'prod' : 'dev'
+        }}`,
       },
     },
     eventsUpdated: {
@@ -194,6 +197,9 @@ module.exports = {
         GOOGLE_API_CREDENTIALS_SECRET_ID: `google-api-credentials-${
           SLS_STAGE === 'production' ? 'prod' : 'dev'
         }`,
+        GOOGLE_API_TOKEN: `\${ssm:google-api-token-${
+          SLS_STAGE === 'production' ? 'prod' : 'dev'
+        }}`,
       },
     },
     ...(NODE_ENV === 'production'


### PR DESCRIPTION
see: https://trello.com/c/emZkLgNb/1016-add-authentication-to-event-webhook

this will enable us to authenticate requests coming from google api

Other changes:
* add the resourceId removal from the db once unsubscribed from the channel - this will prevent us from seeing errors about a failed unsubscribing attempt after the calendar ID was previously set to null