### PR TITLE
chore: Update to node-alpine in the CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -34,7 +34,7 @@ include:
     <<: *tmpl_branch_variables
     GIT_CHECKOUT: 0
 
-image: node:14.15
+image: node:14.15-alpine
 
 workflow:
   rules:


### PR DESCRIPTION
This PR speeds up the CI pipeline by switching from standard node image to node-alpine