### PR TITLE
feat(squidex-setup): update cli to version 6.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN wget -qO - https://www.mongodb.org/static/pgp/server-4.4.asc | apt-key add -
     apt-get update && \
     apt-get install -y mongodb-org
 
-RUN wget https://github.com/Squidex/squidex-samples/releases/download/cli-v5.2/linux-x64.zip && \
+RUN wget https://github.com/Squidex/squidex-samples/releases/download/cli-v6.2/linux-x64.zip && \
     unzip linux-x64.zip && \
     mv sq /bin
 


### PR DESCRIPTION
Running different versions of the CLI on the CI or on our local computers means that the schema we `sync in` - through the CLI sync step - and the schemas we `sync out`  locally are always different. This should fix that.