### PR TITLE
feat: add CTA (Contact PM) to group about template

### DIFF
--- a/apps/storybook/src/GroupProfileAbout.stories.tsx
+++ b/apps/storybook/src/GroupProfileAbout.stories.tsx
@@ -16,7 +16,15 @@ export const Normal = () => (
         ? createGroupResponse({
             leadPiCount: 2,
             projectManagerCount: 2,
-          }).leaders
+          }).leaders.map(({ user }) => ({
+            user: {
+              ...user,
+              teams: user.teams.map((team) => ({ ...team, href: '#' })),
+            },
+            role: boolean('Has PMs', true) ? 'Project Manager' : 'Chair',
+            href: '#',
+            teams: user.teams.map((team) => ({ ...team, href: '#' })),
+          }))
         : []
     }
     teams={

--- a/apps/storybook/src/GroupProfileAbout.stories.tsx
+++ b/apps/storybook/src/GroupProfileAbout.stories.tsx
@@ -17,13 +17,8 @@ export const Normal = () => (
             leadPiCount: 2,
             projectManagerCount: 2,
           }).leaders.map(({ user }) => ({
-            user: {
-              ...user,
-              teams: user.teams.map((team) => ({ ...team, href: '#' })),
-            },
+            user,
             role: boolean('Has PMs', true) ? 'Project Manager' : 'Chair',
-            href: '#',
-            teams: user.teams.map((team) => ({ ...team, href: '#' })),
           }))
         : []
     }

--- a/packages/react-components/src/__tests__/mail.test.ts
+++ b/packages/react-components/src/__tests__/mail.test.ts
@@ -6,8 +6,18 @@ import {
 } from '../mail';
 
 describe('createMailTo', () => {
-  it('generates a mailto link', () => {
-    expect(new URL(createMailTo('test@example.com')).protocol).toBe('mailto:');
+  it('generates a mailto link, when an single email is provided', () => {
+    const mailTo = new URL(createMailTo('test@example.com'));
+    expect(mailTo.protocol).toBe('mailto:');
+    expect(mailTo.href).toBe('mailto:test@example.com');
+  });
+
+  it('generates a mailto link, when multiple emails are provided', () => {
+    const mailTo = new URL(
+      createMailTo(['test@example.com', 'test@example.com']),
+    );
+    expect(mailTo.protocol).toBe('mailto:');
+    expect(mailTo.href).toBe('mailto:test@example.com,test@example.com,');
   });
 
   it('escapes the email address', () => {

--- a/packages/react-components/src/__tests__/mail.test.ts
+++ b/packages/react-components/src/__tests__/mail.test.ts
@@ -9,13 +9,13 @@ describe('createMailTo', () => {
   it('generates a mailto link, when an single email is provided', () => {
     const mailTo = new URL(createMailTo('test@example.com'));
     expect(mailTo.protocol).toBe('mailto:');
-    expect(mailTo.href).toBe('mailto:test@example.com');
+    expect(mailTo.pathname).toBe('test@example.com');
   });
 
   it('generates a mailto link, when a list with a single email is provided', () => {
     const mailTo = new URL(createMailTo(['test@example.com']));
     expect(mailTo.protocol).toBe('mailto:');
-    expect(mailTo.href).toBe('mailto:test@example.com');
+    expect(mailTo.pathname).toBe('test@example.com');
   });
 
   it('generates a mailto link, when multiple emails are provided', () => {
@@ -23,7 +23,7 @@ describe('createMailTo', () => {
       createMailTo(['test@example.com', 'test@example.com']),
     );
     expect(mailTo.protocol).toBe('mailto:');
-    expect(mailTo.href).toBe('mailto:test@example.com,test@example.com');
+    expect(mailTo.pathname).toBe('test@example.com,test@example.com');
   });
 
   it('escapes the email address', () => {

--- a/packages/react-components/src/__tests__/mail.test.ts
+++ b/packages/react-components/src/__tests__/mail.test.ts
@@ -12,6 +12,12 @@ describe('createMailTo', () => {
     expect(mailTo.href).toBe('mailto:test@example.com');
   });
 
+  it('generates a mailto link, when a list with a single email is provided', () => {
+    const mailTo = new URL(createMailTo(['test@example.com']));
+    expect(mailTo.protocol).toBe('mailto:');
+    expect(mailTo.href).toBe('mailto:test@example.com');
+  });
+
   it('generates a mailto link, when multiple emails are provided', () => {
     const mailTo = new URL(
       createMailTo(['test@example.com', 'test@example.com']),

--- a/packages/react-components/src/__tests__/mail.test.ts
+++ b/packages/react-components/src/__tests__/mail.test.ts
@@ -23,7 +23,7 @@ describe('createMailTo', () => {
       createMailTo(['test@example.com', 'test@example.com']),
     );
     expect(mailTo.protocol).toBe('mailto:');
-    expect(mailTo.href).toBe('mailto:test@example.com,test@example.com,');
+    expect(mailTo.href).toBe('mailto:test@example.com,test@example.com');
   });
 
   it('escapes the email address', () => {

--- a/packages/react-components/src/mail.ts
+++ b/packages/react-components/src/mail.ts
@@ -4,12 +4,13 @@ interface MailOptions {
 }
 
 export const createMailTo = (
-  email: string,
+  emails: string | string[],
   { subject, body }: MailOptions = {},
 ): string => {
-  const mailTo = new URL(
-    `mailto:${email.split('@').map(encodeURIComponent).join('@')}`,
-  );
+  const mailTo =
+    typeof emails === 'string'
+      ? convertEmailToMailTo(emails)
+      : convertEmailListToMailTo(emails);
 
   if (subject) mailTo.searchParams.set('subject', subject);
   if (body) mailTo.searchParams.set('body', body);
@@ -34,3 +35,14 @@ export const mailToSupport = (overrides?: MailOptions): string =>
     subject: 'ASAP Hub: Tech support',
     ...overrides,
   });
+
+export const convertEmailToMailTo = (email: string): URL =>
+  new URL(`mailto:${email.split('@').map(encodeURIComponent).join('@')}`);
+
+export const convertEmailListToMailTo = (list: string[]): URL => {
+  const href = list.reduce(
+    (a, e) => `${a}${e.split('@').map(encodeURIComponent).join('@')},`,
+    '',
+  );
+  return new URL(`mailto:${href}`);
+};

--- a/packages/react-components/src/mail.ts
+++ b/packages/react-components/src/mail.ts
@@ -4,12 +4,15 @@ interface MailOptions {
 }
 
 export const createMailTo = (
-  emails: string | string[],
+  emailOrList: string | string[],
   { subject, body }: MailOptions = {},
 ): string => {
-
-  const list = typeof emails === 'string' ? new Array(emails) : [...emails];
-  const mailTo = convertEmailListToMailToUrl(list);
+  const emails = typeof emailOrList === 'string' ? [emailOrList] : emailOrList;
+  const mailTo = new URL(
+    `mailto:${emails
+      .map((email) => email.split('@').map(encodeURIComponent).join('@'))
+      .join(',')}`,
+  );
 
   if (subject) mailTo.searchParams.set('subject', subject);
   if (body) mailTo.searchParams.set('body', body);
@@ -34,14 +37,3 @@ export const mailToSupport = (overrides?: MailOptions): string =>
     subject: 'ASAP Hub: Tech support',
     ...overrides,
   });
-
-export const convertEmailListToMailToUrl = (list: string[]): URL => {
-  const href = list.reduce(
-    (a, e, i) => {
-      const suffix = i === list.length - 1 ? '' : ',';
-      return `${a}${e.split('@').map(encodeURIComponent).join('@')}${suffix}`;
-    },
-    '',
-  );
-  return new URL(`mailto:${href}`);
-};

--- a/packages/react-components/src/mail.ts
+++ b/packages/react-components/src/mail.ts
@@ -7,10 +7,9 @@ export const createMailTo = (
   emails: string | string[],
   { subject, body }: MailOptions = {},
 ): string => {
-  const mailTo =
-    typeof emails === 'string'
-      ? convertEmailToMailTo(emails)
-      : convertEmailListToMailTo(emails);
+
+  const list = typeof emails === 'string' ? new Array(emails) : [...emails];
+  const mailTo = convertEmailListToMailToUrl(list);
 
   if (subject) mailTo.searchParams.set('subject', subject);
   if (body) mailTo.searchParams.set('body', body);
@@ -36,12 +35,12 @@ export const mailToSupport = (overrides?: MailOptions): string =>
     ...overrides,
   });
 
-export const convertEmailToMailTo = (email: string): URL =>
-  new URL(`mailto:${email.split('@').map(encodeURIComponent).join('@')}`);
-
-export const convertEmailListToMailTo = (list: string[]): URL => {
+export const convertEmailListToMailToUrl = (list: string[]): URL => {
   const href = list.reduce(
-    (a, e) => `${a}${e.split('@').map(encodeURIComponent).join('@')},`,
+    (a, e, i) => {
+      const suffix = i === list.length - 1 ? '' : ',';
+      return `${a}${e.split('@').map(encodeURIComponent).join('@')}${suffix}`;
+    },
     '',
   );
   return new URL(`mailto:${href}`);

--- a/packages/react-components/src/templates/GroupProfileAbout.tsx
+++ b/packages/react-components/src/templates/GroupProfileAbout.tsx
@@ -37,8 +37,8 @@ const GroupProfileAbout: React.FC<GroupProfileAboutProps> = ({
   membersSectionId,
 }) => {
   const pmsEmails = leaders
-    .filter((pm) => pm.role.match(/project manager/i))
-    .map((pm) => pm.user.email);
+    .filter(({ role }) => role.match(/project manager/i))
+    .map(({ user }) => user.email);
 
   return (
     <div css={styles}>
@@ -48,14 +48,7 @@ const GroupProfileAbout: React.FC<GroupProfileAboutProps> = ({
         <GroupMembersSection teams={teams} leaders={leaders} />
       </div>
       {pmsEmails.length !== 0 && (
-        <CtaCard
-          href={
-            pmsEmails.length === 1
-              ? createMailTo(pmsEmails[0])
-              : createMailTo(pmsEmails)
-          }
-          buttonText="Contact PM"
-        >
+        <CtaCard href={createMailTo(pmsEmails)} buttonText="Contact PM">
           <strong>Interested in what you have seen?</strong>
           <br /> Reach out to this group and see how you can collaborate
         </CtaCard>

--- a/packages/react-components/src/templates/GroupProfileAbout.tsx
+++ b/packages/react-components/src/templates/GroupProfileAbout.tsx
@@ -7,6 +7,9 @@ import {
   GroupMembersSection,
   GroupTools,
 } from '../organisms';
+import { CtaCard } from '../molecules';
+
+import { createMailTo } from '../mail';
 import { perRem } from '../pixels';
 
 const styles = css({
@@ -32,14 +35,33 @@ const GroupProfileAbout: React.FC<GroupProfileAboutProps> = ({
   leaders,
 
   membersSectionId,
-}) => (
-  <div css={styles}>
-    <GroupInformation tags={tags} description={description} />
-    <GroupTools calendarId={calendars[0] && calendars[0].id} tools={tools} />
-    <div id={membersSectionId}>
-      <GroupMembersSection teams={teams} leaders={leaders} />
+}) => {
+  const pmsEmails = leaders
+    .filter((pm) => pm.role.match(/project manager/i))
+    .map((pm) => pm.user.email);
+
+  return (
+    <div css={styles}>
+      <GroupInformation tags={tags} description={description} />
+      <GroupTools calendarId={calendars[0] && calendars[0].id} tools={tools} />
+      <div id={membersSectionId}>
+        <GroupMembersSection teams={teams} leaders={leaders} />
+      </div>
+      {pmsEmails.length !== 0 && (
+        <CtaCard
+          href={
+            pmsEmails.length === 1
+              ? createMailTo(pmsEmails[0])
+              : createMailTo(pmsEmails)
+          }
+          buttonText="Contact PM"
+        >
+          <strong>Interested in what you have seen?</strong>
+          <br /> Reach out to this group and see how you can collaborate
+        </CtaCard>
+      )}
     </div>
-  </div>
-);
+  );
+};
 
 export default GroupProfileAbout;

--- a/packages/react-components/src/templates/GroupProfileAbout.tsx
+++ b/packages/react-components/src/templates/GroupProfileAbout.tsx
@@ -37,7 +37,7 @@ const GroupProfileAbout: React.FC<GroupProfileAboutProps> = ({
   membersSectionId,
 }) => {
   const pmsEmails = leaders
-    .filter(({ role }) => role.match(/project manager/i))
+    .filter(({ role }) => role ==== "Project Manager" as const)
     .map(({ user }) => user.email);
 
   return (

--- a/packages/react-components/src/templates/GroupProfileAbout.tsx
+++ b/packages/react-components/src/templates/GroupProfileAbout.tsx
@@ -37,7 +37,7 @@ const GroupProfileAbout: React.FC<GroupProfileAboutProps> = ({
   membersSectionId,
 }) => {
   const pmsEmails = leaders
-    .filter(({ role }) => role ==== "Project Manager" as const)
+    .filter(({ role }) => role === 'Project Manager')
     .map(({ user }) => user.email);
 
   return (

--- a/packages/react-components/src/templates/__tests__/GroupProfileAbout.test.tsx
+++ b/packages/react-components/src/templates/__tests__/GroupProfileAbout.test.tsx
@@ -82,3 +82,25 @@ it('renders a call to action button, when a PM is defined on the group', () => {
     'mailto:test@test.com',
   );
 });
+
+it('does not render a call to action button, when a PM is NOT defined on the group', () => {
+  const { queryByText } = render(
+    <GroupProfileAbout
+      {...props}
+      leaders={[
+        {
+          user: {
+            ...createUserResponse(),
+            displayName: 'John',
+            teams: [],
+            email: 'test@test.com',
+          },
+          role: 'Chair',
+          href: '',
+        },
+      ]}
+    />,
+  );
+
+  expect(queryByText(/contact pm/i)).not.toBeInTheDocument();
+});

--- a/packages/react-components/src/templates/__tests__/GroupProfileAbout.test.tsx
+++ b/packages/react-components/src/templates/__tests__/GroupProfileAbout.test.tsx
@@ -71,7 +71,6 @@ it('renders a call to action button, when PMs are defined on the group', () => {
             email: 'test1@test.com',
           },
           role: 'Project Manager',
-          href: '',
         },
         {
           user: {
@@ -81,7 +80,6 @@ it('renders a call to action button, when PMs are defined on the group', () => {
             email: 'test2@test.com',
           },
           role: 'Project Manager',
-          href: '',
         },
       ]}
     />,
@@ -106,7 +104,6 @@ it('does not render a call to action button, when a PM is NOT defined on the gro
             email: 'test@test.com',
           },
           role: 'Chair',
-          href: '',
         },
       ]}
     />,

--- a/packages/react-components/src/templates/__tests__/GroupProfileAbout.test.tsx
+++ b/packages/react-components/src/templates/__tests__/GroupProfileAbout.test.tsx
@@ -57,3 +57,28 @@ it('assigns given id to the members section for deep linking', () => {
     /members/i,
   );
 });
+
+it('renders a call to action button, when a PM is defined on the group', () => {
+  const { getByText } = render(
+    <GroupProfileAbout
+      {...props}
+      leaders={[
+        {
+          user: {
+            ...createUserResponse(),
+            displayName: 'John',
+            teams: [],
+            email: 'test@test.com',
+          },
+          role: 'Project Manager',
+          href: '',
+        },
+      ]}
+    />,
+  );
+
+  expect(getByText(/contact pm/i).closest('a')).toHaveAttribute(
+    'href',
+    'mailto:test@test.com',
+  );
+});

--- a/packages/react-components/src/templates/__tests__/GroupProfileAbout.test.tsx
+++ b/packages/react-components/src/templates/__tests__/GroupProfileAbout.test.tsx
@@ -58,7 +58,7 @@ it('assigns given id to the members section for deep linking', () => {
   );
 });
 
-it('renders a call to action button, when a PM is defined on the group', () => {
+it('renders a call to action button, when PMs are defined on the group', () => {
   const { getByText } = render(
     <GroupProfileAbout
       {...props}
@@ -68,7 +68,17 @@ it('renders a call to action button, when a PM is defined on the group', () => {
             ...createUserResponse(),
             displayName: 'John',
             teams: [],
-            email: 'test@test.com',
+            email: 'test1@test.com',
+          },
+          role: 'Project Manager',
+          href: '',
+        },
+        {
+          user: {
+            ...createUserResponse(),
+            displayName: 'Johnny',
+            teams: [],
+            email: 'test2@test.com',
           },
           role: 'Project Manager',
           href: '',
@@ -79,7 +89,7 @@ it('renders a call to action button, when a PM is defined on the group', () => {
 
   expect(getByText(/contact pm/i).closest('a')).toHaveAttribute(
     'href',
-    'mailto:test@test.com',
+    'mailto:test1@test.com,test2@test.com',
   );
 });
 


### PR DESCRIPTION
This PR introduces the following changes:

- adds a CtaCard to GroupProfileAbout template
- checks whether there's a Group as one or more leaders with the role "Project Manager", and if there's any show the Call to Action, providing the PM's email to the mailTo link
- changes the signature of the createMailTo function, allowing for a single email (string) or a list of emails to be passed
- extracts two functions from the above function, to create both a URL to a single email or a list of emails