### PR TITLE
docs: Update readme with onboarding details

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,27 @@ For a list of individual package and particularly app scripts, look inside the r
 - `yarn test` - This will lint and test all packages and apps in the repository. You may want to run this with `--watch` or other [Jest CLI options](https://jestjs.io/docs/en/cli.html).
 - `yarn test:*` - There are further test configurations being run on CI that are usually slower or more specific and thus not suitable to run during day-to-day development. You can execute those scripts manually. Some of them may require installing native modules via `yarn rebuild` first.
 
+## Setting up your development environment
+
+For you, a newcomer, to be running your development setup, you'll need to complete the following steps:
+#### Create a new user
+- Log in to https://cloud.squidex.io/app/asap-hub-dev
+- In `Content/Users`, create a new user
+- While creating, or editing the user, on `Functional/Connections`, add a new item to store your UUID (you can generate a random one [here](https://www.uuidgenerator.net/version4)) and save that (the save button is the blue one on top!). You'll need that UUID later, so save it.
+
+#### Get everything running
+- create a `.env` file and update it with the necessary details (ask someone for this)
+- You can run all apps in the project with a simple `yarn start` on the project's root. It will load up everything, but you don't need to run everything. Depending on what you're doing, you only need some apps up
+- `yarn watch:babel`: to have babel watching and compiling for you
+- `yarn watch:typecheck`: well... for types checking
+- `yarn start:backend`: to run the backend
+- `yarn start:frontend`: to run the frontend 
+
+#### Now that everything's up
+- On localhost:3000 you should have the hub running. You'll need to get your profile created.
+- Get your UUID from the previous step, and use it on https://dev.hub.asap.science/welcome/{uuid}
+- Reload localhost:3000 and you should now have an account and be logged in.
+
 ## Editor setup
 
 Refer to [this Yarn documentation page](https://yarnpkg.com/advanced/editor-sdks) for how to integrate your editor with the TypeScript compiler and ESLint linter in this repository. You will also need to set up your editor to run ESLint with the same CLI options that the scripts do—they are in [this file](jest-runner-eslint.config.js).

--- a/README.md
+++ b/README.md
@@ -34,20 +34,21 @@ For a list of individual package and particularly app scripts, look inside the r
 ## Setting up your development environment
 
 For you, a newcomer, to be running your development setup, you'll need to complete the following steps:
-#### Create a new user
+### Create a new user
 - Log in to https://cloud.squidex.io/app/asap-hub-dev
 - In `Content/Users`, create a new user
 - While creating, or editing the user, on `Functional/Connections`, add a new item to store your UUID (you can generate a random one [here](https://www.uuidgenerator.net/version4)) and save that (the save button is the blue one on top!). You'll need that UUID later, so save it.
 
-#### Get everything running
+### Get everything running
 - create a `.env` file and update it with the necessary details (ask someone for this)
 - You can run all apps in the project with a simple `yarn start` on the project's root. It will load up everything, but you don't need to run everything. Depending on what you're doing, you only need some apps up
 - `yarn watch:babel`: to have babel watching and compiling for you
 - `yarn watch:typecheck`: well... for types checking
 - `yarn start:backend`: to run the backend
 - `yarn start:frontend`: to run the frontend 
+- `yarn start:storybook`: to run storybook 
 
-#### Now that everything's up
+### Now that everything's up
 - On localhost:3000 you should have the hub running. You'll need to get your profile created.
 - Get your UUID from the previous step, and use it on https://dev.hub.asap.science/welcome/{uuid}
 - Reload localhost:3000 and you should now have an account and be logged in.

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ For a list of individual package and particularly app scripts, look inside the r
 ## Setting up your development environment
 
 For you, a newcomer, to be running your development setup, you'll need to complete the following steps:
-### Create a new user
+### Create a new user on Squidex
 - Log in to https://cloud.squidex.io/app/asap-hub-dev
-- In `Content/Users`, create a new user
+- In `Content/Users`, create a new user (or edit if already created)
 - While creating, or editing the user, on `Functional/Connections`, add a new item to store your UUID (you can generate a random one [here](https://www.uuidgenerator.net/version4)) and save that (the save button is the blue one on top!). You'll need that UUID later, so save it.
 
 ### Get everything running

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ For you, a newcomer, to be running your development setup, you'll need to comple
 ### Get everything running
 - create a `.env` file and update it with the necessary details (ask someone for this)
 - You can run all apps in the project with a simple `yarn start` on the project's root. It will load up everything, but you don't need to run everything. Depending on what you're doing, you only need some apps up
-- `yarn watch:babel`: to have babel watching and compiling for you
-- `yarn watch:typecheck`: well... for types checking
+- `yarn watch:babel`: to have babel watching and compiling for you (you'll need this running most of the time)
+- `yarn watch:typecheck`: well... for types checking (you'll need this running most of the time)
 - `yarn start:backend`: to run the backend
 - `yarn start:frontend`: to run the frontend 
 - `yarn start:storybook`: to run storybook 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "watch:typecheck": "yarn build:typecheck -w",
     "start": "yarn workspaces foreach -vpi -j 1000 run start",
     "start:backend": "yarn workspace @asap-hub/asap-server start:server",
+    "start:frontend": "yarn workspace @asap-hub/frontend start",
     "sls": "node serverless/link-plugins.js && yarn pnpify serverless",
     "fix:format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,html,css,scss,md,mdx,yml,yaml}\"",
     "lint:format": "prettier -l \"**/*.{js,jsx,ts,tsx,json,html,css,scss,md,mdx,yml,yaml}\"",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "start": "yarn workspaces foreach -vpi -j 1000 run start",
     "start:backend": "yarn workspace @asap-hub/asap-server start:server",
     "start:frontend": "yarn workspace @asap-hub/frontend start",
+    "start:sb": "yarn workspace @asap-hub/storybook start",
     "sls": "node serverless/link-plugins.js && yarn pnpify serverless",
     "fix:format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,html,css,scss,md,mdx,yml,yaml}\"",
     "lint:format": "prettier -l \"**/*.{js,jsx,ts,tsx,json,html,css,scss,md,mdx,yml,yaml}\"",


### PR DESCRIPTION
This PR does the following changes:
- updates the README with a "Setting up your development environment" section, with more details on how to get a new user running
- adds a script to run the frontend app from the project's root