### PR TITLE
feat: Add user-id to request info log

### DIFF
--- a/apps/asap-server/@types/express/index.d.ts
+++ b/apps/asap-server/@types/express/index.d.ts
@@ -1,6 +1,7 @@
 import { APIGatewayProxyEventV2 } from 'aws-lambda';
 import { Span } from 'opentracing';
 import { User } from '@asap-hub/auth';
+import { Logger } from 'pino-http';
 
 export {};
 
@@ -11,6 +12,10 @@ declare global {
       context: APIGatewayProxyEventV2['requestContext'];
       loggedUser?: User;
       span?: Span;
+    }
+
+    interface Response {
+      log?: Logger;
     }
   }
 }

--- a/apps/asap-server/src/app.ts
+++ b/apps/asap-server/src/app.ts
@@ -37,7 +37,8 @@ import NewsAndEvents, {
 import { newsAndEventsRouteFactory } from './routes/news-and-events.route';
 import Discover, { DiscoverController } from './controllers/discover';
 import { discoverRouteFactory } from './routes/discover.route';
-import pinoLogger, { redaction } from './utils/logger';
+import pinoLogger from './utils/logger';
+import { userLoggerHandler } from './middleware/user-logger-handler';
 
 export const appFactory = (libs: Libs = {}): Express => {
   const app = express();
@@ -49,8 +50,10 @@ export const appFactory = (libs: Libs = {}): Express => {
   const logger = libs.logger || pinoLogger;
 
   // Middleware
-  const httpLogger = pinoHttp({ logger, serializers: redaction });
-  const errorHandler = errorHandlerFactory(logger);
+  const httpLogger = pinoHttp({
+    logger,
+  });
+  const errorHandler = errorHandlerFactory();
 
   // Controllers
   const calendarController = libs.calendarController || new Calendars();
@@ -114,6 +117,7 @@ export const appFactory = (libs: Libs = {}): Express => {
 
   // Auth
   app.use(authHandler);
+  app.use(userLoggerHandler);
 
   /**
    * Routes requiring authorisation below

--- a/apps/asap-server/src/middleware/error-handler.ts
+++ b/apps/asap-server/src/middleware/error-handler.ts
@@ -1,8 +1,7 @@
 import { ErrorRequestHandler } from 'express';
 import { isBoom } from '@hapi/boom';
-import { Logger } from 'pino';
 
-export const errorHandlerFactory = (logger: Logger): ErrorRequestHandler => (
+export const errorHandlerFactory = (): ErrorRequestHandler => (
   err,
   req,
   res,
@@ -12,7 +11,7 @@ export const errorHandlerFactory = (logger: Logger): ErrorRequestHandler => (
     return next(err);
   }
 
-  logger.error(err);
+  req.log.error(err);
 
   // add error to the trace
   req.span?.log({ 'error.error': err });

--- a/apps/asap-server/src/middleware/user-logger-handler.ts
+++ b/apps/asap-server/src/middleware/user-logger-handler.ts
@@ -1,0 +1,10 @@
+import { RequestHandler } from 'express';
+
+export const userLoggerHandler: RequestHandler = (req, res, next) => {
+  if (req.loggedUser) {
+    req.log = res.log = req.log.child({
+      userId: req.loggedUser.id,
+    });
+  }
+  next();
+};

--- a/apps/asap-server/test/middleware/user-logger-handler.test.ts
+++ b/apps/asap-server/test/middleware/user-logger-handler.test.ts
@@ -1,0 +1,72 @@
+import { User } from '@asap-hub/auth';
+import { RequestHandler, Router } from 'express';
+import pino from 'pino';
+import supertest from 'supertest';
+import { appFactory } from '../../src/app';
+import { userMock } from '../../src/utils/__mocks__/validate-token';
+
+describe('User info logging handler', () => {
+  // mock auth handler
+  const getUser: jest.MockedFunction<() => User | undefined> = jest.fn();
+  const authHandlerMock: RequestHandler = async (req, _res, next) => {
+    req.loggedUser = getUser();
+    next();
+  };
+
+  // logger instance with an extra write stream
+  // only for testing purposes
+  const captureLogs = jest.fn();
+  const logger = pino(
+    {},
+    {
+      write: captureLogs,
+    },
+  );
+
+  // mock test routes
+  const logRoutes = Router();
+  logRoutes.get('/events/error-route', async () => {
+    throw new Error('error message');
+  });
+  logRoutes.get('/events/custom-log', async (req, res) => {
+    res.send('foo');
+  });
+
+  const app = appFactory({
+    mockRequestHandlers: [logRoutes],
+    authHandler: authHandlerMock,
+    logger: logger,
+  });
+
+  afterEach(() => {
+    captureLogs.mockClear();
+    getUser.mockClear();
+  });
+
+  test('Should log user ID when the user is logged in', async () => {
+    getUser.mockReturnValueOnce(userMock);
+
+    await supertest(app).get('/events/custom-log');
+
+    const firstLogCall = JSON.parse(captureLogs.mock.calls[0][0]);
+    expect(firstLogCall).toMatchObject({ userId: userMock.id });
+  });
+
+  test('Should not log user ID when the user is not logged in', async () => {
+    getUser.mockReturnValueOnce(undefined);
+
+    await supertest(app).get('/events/custom-log');
+
+    const firstLogCall = JSON.parse(captureLogs.mock.calls[0][0]);
+    expect(firstLogCall.userId).not.toBeDefined();
+  });
+
+  test('Should add user ID to the error message', async () => {
+    getUser.mockReturnValueOnce(userMock);
+
+    await supertest(app).get('/events/error-route');
+
+    const firstLogCall = JSON.parse(captureLogs.mock.calls[0][0]);
+    expect(firstLogCall).toMatchObject({ userId: userMock.id });
+  });
+});


### PR DESCRIPTION
https://trello.com/c/MXa8c7RB/1112-add-user-id-to-log-output

## Notes
* this PR only adds `userId` property to the request related log lines and not to the custom logs from the `logger` instance