### PR TITLE
feat: change welcome email's copy

### DIFF
--- a/packages/react-components/src/messages/Welcome.tsx
+++ b/packages/react-components/src/messages/Welcome.tsx
@@ -1,15 +1,7 @@
 import React, { ComponentProps } from 'react';
-import css from '@emotion/css';
 import Layout from './Layout';
 import { Display, Paragraph, Link } from '../atoms';
-
-const listStyle = css({
-  margin: 0,
-  paddingLeft: '16px',
-  paddingTop: '12px',
-  paddingBottom: '12px',
-  paddingRight: '12px',
-});
+import { mailToSupport } from '../mail';
 
 type WelcomeProps = ComponentProps<typeof Layout> & {
   readonly firstName: string;
@@ -25,21 +17,25 @@ const Welcome: React.FC<WelcomeProps> = ({
   <Layout privacyPolicyHref={privacyPolicyHref} termsHref={termsHref}>
     <Display styleAsHeading={3}>Dear {firstName}</Display>
     <>
-      <Paragraph>Congratulations on being awarded the ASAP Grant.</Paragraph>
       <Paragraph>
-        We're delighted to be able to invite you to join the ASAP Hub!
+        Thank you for filling out your Profile Form, you’re one step away from
+        joining the ASAP Hub! Please choose a login method and activate your
+        account.
       </Paragraph>
-      <Paragraph>The ASAP Hub is the perfect place to:</Paragraph>
-      <ul css={listStyle}>
-        <li>Collaborate with your team</li>
-        <li>Expand your wider network</li>
-        <li>Gain access to new resources</li>
-      </ul>
-      <Paragraph>Join the community and set up your profile.</Paragraph>
+      <Link buttonStyle primary href={link}>
+        Activate account
+      </Link>
+      <Paragraph>
+        The ASAP Hub is a platform where you’ll be able to collaborate with your
+        team, connect with others, join ASAP events, and access new resources
+        generated throughout the network.
+      </Paragraph>
+      <Paragraph>
+        If you're facing a technical issue with the Hub, please{' '}
+        <Link href={mailToSupport()}>get in touch</Link>. Our Support team is
+        happy to help!
+      </Paragraph>
     </>
-    <Link buttonStyle primary href={link}>
-      Create account
-    </Link>
   </Layout>
 );
 

--- a/packages/react-components/src/messages/__tests__/Welcome.test.tsx
+++ b/packages/react-components/src/messages/__tests__/Welcome.test.tsx
@@ -1,28 +1,40 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, RenderResult } from '@testing-library/react';
 
 import Welcome from '../Welcome';
 
-it('renders the welcome template with name and link', () => {
-  const { getByRole } = render(
-    <Welcome
-      firstName="John Doe"
-      link="https://example.com"
-      privacyPolicyHref={'https://hub.asap.science/privacy-policy'}
-      termsHref={'https://hub.asap.science/terms-and-conditions'}
-    />,
-  );
+describe('welcome email template', () => {
+  let result!: RenderResult;
 
-  const heading = getByRole('heading');
-  const cta = getByRole('link', {
-    name: /activate account/i,
-  }) as HTMLAnchorElement;
-  const mailToSupport = getByRole('link', {
-    name: /get in touch/i,
-  }) as HTMLAnchorElement;
+  beforeEach(() => {
+    result = render(
+      <Welcome
+        firstName="John Doe"
+        link="https://example.com"
+        privacyPolicyHref={'https://hub.asap.science/privacy-policy'}
+        termsHref={'https://hub.asap.science/terms-and-conditions'}
+      />,
+    );
+  });
 
-  expect(heading.textContent).toContain('John Doe');
-  expect(cta.href).toBe('https://example.com/');
-  expect(mailToSupport.protocol).toBe('mailto:');
-  expect(mailToSupport.pathname).toBe('techsupport@asap.science');
+  it('renders the correct grantee name', () => {
+    const heading = result.getByRole('heading');
+    expect(heading.textContent).toContain('John Doe');
+  });
+
+  it('renders the correct link on the Activate Account CTA', () => {
+    const cta = result.getByRole('link', {
+      name: /activate account/i,
+    }) as HTMLAnchorElement;
+    expect(cta.href).toBe('https://example.com/');
+  });
+
+  it('renders the correct mail to on the get in touch mailto link', () => {
+    const mailToSupport = result.getByRole('link', {
+      name: /get in touch/i,
+    }) as HTMLAnchorElement;
+
+    expect(mailToSupport.protocol).toBe('mailto:');
+    expect(mailToSupport.pathname).toBe('techsupport@asap.science');
+  });
 });

--- a/packages/react-components/src/messages/__tests__/Welcome.test.tsx
+++ b/packages/react-components/src/messages/__tests__/Welcome.test.tsx
@@ -23,10 +23,8 @@ describe('welcome email template', () => {
   });
 
   it('renders the correct link on the Activate Account CTA', () => {
-    const cta = result.getByRole('link', {
-      name: /activate account/i,
-    }) as HTMLAnchorElement;
-    expect(cta.href).toBe('https://example.com/');
+    const cta = result.getByText(/activate account/i);
+    expect(cta.closest('a')).toHaveAttribute('href', 'https://example.com');
   });
 
   it('renders the correct mail to on the get in touch mailto link', () => {

--- a/packages/react-components/src/messages/__tests__/Welcome.test.tsx
+++ b/packages/react-components/src/messages/__tests__/Welcome.test.tsx
@@ -14,5 +14,15 @@ it('renders the welcome template with name and link', () => {
   );
 
   const heading = getByRole('heading');
+  const cta = getByRole('link', {
+    name: /activate account/i,
+  }) as HTMLAnchorElement;
+  const mailToSupport = getByRole('link', {
+    name: /get in touch/i,
+  }) as HTMLAnchorElement;
+
   expect(heading.textContent).toContain('John Doe');
+  expect(cta.href).toBe('https://example.com/');
+  expect(mailToSupport.protocol).toBe('mailto:');
+  expect(mailToSupport.pathname).toBe('techsupport@asap.science');
 });


### PR DESCRIPTION
This PR introduces the following changes:

* new copy
* renames the test file to represent the test naming convention of the project
* tests check for CTA to Activate Account and mail to Support