### PR TITLE
perf(frontend): prefetch other network tabs

### DIFF
--- a/apps/frontend/src/network/__tests__/Network.test.tsx
+++ b/apps/frontend/src/network/__tests__/Network.test.tsx
@@ -15,6 +15,7 @@ import { getTeams } from '../teams/api';
 
 jest.mock('../users/api');
 jest.mock('../teams/api');
+jest.mock('../groups/api');
 
 const mockGetUsers = getUsers as jest.MockedFunction<typeof getUsers>;
 const mockGetTeams = getTeams as jest.MockedFunction<typeof getTeams>;

--- a/apps/frontend/src/network/groups/GroupList.tsx
+++ b/apps/frontend/src/network/groups/GroupList.tsx
@@ -3,6 +3,8 @@ import { NetworkGroups } from '@asap-hub/react-components';
 
 import { useGroups } from './state';
 import { usePaginationParams, usePagination } from '../../hooks';
+import { usePrefetchTeams } from '../teams/state';
+import { usePrefetchUsers } from '../users/state';
 
 interface NetworkGroupListProps {
   searchQuery?: string;
@@ -17,6 +19,18 @@ const NetworkGroupList: React.FC<NetworkGroupListProps> = ({
     searchQuery,
     currentPage,
     pageSize,
+    filters: new Set(),
+  });
+  usePrefetchUsers({
+    currentPage: 0,
+    pageSize,
+    searchQuery,
+    filters: new Set(),
+  });
+  usePrefetchTeams({
+    currentPage: 0,
+    pageSize,
+    searchQuery,
     filters: new Set(),
   });
 

--- a/apps/frontend/src/network/groups/__tests__/GroupList.test.tsx
+++ b/apps/frontend/src/network/groups/__tests__/GroupList.test.tsx
@@ -15,6 +15,8 @@ import { groupsState } from '../state';
 import { CARD_VIEW_PAGE_SIZE } from '../../../hooks';
 
 jest.mock('../api');
+jest.mock('../../users/api');
+jest.mock('../../teams/api');
 
 const mockGetGroups = getGroups as jest.MockedFunction<typeof getGroups>;
 

--- a/apps/frontend/src/network/groups/state.ts
+++ b/apps/frontend/src/network/groups/state.ts
@@ -1,3 +1,4 @@
+import useDeepCompareEffect from 'use-deep-compare-effect';
 import {
   useRecoilValue,
   useRecoilState,
@@ -10,6 +11,7 @@ import { ListGroupResponse, GroupResponse } from '@asap-hub/model';
 import { authorizationState } from '@asap-hub/frontend/src/auth/state';
 import { GetListOptions } from '@asap-hub/frontend/src/api-util';
 import { getGroups, getGroup } from './api';
+import { CARD_VIEW_PAGE_SIZE } from '../../hooks';
 
 const groupIndexState = atomFamily<
   { ids: ReadonlyArray<string>; total: number } | Error | undefined,
@@ -70,6 +72,22 @@ export const groupState = atomFamily<GroupResponse | undefined, string>({
   default: fetchGroupState,
 });
 
+export const usePrefetchGroups = (
+  options: GetListOptions = {
+    filters: new Set(),
+    searchQuery: '',
+    pageSize: CARD_VIEW_PAGE_SIZE,
+    currentPage: 0,
+  },
+) => {
+  const authorization = useRecoilValue(authorizationState);
+  const [groups, setGroups] = useRecoilState(groupsState(options));
+  useDeepCompareEffect(() => {
+    if (groups === undefined) {
+      getGroups(options, authorization).then(setGroups).catch();
+    }
+  }, [authorization, groups, options, setGroups]);
+};
 export const useGroups = (options: GetListOptions) => {
   const authorization = useRecoilValue(authorizationState);
   const [groups, setGroups] = useRecoilState(groupsState(options));

--- a/apps/frontend/src/network/teams/TeamList.tsx
+++ b/apps/frontend/src/network/teams/TeamList.tsx
@@ -3,6 +3,8 @@ import { NetworkTeams } from '@asap-hub/react-components';
 
 import { useTeams } from './state';
 import { usePaginationParams, usePagination } from '../../hooks';
+import { usePrefetchUsers } from '../users/state';
+import { usePrefetchGroups } from '../groups/state';
 
 interface NetworkTeamListProps {
   searchQuery?: string;
@@ -17,6 +19,18 @@ const NetworkTeamList: React.FC<NetworkTeamListProps> = ({
     searchQuery,
     currentPage,
     pageSize,
+    filters: new Set(),
+  });
+  usePrefetchUsers({
+    currentPage: 0,
+    pageSize,
+    searchQuery,
+    filters: new Set(),
+  });
+  usePrefetchGroups({
+    currentPage: 0,
+    pageSize,
+    searchQuery,
     filters: new Set(),
   });
 

--- a/apps/frontend/src/network/teams/__tests__/TeamList.test.tsx
+++ b/apps/frontend/src/network/teams/__tests__/TeamList.test.tsx
@@ -14,6 +14,8 @@ import { teamsState } from '../state';
 import { CARD_VIEW_PAGE_SIZE } from '../../../hooks';
 
 jest.mock('../api');
+jest.mock('../../users/api');
+jest.mock('../../groups/api');
 
 const mockGetTeams = getTeams as jest.MockedFunction<typeof getTeams>;
 

--- a/apps/frontend/src/network/teams/state.ts
+++ b/apps/frontend/src/network/teams/state.ts
@@ -16,6 +16,7 @@ import {
 import { getTeam, patchTeam, getTeams } from './api';
 import { authorizationState } from '../../auth/state';
 import { GetListOptions } from '../../api-util';
+import { CARD_VIEW_PAGE_SIZE } from '../../hooks';
 
 const teamIndexState = atomFamily<
   { ids: ReadonlyArray<string>; total: number } | Error | undefined,
@@ -82,7 +83,14 @@ const teamState = selectorFamily<TeamResponse | undefined, string>({
     get(patchedTeamState(id)) ?? get(initialTeamState(id)),
 });
 
-export const usePrefetchTeams = (options: GetListOptions) => {
+export const usePrefetchTeams = (
+  options: GetListOptions = {
+    filters: new Set(),
+    searchQuery: '',
+    pageSize: CARD_VIEW_PAGE_SIZE,
+    currentPage: 0,
+  },
+) => {
   const authorization = useRecoilValue(authorizationState);
   const [teams, setTeams] = useRecoilState(teamsState(options));
   useDeepCompareEffect(() => {

--- a/apps/frontend/src/network/users/UserList.tsx
+++ b/apps/frontend/src/network/users/UserList.tsx
@@ -4,6 +4,8 @@ import { NetworkPeople } from '@asap-hub/react-components';
 
 import { useUsers } from './state';
 import { usePaginationParams, usePagination } from '../../hooks';
+import { usePrefetchTeams } from '../teams/state';
+import { usePrefetchGroups } from '../groups/state';
 
 interface UserListProps {
   searchQuery?: string;
@@ -15,12 +17,26 @@ const UserList: React.FC<UserListProps> = ({
   filters = new Set(),
 }) => {
   const { currentPage, pageSize } = usePaginationParams();
+
   const result = useUsers({
     searchQuery,
     filters,
     currentPage,
     pageSize,
   });
+  usePrefetchTeams({
+    currentPage: 0,
+    pageSize,
+    searchQuery,
+    filters: new Set(),
+  });
+  usePrefetchGroups({
+    currentPage: 0,
+    pageSize,
+    searchQuery,
+    filters: new Set(),
+  });
+
   const { numberOfPages, renderPageHref } = usePagination(
     result.total,
     pageSize,

--- a/apps/frontend/src/network/users/__tests__/UserList.test.tsx
+++ b/apps/frontend/src/network/users/__tests__/UserList.test.tsx
@@ -14,6 +14,9 @@ import { usersState } from '../state';
 import { CARD_VIEW_PAGE_SIZE } from '../../../hooks';
 
 jest.mock('../api');
+jest.mock('../../teams/api');
+jest.mock('../../groups/api');
+
 const mockGetUsers = getUsers as jest.MockedFunction<typeof getUsers>;
 
 const renderUserList = async () => {


### PR DESCRIPTION
It looks like this is actually the only low-hanging fruit left after all.
Everything else is not good to prefetch at this point for one of two reasons:
* Links between user/team/group profiles are always 1-to-n, so we may be prefetching 10 things at once.
* It's an entity still fetched via use-http, in particular shared research has lots of prefetching opportunities once migrated over.
