### PR TITLE
 feat(migrations): migrate publishDate to addedDate

### DIFF
--- a/apps/asap-server/scripts/create-migration.sh
+++ b/apps/asap-server/scripts/create-migration.sh
@@ -1,17 +1,18 @@
 #!/usr/bin/env bash
 
 input=$1
+currentDirectory=$(dirname $0)
 
 if [ -z "$input" ]; then
     echo "Missing argument - migration name"
     exit
 fi
 
-timestamp=$(date +%s%N | cut -b1-13)
+timestamp=$(date +%s| cut -b1-13)
 migration="$timestamp-$input"
 
 echo "Generating migration $migration..."
 
-cp ./scripts/migration.template ./src/migrations/$migration.ts
+cp $currentDirectory/migration.template $currentDirectory/../src/migrations/$migration.ts
 
 echo "Done"

--- a/apps/asap-server/scripts/migration.template
+++ b/apps/asap-server/scripts/migration.template
@@ -1,5 +1,5 @@
 /* istanbul ignore file */
-import { RestResearchOutput, Results, Squidex } from '@asap-hub/squidex';
+import { Results, Squidex } from '@asap-hub/squidex';
 import { Migration } from '../handlers/webhooks/webhook-run-migrations';
 
 export default class MoveResearchOutputTextToDescription extends Migration {

--- a/apps/asap-server/src/migrations/1617196731-move-research-output-text-to-description.ts
+++ b/apps/asap-server/src/migrations/1617196731-move-research-output-text-to-description.ts
@@ -4,18 +4,24 @@ import { Migration } from '../handlers/webhooks/webhook-run-migrations';
 
 export default class MoveResearchOutputTextToDescription extends Migration {
   up = async (): Promise<void> => {
-    const squidexClient = new Squidex<RestResearchOutput>('research-outputs');
+    const squidexClient = new Squidex<RestResearchOutput>('research-outputs', {
+      unpublished: true,
+    });
 
     let pointer = 0;
     let result: Results<RestResearchOutput>;
 
     do {
-      result = await squidexClient.fetch({ $top: 10, $skip: pointer });
+      result = await squidexClient.fetch({
+        $top: 10,
+        $skip: pointer,
+        $orderby: 'created asc',
+      });
 
-      for (const researchOuput of result.items) {
-        await squidexClient.patch(researchOuput.id, {
+      for (const researchOutput of result.items) {
+        await squidexClient.patch(researchOutput.id, {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          description: (researchOuput.data as any).text,
+          description: (researchOutput.data as any).text,
         });
       }
 

--- a/apps/asap-server/src/migrations/1618488149-publish-date-to-added-date.ts
+++ b/apps/asap-server/src/migrations/1618488149-publish-date-to-added-date.ts
@@ -45,7 +45,6 @@ export default class MoveResearchOutputTextToDescription extends Migration {
     } while (pointer < result.total);
   };
 
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
   down = async (): Promise<void> => {
     const squidexClient = new Squidex<RestResearchOutput>('research-outputs', {
       unpublished: true,

--- a/apps/asap-server/src/migrations/1618488149-publish-date-to-added-date.ts
+++ b/apps/asap-server/src/migrations/1618488149-publish-date-to-added-date.ts
@@ -1,0 +1,48 @@
+/* istanbul ignore file */
+import { RestResearchOutput, Results, Squidex } from '@asap-hub/squidex';
+import { Migration } from '../handlers/webhooks/webhook-run-migrations';
+import logger from '../utils/logger';
+
+export default class MoveResearchOutputTextToDescription extends Migration {
+  up = async (): Promise<void> => {
+    const squidexClient = new Squidex<RestResearchOutput>('research-outputs', {
+      unpublished: true,
+    });
+
+    let pointer = 0;
+    let result: Results<RestResearchOutput>;
+
+    do {
+      result = await squidexClient.fetch({
+        $top: 10,
+        $skip: pointer,
+        $orderby: 'created asc',
+      });
+
+      for (const researchOutput of result.items) {
+        const publishDate = researchOutput.data.publishDate?.iv;
+        if (!publishDate) {
+          continue;
+        }
+
+        try {
+          const addedDate = publishDate.includes(' ')
+            ? new Date(`${publishDate} UTC`).toISOString() // for dates in format 'Month Year'
+            : new Date(publishDate).toISOString(); // For dates in ISO format
+
+          await squidexClient.patch(researchOutput.id, {
+            addedDate: { iv: addedDate },
+          });
+        } catch (err) {
+          logger.error(err, `Error migrating RO: ${researchOutput.id}`);
+          continue;
+        }
+      }
+
+      pointer += 10;
+    } while (pointer < result.total);
+  };
+
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  down = async (): Promise<void> => {};
+}

--- a/packages/squidex/schema/schemas/research-outputs.json
+++ b/packages/squidex/schema/schemas/research-outputs.json
@@ -114,6 +114,23 @@
         }
       },
       {
+        "name": "addedDate",
+        "isHidden": false,
+        "isLocked": false,
+        "isDisabled": false,
+        "partitioning": "invariant",
+        "properties": {
+          "fieldType": "DateTime",
+          "editor": "DateTime",
+          "label": "Added Date",
+          "hints": "",
+          "placeholder": "",
+          "isRequired": false,
+          "isRequiredOnPublish": false,
+          "isHalfWidth": false
+        }
+      },
+      {
         "name": "publishDate",
         "isHidden": false,
         "isLocked": false,

--- a/packages/squidex/src/entities/research-output.ts
+++ b/packages/squidex/src/entities/research-output.ts
@@ -8,6 +8,7 @@ export interface ResearchOutput {
   shortText?: string;
   description: string;
   link?: string;
+  addedDate?: string;
   publishDate?: string;
   tags?: string[];
 }


### PR DESCRIPTION
Ticket: https://trello.com/c/ipMAHg9b/1160-migrate-research-output-original-publishing-date-to-added-date?menu=filter&filter=label:BE
> **this PR only addressed the first 2 requirements** 



- fix(migrations): fix date function & old migration
  - makes the date command work on OSX and Linux
  - use script relative paths 
  - simplifies the template
  - fixes pagination on old migraition script (should not run for old envs though)
- feat(migrations): add addedDate migration script
  - successfully ran script agains temp environment
![image](https://user-images.githubusercontent.com/6756384/114894139-4801c500-9e06-11eb-87a2-4c4da8790ed0.png)
