### PR TITLE
refactor(frontend): handle possible 404s on sub resources

### DIFF
--- a/apps/frontend/src/network/groups/events/EventList.tsx
+++ b/apps/frontend/src/network/groups/events/EventList.tsx
@@ -27,7 +27,7 @@ const EventList: React.FC<EventListProps> = ({
     EVENT_CONSIDERED_PAST_HOURS_AFTER_EVENT,
   ).toISOString();
 
-  const { items, total } = useGroupEvents(groupId, {
+  const events = useGroupEvents(groupId, {
     searchQuery,
     ...(past
       ? {
@@ -44,14 +44,23 @@ const EventList: React.FC<EventListProps> = ({
     pageSize,
   });
 
-  const { numberOfPages, renderPageHref } = usePagination(total, pageSize);
+  if (events === 'noSuchGroup') {
+    throw new Error(
+      `Failed to fetch events for group with id ${groupId}. Group does not exist.`,
+    );
+  }
+
+  const { numberOfPages, renderPageHref } = usePagination(
+    events.total,
+    pageSize,
+  );
   return (
     <EventsList
       currentPageIndex={currentPage}
-      numberOfItems={total}
+      numberOfItems={events.total}
       renderPageHref={renderPageHref}
       numberOfPages={numberOfPages}
-      events={items}
+      events={events.items}
     />
   );
 };

--- a/apps/frontend/src/network/groups/events/__tests__/api.test.ts
+++ b/apps/frontend/src/network/groups/events/__tests__/api.test.ts
@@ -31,20 +31,20 @@ describe('getGroupEvents', () => {
 
   it('returns successfully fetched events', async () => {
     const events = createListEventResponse(1);
-    nock(API_BASE_URL)
-      .get('/groups/42/events')
-      .query({ take: '10', skip: '0', after: '2021-01-01' })
-      .reply(200, events);
+    nock(API_BASE_URL).get('/groups/42/events').query(true).reply(200, events);
     expect(await getGroupEvents('42', { after: '2021-01-01' }, '')).toEqual(
       events,
     );
   });
 
+  it('returns undefined for a 404', async () => {
+    nock(API_BASE_URL).get('/groups/42/events').query(true).reply(404);
+    expect(await getGroupEvents('42', { before: '2021-01-01' }, '')).toBe(
+      undefined,
+    );
+  });
   it('errors for error status', async () => {
-    nock(API_BASE_URL)
-      .get('/groups/42/events')
-      .query({ take: '10', skip: '0', after: '2021-01-01' })
-      .reply(500);
+    nock(API_BASE_URL).get('/groups/42/events').query(true).reply(500);
     await expect(
       getGroupEvents('42', { after: '2021-01-01' }, ''),
     ).rejects.toThrowErrorMatchingInlineSnapshot(

--- a/apps/frontend/src/network/groups/events/api.ts
+++ b/apps/frontend/src/network/groups/events/api.ts
@@ -10,14 +10,18 @@ export const getGroupEvents = async (
   id: string,
   options: GetListOptions & BeforeOrAfter,
   authorization: string,
-): Promise<ListEventResponse> => {
+): Promise<ListEventResponse | undefined> => {
   const url = createListApiUrl(`groups/${id}/events`);
   if (options.before) url.searchParams.append('before', options.before);
   else if (options.after) url.searchParams.append('after', options.after);
+
   const resp = await fetch(url.toString(), {
     headers: { authorization },
   });
   if (!resp.ok) {
+    if (resp.status === 404) {
+      return undefined;
+    }
     throw new Error(
       `Failed to fetch events for group with id ${id}. Expected status 2xx. Received status ${`${resp.status} ${resp.statusText}`.trim()}.`,
     );

--- a/apps/frontend/src/network/teams/groups/GroupsCard.tsx
+++ b/apps/frontend/src/network/teams/groups/GroupsCard.tsx
@@ -4,8 +4,15 @@ import { TeamGroupsCard } from '@asap-hub/react-components';
 import { useTeamGroupsById } from './state';
 
 const GroupsCard: React.FC<{ id: string }> = ({ id }) => {
-  const { items, total } = useTeamGroupsById(id);
-  return total > 0 ? <TeamGroupsCard groups={items} /> : null;
+  const groups = useTeamGroupsById(id);
+
+  if (!groups) {
+    throw new Error(
+      `Failed to fetch groups for team with id ${id}. Team does not exist.`,
+    );
+  }
+
+  return groups.total > 0 ? <TeamGroupsCard groups={groups.items} /> : null;
 };
 
 export default GroupsCard;

--- a/apps/frontend/src/network/teams/groups/__tests__/api.test.ts
+++ b/apps/frontend/src/network/teams/groups/__tests__/api.test.ts
@@ -24,12 +24,17 @@ describe('getTeamGroups', () => {
     nock(API_BASE_URL).get('/teams/42/groups').reply(200, groups);
     expect(await getTeamGroups('42', '')).toEqual(groups);
   });
+
+  it('returns undefined for a 404', async () => {
+    nock(API_BASE_URL).get('/teams/42/groups').reply(404);
+    expect(await getTeamGroups('42', '')).toBe(undefined);
+  });
   it('errors for an error status', async () => {
     nock(API_BASE_URL).get('/teams/42/groups').reply(500);
     await expect(
       getTeamGroups('42', ''),
     ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `"Failed to fetch team groups with id 42. Expected status 2xx. Received status 500."`,
+      `"Failed to fetch team groups with id 42. Expected status 2xx or 404. Received status 500."`,
     );
   });
 });

--- a/apps/frontend/src/network/teams/groups/api.ts
+++ b/apps/frontend/src/network/teams/groups/api.ts
@@ -5,13 +5,16 @@ import { API_BASE_URL } from '../../../config';
 export const getTeamGroups = async (
   id: string,
   authorization: string,
-): Promise<ListGroupResponse> => {
+): Promise<ListGroupResponse | undefined> => {
   const resp = await fetch(`${API_BASE_URL}/teams/${id}/groups`, {
     headers: { authorization },
   });
   if (!resp.ok) {
+    if (resp.status === 404) {
+      return undefined;
+    }
     throw new Error(
-      `Failed to fetch team groups with id ${id}. Expected status 2xx. Received status ${`${resp.status} ${resp.statusText}`.trim()}.`,
+      `Failed to fetch team groups with id ${id}. Expected status 2xx or 404. Received status ${`${resp.status} ${resp.statusText}`.trim()}.`,
     );
   }
   return resp.json();

--- a/apps/frontend/src/network/teams/groups/state.ts
+++ b/apps/frontend/src/network/teams/groups/state.ts
@@ -5,7 +5,7 @@ import { authorizationState } from '@asap-hub/frontend/src/auth/state';
 import { refreshTeamState } from '../state';
 import { getTeamGroups } from './api';
 
-const teamGroupsState = selectorFamily<ListGroupResponse, string>({
+const teamGroupsState = selectorFamily<ListGroupResponse | undefined, string>({
   key: 'teamGroups',
   get: (id) => async ({ get }) => {
     get(refreshTeamState(id));

--- a/apps/frontend/src/network/users/Research.tsx
+++ b/apps/frontend/src/network/users/Research.tsx
@@ -11,7 +11,7 @@ import { network } from '@asap-hub/routing';
 
 import { usePatchUserById } from './state';
 import Frame from '../../structure/Frame';
-import Groups from './groups/Groups';
+import GroupsCard from './groups/GroupsCard';
 
 type ResearchProps = {
   user: UserResponse;
@@ -30,7 +30,7 @@ const Research: React.FC<ResearchProps> = ({ user }) => {
         {...user}
         userProfileGroupsCard={
           <Frame fallback={null}>
-            <Groups user={user} />
+            <GroupsCard user={user} />
           </Frame>
         }
         teams={user.teams.map((team) => ({

--- a/apps/frontend/src/network/users/groups/GroupsCard.tsx
+++ b/apps/frontend/src/network/users/groups/GroupsCard.tsx
@@ -4,12 +4,18 @@ import { UserResponse } from '@asap-hub/model';
 
 import { useUserGroupsById } from './state';
 
-const UserGroups: React.FC<{ user: UserResponse }> = ({ user }) => {
+const GroupsCard: React.FC<{ user: UserResponse }> = ({ user }) => {
   const groups = useUserGroupsById(user.id);
+
+  if (!groups) {
+    throw new Error(
+      `Failed to fetch groups for user with id ${user.id}. User does not exist.`,
+    );
+  }
 
   return groups.total ? (
     <UserProfileGroups {...user} groups={groups.items} />
   ) : null;
 };
 
-export default UserGroups;
+export default GroupsCard;

--- a/apps/frontend/src/network/users/groups/__tests__/GroupsCard.test.tsx
+++ b/apps/frontend/src/network/users/groups/__tests__/GroupsCard.test.tsx
@@ -10,18 +10,26 @@ import {
 } from '@asap-hub/frontend/src/auth/test-utils';
 import { StaticRouter } from 'react-router-dom';
 import { RecoilRoot } from 'recoil';
+import { mockConsoleError } from '@asap-hub/dom-test-utils';
 
-import UserGroups from '../Groups';
+import ErrorBoundary from '@asap-hub/frontend/src/structure/ErrorBoundary';
+import GroupsCard from '../GroupsCard';
 import { getUserGroups } from '../api';
+import { refreshUserState } from '../../state';
 
 jest.mock('../api');
-
 const mockGetUserGroups = getUserGroups as jest.MockedFunction<
   typeof getUserGroups
 >;
 
+mockConsoleError();
+
+const userId = 'u42';
+
 const wrapper: React.FC<Record<string, never>> = ({ children }) => (
-  <RecoilRoot>
+  <RecoilRoot
+    initializeState={({ set }) => set(refreshUserState(userId), Math.random())}
+  >
     <React.Suspense fallback="loading">
       <Auth0Provider user={{ id: '42' }}>
         <WhenReady>
@@ -35,7 +43,9 @@ const wrapper: React.FC<Record<string, never>> = ({ children }) => (
 it('is not rendered when there are no groups', async () => {
   mockGetUserGroups.mockResolvedValue(createListGroupResponse(0));
   const { queryByText } = render(
-    <UserGroups user={{ ...createUserResponse({}, 0), firstName: 'test' }} />,
+    <GroupsCard
+      user={{ ...createUserResponse({}, 0), id: userId, firstName: 'test' }}
+    />,
     { wrapper },
   );
   await waitFor(() => {
@@ -48,11 +58,26 @@ it('is not rendered when there are no groups', async () => {
 it('is rendered when there are groups', async () => {
   mockGetUserGroups.mockResolvedValue(createListGroupResponse(1));
   const { queryByText } = render(
-    <UserGroups user={{ ...createUserResponse({}, 1), firstName: 'test' }} />,
+    <GroupsCard
+      user={{ ...createUserResponse({}, 1), id: userId, firstName: 'test' }}
+    />,
     { wrapper },
   );
   await waitFor(() => {
     expect(queryByText(/loading/i)).not.toBeInTheDocument();
     expect(queryByText(/test’ groups/i)).toBeInTheDocument();
   });
+});
+
+it('throws if the user does not exist', async () => {
+  mockGetUserGroups.mockResolvedValue(undefined);
+  const errorWrapper: React.FC = ({ children }) =>
+    React.createElement(wrapper, {}, <ErrorBoundary>{children}</ErrorBoundary>);
+  const { findByText } = render(
+    <GroupsCard user={{ ...createUserResponse(), id: userId }} />,
+    {
+      wrapper: errorWrapper,
+    },
+  );
+  expect(await findByText(/failed.+user.+exist/i)).toBeVisible();
 });

--- a/apps/frontend/src/network/users/groups/__tests__/api.test.ts
+++ b/apps/frontend/src/network/users/groups/__tests__/api.test.ts
@@ -24,12 +24,17 @@ describe('getUserGroups', () => {
     nock(API_BASE_URL).get('/users/42/groups').reply(200, groups);
     expect(await getUserGroups('42', '')).toEqual(groups);
   });
+
+  it('returns undefined for a 404', async () => {
+    nock(API_BASE_URL).get('/users/42/groups').reply(404);
+    expect(await getUserGroups('42', '')).toBe(undefined);
+  });
   it('errors for error status', async () => {
     nock(API_BASE_URL).get('/users/42/groups').reply(500);
     await expect(
       getUserGroups('42', ''),
     ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `"Failed to fetch groups for user with id 42. Expected status 2xx. Received status 500."`,
+      `"Failed to fetch groups for user with id 42. Expected status 2xx or 404. Received status 500."`,
     );
   });
 });

--- a/apps/frontend/src/network/users/groups/api.ts
+++ b/apps/frontend/src/network/users/groups/api.ts
@@ -4,13 +4,16 @@ import { API_BASE_URL } from '@asap-hub/frontend/src/config';
 export const getUserGroups = async (
   id: string,
   authorization: string,
-): Promise<ListGroupResponse> => {
+): Promise<ListGroupResponse | undefined> => {
   const resp = await fetch(`${API_BASE_URL}/users/${id}/groups`, {
     headers: { authorization },
   });
   if (!resp.ok) {
+    if (resp.status === 404) {
+      return undefined;
+    }
     throw new Error(
-      `Failed to fetch groups for user with id ${id}. Expected status 2xx. Received status ${`${resp.status} ${resp.statusText}`.trim()}.`,
+      `Failed to fetch groups for user with id ${id}. Expected status 2xx or 404. Received status ${`${resp.status} ${resp.statusText}`.trim()}.`,
     );
   }
   return resp.json();

--- a/apps/frontend/src/network/users/groups/state.ts
+++ b/apps/frontend/src/network/users/groups/state.ts
@@ -5,7 +5,7 @@ import { authorizationState } from '@asap-hub/frontend/src/auth/state';
 import { refreshUserState } from '../state';
 import { getUserGroups } from './api';
 
-const userGroupsState = selectorFamily<ListGroupResponse, string>({
+const userGroupsState = selectorFamily<ListGroupResponse | undefined, string>({
   key: 'userGroups',
   get: (id) => async ({ get }) => {
     get(refreshUserState(id));


### PR DESCRIPTION
We don't really use this new API client capability yet (all the consumers are components used in contexts where we expect the parent resource has to be present so that you are even able to get to that place in the frontend) and continue to throw (show error boundaries) if these 404s happen.
But still, we should model API clients to represent every expected error with a return value, and only unexpected errors by throwing — at some point somewhere we'll want custom handling for the 404 because we're fetching a sub resource without having tried to fetch the parent yet, and if only then we start modeling the API clients to cover all expected cases, we'll have inconsistencies.
