### PR TITLE
fix: Changing event status to cancelled

### DIFF
--- a/apps/asap-server/src/utils/sync-google-calendar.ts
+++ b/apps/asap-server/src/utils/sync-google-calendar.ts
@@ -36,6 +36,7 @@ const fetchEvents = async (
     pageToken: pageToken || undefined,
     calendarId: googleCalendarId,
     singleEvents: true, // recurring events come returned as single events
+    showDeleted: true,
   };
 
   if (!syncToken) {

--- a/apps/asap-server/test/utils/sync-google-calendar.test.ts
+++ b/apps/asap-server/test/utils/sync-google-calendar.test.ts
@@ -51,6 +51,7 @@ describe('Sync calendar util hook', () => {
     const googleParams = {
       calendarId: 'google-calendar-id',
       singleEvents: true,
+      showDeleted: true,
       timeMin: '2020-10-01T00:00:00.000Z',
       timeMax: '2023-09-04T10:37:50.000Z',
       pageToken: undefined,


### PR DESCRIPTION
Fixes a bug whereby a deleted event remains confirm upon sync after being deleted from the calendar. 

See comments of: https://trello.com/c/1NRKvLxZ/1102-syncing-with-gcal-is-failing for more details