### PR TITLE
Adding CTA (contact PM) to group about template

### DIFF
--- a/packages/react-components/src/__tests__/mail.test.ts
+++ b/packages/react-components/src/__tests__/mail.test.ts
@@ -6,8 +6,18 @@ import {
 } from '../mail';
 
 describe('createMailTo', () => {
-  it('generates a mailto link', () => {
-    expect(new URL(createMailTo('test@example.com')).protocol).toBe('mailto:');
+  it('generates a mailto link, when an single email is provided', () => {
+    const mailTo = new URL(createMailTo('test@example.com'));
+    expect(mailTo.protocol).toBe('mailto:');
+    expect(mailTo.href).toBe('mailto:test@example.com');
+  });
+
+  it('generates a mailto link, when multiple emails are provided', () => {
+    const mailTo = new URL(
+      createMailTo(['test@example.com', 'test@example.com']),
+    );
+    expect(mailTo.protocol).toBe('mailto:');
+    expect(mailTo.href).toBe('mailto:test@example.com,test@example.com,');
   });
 
   it('escapes the email address', () => {

--- a/packages/react-components/src/mail.ts
+++ b/packages/react-components/src/mail.ts
@@ -4,12 +4,13 @@ interface MailOptions {
 }
 
 export const createMailTo = (
-  email: string,
+  emails: string | string[],
   { subject, body }: MailOptions = {},
 ): string => {
-  const mailTo = new URL(
-    `mailto:${email.split('@').map(encodeURIComponent).join('@')}`,
-  );
+  const mailTo =
+    typeof emails === 'string'
+      ? convertEmailToMailTo(emails)
+      : convertEmailListToMailTo(emails);
 
   if (subject) mailTo.searchParams.set('subject', subject);
   if (body) mailTo.searchParams.set('body', body);
@@ -34,3 +35,14 @@ export const mailToSupport = (overrides?: MailOptions): string =>
     subject: 'ASAP Hub: Tech support',
     ...overrides,
   });
+
+export const convertEmailToMailTo = (email: string): URL =>
+  new URL(`mailto:${email.split('@').map(encodeURIComponent).join('@')}`);
+
+export const convertEmailListToMailTo = (list: string[]): URL => {
+  const href = list.reduce(
+    (a, e) => `${a}${e.split('@').map(encodeURIComponent).join('@')},`,
+    '',
+  );
+  return new URL(`mailto:${href}`);
+};

--- a/packages/react-components/src/templates/GroupProfileAbout.tsx
+++ b/packages/react-components/src/templates/GroupProfileAbout.tsx
@@ -7,6 +7,9 @@ import {
   GroupMembersSection,
   GroupTools,
 } from '../organisms';
+import { CtaCard } from '../molecules';
+
+import { createMailTo } from '../mail';
 import { perRem } from '../pixels';
 
 const styles = css({
@@ -32,14 +35,33 @@ const GroupProfileAbout: React.FC<GroupProfileAboutProps> = ({
   leaders,
 
   membersSectionId,
-}) => (
-  <div css={styles}>
-    <GroupInformation tags={tags} description={description} />
-    <GroupTools calendarId={calendars[0] && calendars[0].id} tools={tools} />
-    <div id={membersSectionId}>
-      <GroupMembersSection teams={teams} leaders={leaders} />
+}) => {
+  const pmsEmails = leaders
+    .filter((pm) => pm.role.match(/project manager/i))
+    .map((pm) => pm.user.email);
+
+  return (
+    <div css={styles}>
+      <GroupInformation tags={tags} description={description} />
+      <GroupTools calendarId={calendars[0] && calendars[0].id} tools={tools} />
+      <div id={membersSectionId}>
+        <GroupMembersSection teams={teams} leaders={leaders} />
+      </div>
+      {pmsEmails.length !== 0 && (
+        <CtaCard
+          href={
+            pmsEmails.length === 1
+              ? createMailTo(pmsEmails[0])
+              : createMailTo(pmsEmails)
+          }
+          buttonText="Contact PM"
+        >
+          <strong>Interested in what you have seen?</strong>
+          <br /> Reach out to this group and see how you can collaborate
+        </CtaCard>
+      )}
     </div>
-  </div>
-);
+  );
+};
 
 export default GroupProfileAbout;

--- a/packages/react-components/src/templates/__tests__/GroupProfileAbout.test.tsx
+++ b/packages/react-components/src/templates/__tests__/GroupProfileAbout.test.tsx
@@ -58,3 +58,28 @@ it('assigns given id to the members section for deep linking', () => {
     /members/i,
   );
 });
+
+it('renders a call to action button, when a PM is defined on the group', () => {
+  const { getByText } = render(
+    <GroupProfileAbout
+      {...props}
+      leaders={[
+        {
+          user: {
+            ...createUserResponse(),
+            displayName: 'John',
+            teams: [],
+            email: 'test@test.com',
+          },
+          role: 'Project Manager',
+          href: '',
+        },
+      ]}
+    />,
+  );
+
+  expect(getByText(/contact pm/i).closest('a')).toHaveAttribute(
+    'href',
+    'mailto:test@test.com',
+  );
+});


### PR DESCRIPTION
This PR introduces the following changes:

- adds a CtaCard to GroupProfileAbout template
- checks whether there's a Group as one or more leaders with the role "Project Manager", and if there's any show the Call to Action, providing the PM's email to the mailTo link
- changes the signature of the createMailTo function, allowing for a single email (string) or a list of emails to be passed
- extracts two functions from the above function, to create both a URL to a single email or a list of emails