### PR TITLE
feat: Create schema migration runner

### DIFF
--- a/apps/asap-cli/src/import/protocols/insert.ts
+++ b/apps/asap-cli/src/import/protocols/insert.ts
@@ -97,6 +97,11 @@ export default async (data: Protocol): Promise<void> => {
         data.team
       } || Authors: ${data.authors.join(', ')}.`,
     },
+    description: {
+      iv: `From Team ${data.team} and authors: ${data.authors.join(
+        ', ',
+      )}. Keywords: ${data.keywords.join(', ')}.`,
+    },
     tags: {
       iv: data.keywords,
     },

--- a/apps/asap-cli/test/import/protocols.fixture.ts
+++ b/apps/asap-cli/test/import/protocols.fixture.ts
@@ -7,6 +7,10 @@ export const createProtocolsRequest: RestResearchOutput['data'] = {
   text: {
     iv: 'From Team team || Authors: author 1, author 2.',
   },
+  description: {
+    iv:
+      'From Team team and authors: author 1, author 2. Keywords: a, b, c d, e.',
+  },
   link: {
     iv: 'https://www.protocols.io/view/link1',
   },

--- a/apps/asap-server/.eslintrc.js
+++ b/apps/asap-server/.eslintrc.js
@@ -2,7 +2,14 @@ module.exports = {
   rules: {
     'no-use-before-define': 'off',
     'no-unused-vars': 'off',
+    'no-await-in-loop': 'off',
     'lines-between-class-members': 'off',
     '@typescript-eslint/no-unused-vars': ['error'],
+    'no-restricted-syntax': [
+      'error',
+      'ForInStatement',
+      'LabeledStatement',
+      'WithStatement',
+    ],
   },
 };

--- a/apps/asap-server/package.json
+++ b/apps/asap-server/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "build:babel": "../../scripts/build-babel.sh build",
     "watch:babel": "../../scripts/build-babel.sh watch",
-    "start:server": "tsnd --transpile-only ./src/server.ts"
+    "start:server": "tsnd --transpile-only ./src/server.ts",
+    "migration:create": "./scripts/create-migration.sh"
   },
   "dependencies": {
     "@asap-hub/auth": "workspace:*",

--- a/apps/asap-server/scripts/create-migration.sh
+++ b/apps/asap-server/scripts/create-migration.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+input=$1
+
+if [ -z "$input" ]; then
+    echo "Missing argument - migration name"
+    exit
+fi
+
+timestamp=$(date +%s%N | cut -b1-13)
+migration="$timestamp-$input"
+
+echo "Generating migration $migration..."
+
+cp ./scripts/migration.template ./src/migrations/$migration.ts
+
+echo "Done"

--- a/apps/asap-server/scripts/migration.template
+++ b/apps/asap-server/scripts/migration.template
@@ -1,0 +1,8 @@
+/* istanbul ignore file */
+import { RestResearchOutput, Results, Squidex } from '@asap-hub/squidex';
+import { Migration } from '../handlers/webhooks/webhook-run-migrations';
+
+export default class MoveResearchOutputTextToDescription extends Migration {
+  up = async (): Promise<void> => {};
+  down = async (): Promise<void> => {};
+}

--- a/apps/asap-server/src/config.ts
+++ b/apps/asap-server/src/config.ts
@@ -35,3 +35,4 @@ export const googleApiToken = GOOGLE_API_TOKEN || 'asap-google-api-token';
 export const asapApiUrl = ASAP_API_URL || 'http://localhost:3333';
 export const logLevel = LOG_LEVEL || 'info';
 export const logEnabled = NODE_ENV === 'production' || LOG_ENABLED === 'true';
+export const migrationDir = `${__dirname}/migrations`;

--- a/apps/asap-server/src/handlers/webhooks/webhook-run-migrations.ts
+++ b/apps/asap-server/src/handlers/webhooks/webhook-run-migrations.ts
@@ -1,0 +1,55 @@
+import { Handler } from 'aws-lambda';
+import { promises } from 'fs';
+import logger from '../../utils/logger';
+
+export const run: Handler = async () => {
+  const migrations = await getMigrations();
+
+  for (const migration of migrations) {
+    await migration.up();
+  }
+};
+
+export const rollback: Handler = async () => {
+  const migrations = await getMigrations();
+
+  for (const migration of migrations) {
+    await migration.down();
+  }
+};
+
+const migrationDir = `${__dirname}/../../migrations`;
+
+const getMigrations = async (): Promise<Migration[]> => {
+  const files = (await promises.readdir(migrationDir)).sort();
+
+  const migrations = Promise.all(
+    files.map(async (file) => {
+      logger.debug({ file });
+      const { default: Module } = await import(`${migrationDir}/${file}`);
+
+      if (typeof Module !== 'function') {
+        throw new Error(`${file} does not export a valid module`);
+      }
+
+      const migration = new Module();
+
+      if (!isMigration(migration)) {
+        throw new Error(`${file} does not contain a valid migration`);
+      }
+
+      return migration;
+    }),
+  );
+
+  return migrations;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const isMigration = (instance: any): instance is Migration =>
+  typeof instance.up === 'function' && typeof instance.down === 'function';
+
+export interface Migration {
+  up: () => Promise<void>;
+  down: () => Promise<void>;
+}

--- a/apps/asap-server/src/handlers/webhooks/webhook-run-migrations.ts
+++ b/apps/asap-server/src/handlers/webhooks/webhook-run-migrations.ts
@@ -62,10 +62,8 @@ export const runFactory = (
 export const rollbackFactory = (
   logger: Logger,
   client: Squidex<RestMigration>,
-  readDir: typeof fsPromise.readdir,
   importModule: ImportModuleFromPath,
 ): Handler => async () => {
-  // const getMigrationPaths = getMigrationPathsFromDirectoryFactory(readDir);
   const getLatestMigrationPathFromDb = getLatestMigrationPathFromDbFactory(
     client,
   );
@@ -172,10 +170,9 @@ const getMigrationsFromPathsFactory = (
 const filterUnexecutedMigrationsFactory = (client: Squidex<RestMigration>) =>
   filterMigrationsFactory(client);
 
-const filterMigrationsFactory = (
-  client: Squidex<RestMigration>,
-  unexecuted = true,
-) => (migrationPaths: string[]) => {
+const filterMigrationsFactory = (client: Squidex<RestMigration>) => (
+  migrationPaths: string[],
+) => {
   const asyncFilter = async <T>(
     arr: T[],
     predicate: (elem: T) => Promise<boolean>,
@@ -191,10 +188,10 @@ const filterMigrationsFactory = (
         filter: { path: 'data/name/iv', op: 'eq', value: migration },
       });
 
-      return !unexecuted;
+      return false;
     } catch (error) {
       if (isBoom(error, 404)) {
-        return unexecuted;
+        return true;
       }
 
       throw error;
@@ -252,6 +249,5 @@ export const run = runFactory(
 export const rollback = rollbackFactory(
   pinoLogger,
   squidexClient,
-  fsPromise.readdir,
   importModuleFromPath,
 );

--- a/apps/asap-server/src/handlers/webhooks/webhook-run-migrations.ts
+++ b/apps/asap-server/src/handlers/webhooks/webhook-run-migrations.ts
@@ -6,7 +6,7 @@ import { Logger } from 'pino';
 import { migrationDir } from '../../config';
 import pinoLogger from '../../utils/logger';
 
-const squidexClient = new Squidex<RestMigration>('migration');
+const squidexClient = new Squidex<RestMigration>('migrations');
 
 export const runFactory = (
   logger: Logger,

--- a/apps/asap-server/src/handlers/webhooks/webhook-run-migrations.ts
+++ b/apps/asap-server/src/handlers/webhooks/webhook-run-migrations.ts
@@ -1,30 +1,71 @@
+import { RestMigration, Squidex } from '@asap-hub/squidex';
+import { isBoom } from '@hapi/boom';
 import { Handler } from 'aws-lambda';
+import { basename } from 'path';
 import { promises } from 'fs';
+import { migrationDir } from '../../config';
 import logger from '../../utils/logger';
 
+const squidexClient = new Squidex<RestMigration>('migration');
+
 export const run: Handler = async () => {
-  const migrations = await getMigrations();
+  const migrationPaths = await getMigrationPaths();
+  const unexecutedMigrationPaths = await filterUnexecutedMigrations(
+    migrationPaths,
+  );
+
+  logger.debug(
+    { migrations: unexecutedMigrationPaths },
+    'Outstanding migrations',
+  );
+
+  const migrations = await getMigrationsFromPaths(unexecutedMigrationPaths);
 
   for (const migration of migrations) {
+    logger.debug(`Executing migration '${migration.getPath()}`);
     await migration.up();
+    logger.info(`Executed migration '${migration.getPath()}`);
   }
+
+  logger.debug('Finished executing migrations, saving progress...');
+
+  await saveExecutedMigrations(unexecutedMigrationPaths);
+
+  logger.info(`Executed and saved ${migrations.length} migrations`);
 };
 
 export const rollback: Handler = async () => {
-  const migrations = await getMigrations();
+  const migrationPaths = await getMigrationPaths();
+  const executedMigrationPaths = await filterExecutedMigrations(migrationPaths);
 
-  for (const migration of migrations) {
+  logger.debug({ migrations: executedMigrationPaths }, 'Executed migrations');
+
+  if (executedMigrationPaths.length > 0) {
+    // assert non-null because we know the array has at least one element
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const lastMigrationPath = executedMigrationPaths.slice(-1).pop()!;
+    const [migration] = await getMigrationsFromPaths([lastMigrationPath]);
+
+    logger.debug(`Executing rollback of migration '${migration.getPath()}`);
+
     await migration.down();
+
+    logger.debug('Finished executing rollback, saving progress...');
+
+    await removeExecutedMigration(lastMigrationPath);
+
+    logger.info(`Rolled back and removed migration '${migration.getPath()}'`);
   }
 };
 
-const migrationDir = `${__dirname}/../../migrations`;
+const getMigrationPaths = async () =>
+  (await promises.readdir(migrationDir)).sort();
 
-const getMigrations = async (): Promise<Migration[]> => {
-  const files = (await promises.readdir(migrationDir)).sort();
-
+const getMigrationsFromPaths = async (
+  migrationPaths: string[],
+): Promise<Migration[]> => {
   const migrations = Promise.all(
-    files.map(async (file) => {
+    migrationPaths.map(async (file) => {
       logger.debug({ file });
       const { default: Module } = await import(`${migrationDir}/${file}`);
 
@@ -45,11 +86,64 @@ const getMigrations = async (): Promise<Migration[]> => {
   return migrations;
 };
 
+const filterUnexecutedMigrations = (migrationPaths: string[]) =>
+  filterMigrations(migrationPaths);
+const filterExecutedMigrations = (migrationPaths: string[]) =>
+  filterMigrations(migrationPaths, false);
+
+const filterMigrations = (migrationPaths: string[], unexecuted = true) => {
+  const asyncFilter = async <T>(
+    arr: T[],
+    predicate: (elem: T) => Promise<boolean>,
+  ): Promise<T[]> => {
+    const results = await Promise.all(arr.map(predicate));
+
+    return arr.filter((_v, index) => results[index]);
+  };
+
+  return asyncFilter(migrationPaths, async (migration) => {
+    try {
+      await squidexClient.fetchOne({
+        filter: { path: 'data/name/iv', op: 'eq', value: migration },
+      });
+
+      return !unexecuted;
+    } catch (error) {
+      if (isBoom(error, 404)) {
+        return unexecuted;
+      }
+
+      throw error;
+    }
+  });
+};
+
+const saveExecutedMigrations = async (migrations: string[]): Promise<void> => {
+  for (const migration of migrations) {
+    await squidexClient.create({
+      name: {
+        iv: migration,
+      },
+    });
+  }
+};
+
+const removeExecutedMigration = async (migration: string): Promise<void> => {
+  const migrationRecord = await squidexClient.fetchOne({
+    filter: { path: 'data/name/iv', op: 'eq', value: migration },
+  });
+  await squidexClient.delete(migrationRecord.id);
+};
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const isMigration = (instance: any): instance is Migration =>
   typeof instance.up === 'function' && typeof instance.down === 'function';
 
-export interface Migration {
-  up: () => Promise<void>;
-  down: () => Promise<void>;
+export abstract class Migration {
+  abstract up: () => Promise<void>;
+  abstract down: () => Promise<void>;
+  // eslint-disable-next-line class-methods-use-this
+  getPath(): string {
+    return basename(__filename);
+  }
 }

--- a/apps/asap-server/src/migrations/1617196731-move-research-output-text-to-description.ts
+++ b/apps/asap-server/src/migrations/1617196731-move-research-output-text-to-description.ts
@@ -1,7 +1,7 @@
 import { RestResearchOutput, Results, Squidex } from '@asap-hub/squidex';
 import { Migration } from '../handlers/webhooks/webhook-run-migrations';
 
-export default class MoveResearchOutputTextToDescription implements Migration {
+export default class MoveResearchOutputTextToDescription extends Migration {
   up = async (): Promise<void> => {
     const squidexClient = new Squidex<RestResearchOutput>('research-outputs');
 
@@ -21,5 +21,6 @@ export default class MoveResearchOutputTextToDescription implements Migration {
     } while (pointer < result.total);
   };
 
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
   down = async (): Promise<void> => {};
 }

--- a/apps/asap-server/src/migrations/1617196731-move-research-output-text-to-description.ts
+++ b/apps/asap-server/src/migrations/1617196731-move-research-output-text-to-description.ts
@@ -1,3 +1,4 @@
+/* istanbul ignore file */
 import { RestResearchOutput, Results, Squidex } from '@asap-hub/squidex';
 import { Migration } from '../handlers/webhooks/webhook-run-migrations';
 

--- a/apps/asap-server/src/migrations/1617196731-move-research-output-text-to-description.ts
+++ b/apps/asap-server/src/migrations/1617196731-move-research-output-text-to-description.ts
@@ -1,0 +1,10 @@
+import { Migration } from '../handlers/webhooks/webhook-run-migrations';
+import logger from '../utils/logger';
+
+export default class MoveResearchOutputTextToDescription implements Migration {
+  up = async () => {
+    logger.debug('up');
+  };
+
+  down = async () => {};
+}

--- a/apps/asap-server/src/migrations/1617196731-move-research-output-text-to-description.ts
+++ b/apps/asap-server/src/migrations/1617196731-move-research-output-text-to-description.ts
@@ -1,10 +1,25 @@
+import { RestResearchOutput, Results, Squidex } from '@asap-hub/squidex';
 import { Migration } from '../handlers/webhooks/webhook-run-migrations';
-import logger from '../utils/logger';
 
 export default class MoveResearchOutputTextToDescription implements Migration {
-  up = async () => {
-    logger.debug('up');
+  up = async (): Promise<void> => {
+    const squidexClient = new Squidex<RestResearchOutput>('research-outputs');
+
+    let pointer = 0;
+    let result: Results<RestResearchOutput>;
+
+    do {
+      result = await squidexClient.fetch({ $top: 10, $skip: pointer });
+
+      for (const researchOuput of result.items) {
+        await squidexClient.patch(researchOuput.id, {
+          description: researchOuput.data.text,
+        });
+      }
+
+      pointer += 10;
+    } while (pointer < result.total);
   };
 
-  down = async () => {};
+  down = async (): Promise<void> => {};
 }

--- a/apps/asap-server/src/migrations/1617197205-test-migration.ts
+++ b/apps/asap-server/src/migrations/1617197205-test-migration.ts
@@ -1,0 +1,7 @@
+import { Migration } from '../handlers/webhooks/webhook-run-migrations';
+
+export default class TestMigration implements Migration {
+  up = async () => {};
+
+  down = async () => {};
+}

--- a/apps/asap-server/src/migrations/1617197205-test-migration.ts
+++ b/apps/asap-server/src/migrations/1617197205-test-migration.ts
@@ -1,7 +1,0 @@
-import { Migration } from '../handlers/webhooks/webhook-run-migrations';
-
-export default class TestMigration implements Migration {
-  up = async () => {};
-
-  down = async () => {};
-}

--- a/apps/asap-server/test/handlers/webhooks/webhook-run-migrations.test.ts
+++ b/apps/asap-server/test/handlers/webhooks/webhook-run-migrations.test.ts
@@ -30,7 +30,6 @@ describe('Run-migrations Webhook', () => {
   const rollback = rollbackFactory(
     loggerMock,
     squidexClientMock,
-    mockReadDir,
     mockImportModule,
   );
 

--- a/apps/asap-server/test/handlers/webhooks/webhook-run-migrations.test.ts
+++ b/apps/asap-server/test/handlers/webhooks/webhook-run-migrations.test.ts
@@ -1,0 +1,262 @@
+import Boom from '@hapi/boom';
+import {
+  ImportModuleFromPath,
+  Migration,
+  rollbackFactory,
+  runFactory,
+} from '../../../src/handlers/webhooks/webhook-run-migrations';
+import { loggerMock } from '../../mocks/logger.mock';
+import { squidexClientMock } from '../../mocks/squidex-client.mock';
+import { promises as fsPromise } from 'fs';
+import { identity } from '../../helpers/squidex';
+
+describe('Run-migrations Webhook', () => {
+  const mockReadDir: jest.MockedFunction<typeof fsPromise.readdir> = jest.fn();
+  const mockHandlerArguments = [{}, {}, undefined] as [any, any, any];
+  const mockImportModule: jest.MockedFunction<ImportModuleFromPath> = jest.fn();
+  const mockUp = jest.fn();
+  const mockDown = jest.fn();
+  class MockModule extends Migration {
+    up = mockUp;
+    down = mockDown;
+  }
+
+  const run = runFactory(
+    loggerMock,
+    squidexClientMock,
+    mockReadDir,
+    mockImportModule,
+  );
+  const rollback = rollbackFactory(
+    loggerMock,
+    squidexClientMock,
+    mockReadDir,
+    mockImportModule,
+  );
+
+  beforeAll(() => {
+    identity();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Run action', () => {
+    test('Should not run anything if no migration files are present', async () => {
+      mockReadDir.mockResolvedValueOnce([]);
+
+      await run(...mockHandlerArguments);
+
+      expect(loggerMock.info).toBeCalledWith(`Executed and saved 0 migrations`);
+    });
+
+    test('Should not run anything if migration files are present in the directory but also inside the Migrations schema', async () => {
+      mockReadDir.mockResolvedValueOnce(['test-migration.ts'] as any);
+      squidexClientMock.fetchOne.mockResolvedValueOnce({} as any);
+
+      await run(...mockHandlerArguments);
+
+      expect(loggerMock.info).toBeCalledWith(`Executed and saved 0 migrations`);
+    });
+
+    test('Should run the outstanding migration if it is not inside the Migrations schema, then save it in the schema', async () => {
+      mockReadDir.mockResolvedValueOnce(['test-migration.ts'] as any);
+      squidexClientMock.fetchOne.mockRejectedValueOnce(Boom.notFound());
+
+      const mockDefaultModule = { default: MockModule };
+      mockImportModule.mockResolvedValueOnce(mockDefaultModule);
+
+      await run(...mockHandlerArguments);
+
+      expect(mockUp).toHaveBeenCalled();
+      expect(squidexClientMock.create).toHaveBeenCalledWith({
+        name: {
+          iv: 'test-migration.ts',
+        },
+      });
+      expect(loggerMock.info).toBeCalledWith(`Executed and saved 1 migrations`);
+    });
+
+    test('Should sort the migrations and execute them in the name order', async () => {
+      mockReadDir.mockResolvedValueOnce([
+        '2-test-migration.ts',
+        '3-test-migration.ts',
+        '1-test-migration.ts',
+      ] as any);
+      squidexClientMock.fetchOne.mockRejectedValue(Boom.notFound());
+
+      const mockDefaultModule = { default: MockModule };
+      mockImportModule.mockResolvedValue(mockDefaultModule);
+
+      const executionPaths: string[] = [];
+      mockUp.mockImplementation(function (this: Migration) {
+        executionPaths.push(this.path);
+
+        return Promise.resolve(null);
+      });
+
+      await run(...mockHandlerArguments);
+
+      expect(mockUp).toHaveBeenCalledTimes(3);
+      expect(executionPaths).toEqual([
+        '1-test-migration.ts',
+        '2-test-migration.ts',
+        '3-test-migration.ts',
+      ]);
+    });
+
+    test('Should not insert the migration into Migrations schema if it fails to run', async () => {
+      mockReadDir.mockResolvedValueOnce(['test-migration.ts'] as any);
+      squidexClientMock.fetchOne.mockRejectedValueOnce(Boom.notFound());
+
+      const mockDefaultModule = { default: MockModule };
+      mockImportModule.mockResolvedValueOnce(mockDefaultModule);
+
+      mockUp.mockRejectedValueOnce(new Error('some error'));
+
+      await run(...mockHandlerArguments);
+
+      expect(mockUp).toHaveBeenCalled();
+      expect(squidexClientMock.create).not.toHaveBeenCalled();
+      expect(loggerMock.info).toBeCalledWith(`Executed and saved 0 migrations`);
+    });
+
+    test('Should not run the consecutive migrations after one fails to run and only save the ones that have', async () => {
+      mockReadDir.mockResolvedValueOnce([
+        '1-test-migration.ts',
+        '2-test-migration.ts',
+        '3-test-migration.ts',
+      ] as any);
+      squidexClientMock.fetchOne.mockRejectedValue(Boom.notFound());
+
+      const mockDefaultModule = { default: MockModule };
+      mockImportModule.mockResolvedValue(mockDefaultModule);
+
+      mockUp.mockResolvedValueOnce(null);
+      mockUp.mockRejectedValueOnce(new Error());
+      mockUp.mockResolvedValueOnce(null);
+
+      await run(...mockHandlerArguments);
+
+      expect(mockUp).toHaveBeenCalledTimes(2);
+      expect(squidexClientMock.create).toHaveBeenCalledWith({
+        name: {
+          iv: '1-test-migration.ts',
+        },
+      });
+      expect(loggerMock.error).toHaveBeenCalledWith(
+        expect.any(Error),
+        expect.stringMatching(/2-test-migration/),
+      );
+      expect(loggerMock.info).toBeCalledWith(`Executed and saved 1 migrations`);
+    });
+  });
+
+  describe('Rollback action', () => {
+    test('Should not run anything if no migrations are present in the Migrations schema', async () => {
+      squidexClientMock.fetch.mockResolvedValueOnce({
+        total: 0,
+        items: [],
+      });
+
+      await rollback(...mockHandlerArguments);
+
+      expect(mockDown).not.toHaveBeenCalled();
+    });
+
+    test('Should not run anything if a migration is present in the Migrations schema but the file is not', async () => {
+      squidexClientMock.fetch.mockResolvedValueOnce({
+        total: 1,
+        items: [
+          {
+            created: '',
+            lastModified: '',
+            id: '',
+            data: {
+              name: { iv: '1-test-migration.ts' },
+            },
+          },
+        ],
+      });
+      mockImportModule.mockRejectedValueOnce(new Error('File not found'));
+
+      await rollback(...mockHandlerArguments);
+
+      expect(mockDown).not.toHaveBeenCalled();
+      expect(loggerMock.error).toHaveBeenCalledWith(
+        expect.any(Error),
+        expect.stringMatching(/1-test-migration.ts/),
+      );
+    });
+
+    test('Should only run the latest migration rollback from the Migrations schema and remove it once the rollback has been run', async () => {
+      squidexClientMock.fetch.mockResolvedValueOnce({
+        total: 2,
+        items: [
+          {
+            created: '',
+            lastModified: '',
+            id: 'test-ID-2',
+            data: {
+              name: { iv: '2-test-migration.ts' },
+            },
+          },
+          {
+            created: '',
+            lastModified: '',
+            id: 'test-ID-1',
+            data: {
+              name: { iv: '1-test-migration.ts' },
+            },
+          },
+        ],
+      });
+      const mockDefaultModule = { default: MockModule };
+      mockImportModule.mockResolvedValueOnce(mockDefaultModule);
+      squidexClientMock.fetchOne.mockResolvedValueOnce({
+        created: '',
+        lastModified: '',
+        id: 'test-ID-2',
+        data: {
+          name: { iv: '2-test-migration.ts' },
+        },
+      });
+
+      await rollback(...mockHandlerArguments);
+
+      expect(mockDown).toHaveBeenCalled();
+      expect(squidexClientMock.delete).toHaveBeenCalledWith('test-ID-2');
+      expect(loggerMock.info).toBeCalledWith(
+        `Rolled back and removed migration '2-test-migration.ts'`,
+      );
+    });
+
+    test('Should run rollback and if it fails - report the error but do not remove it from the Migrations schema', async () => {
+      squidexClientMock.fetch.mockResolvedValueOnce({
+        total: 1,
+        items: [
+          {
+            created: '',
+            lastModified: '',
+            id: '',
+            data: {
+              name: { iv: '1-test-migration.ts' },
+            },
+          },
+        ],
+      });
+      const mockDefaultModule = { default: MockModule };
+      mockImportModule.mockResolvedValueOnce(mockDefaultModule);
+      mockDown.mockRejectedValueOnce(new Error());
+
+      await rollback(...mockHandlerArguments);
+
+      expect(squidexClientMock.delete).not.toHaveBeenCalled();
+      expect(loggerMock.error).toHaveBeenCalledWith(
+        expect.any(Error),
+        expect.stringMatching(/1-test-migration.ts/),
+      );
+    });
+  });
+});

--- a/apps/asap-server/test/mocks/squidex-client.mock.ts
+++ b/apps/asap-server/test/mocks/squidex-client.mock.ts
@@ -1,0 +1,14 @@
+import { RestMigration, Squidex } from '@asap-hub/squidex';
+
+export const squidexClientMock: jest.Mocked<Squidex<RestMigration>> = {
+  client: null as any,
+  collection: 'some collection',
+  fetch: jest.fn(),
+  fetchById: jest.fn(),
+  create: jest.fn(),
+  upsert: jest.fn(),
+  delete: jest.fn(),
+  put: jest.fn(),
+  patch: jest.fn(),
+  fetchOne: jest.fn(),
+};

--- a/packages/squidex/schema/schemas/migrations.json
+++ b/packages/squidex/schema/schemas/migrations.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "./../__json/schema.json",
+  "name": "migrations",
+  "isSingleton": false,
+  "isPublished": false,
+  "schema": {
+    "noFieldDeletion": false,
+    "noFieldRecreation": false,
+    "properties": {
+      "label": "Migrations",
+      "validateOnPublish": false
+    },
+    "scripts": {},
+    "fieldsInReferences": [],
+    "fieldsInLists": [],
+    "fields": [
+      {
+        "name": "name",
+        "isHidden": false,
+        "isLocked": false,
+        "isDisabled": true,
+        "partitioning": "invariant",
+        "properties": {
+          "fieldType": "String",
+          "isUnique": true,
+          "inlineEditable": false,
+          "contentType": "Unspecified",
+          "editor": "Input",
+          "label": "Name",
+          "hints": "",
+          "placeholder": "",
+          "isRequired": true,
+          "isRequiredOnPublish": false,
+          "isHalfWidth": false
+        }
+      }
+    ],
+    "previewUrls": {},
+    "category": "Storage",
+    "isPublished": true
+  }
+}

--- a/packages/squidex/schema/schemas/research-outputs.json
+++ b/packages/squidex/schema/schemas/research-outputs.json
@@ -92,6 +92,26 @@
         }
       },
       {
+        "name": "description",
+        "isHidden": false,
+        "isLocked": false,
+        "isDisabled": false,
+        "partitioning": "invariant",
+        "properties": {
+          "fieldType": "String",
+          "isUnique": false,
+          "inlineEditable": false,
+          "contentType": "Unspecified",
+          "editor": "RichText",
+          "label": "Description",
+          "hints": "",
+          "placeholder": "",
+          "isRequired": false,
+          "isRequiredOnPublish": false,
+          "isHalfWidth": false
+        }
+      },
+      {
         "name": "link",
         "isHidden": false,
         "isLocked": false,

--- a/packages/squidex/src/entities/index.ts
+++ b/packages/squidex/src/entities/index.ts
@@ -7,3 +7,4 @@ export * from './user';
 export * from './group';
 export * from './event';
 export * from './webhook';
+export * from './migration';

--- a/packages/squidex/src/entities/migration.ts
+++ b/packages/squidex/src/entities/migration.ts
@@ -1,0 +1,7 @@
+import { Rest, Entity } from './common';
+
+export interface Migration {
+  name: string;
+}
+
+export interface RestMigration extends Entity, Rest<Migration> {}

--- a/packages/squidex/src/entities/research-output.ts
+++ b/packages/squidex/src/entities/research-output.ts
@@ -7,6 +7,7 @@ export interface ResearchOutput {
   title: string;
   shortText?: string;
   text: string;
+  description: string;
   link?: string;
   publishDate?: string;
   tags: string[];

--- a/serverless.js
+++ b/serverless.js
@@ -234,7 +234,7 @@ module.exports = {
     runMigrations: {
       handler:
         'apps/asap-server/build-cjs/handlers/webhooks/webhook-run-migrations.run',
-      timeout: 120,
+      timeout: 900,
     },
     rollbackMigrations: {
       handler:

--- a/serverless.js
+++ b/serverless.js
@@ -235,27 +235,11 @@ module.exports = {
       handler:
         'apps/asap-server/build-cjs/handlers/webhooks/webhook-run-migrations.run',
       timeout: 120,
-      events: [
-        {
-          httpApi: {
-            method: 'POST',
-            path: `/webhook/run-migrations`,
-          },
-        },
-      ],
     },
     rollbackMigrations: {
       handler:
         'apps/asap-server/build-cjs/handlers/webhooks/webhook-run-migrations.rollback',
       timeout: 120,
-      events: [
-        {
-          httpApi: {
-            method: 'POST',
-            path: `/webhook/rollback-migrations`,
-          },
-        },
-      ],
     },
     ...(NODE_ENV === 'production'
       ? {

--- a/serverless.js
+++ b/serverless.js
@@ -231,6 +231,32 @@ module.exports = {
         }}`,
       },
     },
+    runMigrations: {
+      handler:
+        'apps/asap-server/build-cjs/handlers/webhooks/webhook-run-migrations.run',
+      timeout: 120,
+      events: [
+        {
+          httpApi: {
+            method: 'POST',
+            path: `/webhook/run-migrations`,
+          },
+        },
+      ],
+    },
+    rollbackMigrations: {
+      handler:
+        'apps/asap-server/build-cjs/handlers/webhooks/webhook-run-migrations.rollback',
+      timeout: 120,
+      events: [
+        {
+          httpApi: {
+            method: 'POST',
+            path: `/webhook/rollback-migrations`,
+          },
+        },
+      ],
+    },
     ...(NODE_ENV === 'production'
       ? {
           cronjobSyncOrcid: {

--- a/serverless.js
+++ b/serverless.js
@@ -239,7 +239,7 @@ module.exports = {
     rollbackMigrations: {
       handler:
         'apps/asap-server/build-cjs/handlers/webhooks/webhook-run-migrations.rollback',
-      timeout: 120,
+      timeout: 900,
     },
     ...(NODE_ENV === 'production'
       ? {


### PR DESCRIPTION
Creates a tool for running schema migrations. Can be used with squidex or any other types of migrations.

Work required for: https://trello.com/c/K7U0AkBH/1157-rename-shared-output-schemas-text-field-to-description