### PR TITLE
Fix: group card's title

### DIFF
--- a/apps/frontend/src/network/users/groups/__tests__/GroupsCard.test.tsx
+++ b/apps/frontend/src/network/users/groups/__tests__/GroupsCard.test.tsx
@@ -63,7 +63,7 @@ it('is rendered when there are groups', async () => {
   );
   await waitFor(() => {
     expect(queryByText(/loading/i)).not.toBeInTheDocument();
-    expect(queryByText(/test’ groups/i)).toBeInTheDocument();
+    expect(queryByText(/test’s groups/i)).toBeInTheDocument();
   });
 });
 

--- a/apps/frontend/src/network/users/groups/__tests__/GroupsCard.test.tsx
+++ b/apps/frontend/src/network/users/groups/__tests__/GroupsCard.test.tsx
@@ -50,7 +50,7 @@ it('is not rendered when there are no groups', async () => {
     expect(queryByText(/loading/i)).not.toBeInTheDocument();
   });
 
-  expect(queryByText(/test’ groups/i)).not.toBeInTheDocument();
+  expect(queryByText(/groups/i, { selector: 'h2' })).not.toBeInTheDocument();
 });
 
 it('is rendered when there are groups', async () => {
@@ -63,7 +63,7 @@ it('is rendered when there are groups', async () => {
   );
   await waitFor(() => {
     expect(queryByText(/loading/i)).not.toBeInTheDocument();
-    expect(queryByText(/test’s groups/i)).toBeInTheDocument();
+    expect(queryByText(/groups/i, { selector: 'h2' })).toBeInTheDocument();
   });
 });
 

--- a/packages/react-components/src/organisms/UserProfileGroups.tsx
+++ b/packages/react-components/src/organisms/UserProfileGroups.tsx
@@ -63,7 +63,7 @@ const UserProfileGroups: React.FC<UserProfileGroupsProps> = ({
         flexDirection: 'column',
       }}
     >
-      <Headline2 styleAsHeading={3}>{firstName}’ Groups</Headline2>
+      <Headline2 styleAsHeading={3}>{firstName}’s Groups</Headline2>
       <Paragraph accent="lead">
         {firstName}’s team is collaborating with other teams via groups, which
         meet frequently

--- a/packages/react-components/src/organisms/__tests__/UserProfileGroups.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/UserProfileGroups.test.tsx
@@ -21,7 +21,7 @@ it('render a heading', () => {
 
   expect(
     getByText(/phillip/i, { selector: 'h2' }).textContent,
-  ).toMatchInlineSnapshot(`"Phillip’ Groups"`);
+  ).toMatchInlineSnapshot(`"Phillip’s Groups"`);
   expect(
     getByText(/phillip/i, { selector: 'p' }).textContent,
   ).toMatchInlineSnapshot(


### PR DESCRIPTION
Fix a typo on the Title of Profile's Group Card.

Note:
- Are we testing this twice??