### PR TITLE
chore: Apply correct order to squidex sync in ci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -47,9 +47,10 @@ variables:
 stages:
   - build
   - test
-  - prepare
+  - prepare-dev
   - deploy-dev
   - verify-dev
+  - prepare-prod
   - deploy-prod
   - verify-prod
 
@@ -186,6 +187,7 @@ deploy:sls:development:
   needs:
     - build:ts
     - build:native
+    - sync:squidex:dev
 
 ####################
 # stage verify-dev #

--- a/ci/.gitlab-ci.squidex.yml
+++ b/ci/.gitlab-ci.squidex.yml
@@ -26,12 +26,12 @@ setup:squidex-image:
     - sq config add asap-hub $SQUIDEX_CLIENT_ID $SQUIDEX_CLIENT_SECRET -u $SQUIDEX_BASE_URL
     - sq config use asap-hub
     - sq sync in packages/squidex/schema -t schemas -t rules
-  stage: prepare
   rules:
     - if: $CI_COMMIT_BRANCH == 'master'
 
 sync:squidex:dev:
   <<: *tmpl_sync
+  stage: prepare-dev
   rules:
     - if: $CI_COMMIT_BRANCH == 'master'
       when: manual
@@ -39,5 +39,6 @@ sync:squidex:dev:
 
 sync:squidex:production:
   <<: *tmpl_sync
+  stage: prepare-prod
   environment:
     name: production

--- a/ci/.gitlab-ci.squidex.yml
+++ b/ci/.gitlab-ci.squidex.yml
@@ -32,10 +32,6 @@ setup:squidex-image:
 sync:squidex:dev:
   <<: *tmpl_sync
   stage: prepare-dev
-  rules:
-    - if: $CI_COMMIT_BRANCH == 'master'
-      when: manual
-      allow_failure: true
 
 sync:squidex:production:
   <<: *tmpl_sync


### PR DESCRIPTION
This puts the `squidex sync:dev` step before the dev deployment and adds a dependency on the sync itself thus making it required to run the entire pipeline.