### PR TITLE
feat(shared-research-output): teams in header

### DIFF
--- a/apps/storybook/src/SharedResearchOutput.stories.tsx
+++ b/apps/storybook/src/SharedResearchOutput.stories.tsx
@@ -3,9 +3,12 @@ import {
   SharedResearchOutput,
   SharedResearchProposal,
 } from '@asap-hub/react-components';
-import { text, date, array } from '@storybook/addon-knobs';
+import { text, date, array, number } from '@storybook/addon-knobs';
 
-import { createResearchOutputResponse } from '@asap-hub/fixtures';
+import {
+  createListTeamResponse,
+  createResearchOutputResponse,
+} from '@asap-hub/fixtures';
 
 export default {
   title: 'Templates / Shared Research / Details',
@@ -26,17 +29,16 @@ const props = (): ComponentProps<typeof SharedResearchOutput> => ({
     'Title',
     'Molecular actions of PD-associated pathological proteins using in vitro human pluripotent stem cell-derived brain',
   ),
-  link: text('link', 'http://example.com'),
+  link: text('Link', 'http://example.com'),
   tags: array('Tags', ['Tag 1', 'Tag 2', 'Tag 3', 'Tag 4', 'Tag 5']),
   lastModifiedDate: new Date(
     date('Last Modified Date', new Date(2020, 6, 12, 14, 32)),
   ).toISOString(),
   backHref: '#',
+  teams: createListTeamResponse(number('Number of teams', 3)).items,
 });
 
-export const Normal = () => (
-  <SharedResearchOutput {...props()} type="Proposal" />
-);
+export const Normal = () => <SharedResearchOutput {...props()} />;
 export const Proposal = () => (
   <SharedResearchProposal {...props()} type="Proposal" />
 );

--- a/apps/storybook/src/TeamsList.stories.tsx
+++ b/apps/storybook/src/TeamsList.stories.tsx
@@ -4,12 +4,19 @@ import { number } from '@storybook/addon-knobs';
 import { createListTeamResponse } from '@asap-hub/fixtures';
 
 export default {
-  title: 'Molecules / Group Profile / Teams List',
+  title: 'Molecules / Teams / List',
   component: TeamsList,
 };
 
 export const Normal = () => (
   <TeamsList
+    teams={createListTeamResponse(number('Number of Teams', 6)).items}
+  />
+);
+
+export const Inline = () => (
+  <TeamsList
+    inline
     teams={createListTeamResponse(number('Number of Teams', 6)).items}
   />
 );

--- a/packages/model/src/research-output.ts
+++ b/packages/model/src/research-output.ts
@@ -41,7 +41,7 @@ export type ResearchOutputResponse = Omit<
    * @deprecated in favour of teams
    */
   readonly team?: Pick<TeamResponse, 'id' | 'displayName'>;
-  readonly teams: Pick<TeamResponse, 'id' | 'displayName'>[];
+  readonly teams: ReadonlyArray<Pick<TeamResponse, 'id' | 'displayName'>>;
   readonly tags: string[];
   readonly addedDate?: string;
   readonly lastModifiedDate?: string;

--- a/packages/react-components/src/molecules/TeamsList.tsx
+++ b/packages/react-components/src/molecules/TeamsList.tsx
@@ -5,39 +5,90 @@ import { network } from '@asap-hub/routing';
 import { Divider, Link } from '../atoms';
 import { perRem } from '../pixels';
 import { teamIcon } from '../icons';
+import { lead } from '../colors';
+import { themeStyles as linkStyles } from '../atoms/Link';
 
-const listStyles = css({
-  display: 'grid',
-  listStyle: 'none',
-  margin: 0,
-  padding: 0,
-});
-const rowStyles = css({
-  padding: `${12 / perRem}em 0`,
-
+const containerInlineStyles = css({
   display: 'grid',
   gridTemplateColumns: 'max-content 1fr',
   gridColumnGap: `${12 / perRem}em`,
+});
+
+const listStyles = css({
+  listStyle: 'none',
+  margin: 0,
+  padding: 0,
+
+  overflow: 'hidden',
+});
+const listBlockStyles = css({
+  padding: `${12 / perRem}em 0`,
+  display: 'grid',
+  gridRowGap: `${12 / perRem}em`,
+});
+const listInlineStyles = css({
+  display: 'flex',
+  flexWrap: 'wrap',
   alignItems: 'center',
+});
+
+const itemBlockStyles = css({
+  display: 'grid',
+  gridTemplateColumns: 'max-content 1fr',
+  gridGap: `${12 / perRem}em`,
+});
+const itemInlineStyles = css({
+  paddingBottom: `${6 / perRem}em`,
+  overflow: 'hidden',
+});
+
+const inlinePaddingStyles = css({
+  'li:not(:last-of-type) > &': {
+    paddingRight: `${6 / perRem}em`,
+  },
+});
+
+const teamInlineStyles = css(inlinePaddingStyles, linkStyles.light, {
+  overflow: 'hidden',
+  whiteSpace: 'nowrap',
+  textOverflow: 'ellipsis',
+});
+const dividerStyles = css({
+  gridColumn: '1 / -1',
+  'li:last-of-type > &': {
+    display: 'none',
+  },
+});
+const bulletStyles = css({
+  color: lead.rgb,
+  paddingLeft: `${6 / perRem}em`,
+  'li:last-of-type > * > &': {
+    display: 'none',
+  },
 });
 
 interface TeamsListProps {
   readonly teams: ReadonlyArray<{ id: string; displayName: string }>;
+  readonly inline?: boolean;
 }
-const TeamsList: React.FC<TeamsListProps> = ({ teams }) => (
-  <ul css={listStyles}>
-    {teams.flatMap(({ id, displayName }, i) => (
-      <li key={`sep-${i}`}>
-        {i > 0 && <Divider />}
-        <div css={rowStyles}>
-          {teamIcon}
-          <Link href={network({}).teams({}).team({ teamId: id }).$}>
-            Team {displayName}
-          </Link>
-        </div>
-      </li>
-    ))}
-  </ul>
+const TeamsList: React.FC<TeamsListProps> = ({ teams, inline = false }) => (
+  <div css={inline && containerInlineStyles}>
+    {inline && teamIcon}
+    <ul css={[listStyles, inline ? listInlineStyles : listBlockStyles]}>
+      {teams.flatMap(({ id, displayName }, i) => (
+        <li css={inline ? itemInlineStyles : itemBlockStyles} key={`sep-${i}`}>
+          {inline || teamIcon}
+          <div css={inline && teamInlineStyles}>
+            <Link href={network({}).teams({}).team({ teamId: id }).$}>
+              Team {displayName}
+            </Link>
+            {inline && <span css={bulletStyles}>·</span>}
+          </div>
+          <div css={dividerStyles}>{inline || <Divider />}</div>
+        </li>
+      ))}
+    </ul>
+  </div>
 );
 
 export default TeamsList;

--- a/packages/react-components/src/molecules/__tests__/TeamsList.browser-test.tsx
+++ b/packages/react-components/src/molecules/__tests__/TeamsList.browser-test.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import domToPlaywright from 'dom-to-playwright';
+
+import TeamsList from '../TeamsList';
+import { largeDesktopScreen } from '../../pixels';
+import { getBoundingClientRect } from '../../browser-test-utils';
+
+beforeEach(async () => {
+  await page.setViewportSize(largeDesktopScreen);
+});
+afterEach(async () => {
+  await jestPlaywright.resetPage();
+});
+
+it('supports the block and inline modes', async () => {
+  const { getByText, rerender } = render(
+    <TeamsList
+      inline={false}
+      teams={[
+        { displayName: 'One', id: 't0' },
+        { displayName: 'Two', id: 't1' },
+      ]}
+    />,
+  );
+  const { select, update } = await domToPlaywright(page, document);
+
+  const { x: blockX1, y: blockY1 } = await getBoundingClientRect(
+    select(getByText(/One/)),
+  );
+  const { x: blockX2, y: blockY2 } = await getBoundingClientRect(
+    select(getByText(/Two/)),
+  );
+  expect(blockX2).toEqual(blockX1);
+  expect(blockY2).toBeGreaterThan(blockY1);
+
+  rerender(
+    <TeamsList
+      inline
+      teams={[
+        { displayName: 'One', id: 't0' },
+        { displayName: 'Two', id: 't1' },
+      ]}
+    />,
+  );
+  await update(document);
+
+  const { x: inlineX1, y: inlineY1 } = await getBoundingClientRect(
+    select(getByText(/One/)),
+  );
+  const { x: inlineX2, y: inlineY2 } = await getBoundingClientRect(
+    select(getByText(/Two/)),
+  );
+  expect(inlineX2).toBeGreaterThan(inlineX1);
+  expect(inlineY2).toEqual(inlineY1);
+});

--- a/packages/react-components/src/molecules/__tests__/TeamsList.test.tsx
+++ b/packages/react-components/src/molecules/__tests__/TeamsList.test.tsx
@@ -29,3 +29,28 @@ it('links to the teams', () => {
     expect.stringMatching(/t0$/),
   );
 });
+
+describe('in inline mode', () => {
+  it('renders one team icon as opposed to one each', () => {
+    const { getAllByTitle, rerender } = render(
+      <TeamsList
+        teams={[
+          { displayName: 'One', id: 't0' },
+          { displayName: 'Two', id: 't1' },
+        ]}
+      />,
+    );
+    expect(getAllByTitle(/team/i)).toHaveLength(2);
+
+    rerender(
+      <TeamsList
+        inline
+        teams={[
+          { displayName: 'One', id: 't0' },
+          { displayName: 'Two', id: 't1' },
+        ]}
+      />,
+    );
+    expect(getAllByTitle(/team/i)).toHaveLength(1);
+  });
+});

--- a/packages/react-components/src/organisms/SharedResearchOutputHeaderCard.tsx
+++ b/packages/react-components/src/organisms/SharedResearchOutputHeaderCard.tsx
@@ -7,6 +7,7 @@ import { lead } from '../colors';
 import { formatDate } from '../date';
 import { perRem, mobileScreen } from '../pixels';
 import { captionStyles } from '../text';
+import { TeamsList } from '../molecules';
 
 const headerStyles = css({
   flex: 1,
@@ -65,6 +66,7 @@ const SharedResearchOutputHeaderCard: React.FC<SharedResearchOutputHeaderCardPro
       ) : null}
     </div>
     <Display styleAsHeading={3}>{title}</Display>
+    <TeamsList inline teams={teams} />
     <div css={[timestampStyles, captionStyles]}>
       <span>
         Date added: {formatDate(new Date(addedDate || created))}

--- a/packages/react-components/src/organisms/SharedResearchOutputHeaderCard.tsx
+++ b/packages/react-components/src/organisms/SharedResearchOutputHeaderCard.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { researchOutputLabels, ResearchOutputResponse } from '@asap-hub/model';
+import css from '@emotion/css';
+
+import { Card, TagLabel, ExternalLink, Display } from '..';
+import { lead } from '../colors';
+import { formatDate } from '../date';
+import { perRem, mobileScreen } from '../pixels';
+import { captionStyles } from '../text';
+
+const headerStyles = css({
+  flex: 1,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+});
+
+const typeStyles = css({
+  display: 'flex',
+  alignItems: 'center',
+  textTransform: 'capitalize',
+});
+
+const timestampStyles = css({
+  color: lead.rgb,
+  display: 'flex',
+  flexDirection: 'row',
+  whiteSpace: 'pre',
+  marginTop: `${24 / perRem}em`,
+  marginBottom: 0,
+  [`@media (max-width: ${mobileScreen.max}px)`]: {
+    flexDirection: 'column',
+    marginTop: `${12 / perRem}em`,
+    marginBottom: `${12 / perRem}em`,
+  },
+});
+
+type SharedResearchOutputHeaderCardProps = Pick<
+  ResearchOutputResponse,
+  | 'created'
+  | 'addedDate'
+  | 'teams'
+  | 'title'
+  | 'type'
+  | 'link'
+  | 'lastModifiedDate'
+>;
+
+const SharedResearchOutputHeaderCard: React.FC<SharedResearchOutputHeaderCardProps> = ({
+  created,
+  addedDate,
+  teams,
+  title,
+  type,
+  link,
+  lastModifiedDate,
+}) => (
+  <Card>
+    <div css={headerStyles}>
+      <div css={typeStyles}>
+        <TagLabel>{type}</TagLabel>
+      </div>
+      {link ? (
+        <ExternalLink label={researchOutputLabels[type]} href={link} />
+      ) : null}
+    </div>
+    <Display styleAsHeading={3}>{title}</Display>
+    <div css={[timestampStyles, captionStyles]}>
+      <span>
+        Date added: {formatDate(new Date(addedDate || created))}
+        {lastModifiedDate && ' · '}
+      </span>
+      {lastModifiedDate && (
+        <span>Last updated: {formatDate(new Date(lastModifiedDate))}</span>
+      )}
+    </div>
+  </Card>
+);
+
+export default SharedResearchOutputHeaderCard;

--- a/packages/react-components/src/organisms/__tests__/SharedResearchOutputHeaderCard.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/SharedResearchOutputHeaderCard.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { createResearchOutputResponse } from '@asap-hub/fixtures';
+
+import SharedResearchOutputHeaderCard from '../SharedResearchOutputHeaderCard';
+
+it('renders an output with an external link if available', () => {
+  const { queryByTitle, getByTitle, rerender } = render(
+    <SharedResearchOutputHeaderCard
+      {...createResearchOutputResponse()}
+      link={undefined}
+    />,
+  );
+  expect(queryByTitle(/external link/i)).not.toBeInTheDocument();
+  rerender(
+    <SharedResearchOutputHeaderCard
+      {...createResearchOutputResponse()}
+      link="http://example.com"
+    />,
+  );
+  expect(getByTitle(/external link/i).closest('a')).toHaveAttribute(
+    'href',
+    'http://example.com',
+  );
+});
+
+it('renders an output with a modified date', () => {
+  const { queryByText, getByText, rerender } = render(
+    <SharedResearchOutputHeaderCard
+      {...createResearchOutputResponse()}
+      lastModifiedDate={undefined}
+    />,
+  );
+  expect(queryByText(/2003/)).not.toBeInTheDocument();
+  rerender(
+    <SharedResearchOutputHeaderCard
+      {...createResearchOutputResponse()}
+      addedDate={new Date(2003, 1, 1, 1).toISOString()}
+    />,
+  );
+  expect(getByText(/2003/)).toBeVisible();
+});
+
+it('falls back to created date when added date omitted', () => {
+  const { getByText, rerender } = render(
+    <SharedResearchOutputHeaderCard
+      {...createResearchOutputResponse()}
+      created={new Date(2019, 1, 1, 1).toISOString()}
+      addedDate={new Date(2020, 1, 1, 1).toISOString()}
+      lastModifiedDate={undefined}
+    />,
+  );
+  expect(getByText(/2020/)).toBeVisible();
+  rerender(
+    <SharedResearchOutputHeaderCard
+      {...createResearchOutputResponse()}
+      created={new Date(2019, 1, 1, 1).toISOString()}
+      addedDate={undefined}
+      lastModifiedDate={undefined}
+    />,
+  );
+  expect(getByText(/2019/)).toBeVisible();
+});

--- a/packages/react-components/src/organisms/index.ts
+++ b/packages/react-components/src/organisms/index.ts
@@ -35,6 +35,7 @@ export { default as RichTextCard } from './RichTextCard';
 export { default as SearchAndFilter } from './SearchAndFilter';
 export { default as SharedResearchCard } from './SharedResearchCard';
 export { default as SharedResearchListCard } from './SharedResearchListCard';
+export { default as SharedResearchOutputHeaderCard } from './SharedResearchOutputHeaderCard';
 export { default as TeamCard } from './TeamCard';
 export { default as TeamGroupsCard } from './TeamGroupsCard';
 export { default as TeamMembersSection } from './TeamMembersSection';

--- a/packages/react-components/src/templates/SharedResearchOutput.tsx
+++ b/packages/react-components/src/templates/SharedResearchOutput.tsx
@@ -1,45 +1,15 @@
-import React from 'react';
+import React, { ComponentProps } from 'react';
 import css from '@emotion/css';
-import { researchOutputLabels, ResearchOutputResponse } from '@asap-hub/model';
+import { ResearchOutputResponse } from '@asap-hub/model';
 
-import { TagLabel, Display, Card, Headline2, Divider } from '../atoms';
-import { lead } from '../colors';
-import { mobileScreen, perRem } from '../pixels';
+import { Card, Headline2, Divider } from '../atoms';
+import { perRem } from '../pixels';
 import { contentSidePaddingWithNavigation } from '../layout';
-import { BackLink, ExternalLink, TagList } from '../molecules';
-import { captionStyles } from '../text';
-import { RichText } from '../organisms';
-import { formatDate } from '../date';
+import { BackLink, TagList } from '../molecules';
+import { RichText, SharedResearchOutputHeaderCard } from '../organisms';
 
 const containerStyles = css({
   padding: `${36 / perRem}em ${contentSidePaddingWithNavigation(8)}`,
-});
-
-const headerStyles = css({
-  flex: 1,
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'space-between',
-});
-
-const typeStyles = css({
-  display: 'flex',
-  alignItems: 'center',
-  textTransform: 'capitalize',
-});
-
-const timestampStyles = css({
-  color: lead.rgb,
-  display: 'flex',
-  flexDirection: 'row',
-  whiteSpace: 'pre',
-  marginTop: `${24 / perRem}em`,
-  marginBottom: 0,
-  [`@media (max-width: ${mobileScreen.max}px)`]: {
-    flexDirection: 'column',
-    marginTop: `${12 / perRem}em`,
-    marginBottom: `${12 / perRem}em`,
-  },
 });
 
 const cardsStyles = css({
@@ -47,55 +17,24 @@ const cardsStyles = css({
   rowGap: `${36 / perRem}em`,
 });
 
-type SharedResearchProposalProps = Pick<
+type SharedResearchOutputProps = Pick<
   ResearchOutputResponse,
-  | 'created'
-  | 'addedDate'
-  | 'team'
-  | 'description'
-  | 'title'
-  | 'type'
-  | 'link'
-  | 'tags'
-  | 'lastModifiedDate'
-> & {
-  backHref: string;
-};
+  'description' | 'tags'
+> &
+  ComponentProps<typeof SharedResearchOutputHeaderCard> & {
+    backHref: string;
+  };
 
-const SharedResearchOutput: React.FC<SharedResearchProposalProps> = ({
-  created,
-  addedDate,
-  title,
+const SharedResearchOutput: React.FC<SharedResearchOutputProps> = ({
   description,
-  type,
   backHref,
   tags,
-  link,
-  lastModifiedDate,
+  ...props
 }) => (
   <div css={containerStyles}>
     <BackLink href={backHref} />
     <div css={cardsStyles}>
-      <Card>
-        <div css={headerStyles}>
-          <div css={typeStyles}>
-            <TagLabel>{type}</TagLabel>
-          </div>
-          {link ? (
-            <ExternalLink label={researchOutputLabels[type]} href={link} />
-          ) : null}
-        </div>
-        <Display styleAsHeading={3}>{title}</Display>
-        <div css={[timestampStyles, captionStyles]}>
-          <span>
-            Date added: {formatDate(new Date(addedDate || created))}
-            {lastModifiedDate && ' · '}
-          </span>
-          {lastModifiedDate && (
-            <span>Last updated: {formatDate(new Date(lastModifiedDate))}</span>
-          )}
-        </div>
-      </Card>
+      <SharedResearchOutputHeaderCard {...props} />
       {(description || !!tags.length) && (
         <Card>
           {description && (

--- a/packages/react-components/src/templates/__tests__/SharedResearchOutput.test.tsx
+++ b/packages/react-components/src/templates/__tests__/SharedResearchOutput.test.tsx
@@ -23,61 +23,6 @@ it('renders an output with title and content', () => {
   expect(getByText(/content/i)).toBeVisible();
 });
 
-it('renders an output with an external link', () => {
-  const { queryByTitle, getByTitle, rerender } = render(
-    <SharedResearchOutput {...props} link={undefined} />,
-  );
-  expect(queryByTitle(/external link/i)).not.toBeInTheDocument();
-  rerender(<SharedResearchOutput {...props} link={'http://example.com'} />);
-  expect(getByTitle(/external link/i).closest('a')).toHaveAttribute(
-    'href',
-    'http://example.com',
-  );
-});
-
-it('falls back to created date when added date omitted', () => {
-  const { getByText, rerender } = render(
-    <SharedResearchOutput
-      {...props}
-      created={new Date(2019, 1, 1, 1).toISOString()}
-      addedDate={new Date(2020, 1, 1, 1).toISOString()}
-      lastModifiedDate={undefined}
-    />,
-  );
-  expect(getByText(/2020/)).toBeVisible();
-  rerender(
-    <SharedResearchOutput
-      {...props}
-      created={new Date(2019, 1, 1, 1).toISOString()}
-      addedDate={undefined}
-      lastModifiedDate={undefined}
-    />,
-  );
-  expect(getByText(/2019/)).toBeVisible();
-});
-
-it('renders an output with a modified date', () => {
-  const { queryByText, getByText, rerender } = render(
-    <SharedResearchOutput
-      {...props}
-      addedDate={new Date(2019, 1, 1, 1).toISOString()}
-      lastModifiedDate={undefined}
-    />,
-  );
-  expect(getByText(/2019/)).toBeVisible();
-  expect(queryByText(/·/i)).not.toBeInTheDocument();
-  rerender(
-    <SharedResearchOutput
-      {...props}
-      addedDate={new Date(2019, 1, 1, 1).toISOString()}
-      lastModifiedDate={new Date(2020, 1, 1, 1).toISOString()}
-    />,
-  );
-  expect(getByText(/2019/)).toBeVisible();
-  expect(queryByText(/2020/)).toBeVisible();
-  expect(queryByText(/·/i)).toBeInTheDocument();
-});
-
 describe('tags and description', () => {
   it('handles tags and description omitted', () => {
     const { queryByText, queryByRole } = render(


### PR DESCRIPTION
Recommend looking at the two commits separately:

- refactor(shared-research-output): extract header card component
- feat(shared-research-output): teams in header
