### PR TITLE
fix: Make Calendar ID required

### DIFF
--- a/packages/squidex/schema/schemas/calendars.json
+++ b/packages/squidex/schema/schemas/calendars.json
@@ -35,11 +35,12 @@
         "properties": {
           "fieldType": "String",
           "pattern": "^[a-zA-Z0-9.!#$%&’*+\\/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:.[a-zA-Z0-9-]+)*$",
+          "minLength": 8,
           "isUnique": true,
           "inlineEditable": false,
           "editor": "Input",
           "label": "Google Calendar ID",
-          "isRequired": false
+          "isRequired": true
         }
       },
       {


### PR DESCRIPTION
Makes the calendar ID required and applies a min length validation of 8 characters