### PR TITLE
fix(ROMS): remove 'Other' subtype, accessInstructions RTF

### DIFF
--- a/packages/model/src/research-output.ts
+++ b/packages/model/src/research-output.ts
@@ -42,8 +42,7 @@ export type ResearchOutputSubtype =
   | 'Compounds'
   | 'Plasmid'
   | 'Protein'
-  | 'Viral Vector'
-  | 'Other';
+  | 'Viral Vector';
 
 export type ResearchOutputSharingStatus = 'Public' | 'Network Only';
 

--- a/packages/squidex/schema/schemas/research-outputs.json
+++ b/packages/squidex/schema/schemas/research-outputs.json
@@ -275,8 +275,7 @@
             "Compounds",
             "Plasmid",
             "Protein",
-            "Viral Vector",
-            "Other"
+            "Viral Vector"
           ],
           "contentType": "Unspecified",
           "label": "Subtype"
@@ -293,7 +292,7 @@
           "isRequiredOnPublish": false,
           "isHalfWidth": false,
           "fieldType": "String",
-          "editor": "Input",
+          "editor": "RichText",
           "inlineEditable": false,
           "isUnique": false,
           "contentType": "Unspecified",


### PR DESCRIPTION
QA comments on the ticket: https://trello.com/c/gK3a6puv/1132-update-roms-schema

- `accessInstructions` is RTF
- `subType` 'Other' should be removed
