### PR TITLE
feat: event 'hidden' flag

### DIFF
--- a/apps/asap-server/src/controllers/events.ts
+++ b/apps/asap-server/src/controllers/events.ts
@@ -54,6 +54,8 @@ export default class Events implements EventController {
         [],
       );
 
+    filters.push('data/hidden/iv ne true');
+
     if (after) {
       filters.push(`data/endDate/iv gt ${after}`);
     }

--- a/apps/asap-server/test/fixtures/events.fixtures.ts
+++ b/apps/asap-server/test/fixtures/events.fixtures.ts
@@ -9,7 +9,6 @@ import {
   ListEventResponse,
   GroupResponse,
   EventResponse,
-  EventStatus,
 } from '@asap-hub/model';
 
 export const fetchEventsResponse: { data: ResponseFetchEvents } = {

--- a/apps/asap-server/test/fixtures/events.fixtures.ts
+++ b/apps/asap-server/test/fixtures/events.fixtures.ts
@@ -237,8 +237,9 @@ export const restEvent: RestEvent = {
     endDate: { iv: '2021-02-23T19:32:00Z' },
     endDateTimeZone: { iv: 'Europe/Lisbon' },
     calendar: { iv: ['squidex-calendar-id'] },
-    status: { iv: 'confirmed' as EventStatus },
+    status: { iv: 'Confirmed' },
     tags: { iv: [] },
     meetingLink: { iv: 'https://meetings.com' },
+    hidden: { iv: false },
   },
 };

--- a/apps/asap-server/test/utils/sync-google-event.test.ts
+++ b/apps/asap-server/test/utils/sync-google-event.test.ts
@@ -2,6 +2,7 @@ import { calendar_v3 as calendarV3 } from 'googleapis';
 import { syncEventFactory } from '../../src/utils/sync-google-event';
 import { eventControllerMock } from '../mocks/event-controller.mock';
 import { restEvent } from '../fixtures/events.fixtures';
+import { RestEvent } from '@asap-hub/squidex';
 
 describe('Sync calendar util hook', () => {
   const calendarId = 'squidex-calendar-id';
@@ -29,6 +30,7 @@ describe('Sync calendar util hook', () => {
       status: 'Confirmed',
       calendar: ['squidex-calendar-id'],
       tags: [],
+      hidden: false,
     });
   });
 
@@ -50,8 +52,156 @@ describe('Sync calendar util hook', () => {
         endDateTimeZone: 'Europe/Lisbon',
         status: 'Confirmed',
         calendar: ['squidex-calendar-id'],
+        hidden: false,
       },
     );
+  });
+
+  describe('Hidden flag', () => {
+    test('Should update to hidden when the event status changes to cancelled', async () => {
+      const existingEvent: RestEvent = {
+        ...restEvent,
+        data: {
+          ...restEvent.data,
+          status: { iv: 'Confirmed' },
+        },
+      };
+
+      eventControllerMock.fetchByGoogleId.mockResolvedValueOnce(existingEvent);
+
+      const updatedEvent = {
+        ...event,
+        status: 'cancelled',
+      };
+      await syncEvent(updatedEvent, defaultCalendarTimezone);
+
+      expect(eventControllerMock.update).toHaveBeenCalledWith(
+        'squidex-event-id',
+        {
+          googleId: '04rteq6hj3gfq9g3i8v2oqetvd',
+          title: 'Event Title',
+          description: 'Event Description',
+          startDate: '2021-02-27T00:00:00.000Z',
+          startDateTimeZone: 'Europe/Lisbon',
+          endDate: '2021-02-28T00:00:00.000Z',
+          endDateTimeZone: 'Europe/Lisbon',
+          status: 'Cancelled',
+          calendar: ['squidex-calendar-id'],
+          hidden: true,
+        },
+      );
+    });
+
+    test('Should remain hidden when the event status remains cancelled', async () => {
+      const existingEvent: RestEvent = {
+        ...restEvent,
+        data: {
+          ...restEvent.data,
+          status: { iv: 'Cancelled' },
+          hidden: {
+            iv: true,
+          },
+        },
+      };
+
+      eventControllerMock.fetchByGoogleId.mockResolvedValueOnce(existingEvent);
+
+      const updatedEvent = {
+        ...event,
+        status: 'cancelled',
+      };
+      await syncEvent(updatedEvent, defaultCalendarTimezone);
+
+      expect(eventControllerMock.update).toHaveBeenCalledWith(
+        'squidex-event-id',
+        {
+          googleId: '04rteq6hj3gfq9g3i8v2oqetvd',
+          title: 'Event Title',
+          description: 'Event Description',
+          startDate: '2021-02-27T00:00:00.000Z',
+          startDateTimeZone: 'Europe/Lisbon',
+          endDate: '2021-02-28T00:00:00.000Z',
+          endDateTimeZone: 'Europe/Lisbon',
+          status: 'Cancelled',
+          calendar: ['squidex-calendar-id'],
+          hidden: true,
+        },
+      );
+    });
+
+    test('Should remain visible (ie not hidden) when the event status remains cancelled', async () => {
+      const existingEvent: RestEvent = {
+        ...restEvent,
+        data: {
+          ...restEvent.data,
+          status: { iv: 'Cancelled' },
+          hidden: {
+            iv: false,
+          },
+        },
+      };
+
+      eventControllerMock.fetchByGoogleId.mockResolvedValueOnce(existingEvent);
+
+      const updatedEvent = {
+        ...event,
+        status: 'cancelled',
+      };
+      await syncEvent(updatedEvent, defaultCalendarTimezone);
+
+      expect(eventControllerMock.update).toHaveBeenCalledWith(
+        'squidex-event-id',
+        {
+          googleId: '04rteq6hj3gfq9g3i8v2oqetvd',
+          title: 'Event Title',
+          description: 'Event Description',
+          startDate: '2021-02-27T00:00:00.000Z',
+          startDateTimeZone: 'Europe/Lisbon',
+          endDate: '2021-02-28T00:00:00.000Z',
+          endDateTimeZone: 'Europe/Lisbon',
+          status: 'Cancelled',
+          calendar: ['squidex-calendar-id'],
+          hidden: false,
+        },
+      );
+    });
+
+    test('Should remain hidden when the status changes from confirmed to tentative', async () => {
+      const existingEvent: RestEvent = {
+        ...restEvent,
+        data: {
+          ...restEvent.data,
+          status: { iv: 'Confirmed' },
+          hidden: {
+            iv: true,
+          },
+        },
+      };
+
+      eventControllerMock.fetchByGoogleId.mockResolvedValueOnce(existingEvent);
+
+      const updatedEvent = {
+        ...event,
+        status: 'tentative',
+      };
+      await syncEvent(updatedEvent, defaultCalendarTimezone);
+
+      expect(eventControllerMock.update).toHaveBeenCalledWith(
+        'squidex-event-id',
+        {
+          googleId: '04rteq6hj3gfq9g3i8v2oqetvd',
+          title: 'Event Title',
+          description: 'Event Description',
+          startDate: '2021-02-27T00:00:00.000Z',
+          startDateTimeZone: 'Europe/Lisbon',
+          endDate: '2021-02-28T00:00:00.000Z',
+          endDateTimeZone: 'Europe/Lisbon',
+          status: 'Tentative',
+          calendar: ['squidex-calendar-id'],
+          hidden: true,
+        },
+      );
+    });
   });
 
   describe('Should throw when a remote operation throws', () => {
@@ -99,6 +249,7 @@ describe('Sync calendar util hook', () => {
       status: 'Confirmed',
       calendar: ['squidex-calendar-id'],
       tags: [],
+      hidden: false,
     });
   });
 
@@ -129,6 +280,7 @@ describe('Sync calendar util hook', () => {
       status: 'Confirmed',
       calendar: ['squidex-calendar-id'],
       tags: [],
+      hidden: false,
     });
   });
 

--- a/packages/squidex/schema/schemas/events.json
+++ b/packages/squidex/schema/schemas/events.json
@@ -412,7 +412,85 @@
           "label": "Status",
           "hints": "",
           "placeholder": "",
-          "isRequired": false,
+          "isRequired": false
+        }
+      },
+      {
+        "name": "meetingMaterials",
+        "isHidden": false,
+        "isLocked": false,
+        "isDisabled": false,
+        "partitioning": "invariant",
+        "properties": {
+          "fieldType": "Array",
+          "label": "Additional Meeting Materials",
+          "hints": "",
+          "placeholder": "",
+          "isRequired": false
+        },
+        "nested": [
+          {
+            "name": "title",
+            "isHidden": false,
+            "isLocked": false,
+            "isDisabled": false,
+            "properties": {
+              "fieldType": "String",
+              "isUnique": false,
+              "inlineEditable": false,
+              "editor": "Input",
+              "label": "Title",
+              "hints": "",
+              "placeholder": "",
+              "isRequired": true
+            }
+          },
+          {
+            "name": "url",
+            "isHidden": false,
+            "isLocked": false,
+            "isDisabled": false,
+            "properties": {
+              "fieldType": "String",
+              "pattern": "^(?:http(s)?:\\/\\/)?[\\w.-]+(?:\\.[\\w\\.-]+)+[\\w\\-\\._~:\\/?#%[\\]@!\\$&'\\(\\)\\*\\+,;=.]+$",
+              "isUnique": false,
+              "inlineEditable": false,
+              "editor": "Input",
+              "label": "URL",
+              "isRequired": true
+            }
+          },
+          {
+            "name": "label",
+            "isHidden": false,
+            "isLocked": false,
+            "isDisabled": false,
+            "properties": {
+              "fieldType": "String",
+              "isUnique": false,
+              "inlineEditable": false,
+              "editor": "Input",
+              "label": "Label",
+              "isRequired": false
+            }
+          }
+        ]
+      },
+      {
+        "name": "hidden",
+        "isHidden": false,
+        "isLocked": false,
+        "isDisabled": false,
+        "partitioning": "invariant",
+        "properties": {
+          "fieldType": "Boolean",
+          "defaultValue": false,
+          "inlineEditable": false,
+          "editor": "Checkbox",
+          "label": "Hidden",
+          "hints": "Should the event be hidden in the HUB",
+          "placeholder": "",
+          "isRequired": true,
           "isHalfWidth": false
         }
       }

--- a/packages/squidex/schema/schemas/events.json
+++ b/packages/squidex/schema/schemas/events.json
@@ -416,67 +416,6 @@
         }
       },
       {
-        "name": "meetingMaterials",
-        "isHidden": false,
-        "isLocked": false,
-        "isDisabled": false,
-        "partitioning": "invariant",
-        "properties": {
-          "fieldType": "Array",
-          "label": "Additional Meeting Materials",
-          "hints": "",
-          "placeholder": "",
-          "isRequired": false
-        },
-        "nested": [
-          {
-            "name": "title",
-            "isHidden": false,
-            "isLocked": false,
-            "isDisabled": false,
-            "properties": {
-              "fieldType": "String",
-              "isUnique": false,
-              "inlineEditable": false,
-              "editor": "Input",
-              "label": "Title",
-              "hints": "",
-              "placeholder": "",
-              "isRequired": true
-            }
-          },
-          {
-            "name": "url",
-            "isHidden": false,
-            "isLocked": false,
-            "isDisabled": false,
-            "properties": {
-              "fieldType": "String",
-              "pattern": "^(?:http(s)?:\\/\\/)?[\\w.-]+(?:\\.[\\w\\.-]+)+[\\w\\-\\._~:\\/?#%[\\]@!\\$&'\\(\\)\\*\\+,;=.]+$",
-              "isUnique": false,
-              "inlineEditable": false,
-              "editor": "Input",
-              "label": "URL",
-              "isRequired": true
-            }
-          },
-          {
-            "name": "label",
-            "isHidden": false,
-            "isLocked": false,
-            "isDisabled": false,
-            "properties": {
-              "fieldType": "String",
-              "isUnique": false,
-              "inlineEditable": false,
-              "editor": "Input",
-              "label": "Label",
-              "isRequired": false
-            }
-          }
-        ]
-      },
-      {
         "name": "hidden",
         "isHidden": false,
         "isLocked": false,

--- a/packages/squidex/src/entities/event.ts
+++ b/packages/squidex/src/entities/event.ts
@@ -25,6 +25,7 @@ export interface Event<TCalendar = string, TThumbnail = string> {
   thumbnail?: TThumbnail[];
   calendar: TCalendar[];
   tags: string[];
+  hidden: boolean;
 }
 
 export interface RestEvent extends Entity, Rest<Event> {}


### PR DESCRIPTION
Add a new 'hidden' flag to the event entity plus enables the filter inside event control so they are removed from the response by default.

see: https://trello.com/c/DSugpat0/1064-as-an-admin-i-want-to-be-able-to-hide-cms-events-from-fe-and-keep-them-hidden