### PR TITLE
chore(config): app origin default points to dev

### DIFF
--- a/apps/asap-server/src/config.ts
+++ b/apps/asap-server/src/config.ts
@@ -4,7 +4,6 @@ const {
   APP_ORIGIN,
   AUTH0_SHARED_SECRET,
   AWS_SES_ENDPOINT,
-  GLOBAL_TOKEN,
   SQUIDEX_SHARED_SECRET,
   LIGHTSTEP_TOKEN,
   ENVIRONMENT,
@@ -17,8 +16,7 @@ const {
   NODE_ENV,
 } = process.env;
 
-export const globalToken = GLOBAL_TOKEN || 'change_me_when_we_have_admins';
-export const origin = APP_ORIGIN || 'http://localhost:3000';
+export const origin = APP_ORIGIN || 'https://dev.hub.asap.science';
 export const sesEndpoint = AWS_SES_ENDPOINT;
 export const lightstepToken = LIGHTSTEP_TOKEN;
 export const environment = ENVIRONMENT


### PR DESCRIPTION
The `APP_ORIGIN` variable is only used for auth purposes. 
We use is to select the user metadata on Auth0's id_token correct namespace.
We always run against our dev environment, hence I'm changing the default to point to that.
