### PR TITLE
feat: Rename short-text to admin-notes

### DIFF
--- a/apps/asap-server/src/migrations/1618575365-move-short-text-to-admin-notes.ts
+++ b/apps/asap-server/src/migrations/1618575365-move-short-text-to-admin-notes.ts
@@ -1,0 +1,56 @@
+/* istanbul ignore file */
+import { RestResearchOutput, Results, Squidex } from '@asap-hub/squidex';
+import { Migration } from '../handlers/webhooks/webhook-run-migrations';
+
+export default class MoveResearchOutputTextToDescription extends Migration {
+  up = async (): Promise<void> => {
+    const squidexClient = new Squidex<RestResearchOutput>('research-outputs', {
+      unpublished: true,
+    });
+
+    let pointer = 0;
+    let result: Results<RestResearchOutput>;
+
+    do {
+      result = await squidexClient.fetch({
+        $top: 10,
+        $skip: pointer,
+        $orderby: 'created asc',
+      });
+
+      for (const researchOutput of result.items) {
+        await squidexClient.patch(researchOutput.id, {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          adminNotes: (researchOutput.data as any).shortText,
+        });
+      }
+
+      pointer += 10;
+    } while (pointer < result.total);
+  };
+  down = async (): Promise<void> => {
+    const squidexClient = new Squidex<RestResearchOutput>('research-outputs', {
+      unpublished: true,
+    });
+
+    let pointer = 0;
+    let result: Results<RestResearchOutput>;
+
+    do {
+      result = await squidexClient.fetch({
+        $top: 10,
+        $skip: pointer,
+        $orderby: 'created asc',
+      });
+
+      for (const researchOutput of result.items) {
+        await squidexClient.patch(researchOutput.id, {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          adminNotes: null as any, // types dont cover null values
+        });
+      }
+
+      pointer += 10;
+    } while (pointer < result.total);
+  };
+}

--- a/packages/squidex/schema/schemas/research-outputs.json
+++ b/packages/squidex/schema/schemas/research-outputs.json
@@ -65,7 +65,7 @@
         "name": "shortText",
         "isHidden": false,
         "isLocked": false,
-        "isDisabled": false,
+        "isDisabled": true,
         "partitioning": "invariant",
         "properties": {
           "fieldType": "String",

--- a/packages/squidex/schema/schemas/research-outputs.json
+++ b/packages/squidex/schema/schemas/research-outputs.json
@@ -193,6 +193,26 @@
           "isRequiredOnPublish": false,
           "isHalfWidth": false
         }
+      },
+      {
+        "name": "adminNotes",
+        "isHidden": false,
+        "isLocked": false,
+        "isDisabled": false,
+        "partitioning": "invariant",
+        "properties": {
+          "fieldType": "String",
+          "isUnique": false,
+          "inlineEditable": false,
+          "contentType": "Unspecified",
+          "editor": "Input",
+          "label": "Admin notes",
+          "hints": "This is ASAP internal content and it's not being shown on the Hub",
+          "placeholder": "",
+          "isRequired": false,
+          "isRequiredOnPublish": false,
+          "isHalfWidth": false
+        }
       }
     ],
     "previewUrls": {

--- a/packages/squidex/src/entities/research-output.ts
+++ b/packages/squidex/src/entities/research-output.ts
@@ -11,6 +11,7 @@ export interface ResearchOutput {
   addedDate?: string;
   publishDate?: string;
   tags?: string[];
+  adminNotes?: string;
 }
 
 export interface RestResearchOutput extends Entity, Rest<ResearchOutput> {}


### PR DESCRIPTION
https://trello.com/c/YUtW7fLX/1159-rename-short-text-field-to-admin-notes

Creates a new field - `adminNotes`, and moves all the data from the `shortText` field. 

A follow up PR is expected to remove the `shortText` field