### PR TITLE
feat: Add teams to research-output response

### DIFF
--- a/apps/asap-server/src/controllers/groups.ts
+++ b/apps/asap-server/src/controllers/groups.ts
@@ -7,7 +7,7 @@ import { InstrumentedSquidexGraphql } from '../utils/instrumented-client';
 import { FetchOptions } from '../utils/types';
 import { parseGraphQLGroup } from '../entities';
 import { GraphQLQueryUser } from './users';
-import { GraphQLQueryTeam } from './teams';
+import { getGraphQLQueryTeam } from './teams';
 import { sanitiseForSquidex } from '../utils/squidex';
 
 export const GraphQLQueryGroup = `
@@ -23,7 +23,7 @@ flatData {
     googleDrive
   }
   teams {
-  ${GraphQLQueryTeam}
+  ${getGraphQLQueryTeam(false)}
   }
   leaders{
     role

--- a/apps/asap-server/src/controllers/groups.ts
+++ b/apps/asap-server/src/controllers/groups.ts
@@ -23,7 +23,7 @@ flatData {
     googleDrive
   }
   teams {
-  ${getGraphQLQueryTeam(false)}
+  ${getGraphQLQueryTeam({ researchOutputsWithTeams: false })}
   }
   leaders{
     role

--- a/apps/asap-server/src/controllers/research-outputs.ts
+++ b/apps/asap-server/src/controllers/research-outputs.ts
@@ -33,7 +33,7 @@ function transform(
   };
 }
 
-export const GraphQLQueryResearchOutput = `
+export const getGraphQLQueryResearchOutput = (withTeams = false): string => `
 id
 created
 lastModified
@@ -50,7 +50,20 @@ flatData{
       name
     }
   }
-}`;
+}
+${
+  (withTeams &&
+    `referencingTeamsContents {
+  id
+  created
+  lastModified
+  flatData {
+    displayName
+  }
+}`) ||
+  ''
+}
+`;
 
 export default class ResearchOutputs implements ResearchOutputController {
   researchOutputs: InstrumentedSquidex<RestResearchOutput>;

--- a/apps/asap-server/src/controllers/research-outputs.ts
+++ b/apps/asap-server/src/controllers/research-outputs.ts
@@ -33,7 +33,11 @@ function transform(
   };
 }
 
-export const getGraphQLQueryResearchOutput = (withTeams = false): string => `
+export const getGraphQLQueryResearchOutput = ({
+  withTeams = false,
+}: {
+  withTeams: boolean;
+}): string => `
 id
 created
 lastModified

--- a/apps/asap-server/src/controllers/research-outputs.ts
+++ b/apps/asap-server/src/controllers/research-outputs.ts
@@ -56,16 +56,16 @@ flatData{
   }
 }
 ${
-  (withTeams &&
-    `referencingTeamsContents {
+  withTeams
+    ? `referencingTeamsContents {
   id
   created
   lastModified
   flatData {
     displayName
   }
-}`) ||
-  ''
+}`
+    : ''
 }
 `;
 

--- a/apps/asap-server/src/controllers/research-outputs.ts
+++ b/apps/asap-server/src/controllers/research-outputs.ts
@@ -34,7 +34,7 @@ function transform(
 }
 
 export const getGraphQLQueryResearchOutput = ({
-  withTeams = false,
+  withTeams,
 }: {
   withTeams: boolean;
 }): string => `

--- a/apps/asap-server/src/controllers/teams.ts
+++ b/apps/asap-server/src/controllers/teams.ts
@@ -15,11 +15,13 @@ import {
   InstrumentedSquidex,
   InstrumentedSquidexGraphql,
 } from '../utils/instrumented-client';
-import { GraphQLQueryResearchOutput } from './research-outputs';
+import { getGraphQLQueryResearchOutput } from './research-outputs';
 import { parseGraphQLTeam } from '../entities';
 import { createURL, sanitiseForSquidex } from '../utils/squidex';
 
-export const GraphQLQueryTeam = `
+export const getGraphQLQueryTeam = (
+  researchOutputsWithTeams = false,
+): string => `
 id
 created
 lastModified
@@ -27,7 +29,7 @@ flatData {
   applicationNumber
   displayName
   outputs {
-    ${GraphQLQueryResearchOutput}
+    ${getGraphQLQueryResearchOutput(researchOutputsWithTeams)}
   }
   projectSummary
   projectTitle
@@ -51,7 +53,7 @@ export const buildGraphQLQueryFetchTeams = (
   queryTeamsContentsWithTotal(top: ${top}, skip: ${skip}, filter: "${filter}", orderby: "data/displayName/iv") {
     total
     items {
-      ${GraphQLQueryTeam}
+      ${getGraphQLQueryTeam(true)}
     }
   }
 }`;
@@ -59,7 +61,7 @@ export const buildGraphQLQueryFetchTeams = (
 export const buildGraphQLQueryFetchTeam = (id: string): string =>
   `{
   findTeamsContent(id: "${id}") {
-    ${GraphQLQueryTeam}
+    ${getGraphQLQueryTeam(true)}
   }
 }`;
 

--- a/apps/asap-server/src/controllers/teams.ts
+++ b/apps/asap-server/src/controllers/teams.ts
@@ -19,9 +19,11 @@ import { getGraphQLQueryResearchOutput } from './research-outputs';
 import { parseGraphQLTeam } from '../entities';
 import { createURL, sanitiseForSquidex } from '../utils/squidex';
 
-export const getGraphQLQueryTeam = (
+export const getGraphQLQueryTeam = ({
   researchOutputsWithTeams = false,
-): string => `
+}: {
+  researchOutputsWithTeams: boolean;
+}): string => `
 id
 created
 lastModified
@@ -29,7 +31,7 @@ flatData {
   applicationNumber
   displayName
   outputs {
-    ${getGraphQLQueryResearchOutput(researchOutputsWithTeams)}
+    ${getGraphQLQueryResearchOutput({ withTeams: researchOutputsWithTeams })}
   }
   projectSummary
   projectTitle
@@ -53,7 +55,7 @@ export const buildGraphQLQueryFetchTeams = (
   queryTeamsContentsWithTotal(top: ${top}, skip: ${skip}, filter: "${filter}", orderby: "data/displayName/iv") {
     total
     items {
-      ${getGraphQLQueryTeam(true)}
+      ${getGraphQLQueryTeam({ researchOutputsWithTeams: true })}
     }
   }
 }`;
@@ -61,7 +63,7 @@ export const buildGraphQLQueryFetchTeams = (
 export const buildGraphQLQueryFetchTeam = (id: string): string =>
   `{
   findTeamsContent(id: "${id}") {
-    ${getGraphQLQueryTeam(true)}
+    ${getGraphQLQueryTeam({ researchOutputsWithTeams: true })}
   }
 }`;
 

--- a/apps/asap-server/src/controllers/teams.ts
+++ b/apps/asap-server/src/controllers/teams.ts
@@ -20,7 +20,7 @@ import { parseGraphQLTeam } from '../entities';
 import { createURL, sanitiseForSquidex } from '../utils/squidex';
 
 export const getGraphQLQueryTeam = ({
-  researchOutputsWithTeams = false,
+  researchOutputsWithTeams,
 }: {
   researchOutputsWithTeams: boolean;
 }): string => `

--- a/apps/asap-server/src/entities/research-output.ts
+++ b/apps/asap-server/src/entities/research-output.ts
@@ -19,7 +19,7 @@ export const parseResearchOutput = (
 
 export const parseGraphQLResearchOutput = (
   output: GraphqlResearchOutput,
-): ResearchOutputResponse => ({
+): Omit<ResearchOutputResponse, 'teams'> => ({
   id: output.id,
   created: parseDate(output.created).toISOString(),
   link: output.flatData?.link || undefined,

--- a/apps/asap-server/src/entities/team.ts
+++ b/apps/asap-server/src/entities/team.ts
@@ -43,7 +43,17 @@ export const parseGraphQLTeam = (
   const outputs: ResearchOutputResponse[] = flatOutputs
     .map((o) => {
       const output = parseGraphQLResearchOutput(o as GraphqlResearchOutput);
-      return { ...output, team: { id: team.id, displayName } };
+
+      return {
+        ...output,
+        team: { id: team.id, displayName },
+        teams: (o as GraphqlResearchOutput).referencingTeamsContents?.map(
+          (t) => ({
+            displayName: t.flatData?.displayName || '',
+            id: t.id,
+          }),
+        ) || [{ id: team.id, displayName }],
+      };
     })
     .sort(
       (a, b) => new Date(b.created).getTime() - new Date(a.created).getTime(),

--- a/apps/asap-server/src/routes/research-outputs.route.ts
+++ b/apps/asap-server/src/routes/research-outputs.route.ts
@@ -1,6 +1,10 @@
-import { Router } from 'express';
+import { Router, Response } from 'express';
 import Joi from '@hapi/joi';
 import { framework } from '@asap-hub/services-common';
+import {
+  ListResearchOutputResponse,
+  ResearchOutputResponse,
+} from '@asap-hub/model';
 import { ResearchOutputController } from '../controllers/research-outputs';
 
 export const researchOutputRouteFactory = (
@@ -8,28 +12,31 @@ export const researchOutputRouteFactory = (
 ): Router => {
   const researchOutputRoutes = Router();
 
-  researchOutputRoutes.get('/research-outputs', async (req, res) => {
-    const { query } = req;
+  researchOutputRoutes.get(
+    '/research-outputs',
+    async (req, res: Response<ListResearchOutputResponse>) => {
+      const { query } = req;
 
-    const options = (framework.validate(
-      'query',
-      query,
-      querySchema,
-    ) as unknown) as {
-      take: number;
-      skip: number;
-      search?: string;
-      filter?: string[];
-    };
+      const options = (framework.validate(
+        'query',
+        query,
+        querySchema,
+      ) as unknown) as {
+        take: number;
+        skip: number;
+        search?: string;
+        filter?: string[];
+      };
 
-    const result = await researchOutputController.fetch(options);
+      const result = await researchOutputController.fetch(options);
 
-    res.json(result);
-  });
+      res.json(result);
+    },
+  );
 
   researchOutputRoutes.get(
     '/research-outputs/:researchOutputId',
-    async (req, res) => {
+    async (req, res: Response<ResearchOutputResponse>) => {
       const { params } = req;
       const { researchOutputId } = framework.validate(
         'parameters',

--- a/apps/asap-server/test/controllers/research-outputs.test.ts
+++ b/apps/asap-server/test/controllers/research-outputs.test.ts
@@ -96,6 +96,7 @@ describe('ResearchOutputs controller', () => {
             type: 'Proposal',
             link: 'test',
             tags: ['tag', 'test'],
+            teams: [],
           },
         ],
       };
@@ -178,7 +179,7 @@ describe('ResearchOutputs controller', () => {
                 displayName: { iv: 'Team 2' },
                 applicationNumber: { iv: 'APP' },
                 outputs: {
-                  iv: ['uuid-2'],
+                  iv: ['uuid-1', 'uuid-2'],
                 },
               },
             },
@@ -206,6 +207,16 @@ describe('ResearchOutputs controller', () => {
               id: 'uuid-team-1',
               displayName: 'Team 1',
             },
+            teams: [
+              {
+                id: 'uuid-team-1',
+                displayName: 'Team 1',
+              },
+              {
+                id: 'uuid-team-2',
+                displayName: 'Team 2',
+              },
+            ],
           },
           {
             created: '2020-09-23T16:34:26.842Z',
@@ -218,6 +229,12 @@ describe('ResearchOutputs controller', () => {
               id: 'uuid-team-2',
               displayName: 'Team 2',
             },
+            teams: [
+              {
+                id: 'uuid-team-2',
+                displayName: 'Team 2',
+              },
+            ],
           },
           {
             created: '2020-09-23T16:34:26.842Z',
@@ -230,6 +247,12 @@ describe('ResearchOutputs controller', () => {
               id: 'uuid-team-1',
               displayName: 'Team 1',
             },
+            teams: [
+              {
+                id: 'uuid-team-1',
+                displayName: 'Team 1',
+              },
+            ],
           },
         ],
       };
@@ -304,6 +327,12 @@ describe('ResearchOutputs controller', () => {
               id: 'uuid-team-1',
               displayName: 'Team 1',
             },
+            teams: [
+              {
+                id: 'uuid-team-1',
+                displayName: 'Team 1',
+              },
+            ],
           },
         ],
       };
@@ -378,6 +407,12 @@ describe('ResearchOutputs controller', () => {
               id: 'uuid-team-1',
               displayName: 'Team 1',
             },
+            teams: [
+              {
+                id: 'uuid-team-1',
+                displayName: 'Team 1',
+              },
+            ],
           },
         ],
       };
@@ -452,6 +487,12 @@ describe('ResearchOutputs controller', () => {
               id: 'uuid-team-1',
               displayName: 'Team 1',
             },
+            teams: [
+              {
+                id: 'uuid-team-1',
+                displayName: 'Team 1',
+              },
+            ],
           },
         ],
       };
@@ -460,7 +501,7 @@ describe('ResearchOutputs controller', () => {
     });
   });
 
-  describe('Fetch-by-ID method', () => {
+  describe(' -ID method', () => {
     const researchOutputId = 'uuid';
 
     test('Should throw a Not Found error when the research output is not found', async () => {
@@ -495,7 +536,7 @@ describe('ResearchOutputs controller', () => {
         .get(`/api/content/${config.appName}/teams`)
         .query({
           q: JSON.stringify({
-            take: 1,
+            take: 8,
             filter: {
               path: 'data.outputs.iv',
               op: 'eq',
@@ -531,6 +572,12 @@ describe('ResearchOutputs controller', () => {
           id: 'uuid-team',
           displayName: 'team',
         },
+        teams: [
+          {
+            id: 'uuid-team',
+            displayName: 'team',
+          },
+        ],
       };
       expect(result).toEqual(expectedResult);
     });
@@ -555,7 +602,7 @@ describe('ResearchOutputs controller', () => {
         .get(`/api/content/${config.appName}/teams`)
         .query({
           q: JSON.stringify({
-            take: 1,
+            take: 8,
             filter: {
               path: 'data.outputs.iv',
               op: 'eq',
@@ -576,6 +623,7 @@ describe('ResearchOutputs controller', () => {
         title: 'Title',
         type: 'Proposal',
         tags: ['tag', 'test'],
+        teams: [],
       };
 
       expect(result).toEqual(expectedResult);

--- a/apps/asap-server/test/controllers/research-outputs.test.ts
+++ b/apps/asap-server/test/controllers/research-outputs.test.ts
@@ -501,7 +501,7 @@ describe('ResearchOutputs controller', () => {
     });
   });
 
-  describe(' -ID method', () => {
+  describe('Fetch-by-ID method', () => {
     const researchOutputId = 'uuid';
 
     test('Should throw a Not Found error when the research output is not found', async () => {

--- a/apps/asap-server/test/controllers/teams.test.ts
+++ b/apps/asap-server/test/controllers/teams.test.ts
@@ -1,5 +1,5 @@
 import nock from 'nock';
-import { config, GraphqlUser, RestUser } from '@asap-hub/squidex';
+import { config, RestUser } from '@asap-hub/squidex';
 import { User } from '@asap-hub/auth';
 import {
   graphQlTeamsResponseSingle,
@@ -383,25 +383,6 @@ describe('Team controller', () => {
 
         expect(result).toEqual(expectedResponse);
       });
-    });
-
-    test('Should return more than a single team on the nested research-output', async () => {
-      const teamId = 'team-id-1';
-
-      nock(config.baseUrl)
-        .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryFetchTeam(teamId),
-        })
-        .reply(200, graphQlTeamResponse)
-        .get(`/api/content/${config.appName}/users`)
-        .query({
-          $filter: `data/teams/iv/id eq '${teamId}'`,
-        })
-        .reply(200, fetchByIdUserResponse);
-
-      const result = await teams.fetchById(teamId, mockUser);
-
-      expect(result).toEqual(fetchTeamByIdExpectation);
     });
   });
 

--- a/apps/asap-server/test/controllers/teams.test.ts
+++ b/apps/asap-server/test/controllers/teams.test.ts
@@ -1,5 +1,5 @@
 import nock from 'nock';
-import { config } from '@asap-hub/squidex';
+import { config, GraphqlUser, RestUser } from '@asap-hub/squidex';
 import { User } from '@asap-hub/auth';
 import {
   graphQlTeamsResponseSingle,
@@ -304,11 +304,11 @@ describe('Team controller', () => {
     });
 
     describe('Avatar', () => {
-      const user = {
+      const user: RestUser = {
         ...fetchByIdUserResponse.items[0],
         data: {
           ...fetchByIdUserResponse.items[0].data,
-          avatar: { iv: 'test avatar' },
+          avatar: { iv: ['test-avatar'] },
         },
       };
 

--- a/apps/asap-server/test/controllers/teams.test.ts
+++ b/apps/asap-server/test/controllers/teams.test.ts
@@ -303,51 +303,90 @@ describe('Team controller', () => {
       });
     });
 
-    test('Should parse the team user correctly when the avatar is null', async () => {
-      const teamId = 'team-id-1';
-      const user = fetchByIdUserResponse.items[0];
-      user.data.avatar.iv = null as any;
-
-      const userResponse = {
-        total: 1,
-        items: [user],
+    describe('Avatar', () => {
+      const user = {
+        ...fetchByIdUserResponse.items[0],
+        data: {
+          ...fetchByIdUserResponse.items[0].data,
+          avatar: { iv: 'test avatar' },
+        },
       };
 
-      nock(config.baseUrl)
-        .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryFetchTeam(teamId),
-        })
-        .reply(200, graphQlTeamResponse)
-        .get(`/api/content/${config.appName}/users`)
-        .query({
-          $filter: `data/teams/iv/id eq '${teamId}'`,
-        })
-        .reply(200, userResponse);
+      test('Should parse the team user correctly when the avatar is null', async () => {
+        const teamId = 'team-id-1';
 
-      const result = await teams.fetchById(teamId, mockUser);
+        user.data.avatar.iv = null as any;
 
-      const expectedResponse = {
-        ...fetchTeamByIdExpectation,
-        members: [
-          {
-            ...fetchTeamByIdExpectation.members[0],
-            avatarUrl: undefined,
-          },
-        ],
-      };
+        const userResponse = {
+          total: 1,
+          items: [user],
+        };
 
-      expect(result).toEqual(expectedResponse);
+        nock(config.baseUrl)
+          .post(`/api/content/${config.appName}/graphql`, {
+            query: buildGraphQLQueryFetchTeam(teamId),
+          })
+          .reply(200, graphQlTeamResponse)
+          .get(`/api/content/${config.appName}/users`)
+          .query({
+            $filter: `data/teams/iv/id eq '${teamId}'`,
+          })
+          .reply(200, userResponse);
+
+        const result = await teams.fetchById(teamId, mockUser);
+
+        const expectedResponse = {
+          ...fetchTeamByIdExpectation,
+          members: [
+            {
+              ...fetchTeamByIdExpectation.members[0],
+              avatarUrl: undefined,
+            },
+          ],
+        };
+
+        expect(result).toEqual(expectedResponse);
+      });
+
+      test('Should parse the team user correctly when the avatar is undefined', async () => {
+        const teamId = 'team-id-1';
+
+        delete (user.data as any).avatar;
+
+        const userResponse = {
+          total: 1,
+          items: [user],
+        };
+
+        nock(config.baseUrl)
+          .post(`/api/content/${config.appName}/graphql`, {
+            query: buildGraphQLQueryFetchTeam(teamId),
+          })
+          .reply(200, graphQlTeamResponse)
+          .get(`/api/content/${config.appName}/users`)
+          .query({
+            $filter: `data/teams/iv/id eq '${teamId}'`,
+          })
+          .reply(200, userResponse);
+
+        const result = await teams.fetchById(teamId, mockUser);
+
+        const expectedResponse = {
+          ...fetchTeamByIdExpectation,
+          members: [
+            {
+              ...fetchTeamByIdExpectation.members[0],
+              avatarUrl: undefined,
+            },
+          ],
+        };
+
+        expect(result).toEqual(expectedResponse);
+      });
     });
 
-    test('Should parse the team user correctly when the avatar is undefined', async () => {
+    test('Should return more than a single team on the nested research-output', async () => {
       const teamId = 'team-id-1';
-      const user = fetchByIdUserResponse.items[0];
-      delete (user.data as any).avatar;
-
-      const userResponse = {
-        total: 1,
-        items: [user],
-      };
 
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {
@@ -358,21 +397,11 @@ describe('Team controller', () => {
         .query({
           $filter: `data/teams/iv/id eq '${teamId}'`,
         })
-        .reply(200, userResponse);
+        .reply(200, fetchByIdUserResponse);
 
       const result = await teams.fetchById(teamId, mockUser);
 
-      const expectedResponse = {
-        ...fetchTeamByIdExpectation,
-        members: [
-          {
-            ...fetchTeamByIdExpectation.members[0],
-            avatarUrl: undefined,
-          },
-        ],
-      };
-
-      expect(result).toEqual(expectedResponse);
+      expect(result).toEqual(fetchTeamByIdExpectation);
     });
   });
 

--- a/apps/asap-server/test/fixtures/groups.fixtures.ts
+++ b/apps/asap-server/test/fixtures/groups.fixtures.ts
@@ -257,6 +257,7 @@ export const queryGroupsExpectation: ListGroupResponse = {
               description: '',
               tags: ['test', 'tag'],
               team: { id: 'team-id-1', displayName: 'Lee, M' },
+              teams: [{ id: 'team-id-1', displayName: 'Lee, M' }],
             },
           ],
           projectTitle:

--- a/apps/asap-server/test/fixtures/teams.fixtures.ts
+++ b/apps/asap-server/test/fixtures/teams.fixtures.ts
@@ -400,6 +400,24 @@ export const graphQlTeamResponse: { data: ResponseFetchTeam } = {
               title: "Team Salzer's intro slide deck",
               type: 'Presentation',
             },
+            referencingTeamsContents: [
+              {
+                id: 'team-id-1',
+                created: '2020-09-23T20:33:36Z',
+                lastModified: '2020-11-26T11:56:04Z',
+                flatData: {
+                  displayName: 'Schipa, A',
+                },
+              },
+              {
+                id: 'team-id-2',
+                created: '2020-09-23T20:33:36Z',
+                lastModified: '2020-11-26T11:56:04Z',
+                flatData: {
+                  displayName: 'Team, B',
+                },
+              },
+            ],
           },
         ],
         projectSummary: null,
@@ -503,6 +521,10 @@ export const fetchTeamByIdExpectation: TeamResponse = {
           id: 'team-id-1',
           displayName: 'Schipa, A',
         },
+        {
+          id: 'team-id-2',
+          displayName: 'Team, B',
+        },
       ],
     },
     {
@@ -586,6 +608,16 @@ export const getGraphQlTeamResponse = (
               type: 'Proposal',
               tags: ['test', 'tag'],
             },
+            referencingTeamsContents: [
+              {
+                id: 'team-id-1',
+                created: '2020-09-17T08:18:01Z',
+                lastModified: '2020-10-21T13:11:50Z',
+                flatData: {
+                  displayName: 'Schipa, A',
+                },
+              },
+            ],
           },
           {
             id: '7198d072-de87-4b80-90ca-4a1abe67952e',
@@ -598,6 +630,24 @@ export const getGraphQlTeamResponse = (
               title: "Team Salzer's intro slide deck",
               type: 'Presentation',
             },
+            referencingTeamsContents: [
+              {
+                id: 'team-id-1',
+                created: '2020-09-17T08:18:01Z',
+                lastModified: '2020-10-21T13:11:50Z',
+                flatData: {
+                  displayName: 'Schipa, A',
+                },
+              },
+              {
+                id: 'team-id-2',
+                created: '2020-09-17T08:18:01Z',
+                lastModified: '2020-10-21T13:11:50Z',
+                flatData: {
+                  displayName: 'Team, B',
+                },
+              },
+            ],
           },
         ],
         projectSummary: null,
@@ -672,6 +722,10 @@ export const updateExpectation: TeamResponse = {
         {
           id: 'team-id-1',
           displayName: 'Schipa, A',
+        },
+        {
+          id: 'team-id-2',
+          displayName: 'Team, B',
         },
       ],
     },

--- a/apps/asap-server/test/fixtures/teams.fixtures.ts
+++ b/apps/asap-server/test/fixtures/teams.fixtures.ts
@@ -265,6 +265,12 @@ export const listTeamResponse: ListTeamResponse = {
             id: 'team-id-1',
             displayName: 'Schipa, A',
           },
+          teams: [
+            {
+              id: 'team-id-1',
+              displayName: 'Schipa, A',
+            },
+          ],
         },
         {
           id: '4cfb1b7b-bafe-4fca-b2ab-197e84d98996',
@@ -277,6 +283,12 @@ export const listTeamResponse: ListTeamResponse = {
             id: 'team-id-1',
             displayName: 'Schipa, A',
           },
+          teams: [
+            {
+              id: 'team-id-1',
+              displayName: 'Schipa, A',
+            },
+          ],
         },
       ],
       members: [
@@ -486,6 +498,12 @@ export const fetchTeamByIdExpectation: TeamResponse = {
         id: 'team-id-1',
         displayName: 'Schipa, A',
       },
+      teams: [
+        {
+          id: 'team-id-1',
+          displayName: 'Schipa, A',
+        },
+      ],
     },
     {
       id: '4cfb1b7b-bafe-4fca-b2ab-197e84d98996',
@@ -498,6 +516,12 @@ export const fetchTeamByIdExpectation: TeamResponse = {
         id: 'team-id-1',
         displayName: 'Schipa, A',
       },
+      teams: [
+        {
+          id: 'team-id-1',
+          displayName: 'Schipa, A',
+        },
+      ],
     },
   ],
   members: [
@@ -644,6 +668,12 @@ export const updateExpectation: TeamResponse = {
         id: 'team-id-1',
         displayName: 'Schipa, A',
       },
+      teams: [
+        {
+          id: 'team-id-1',
+          displayName: 'Schipa, A',
+        },
+      ],
     },
     {
       id: '4cfb1b7b-bafe-4fca-b2ab-197e84d98996',
@@ -656,6 +686,12 @@ export const updateExpectation: TeamResponse = {
         id: 'team-id-1',
         displayName: 'Schipa, A',
       },
+      teams: [
+        {
+          id: 'team-id-1',
+          displayName: 'Schipa, A',
+        },
+      ],
     },
   ],
   members: [

--- a/apps/asap-server/test/routes/research-outputs.route.test.ts
+++ b/apps/asap-server/test/routes/research-outputs.route.test.ts
@@ -47,6 +47,7 @@ describe('/research-outputs/ route', () => {
             type: 'Proposal',
             link: 'test',
             tags: ['test', 'tag'],
+            teams: [],
           },
         ],
       };
@@ -113,6 +114,12 @@ describe('/research-outputs/ route', () => {
           id: 'uuid-team',
           displayName: 'team',
         },
+        teams: [
+          {
+            id: 'uuid-team',
+            displayName: 'team',
+          },
+        ],
       };
 
       researchOutputControllerMock.fetchById.mockResolvedValueOnce(

--- a/packages/fixtures/src/research-outputs.ts
+++ b/packages/fixtures/src/research-outputs.ts
@@ -18,6 +18,12 @@ const researchOutputResponse: Omit<
     id: 'e12729e0-a244-471f-a554-7b58eae83a8d',
     displayName: 'Jakobsson, J',
   },
+  teams: [
+    {
+      id: 'e12729e0-a244-471f-a554-7b58eae83a8d',
+      displayName: 'Jakobsson, J',
+    },
+  ],
 };
 
 export const createResearchOutputResponse = (

--- a/packages/model/src/research-output.ts
+++ b/packages/model/src/research-output.ts
@@ -38,6 +38,7 @@ export type ResearchOutputResponse = Omit<
   readonly link?: string;
   readonly created: string;
   readonly team?: Pick<TeamResponse, 'id' | 'displayName'>;
+  readonly teams: Pick<TeamResponse, 'id' | 'displayName'>[];
   readonly tags: string[];
   readonly addedDate?: string;
   readonly lastModifiedDate?: string;

--- a/packages/squidex/src/entities/research-output.ts
+++ b/packages/squidex/src/entities/research-output.ts
@@ -1,6 +1,7 @@
 import { ResearchOutputType } from '@asap-hub/model';
 
 import { Rest, Entity, Graphql } from './common';
+import { GraphqlTeam } from './team';
 
 export interface ResearchOutput {
   type: ResearchOutputType;
@@ -14,6 +15,6 @@ export interface ResearchOutput {
 }
 
 export interface RestResearchOutput extends Entity, Rest<ResearchOutput> {}
-export interface GraphqlResearchOutput
-  extends Entity,
-    Graphql<ResearchOutput> {}
+export interface GraphqlResearchOutput extends Entity, Graphql<ResearchOutput> {
+  referencingTeamsContents?: GraphqlTeam[];
+}


### PR DESCRIPTION
This PR adds teams do research-output response. 

Previously only a single team was present. However - because the RO response itself is also being attached to other various responses (ie Group response or Team response), this PR attaches them only for teams, not for groups.

This means that a team->RO->teams traversal is possible, but group->team->RO->teams is not. In order to adhere to the same contract - for the Group response only the parent team is being copied across into the `teams` property.

https://trello.com/c/FarA5LEp/1130-as-an-admin-i-want-to-associate-an-output-to-more-than-one-team-to-correctly-address-authorship