### PR TITLE
feat: Remove short-text field from Research Outputs

### DIFF
--- a/apps/asap-server/src/controllers/teams.ts
+++ b/apps/asap-server/src/controllers/teams.ts
@@ -31,7 +31,6 @@ flatData {
     flatData{
       link
       publishDate
-      shortText
       title
       type
       tags

--- a/apps/asap-server/test/fixtures/groups.fixtures.ts
+++ b/apps/asap-server/test/fixtures/groups.fixtures.ts
@@ -57,7 +57,6 @@ export const queryGroupsResponse: { data: ResponseFetchGroups } = {
                       flatData: {
                         link: null,
                         publishDate: null,
-                        shortText: null,
                         title: 'Proposal',
                         type: 'Proposal',
                         tags: ['test', 'tag'],

--- a/apps/asap-server/test/fixtures/teams.fixtures.ts
+++ b/apps/asap-server/test/fixtures/teams.fixtures.ts
@@ -26,7 +26,6 @@ export const graphQlTeamsResponse: { data: ResponseFetchTeams } = {
                 flatData: {
                   link: null,
                   publishDate: null,
-                  shortText: null,
                   title: 'Proposal',
                   type: 'Proposal',
                   tags: ['test', 'tag'],
@@ -39,7 +38,6 @@ export const graphQlTeamsResponse: { data: ResponseFetchTeams } = {
                 flatData: {
                   link: 'docs.google.com',
                   publishDate: null,
-                  shortText: null,
                   title: "Team Salzer's intro slide deck",
                   type: 'Presentation',
                   tags: ['test', 'tag'],
@@ -370,7 +368,6 @@ export const graphQlTeamResponse: { data: ResponseFetchTeam } = {
             flatData: {
               link: null,
               publishDate: null,
-              shortText: null,
               title: 'Proposal',
               type: 'Proposal',
               tags: ['test', 'tag'],
@@ -383,7 +380,6 @@ export const graphQlTeamResponse: { data: ResponseFetchTeam } = {
             flatData: {
               link: 'docs.google.com',
               publishDate: null,
-              shortText: null,
               title: "Team Salzer's intro slide deck",
               type: 'Presentation',
             },
@@ -556,7 +552,6 @@ export const getGraphQlTeamResponse = (
             flatData: {
               link: null,
               publishDate: null,
-              shortText: null,
               title: 'Proposal',
               type: 'Proposal',
               tags: ['test', 'tag'],
@@ -569,7 +564,6 @@ export const getGraphQlTeamResponse = (
             flatData: {
               link: 'docs.google.com',
               publishDate: null,
-              shortText: null,
               title: "Team Salzer's intro slide deck",
               type: 'Presentation',
             },

--- a/packages/squidex/schema/schemas/research-outputs.json
+++ b/packages/squidex/schema/schemas/research-outputs.json
@@ -62,24 +62,6 @@
         }
       },
       {
-        "name": "shortText",
-        "isHidden": false,
-        "isLocked": false,
-        "isDisabled": true,
-        "partitioning": "invariant",
-        "properties": {
-          "fieldType": "String",
-          "isUnique": false,
-          "inlineEditable": false,
-          "contentType": "Unspecified",
-          "editor": "Input",
-          "label": "Short Text",
-          "isRequired": false,
-          "isRequiredOnPublish": false,
-          "isHalfWidth": false
-        }
-      },
-      {
         "name": "description",
         "isHidden": false,
         "isLocked": false,

--- a/packages/squidex/src/entities/research-output.ts
+++ b/packages/squidex/src/entities/research-output.ts
@@ -5,7 +5,6 @@ import { Rest, Entity, Graphql } from './common';
 export interface ResearchOutput {
   type: ResearchOutputType;
   title: string;
-  shortText?: string;
   description: string;
   link?: string;
   addedDate?: string;


### PR DESCRIPTION
see: https://trello.com/c/YUtW7fLX/1159-rename-short-text-field-to-admin-notes