### PR TITLE
feat(external-links): URL needs to start with http(s)

### DIFF
--- a/packages/squidex/schema/schemas/events.json
+++ b/packages/squidex/schema/schemas/events.json
@@ -290,6 +290,7 @@
             "properties": {
               "fieldType": "String",
               "pattern": "^(?:http(s)?:\\/\\/)[\\w.-]+(?:\\.[\\w\\.-]+)+[\\w\\-\\._~:\\/?#%[\\]@!\\$&'\\(\\)\\*\\+,;=.]+$",
+              "patternMessage": "URL must start with http:// or https://",
               "isUnique": false,
               "inlineEditable": false,
               "contentType": "Unspecified",

--- a/packages/squidex/schema/schemas/research-outputs.json
+++ b/packages/squidex/schema/schemas/research-outputs.json
@@ -99,6 +99,8 @@
         "partitioning": "invariant",
         "properties": {
           "fieldType": "String",
+          "pattern": "^(?:http(s)?:\\/\\/)[\\w.-]+(?:\\.[\\w\\.-]+)+[\\w\\-\\._~:\\/?#%[\\]@!\\$&'\\(\\)\\*\\+,;=.]+$",
+          "patternMessage": "URL must start with http:// or https://",
           "isUnique": false,
           "inlineEditable": false,
           "contentType": "Unspecified",


### PR DESCRIPTION
Ticket: https://trello.com/c/8L0uIAHV/1158-validate-external-link-on-shared-output-schema-on-the-cms

Production data is conforming to the new restrictions (i.e. all start with `https`)
