### PR TITLE
fix: Current event showing up as a past event

### DIFF
--- a/apps/asap-server/src/controllers/events.ts
+++ b/apps/asap-server/src/controllers/events.ts
@@ -61,7 +61,7 @@ export default class Events implements EventController {
     }
 
     if (before) {
-      filters.push(`data/startDate/iv lt ${before}`);
+      filters.push(`data/endDate/iv lt ${before}`);
     }
 
     let orderby = '';

--- a/apps/asap-server/test/controllers/events.test.ts
+++ b/apps/asap-server/test/controllers/events.test.ts
@@ -94,7 +94,7 @@ describe('Event controller', () => {
     });
 
     describe('Date filters', () => {
-      test('Should apply the "after" filter', async () => {
+      test('Should apply the "after" filter to the end-date', async () => {
         nock(config.baseUrl)
           .post(`/api/content/${config.appName}/graphql`, {
             query: buildGraphQLQueryFetchEvents(
@@ -108,11 +108,11 @@ describe('Event controller', () => {
         });
       });
 
-      test('Should apply the "before" filter', async () => {
+      test('Should apply the "before" filter to the end-date', async () => {
         nock(config.baseUrl)
           .post(`/api/content/${config.appName}/graphql`, {
             query: buildGraphQLQueryFetchEvents(
-              'data/hidden/iv ne true and data/startDate/iv lt before-date',
+              'data/hidden/iv ne true and data/endDate/iv lt before-date',
             ),
           })
           .reply(200, fetchEventsResponse);
@@ -124,7 +124,7 @@ describe('Event controller', () => {
 
       test('Should apply both the "after" and "before" filters', async () => {
         const expectedFilter =
-          'data/hidden/iv ne true and data/endDate/iv gt after-date and data/startDate/iv lt before-date';
+          'data/hidden/iv ne true and data/endDate/iv gt after-date and data/endDate/iv lt before-date';
 
         nock(config.baseUrl)
           .post(`/api/content/${config.appName}/graphql`, {


### PR DESCRIPTION
Modifies the 'before' filter to use the end-date.

see: https://trello.com/c/5c8774jp/1138-current-event-showing-up-as-a-past-event