### PR TITLE
fix(frontend): show page titles on suspended pages

### DIFF
--- a/apps/frontend/src/GuardedApp.tsx
+++ b/apps/frontend/src/GuardedApp.tsx
@@ -14,6 +14,7 @@ import {
 
 import { auth0State } from './auth/state';
 import Logout from './auth/Logout';
+import Frame from './structure/Frame';
 
 const loadNewsAndEvents = () =>
   import(/* webpackChunkName: "news-and-events" */ './news/Routes');
@@ -56,28 +57,44 @@ const GuardedApp: React.FC<Record<string, never>> = () => {
   return (
     <Switch>
       <Route exact path="/">
-        <Dashboard />
+        <Frame title="Dashboard">
+          <Dashboard />
+        </Frame>
       </Route>
       <Route path={logout.template}>
-        <Logout />
+        <Frame title="Logout">
+          <Logout />
+        </Frame>
       </Route>
       <Route path={discover.template}>
-        <Discover />
+        <Frame title="Discover ASAP">
+          <Discover />
+        </Frame>
       </Route>
       <Route path={news.template}>
-        <NewsAndEvents />
+        <Frame title="News">
+          <NewsAndEvents />
+        </Frame>
       </Route>
       <Route path={network.template}>
-        <Network />
+        <Frame title={null}>
+          <Network />
+        </Frame>
       </Route>
       <Route path={sharedResearch.template}>
-        <SharedResearch />
+        <Frame title="Shared Research">
+          <SharedResearch />
+        </Frame>
       </Route>
       <Route path={events.template}>
-        <Events />
+        <Frame title={null}>
+          <Events />
+        </Frame>
       </Route>
       <Route>
-        <NotFoundPage />
+        <Frame title="Not Found">
+          <NotFoundPage />
+        </Frame>
       </Route>
     </Switch>
   );

--- a/apps/frontend/src/auth/Logout.tsx
+++ b/apps/frontend/src/auth/Logout.tsx
@@ -1,8 +1,6 @@
 import React, { useEffect } from 'react';
 import { useAuth0 } from '@asap-hub/react-context';
 
-import Frame from '../structure/Frame';
-
 const Logout: React.FC<Record<string, never>> = () => {
   const { logout } = useAuth0();
 
@@ -10,7 +8,7 @@ const Logout: React.FC<Record<string, never>> = () => {
     logout({ returnTo: globalThis.location.origin });
   });
 
-  return <Frame title="Logout">Logging you out ...</Frame>;
+  return <>Logging you out ...</>;
 };
 
 export default Logout;

--- a/apps/frontend/src/dashboard/Dashboard.tsx
+++ b/apps/frontend/src/dashboard/Dashboard.tsx
@@ -42,7 +42,7 @@ const Dashboard: React.FC<Record<string, never>> = () => {
   if (dashboard) {
     return (
       <DashboardPage firstName={firstName}>
-        <Frame title="Dashboard">
+        <Frame title={null}>
           <Body {...dashboard} userId={id} teamId={teams[0]?.id} />
         </Frame>
       </DashboardPage>

--- a/apps/frontend/src/discover/Discover.tsx
+++ b/apps/frontend/src/discover/Discover.tsx
@@ -31,7 +31,7 @@ const Discover: React.FC<Record<string, never>> = () => {
     };
     return (
       <DiscoverPage>
-        <Frame title="Discover ASAP">
+        <Frame title={null}>
           <Body {...discover} />
         </Frame>
       </DiscoverPage>

--- a/apps/frontend/src/news/Routes.tsx
+++ b/apps/frontend/src/news/Routes.tsx
@@ -20,15 +20,13 @@ const NewsAndEvents: React.FC<Record<string, never>> = () => {
     <Switch>
       <Route exact path={path}>
         <NewsAndEventsPage>
-          <Frame title="News">
+          <Frame title={null}>
             <NewsAndEventsList />
           </Frame>
         </NewsAndEventsPage>
       </Route>
       <Route path={path + news({}).article.template}>
-        <Frame title="News">
-          <NewsOrEventPage />
-        </Frame>
+        <NewsOrEventPage />
       </Route>
     </Switch>
   );

--- a/apps/frontend/src/shared-research/Routes.tsx
+++ b/apps/frontend/src/shared-research/Routes.tsx
@@ -4,7 +4,7 @@ import { SharedResearchPage } from '@asap-hub/react-components';
 import { sharedResearch } from '@asap-hub/routing';
 
 import { useSearch } from '../hooks';
-import Frame, { SearchFrame } from '../structure/Frame';
+import { SearchFrame } from '../structure/Frame';
 
 const loadResearchOutputList = () =>
   import(
@@ -39,7 +39,7 @@ const SharedResearch: React.FC<Record<string, never>> = () => {
           onChangeFilter={toggleFilter}
           filters={filters}
         >
-          <SearchFrame title="Shared Research">
+          <SearchFrame title={null}>
             <ResearchOutputList
               searchQuery={debouncedSearchQuery}
               filters={filters}
@@ -48,9 +48,7 @@ const SharedResearch: React.FC<Record<string, never>> = () => {
         </SharedResearchPage>
       </Route>
       <Route path={path + sharedResearch({}).researchOutput.template}>
-        <Frame title="Shared Research">
-          <ResearchOutput />
-        </Frame>
+        <ResearchOutput />
       </Route>
     </Switch>
   );


### PR DESCRIPTION
Frame title placement was inconsistent. This makes it more consistent
and fixes some titles being inside the relevant suspense boundaries,
such as for Dashboard and Discover.
It should be `<Frame title="SomeAreaOfTheHub"><SomeAreaOfTheHub /></Frame>`,
the Frame with the title should not be inside the `SomeAreaOfTheHub` component.