### PR TITLE
feat: event content is stale after 14 days

### DIFF
--- a/apps/asap-server/src/entities/event.ts
+++ b/apps/asap-server/src/entities/event.ts
@@ -31,7 +31,7 @@ export const parseGraphQLEvent = (item: GraphqlEvent): EventResponse => {
     : undefined;
 
   const endDate = DateTime.fromISO(item.flatData!.endDate!);
-  const isStale = endDate.diffNow('days').get('days') < -10; // 10 days have passed after the event
+  const isStale = endDate.diffNow('days').get('days') < -14; // 14 days have passed after the event
 
   const {
     notesPermanentlyUnavailable,


### PR DESCRIPTION
This PR is an iteration on the requirements of this ticket: https://trello.com/c/aEpe05ua/1060-marking-meeting-materials-of-an-event-as-permanently-unavailable-tick-box.
- As stated in the comments. The tickbox takes precedence over contente (was already implemented)
- Content is considered permanently unavailable if empty and event is more than 14 days old