### PR TITLE
fix: Quotation marks search bug

### DIFF
--- a/apps/asap-server/src/controllers/events.ts
+++ b/apps/asap-server/src/controllers/events.ts
@@ -41,9 +41,10 @@ export default class Events implements EventController {
       sortOrder,
     } = options;
 
-    const filters = ((search && sanitiseForSquidex(search)) || '')
+    const filters = (search || '')
       .split(' ')
       .filter(Boolean)
+      .map(sanitiseForSquidex)
       .reduce(
         (acc: string[], word: string) =>
           acc.concat(

--- a/apps/asap-server/src/controllers/events.ts
+++ b/apps/asap-server/src/controllers/events.ts
@@ -9,6 +9,7 @@ import {
 import { FetchOptions, AllOrNone } from '../utils/types';
 import { parseGraphQLEvent } from '../entities/event';
 import { ResponseFetchGroup, GraphQLQueryGroup } from './groups';
+import { sanitiseForSquidex } from '../utils/squidex';
 
 export interface EventController {
   fetch: (options: FetchEventsOptions) => Promise<ListEventResponse>;
@@ -40,7 +41,7 @@ export default class Events implements EventController {
       sortOrder,
     } = options;
 
-    const filters = (search || '')
+    const filters = ((search && sanitiseForSquidex(search)) || '')
       .split(' ')
       .filter(Boolean)
       .reduce(

--- a/apps/asap-server/src/controllers/groups.ts
+++ b/apps/asap-server/src/controllers/groups.ts
@@ -8,6 +8,7 @@ import { FetchOptions } from '../utils/types';
 import { parseGraphQLGroup } from '../entities';
 import { GraphQLQueryUser } from './users';
 import { GraphQLQueryTeam } from './teams';
+import { sanitiseForSquidex } from '../utils/squidex';
 
 export const GraphQLQueryGroup = `
 id
@@ -116,7 +117,7 @@ export default class Groups implements GroupController {
   async fetch(options: FetchOptions): Promise<ListGroupResponse> {
     const { search } = options;
 
-    const searchQ = (search || '')
+    const searchQ = ((search && sanitiseForSquidex(search)) || '')
       .split(' ')
       .filter(Boolean) // removes whitespaces
       .reduce(

--- a/apps/asap-server/src/controllers/groups.ts
+++ b/apps/asap-server/src/controllers/groups.ts
@@ -117,9 +117,10 @@ export default class Groups implements GroupController {
   async fetch(options: FetchOptions): Promise<ListGroupResponse> {
     const { search } = options;
 
-    const searchQ = ((search && sanitiseForSquidex(search)) || '')
+    const searchQ = (search || '')
       .split(' ')
       .filter(Boolean) // removes whitespaces
+      .map(sanitiseForSquidex)
       .reduce(
         (acc: string[], word: string) =>
           acc.concat(

--- a/apps/asap-server/src/controllers/research-outputs.ts
+++ b/apps/asap-server/src/controllers/research-outputs.ts
@@ -83,9 +83,10 @@ export default class ResearchOutputs implements ResearchOutputController {
   }): Promise<ListResearchOutputResponse> {
     const { search, filter, take = 8, skip = 0 } = options;
 
-    const searchQ = ((search && sanitiseForSquidex(search)) || '')
+    const searchQ = (search || '')
       .split(' ')
       .filter(Boolean)
+      .map(sanitiseForSquidex)
       .reduce(
         (acc: string[], word: string) =>
           acc.concat(

--- a/apps/asap-server/src/controllers/research-outputs.ts
+++ b/apps/asap-server/src/controllers/research-outputs.ts
@@ -7,6 +7,7 @@ import { RestTeam, RestResearchOutput } from '@asap-hub/squidex';
 
 import { parseResearchOutput } from '../entities/research-output';
 import { InstrumentedSquidex } from '../utils/instrumented-client';
+import { sanitiseForSquidex } from '../utils/squidex';
 
 function transform(
   output: RestResearchOutput,
@@ -82,7 +83,7 @@ export default class ResearchOutputs implements ResearchOutputController {
   }): Promise<ListResearchOutputResponse> {
     const { search, filter, take = 8, skip = 0 } = options;
 
-    const searchQ = (search || '')
+    const searchQ = ((search && sanitiseForSquidex(search)) || '')
       .split(' ')
       .filter(Boolean)
       .reduce(

--- a/apps/asap-server/src/controllers/teams.ts
+++ b/apps/asap-server/src/controllers/teams.ts
@@ -17,7 +17,7 @@ import {
 } from '../utils/instrumented-client';
 import { GraphQLQueryResearchOutput } from './research-outputs';
 import { parseGraphQLTeam } from '../entities';
-import { createURL } from '../utils/squidex';
+import { createURL, sanitiseForSquidex } from '../utils/squidex';
 
 export const GraphQLQueryTeam = `
 id
@@ -178,7 +178,7 @@ export default class Teams implements TeamController {
   ): Promise<ListTeamResponse> {
     const { take, skip, search } = options;
 
-    const searchQ = (search || '')
+    const searchQ = ((search && sanitiseForSquidex(search)) || '')
       .split(' ')
       .filter(Boolean) // removes whitespaces
       .reduce(

--- a/apps/asap-server/src/controllers/teams.ts
+++ b/apps/asap-server/src/controllers/teams.ts
@@ -178,9 +178,10 @@ export default class Teams implements TeamController {
   ): Promise<ListTeamResponse> {
     const { take, skip, search } = options;
 
-    const searchQ = ((search && sanitiseForSquidex(search)) || '')
+    const searchQ = (search || '')
       .split(' ')
       .filter(Boolean) // removes whitespaces
+      .map(sanitiseForSquidex)
       .reduce(
         (acc: string[], word: string) =>
           acc.concat(

--- a/apps/asap-server/src/controllers/users.ts
+++ b/apps/asap-server/src/controllers/users.ts
@@ -246,9 +246,10 @@ export default class Users {
 
     const searchQ = [
       "data/role/iv ne 'Hidden'",
-      ...((search && sanitiseForSquidex(search)) || '')
+      ...(search || '')
         .split(' ')
         .filter(Boolean) // removes whitespaces
+        .map(sanitiseForSquidex)
         .reduce(
           (acc: string[], word: string) =>
             acc.concat(

--- a/apps/asap-server/src/controllers/users.ts
+++ b/apps/asap-server/src/controllers/users.ts
@@ -17,6 +17,7 @@ import {
 import { parseUser, parseGraphQLUser } from '../entities';
 import { fetchOrcidProfile, transformOrcidWorks } from '../utils/fetch-orcid';
 import { FetchOptions } from '../utils/types';
+import { sanitiseForSquidex } from '../utils/squidex';
 
 export const GraphQLQueryUser = `
 id
@@ -245,7 +246,7 @@ export default class Users {
 
     const searchQ = [
       "data/role/iv ne 'Hidden'",
-      ...(search || '')
+      ...((search && sanitiseForSquidex(search)) || '')
         .split(' ')
         .filter(Boolean) // removes whitespaces
         .reduce(

--- a/apps/asap-server/src/utils/squidex.ts
+++ b/apps/asap-server/src/utils/squidex.ts
@@ -12,3 +12,6 @@ export const createURL = (assets: string[]): string[] =>
 
 export const parseDate = (date: string): Date =>
   DateTime.fromISO(date).toJSDate();
+
+export const sanitiseForSquidex = (text: string): string =>
+  text.replace(/'/g, "''").replace(/"/g, '\\"');

--- a/apps/asap-server/src/utils/squidex.ts
+++ b/apps/asap-server/src/utils/squidex.ts
@@ -14,4 +14,4 @@ export const parseDate = (date: string): Date =>
   DateTime.fromISO(date).toJSDate();
 
 export const sanitiseForSquidex = (text: string): string =>
-  text.replace(/'/g, "''").replace(/"/g, '\\"');
+  escape(text.replace(/'/g, "''"));

--- a/apps/asap-server/test/controllers/events.test.ts
+++ b/apps/asap-server/test/controllers/events.test.ts
@@ -159,10 +159,9 @@ describe('Event controller', () => {
         });
       });
 
-      test('Should sanitise single quotation mark by using two single quotes', async () => {
-        // http://docs.oasis-open.org/odata/odata/v4.01/cs01/part2-url-conventions/odata-v4.01-cs01-part2-url-conventions.html#sec_URLComponents
+      test('Should sanitise single quotes by doubling them and encoding to hex', async () => {
         const expectedFilter =
-          "(contains(data/title/iv, '''') or contains(data/tags/iv, '''')) and data/hidden/iv ne true and data/endDate/iv gt after-date";
+          "(contains(data/title/iv, '%27%27') or contains(data/tags/iv, '%27%27')) and data/hidden/iv ne true and data/endDate/iv gt after-date";
 
         nock(config.baseUrl)
           .post(`/api/content/${config.appName}/graphql`, {
@@ -176,9 +175,9 @@ describe('Event controller', () => {
         });
       });
 
-      test('Should sanitise double quotation mark by using a backslash', async () => {
+      test('Should sanitise double quotation mark by encoding to hex', async () => {
         const expectedFilter =
-          "(contains(data/title/iv, '\\\"') or contains(data/tags/iv, '\\\"')) and data/hidden/iv ne true and data/endDate/iv gt after-date";
+          "(contains(data/title/iv, '%22') or contains(data/tags/iv, '%22')) and data/hidden/iv ne true and data/endDate/iv gt after-date";
 
         nock(config.baseUrl)
           .post(`/api/content/${config.appName}/graphql`, {

--- a/apps/asap-server/test/controllers/groups.test.ts
+++ b/apps/asap-server/test/controllers/groups.test.ts
@@ -70,8 +70,7 @@ describe('Group controller', () => {
       expect(result).toEqual(fixtures.queryGroupsExpectation);
     });
 
-    test('Should sanitise single quotation mark by using two single quotes', async () => {
-      // http://docs.oasis-open.org/odata/odata/v4.01/cs01/part2-url-conventions/odata-v4.01-cs01-part2-url-conventions.html#sec_URLComponents
+    test('Should sanitise single quotes by doubling them and encoding to hex', async () => {
       const fetchOptions: FetchOptions = {
         take: 12,
         skip: 2,
@@ -79,9 +78,9 @@ describe('Group controller', () => {
       };
 
       const expectedFilter =
-        "(contains(data/name/iv, '''')" +
-        " or contains(data/description/iv, '''')" +
-        " or contains(data/tags/iv, ''''))";
+        "(contains(data/name/iv, '%27%27')" +
+        " or contains(data/description/iv, '%27%27')" +
+        " or contains(data/tags/iv, '%27%27'))";
 
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {
@@ -94,7 +93,7 @@ describe('Group controller', () => {
       expect(result).toEqual(fixtures.queryGroupsExpectation);
     });
 
-    test('Should sanitise double quotation mark by using a backslash', async () => {
+    test('Should sanitise double quotation mark by encoding to hex', async () => {
       const fetchOptions: FetchOptions = {
         take: 12,
         skip: 2,
@@ -102,9 +101,9 @@ describe('Group controller', () => {
       };
 
       const expectedFilter =
-        "(contains(data/name/iv, '\\\"')" +
-        " or contains(data/description/iv, '\\\"')" +
-        " or contains(data/tags/iv, '\\\"'))";
+        "(contains(data/name/iv, '%22')" +
+        " or contains(data/description/iv, '%22')" +
+        " or contains(data/tags/iv, '%22'))";
 
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {

--- a/apps/asap-server/test/controllers/research-outputs.test.ts
+++ b/apps/asap-server/test/controllers/research-outputs.test.ts
@@ -311,8 +311,7 @@ describe('ResearchOutputs controller', () => {
       expect(result).toEqual(expectedResult);
     });
 
-    test('Should sanitise single quotation mark by using two single quotes', async () => {
-      // http://docs.oasis-open.org/odata/odata/v4.01/cs01/part2-url-conventions/odata-v4.01-cs01-part2-url-conventions.html#sec_URLComponents
+    test('Should sanitise single quotes by doubling them and encoding to hex', async () => {
       nock(config.baseUrl)
         .get(`/api/content/${config.appName}/research-outputs`)
         .query({
@@ -320,7 +319,7 @@ describe('ResearchOutputs controller', () => {
           $skip: 0,
           $orderby: 'created desc',
           $filter:
-            "(contains(data/title/iv, '''') or contains(data/tags/iv, ''''))",
+            "(contains(data/title/iv, '%27%27') or contains(data/tags/iv, '%27%27'))",
         })
         .reply(200, {
           total: 1,
@@ -386,7 +385,7 @@ describe('ResearchOutputs controller', () => {
       expect(result).toEqual(expectedResult);
     });
 
-    test('Should sanitise double quotation mark by using a backslash', async () => {
+    test('Should sanitise double quotation mark by encoding to hex', async () => {
       nock(config.baseUrl)
         .get(`/api/content/${config.appName}/research-outputs`)
         .query({
@@ -394,7 +393,7 @@ describe('ResearchOutputs controller', () => {
           $skip: 0,
           $orderby: 'created desc',
           $filter:
-            "(contains(data/title/iv, '\\\"') or contains(data/tags/iv, '\\\"'))",
+            "(contains(data/title/iv, '%22') or contains(data/tags/iv, '%22'))",
         })
         .reply(200, {
           total: 1,

--- a/apps/asap-server/test/controllers/teams.test.ts
+++ b/apps/asap-server/test/controllers/teams.test.ts
@@ -107,12 +107,11 @@ describe('Team controller', () => {
       });
     });
 
-    test('Should sanitise single quotation mark by using two single quotes', async () => {
-      // http://docs.oasis-open.org/odata/odata/v4.01/cs01/part2-url-conventions/odata-v4.01-cs01-part2-url-conventions.html#sec_URLComponents
+    test('Should sanitise single quotes by doubling them and encoding to hex', async () => {
       const expectedSearchFilter =
-        `(contains(data/displayName/iv, '''')` +
-        ` or contains(data/projectTitle/iv, '''')` +
-        ` or contains(data/skills/iv, ''''))`;
+        `(contains(data/displayName/iv, '%27%27')` +
+        ` or contains(data/projectTitle/iv, '%27%27')` +
+        ` or contains(data/skills/iv, '%27%27'))`;
 
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {
@@ -136,11 +135,11 @@ describe('Team controller', () => {
       });
     });
 
-    test('Should sanitise double quotation mark by using a backslash', async () => {
+    test('Should sanitise double quotation mark by encoding to hex', async () => {
       const expectedSearchFilter =
-        `(contains(data/displayName/iv, '\\\"')` +
-        ` or contains(data/projectTitle/iv, '\\\"')` +
-        ` or contains(data/skills/iv, '\\\"'))`;
+        `(contains(data/displayName/iv, '%22')` +
+        ` or contains(data/projectTitle/iv, '%22')` +
+        ` or contains(data/skills/iv, '%22'))`;
 
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {

--- a/apps/asap-server/test/controllers/users.test.ts
+++ b/apps/asap-server/test/controllers/users.test.ts
@@ -78,8 +78,7 @@ describe('Users controller', () => {
       expect(result).toEqual(fixtures.fetchExpectation);
     });
 
-    test('Should sanitise single quotation mark by using two single quotes', async () => {
-      // http://docs.oasis-open.org/odata/odata/v4.01/cs01/part2-url-conventions/odata-v4.01-cs01-part2-url-conventions.html#sec_URLComponents
+    test('Should sanitise single quotes by doubling them and encoding to hex', async () => {
       const fetchOptions: FetchOptions = {
         take: 12,
         skip: 2,
@@ -88,10 +87,10 @@ describe('Users controller', () => {
 
       const expectedFilter =
         "data/role/iv ne 'Hidden' and" +
-        " (contains(data/firstName/iv, '''')" +
-        " or contains(data/lastName/iv, '''')" +
-        " or contains(data/institution/iv, '''')" +
-        " or contains(data/skills/iv, ''''))";
+        " (contains(data/firstName/iv, '%27%27')" +
+        " or contains(data/lastName/iv, '%27%27')" +
+        " or contains(data/institution/iv, '%27%27')" +
+        " or contains(data/skills/iv, '%27%27'))";
 
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {
@@ -104,7 +103,7 @@ describe('Users controller', () => {
       expect(result).toEqual(fixtures.fetchExpectation);
     });
 
-    test('Should sanitise double quotation mark by using a backslash', async () => {
+    test('Should sanitise double quotation mark by encoding to hex', async () => {
       const fetchOptions: FetchOptions = {
         take: 12,
         skip: 2,
@@ -113,10 +112,10 @@ describe('Users controller', () => {
 
       const expectedFilter =
         "data/role/iv ne 'Hidden' and" +
-        " (contains(data/firstName/iv, '\\\"')" +
-        " or contains(data/lastName/iv, '\\\"')" +
-        " or contains(data/institution/iv, '\\\"')" +
-        " or contains(data/skills/iv, '\\\"'))";
+        " (contains(data/firstName/iv, '%22')" +
+        " or contains(data/lastName/iv, '%22')" +
+        " or contains(data/institution/iv, '%22')" +
+        " or contains(data/skills/iv, '%22'))";
 
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {


### PR DESCRIPTION
Sanitise search inputs by escaping to hex.

see: https://trello.com/c/7pUQV9hP/1242-%F0%9F%90%9B-searching-with-apostrophes-breaks-the-search

## Notes
* The sanitisation should, imho, happen inside the client as its client specific. The reason I did not do it there is because the client currently only accepts a formatted query, and query generation happens at the controller level anyway. 
* Following up on the above - I think it would be much better to use `variables` part of the graphql queries rather than embed all the params in the query - a tech debt ticket can be found here: https://trello.com/c/Ahlq8rgV/1259-move-graphql-query-parameters-to-the-variables
* We use the, technically deprecated, built in `escape` function to escape these characters - so far i have not been able to find any better npm package that would achieve the same result, plus it doesn't look like its going to go away any soon