### PR TITLE
feat: Show additional research-output information

### DIFF
--- a/apps/asap-server/src/controllers/research-outputs.ts
+++ b/apps/asap-server/src/controllers/research-outputs.ts
@@ -43,6 +43,7 @@ ${
   }
   sharingStatus
   asapFunded
+  usedInAPublication
 }`
     : ''
 }

--- a/apps/asap-server/src/controllers/research-outputs.ts
+++ b/apps/asap-server/src/controllers/research-outputs.ts
@@ -42,6 +42,7 @@ ${
     displayName
   }
   sharingStatus
+  asapFunded
 }`
     : ''
 }

--- a/apps/asap-server/src/controllers/research-outputs.ts
+++ b/apps/asap-server/src/controllers/research-outputs.ts
@@ -28,6 +28,9 @@ flatData{
   tags
   lastUpdatedPartial
   accessInstructions
+  sharingStatus
+  asapFunded
+  usedInAPublication
   authors {
     ${GraphQLQueryUser}
   }
@@ -41,9 +44,6 @@ ${
   flatData {
     displayName
   }
-  sharingStatus
-  asapFunded
-  usedInAPublication
 }`
     : ''
 }

--- a/apps/asap-server/src/controllers/research-outputs.ts
+++ b/apps/asap-server/src/controllers/research-outputs.ts
@@ -41,6 +41,7 @@ ${
   flatData {
     displayName
   }
+  sharingStatus
 }`
     : ''
 }

--- a/apps/asap-server/src/entities/research-output.ts
+++ b/apps/asap-server/src/entities/research-output.ts
@@ -1,4 +1,8 @@
-import { ResearchOutputResponse } from '@asap-hub/model';
+import {
+  DecisionOption,
+  DecisionOptionSimple,
+  ResearchOutputResponse,
+} from '@asap-hub/model';
 import { GraphqlResearchOutput, GraphqlTeam } from '@asap-hub/squidex';
 import { parseDate } from '../utils/squidex';
 import { parseGraphQLUser } from './user';
@@ -50,6 +54,7 @@ export const parseGraphQLResearchOutput = (
     ...optionalAuthors,
     ...optionalTeams,
     sharingStatus: output.flatData?.sharingStatus || 'Public',
+    asapFunded: convertNotSureToUndefined(output.flatData?.asapFunded),
   };
 };
 
@@ -59,3 +64,10 @@ const parseGraphqlTeamLite = (
   id: graphqlTeam.id,
   displayName: graphqlTeam.flatData?.displayName || '',
 });
+
+const convertNotSureToUndefined = (
+  decision?: DecisionOption | null,
+): DecisionOptionSimple | undefined =>
+  decision && ['Yes', 'No'].includes(decision)
+    ? (decision as 'Yes' | 'No')
+    : undefined;

--- a/apps/asap-server/src/entities/research-output.ts
+++ b/apps/asap-server/src/entities/research-output.ts
@@ -53,7 +53,7 @@ export const parseGraphQLResearchOutput = (
     accessInstructions: output.flatData?.accessInstructions || undefined,
     ...optionalAuthors,
     ...optionalTeams,
-    sharingStatus: output.flatData?.sharingStatus || 'Public',
+    sharingStatus: output.flatData?.sharingStatus || 'Network Only',
     asapFunded: convertNotSureToUndefined(output.flatData?.asapFunded),
     usedInPublication: convertNotSureToUndefined(
       output.flatData?.usedInAPublication,

--- a/apps/asap-server/src/entities/research-output.ts
+++ b/apps/asap-server/src/entities/research-output.ts
@@ -1,8 +1,4 @@
-import {
-  DecisionOption,
-  DecisionOptionSimple,
-  ResearchOutputResponse,
-} from '@asap-hub/model';
+import { DecisionOption, ResearchOutputResponse } from '@asap-hub/model';
 import { GraphqlResearchOutput, GraphqlTeam } from '@asap-hub/squidex';
 import { parseDate } from '../utils/squidex';
 import { parseGraphQLUser } from './user';
@@ -70,7 +66,5 @@ const parseGraphqlTeamLite = (
 
 const convertNotSureToUndefined = (
   decision?: DecisionOption | null,
-): DecisionOptionSimple | undefined =>
-  decision && ['Yes', 'No'].includes(decision)
-    ? (decision as 'Yes' | 'No')
-    : undefined;
+): boolean | undefined =>
+  decision && ['Yes', 'No'].includes(decision) ? decision === 'Yes' : undefined;

--- a/apps/asap-server/src/entities/research-output.ts
+++ b/apps/asap-server/src/entities/research-output.ts
@@ -50,8 +50,8 @@ export const parseGraphQLResearchOutput = (
     ...optionalAuthors,
     ...optionalTeams,
     sharingStatus: output.flatData?.sharingStatus || 'Network Only',
-    asapFunded: convertNotSureToUndefined(output.flatData?.asapFunded),
-    usedInPublication: convertNotSureToUndefined(
+    asapFunded: convertDecisionToBoolean(output.flatData?.asapFunded),
+    usedInPublication: convertDecisionToBoolean(
       output.flatData?.usedInAPublication,
     ),
   };
@@ -64,7 +64,7 @@ const parseGraphqlTeamLite = (
   displayName: graphqlTeam.flatData?.displayName || '',
 });
 
-const convertNotSureToUndefined = (
+const convertDecisionToBoolean = (
   decision?: DecisionOption | null,
 ): boolean | undefined =>
   decision && ['Yes', 'No'].includes(decision) ? decision === 'Yes' : undefined;

--- a/apps/asap-server/src/entities/research-output.ts
+++ b/apps/asap-server/src/entities/research-output.ts
@@ -55,6 +55,9 @@ export const parseGraphQLResearchOutput = (
     ...optionalTeams,
     sharingStatus: output.flatData?.sharingStatus || 'Public',
     asapFunded: convertNotSureToUndefined(output.flatData?.asapFunded),
+    usedInPublication: convertNotSureToUndefined(
+      output.flatData?.usedInAPublication,
+    ),
   };
 };
 

--- a/apps/asap-server/src/entities/research-output.ts
+++ b/apps/asap-server/src/entities/research-output.ts
@@ -49,6 +49,7 @@ export const parseGraphQLResearchOutput = (
     accessInstructions: output.flatData?.accessInstructions || undefined,
     ...optionalAuthors,
     ...optionalTeams,
+    sharingStatus: output.flatData?.sharingStatus || 'Public',
   };
 };
 

--- a/apps/asap-server/test/controllers/research-outputs.test.ts
+++ b/apps/asap-server/test/controllers/research-outputs.test.ts
@@ -215,7 +215,8 @@ describe('ResearchOutputs controller', () => {
 
     test('Should default sharingStatus to Public when missing', async () => {
       const squidexGraphqlResponse = getSquidexResearchOutputGraphqlResponse();
-      delete squidexGraphqlResponse.findResearchOutputsContent.flatData?.sharingStatus;
+      delete squidexGraphqlResponse.findResearchOutputsContent.flatData
+        ?.sharingStatus;
 
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {
@@ -226,6 +227,38 @@ describe('ResearchOutputs controller', () => {
       const result = await researchOutputs.fetchById(researchOutputId);
 
       expect(result.sharingStatus).toEqual('Public');
+    });
+
+    test('Should default asapFunded to undefined when missing', async () => {
+      const squidexGraphqlResponse = getSquidexResearchOutputGraphqlResponse();
+      delete squidexGraphqlResponse.findResearchOutputsContent.flatData
+        ?.asapFunded;
+
+      nock(config.baseUrl)
+        .post(`/api/content/${config.appName}/graphql`, {
+          query: buildGraphQLQueryResearchOutput(researchOutputId),
+        })
+        .reply(200, { data: squidexGraphqlResponse });
+
+      const result = await researchOutputs.fetchById(researchOutputId);
+
+      expect(result.asapFunded).not.toBeDefined();
+    });
+
+    test('Should default asapFunded "Not Sure" option to undefined', async () => {
+      const squidexGraphqlResponse = getSquidexResearchOutputGraphqlResponse();
+      squidexGraphqlResponse.findResearchOutputsContent.flatData!.asapFunded =
+        'Not Sure';
+
+      nock(config.baseUrl)
+        .post(`/api/content/${config.appName}/graphql`, {
+          query: buildGraphQLQueryResearchOutput(researchOutputId),
+        })
+        .reply(200, { data: squidexGraphqlResponse });
+
+      const result = await researchOutputs.fetchById(researchOutputId);
+
+      expect(result.asapFunded).not.toBeDefined();
     });
 
     test('Should default authors to an empty array when missing', async () => {

--- a/apps/asap-server/test/controllers/research-outputs.test.ts
+++ b/apps/asap-server/test/controllers/research-outputs.test.ts
@@ -213,6 +213,21 @@ describe('ResearchOutputs controller', () => {
       expect(result.type).toEqual('Proposal');
     });
 
+    test('Should default sharingStatus to Public when missing', async () => {
+      const squidexGraphqlResponse = getSquidexResearchOutputGraphqlResponse();
+      delete squidexGraphqlResponse.findResearchOutputsContent.flatData?.sharingStatus;
+
+      nock(config.baseUrl)
+        .post(`/api/content/${config.appName}/graphql`, {
+          query: buildGraphQLQueryResearchOutput(researchOutputId),
+        })
+        .reply(200, { data: squidexGraphqlResponse });
+
+      const result = await researchOutputs.fetchById(researchOutputId);
+
+      expect(result.sharingStatus).toEqual('Public');
+    });
+
     test('Should default authors to an empty array when missing', async () => {
       const squidexGraphqlResponse = getSquidexResearchOutputGraphqlResponse();
       delete squidexGraphqlResponse.findResearchOutputsContent.flatData

--- a/apps/asap-server/test/controllers/research-outputs.test.ts
+++ b/apps/asap-server/test/controllers/research-outputs.test.ts
@@ -213,7 +213,7 @@ describe('ResearchOutputs controller', () => {
       expect(result.type).toEqual('Proposal');
     });
 
-    test('Should default sharingStatus to Public when missing', async () => {
+    test('Should default sharingStatus to Network Only when missing', async () => {
       const squidexGraphqlResponse = getSquidexResearchOutputGraphqlResponse();
       delete squidexGraphqlResponse.findResearchOutputsContent.flatData
         ?.sharingStatus;
@@ -226,7 +226,7 @@ describe('ResearchOutputs controller', () => {
 
       const result = await researchOutputs.fetchById(researchOutputId);
 
-      expect(result.sharingStatus).toEqual('Public');
+      expect(result.sharingStatus).toEqual('Network Only');
     });
 
     test('Should default asapFunded to undefined when missing', async () => {

--- a/apps/asap-server/test/controllers/research-outputs.test.ts
+++ b/apps/asap-server/test/controllers/research-outputs.test.ts
@@ -261,6 +261,38 @@ describe('ResearchOutputs controller', () => {
       expect(result.asapFunded).not.toBeDefined();
     });
 
+    test('Should default usedInPublication to undefined when missing', async () => {
+      const squidexGraphqlResponse = getSquidexResearchOutputGraphqlResponse();
+      delete squidexGraphqlResponse.findResearchOutputsContent.flatData
+        ?.usedInAPublication;
+
+      nock(config.baseUrl)
+        .post(`/api/content/${config.appName}/graphql`, {
+          query: buildGraphQLQueryResearchOutput(researchOutputId),
+        })
+        .reply(200, { data: squidexGraphqlResponse });
+
+      const result = await researchOutputs.fetchById(researchOutputId);
+
+      expect(result.usedInPublication).not.toBeDefined();
+    });
+
+    test('Should default usedInPublication "Not Sure" option to undefined', async () => {
+      const squidexGraphqlResponse = getSquidexResearchOutputGraphqlResponse();
+      squidexGraphqlResponse.findResearchOutputsContent.flatData!.usedInAPublication =
+        'Not Sure';
+
+      nock(config.baseUrl)
+        .post(`/api/content/${config.appName}/graphql`, {
+          query: buildGraphQLQueryResearchOutput(researchOutputId),
+        })
+        .reply(200, { data: squidexGraphqlResponse });
+
+      const result = await researchOutputs.fetchById(researchOutputId);
+
+      expect(result.usedInPublication).not.toBeDefined();
+    });
+
     test('Should default authors to an empty array when missing', async () => {
       const squidexGraphqlResponse = getSquidexResearchOutputGraphqlResponse();
       delete squidexGraphqlResponse.findResearchOutputsContent.flatData

--- a/apps/asap-server/test/fixtures/groups.fixtures.ts
+++ b/apps/asap-server/test/fixtures/groups.fixtures.ts
@@ -63,6 +63,7 @@ export const queryGroupsResponse: { data: ResponseFetchGroups } = {
                         type: 'Proposal',
                         tags: ['test', 'tag'],
                         accessInstructions: 'some access instructions',
+                        sharingStatus: 'Network Only',
                         authors:
                           graphQlResponseFetchUsers.data
                             .queryUsersContentsWithTotal.items,
@@ -266,6 +267,7 @@ export const queryGroupsExpectation: ListGroupResponse = {
               teams: [{ id: 'team-id-1', displayName: 'Lee, M' }],
               lastUpdatedPartial: '2020-12-11T14:33:18.000Z',
               accessInstructions: 'some access instructions',
+              sharingStatus: 'Network Only',
             },
           ],
           projectTitle:

--- a/apps/asap-server/test/fixtures/groups.fixtures.ts
+++ b/apps/asap-server/test/fixtures/groups.fixtures.ts
@@ -64,6 +64,7 @@ export const queryGroupsResponse: { data: ResponseFetchGroups } = {
                         tags: ['test', 'tag'],
                         accessInstructions: 'some access instructions',
                         sharingStatus: 'Network Only',
+                        asapFunded: 'No',
                         authors:
                           graphQlResponseFetchUsers.data
                             .queryUsersContentsWithTotal.items,
@@ -268,6 +269,7 @@ export const queryGroupsExpectation: ListGroupResponse = {
               lastUpdatedPartial: '2020-12-11T14:33:18.000Z',
               accessInstructions: 'some access instructions',
               sharingStatus: 'Network Only',
+              asapFunded: 'No',
             },
           ],
           projectTitle:

--- a/apps/asap-server/test/fixtures/groups.fixtures.ts
+++ b/apps/asap-server/test/fixtures/groups.fixtures.ts
@@ -65,6 +65,7 @@ export const queryGroupsResponse: { data: ResponseFetchGroups } = {
                         accessInstructions: 'some access instructions',
                         sharingStatus: 'Network Only',
                         asapFunded: 'No',
+                        usedInAPublication: 'No',
                         authors:
                           graphQlResponseFetchUsers.data
                             .queryUsersContentsWithTotal.items,
@@ -270,6 +271,7 @@ export const queryGroupsExpectation: ListGroupResponse = {
               accessInstructions: 'some access instructions',
               sharingStatus: 'Network Only',
               asapFunded: 'No',
+              usedInPublication: 'No',
             },
           ],
           projectTitle:

--- a/apps/asap-server/test/fixtures/groups.fixtures.ts
+++ b/apps/asap-server/test/fixtures/groups.fixtures.ts
@@ -270,8 +270,8 @@ export const queryGroupsExpectation: ListGroupResponse = {
               lastUpdatedPartial: '2020-12-11T14:33:18.000Z',
               accessInstructions: 'some access instructions',
               sharingStatus: 'Network Only',
-              asapFunded: 'No',
-              usedInPublication: 'No',
+              asapFunded: false,
+              usedInPublication: false,
             },
           ],
           projectTitle:

--- a/apps/asap-server/test/fixtures/research-output.fixtures.ts
+++ b/apps/asap-server/test/fixtures/research-output.fixtures.ts
@@ -41,6 +41,7 @@ export const getSquidexGraphqlResearchOutput = (): GraphqlResearchOutput => ({
     accessInstructions: 'some access instructions',
     sharingStatus: 'Network Only',
     asapFunded: 'Yes',
+    usedInAPublication: 'No',
   },
   referencingTeamsContents: [
     {
@@ -103,6 +104,7 @@ export const getResearchOutputResponse =
   accessInstructions: 'some access instructions',
   sharingStatus: 'Network Only',
   asapFunded: 'Yes',
+  usedInPublication: 'No',
 });
 >>>>>>> added asap-funded to controllers and route
 

--- a/apps/asap-server/test/fixtures/research-output.fixtures.ts
+++ b/apps/asap-server/test/fixtures/research-output.fixtures.ts
@@ -40,6 +40,7 @@ export const getSquidexGraphqlResearchOutput = (): GraphqlResearchOutput => ({
     authors: graphQlResponseFetchUsers.data.queryUsersContentsWithTotal.items,
     accessInstructions: 'some access instructions',
     sharingStatus: 'Network Only',
+    asapFunded: 'Yes',
   },
   referencingTeamsContents: [
     {
@@ -74,6 +75,7 @@ export const getResearchOutputResponse =
       id: 'team-id-1',
       displayName: 'Schipa, A',
     },
+<<<<<<< HEAD
     teams: [
       {
         id: 'team-id-1',
@@ -88,7 +90,21 @@ export const getResearchOutputResponse =
     lastUpdatedPartial: '2020-09-23T16:34:26.842Z',
     accessInstructions: 'some access instructions',
     sharingStatus: 'Network Only',
+    asapFunded: 'Yes',
   });
+=======
+    {
+      id: 'team-id-2',
+      displayName: 'Team, B',
+    },
+  ],
+  publishDate: '2021-05-21T13:18:31Z',
+  lastUpdatedPartial: '2020-09-23T16:34:26.842Z',
+  accessInstructions: 'some access instructions',
+  sharingStatus: 'Network Only',
+  asapFunded: 'Yes',
+});
+>>>>>>> added asap-funded to controllers and route
 
 export const getListResearchOutputResponse =
   (): ListResearchOutputResponse => ({

--- a/apps/asap-server/test/fixtures/research-output.fixtures.ts
+++ b/apps/asap-server/test/fixtures/research-output.fixtures.ts
@@ -90,8 +90,8 @@ export const getResearchOutputResponse =
     lastUpdatedPartial: '2020-09-23T16:34:26.842Z',
     accessInstructions: 'some access instructions',
     sharingStatus: 'Network Only',
-    asapFunded: 'Yes',
-    usedInPublication: 'No',
+    asapFunded: true,
+    usedInPublication: false,
   });
 
 export const getListResearchOutputResponse =

--- a/apps/asap-server/test/fixtures/research-output.fixtures.ts
+++ b/apps/asap-server/test/fixtures/research-output.fixtures.ts
@@ -76,7 +76,6 @@ export const getResearchOutputResponse =
       id: 'team-id-1',
       displayName: 'Schipa, A',
     },
-<<<<<<< HEAD
     teams: [
       {
         id: 'team-id-1',
@@ -92,21 +91,8 @@ export const getResearchOutputResponse =
     accessInstructions: 'some access instructions',
     sharingStatus: 'Network Only',
     asapFunded: 'Yes',
+    usedInPublication: 'No',
   });
-=======
-    {
-      id: 'team-id-2',
-      displayName: 'Team, B',
-    },
-  ],
-  publishDate: '2021-05-21T13:18:31Z',
-  lastUpdatedPartial: '2020-09-23T16:34:26.842Z',
-  accessInstructions: 'some access instructions',
-  sharingStatus: 'Network Only',
-  asapFunded: 'Yes',
-  usedInPublication: 'No',
-});
->>>>>>> added asap-funded to controllers and route
 
 export const getListResearchOutputResponse =
   (): ListResearchOutputResponse => ({

--- a/apps/asap-server/test/fixtures/research-output.fixtures.ts
+++ b/apps/asap-server/test/fixtures/research-output.fixtures.ts
@@ -39,6 +39,7 @@ export const getSquidexGraphqlResearchOutput = (): GraphqlResearchOutput => ({
     lastUpdatedPartial: '2020-09-23T16:34:26.842Z',
     authors: graphQlResponseFetchUsers.data.queryUsersContentsWithTotal.items,
     accessInstructions: 'some access instructions',
+    sharingStatus: 'Network Only',
   },
   referencingTeamsContents: [
     {
@@ -86,6 +87,7 @@ export const getResearchOutputResponse =
     publishDate: '2021-05-21T13:18:31Z',
     lastUpdatedPartial: '2020-09-23T16:34:26.842Z',
     accessInstructions: 'some access instructions',
+    sharingStatus: 'Network Only',
   });
 
 export const getListResearchOutputResponse =

--- a/apps/asap-server/test/fixtures/teams.fixtures.ts
+++ b/apps/asap-server/test/fixtures/teams.fixtures.ts
@@ -429,6 +429,7 @@ export const graphQlTeamResponse: { data: ResponseFetchTeam } = {
                 graphQlResponseFetchUsers.data.queryUsersContentsWithTotal
                   .items[1],
               ],
+              usedInAPublication: 'No',
             },
             referencingTeamsContents: [
               {
@@ -559,6 +560,7 @@ export const fetchTeamByIdExpectation: TeamResponse = {
       ],
       lastUpdatedPartial: '2020-11-26T13:45:49.000Z',
       sharingStatus: 'Public',
+      usedInPublication: 'No',
     },
     {
       id: '4cfb1b7b-bafe-4fca-b2ab-197e84d98996',
@@ -674,6 +676,7 @@ export const getGraphQlTeamResponse = (
                 graphQlResponseFetchUsers.data.queryUsersContentsWithTotal
                   .items[1],
               ],
+              usedInAPublication: 'No',
             },
             referencingTeamsContents: [
               {
@@ -776,6 +779,7 @@ export const updateExpectation: TeamResponse = {
       ],
       lastUpdatedPartial: '2020-11-26T13:45:49.000Z',
       sharingStatus: 'Public',
+      usedInPublication: 'No',
     },
     {
       id: '4cfb1b7b-bafe-4fca-b2ab-197e84d98996',

--- a/apps/asap-server/test/fixtures/teams.fixtures.ts
+++ b/apps/asap-server/test/fixtures/teams.fixtures.ts
@@ -308,7 +308,7 @@ export const listTeamResponse: ListTeamResponse = {
           ],
           lastUpdatedPartial: '2020-10-21T13:11:50.000Z',
           sharingStatus: 'Network Only',
-          asapFunded: 'No',
+          asapFunded: false,
         },
       ],
       members: [
@@ -560,7 +560,7 @@ export const fetchTeamByIdExpectation: TeamResponse = {
       ],
       lastUpdatedPartial: '2020-11-26T13:45:49.000Z',
       sharingStatus: 'Network Only',
-      usedInPublication: 'No',
+      usedInPublication: false,
     },
     {
       id: '4cfb1b7b-bafe-4fca-b2ab-197e84d98996',
@@ -582,7 +582,7 @@ export const fetchTeamByIdExpectation: TeamResponse = {
       ],
       lastUpdatedPartial: '2020-10-21T13:11:50.000Z',
       sharingStatus: 'Network Only',
-      asapFunded: 'No',
+      asapFunded: false,
     },
   ],
   members: [
@@ -779,7 +779,7 @@ export const updateExpectation: TeamResponse = {
       ],
       lastUpdatedPartial: '2020-11-26T13:45:49.000Z',
       sharingStatus: 'Network Only',
-      usedInPublication: 'No',
+      usedInPublication: false,
     },
     {
       id: '4cfb1b7b-bafe-4fca-b2ab-197e84d98996',
@@ -801,7 +801,7 @@ export const updateExpectation: TeamResponse = {
       ],
       lastUpdatedPartial: '2020-10-21T13:11:50.000Z',
       sharingStatus: 'Network Only',
-      asapFunded: 'No',
+      asapFunded: false,
     },
   ],
   members: [

--- a/apps/asap-server/test/fixtures/teams.fixtures.ts
+++ b/apps/asap-server/test/fixtures/teams.fixtures.ts
@@ -35,6 +35,7 @@ export const graphQlTeamsResponse: { data: ResponseFetchTeams } = {
                     graphQlResponseFetchUsers.data.queryUsersContentsWithTotal
                       .items[0],
                   ],
+                  sharingStatus: 'Network Only',
                 },
               },
               {
@@ -284,6 +285,7 @@ export const listTeamResponse: ListTeamResponse = {
           ],
           lastUpdatedPartial: '2020-11-26T13:45:49.000Z',
           accessInstructions: 'some access instructions',
+          sharingStatus: 'Public',
         },
         {
           id: '4cfb1b7b-bafe-4fca-b2ab-197e84d98996',
@@ -304,6 +306,7 @@ export const listTeamResponse: ListTeamResponse = {
             },
           ],
           lastUpdatedPartial: '2020-10-21T13:11:50.000Z',
+          sharingStatus: 'Network Only',
         },
       ],
       members: [
@@ -402,6 +405,7 @@ export const graphQlTeamResponse: { data: ResponseFetchTeam } = {
               title: 'Proposal',
               type: 'Proposal',
               tags: ['test', 'tag'],
+              sharingStatus: 'Network Only',
               authors: [
                 graphQlResponseFetchUsers.data.queryUsersContentsWithTotal
                   .items[0],
@@ -551,6 +555,7 @@ export const fetchTeamByIdExpectation: TeamResponse = {
         },
       ],
       lastUpdatedPartial: '2020-11-26T13:45:49.000Z',
+      sharingStatus: 'Public',
     },
     {
       id: '4cfb1b7b-bafe-4fca-b2ab-197e84d98996',
@@ -571,6 +576,7 @@ export const fetchTeamByIdExpectation: TeamResponse = {
         },
       ],
       lastUpdatedPartial: '2020-10-21T13:11:50.000Z',
+      sharingStatus: 'Network Only',
     },
   ],
   members: [
@@ -636,6 +642,7 @@ export const getGraphQlTeamResponse = (
                 graphQlResponseFetchUsers.data.queryUsersContentsWithTotal
                   .items[0],
               ],
+              sharingStatus: 'Network Only',
             },
             referencingTeamsContents: [
               {
@@ -763,6 +770,7 @@ export const updateExpectation: TeamResponse = {
         },
       ],
       lastUpdatedPartial: '2020-11-26T13:45:49.000Z',
+      sharingStatus: 'Public',
     },
     {
       id: '4cfb1b7b-bafe-4fca-b2ab-197e84d98996',
@@ -783,6 +791,7 @@ export const updateExpectation: TeamResponse = {
         },
       ],
       lastUpdatedPartial: '2020-10-21T13:11:50.000Z',
+      sharingStatus: 'Network Only',
     },
   ],
   members: [

--- a/apps/asap-server/test/fixtures/teams.fixtures.ts
+++ b/apps/asap-server/test/fixtures/teams.fixtures.ts
@@ -36,6 +36,7 @@ export const graphQlTeamsResponse: { data: ResponseFetchTeams } = {
                       .items[0],
                   ],
                   sharingStatus: 'Network Only',
+                  asapFunded: 'No',
                 },
               },
               {
@@ -307,6 +308,7 @@ export const listTeamResponse: ListTeamResponse = {
           ],
           lastUpdatedPartial: '2020-10-21T13:11:50.000Z',
           sharingStatus: 'Network Only',
+          asapFunded: 'No',
         },
       ],
       members: [
@@ -406,6 +408,7 @@ export const graphQlTeamResponse: { data: ResponseFetchTeam } = {
               type: 'Proposal',
               tags: ['test', 'tag'],
               sharingStatus: 'Network Only',
+              asapFunded: 'No',
               authors: [
                 graphQlResponseFetchUsers.data.queryUsersContentsWithTotal
                   .items[0],
@@ -577,6 +580,7 @@ export const fetchTeamByIdExpectation: TeamResponse = {
       ],
       lastUpdatedPartial: '2020-10-21T13:11:50.000Z',
       sharingStatus: 'Network Only',
+      asapFunded: 'No',
     },
   ],
   members: [
@@ -643,6 +647,7 @@ export const getGraphQlTeamResponse = (
                   .items[0],
               ],
               sharingStatus: 'Network Only',
+              asapFunded: 'No',
             },
             referencingTeamsContents: [
               {
@@ -792,6 +797,7 @@ export const updateExpectation: TeamResponse = {
       ],
       lastUpdatedPartial: '2020-10-21T13:11:50.000Z',
       sharingStatus: 'Network Only',
+      asapFunded: 'No',
     },
   ],
   members: [

--- a/apps/asap-server/test/fixtures/teams.fixtures.ts
+++ b/apps/asap-server/test/fixtures/teams.fixtures.ts
@@ -286,7 +286,7 @@ export const listTeamResponse: ListTeamResponse = {
           ],
           lastUpdatedPartial: '2020-11-26T13:45:49.000Z',
           accessInstructions: 'some access instructions',
-          sharingStatus: 'Public',
+          sharingStatus: 'Network Only',
         },
         {
           id: '4cfb1b7b-bafe-4fca-b2ab-197e84d98996',
@@ -559,7 +559,7 @@ export const fetchTeamByIdExpectation: TeamResponse = {
         },
       ],
       lastUpdatedPartial: '2020-11-26T13:45:49.000Z',
-      sharingStatus: 'Public',
+      sharingStatus: 'Network Only',
       usedInPublication: 'No',
     },
     {
@@ -778,7 +778,7 @@ export const updateExpectation: TeamResponse = {
         },
       ],
       lastUpdatedPartial: '2020-11-26T13:45:49.000Z',
-      sharingStatus: 'Public',
+      sharingStatus: 'Network Only',
       usedInPublication: 'No',
     },
     {

--- a/apps/asap-server/test/routes/research-outputs.route.test.ts
+++ b/apps/asap-server/test/routes/research-outputs.route.test.ts
@@ -78,7 +78,7 @@ describe('/research-outputs/ route', () => {
     });
   });
 
-  describe('GET /research-outputs/{research_output_it}', () => {
+  describe('GET /research-outputs/{research_output_id}', () => {
     test('Should return a 404 error when the team or members are not found', async () => {
       researchOutputControllerMock.fetchById.mockRejectedValueOnce(
         Boom.notFound(),

--- a/packages/fixtures/src/research-outputs.ts
+++ b/packages/fixtures/src/research-outputs.ts
@@ -32,6 +32,7 @@ const researchOutputResponse: Omit<
     },
   ],
   lastUpdatedPartial: '2020-09-09T20:36:54Z',
+  sharingStatus: 'Public',
 };
 
 export const createResearchOutputResponse = (

--- a/packages/model/src/research-output.ts
+++ b/packages/model/src/research-output.ts
@@ -61,6 +61,7 @@ export type ResearchOutputResponse = {
   readonly lastModifiedDate?: string;
   readonly lastUpdatedPartial: string;
   readonly accessInstructions?: string;
+  readonly sharingStatus: ResearchOutputSharingStatus;
 
   readonly authors: ReadonlyArray<UserResponse>;
   /**

--- a/packages/model/src/research-output.ts
+++ b/packages/model/src/research-output.ts
@@ -46,7 +46,6 @@ export type ResearchOutputSubtype =
   | 'Viral Vector';
 
 export type ResearchOutputSharingStatus = 'Public' | 'Network Only';
-export type DecisionOptionSimple = 'Yes' | 'No';
 
 export type ResearchOutputResponse = {
   readonly id: string;
@@ -63,8 +62,8 @@ export type ResearchOutputResponse = {
   readonly lastUpdatedPartial: string;
   readonly accessInstructions?: string;
   readonly sharingStatus: ResearchOutputSharingStatus;
-  readonly asapFunded?: DecisionOptionSimple;
-  readonly usedInPublication?: DecisionOptionSimple;
+  readonly asapFunded?: boolean;
+  readonly usedInPublication?: boolean;
 
   readonly authors: ReadonlyArray<UserResponse>;
   /**

--- a/packages/model/src/research-output.ts
+++ b/packages/model/src/research-output.ts
@@ -64,6 +64,7 @@ export type ResearchOutputResponse = {
   readonly accessInstructions?: string;
   readonly sharingStatus: ResearchOutputSharingStatus;
   readonly asapFunded?: DecisionOptionSimple;
+  readonly usedInPublication?: DecisionOptionSimple;
 
   readonly authors: ReadonlyArray<UserResponse>;
   /**
@@ -84,4 +85,3 @@ export const researchOutputLabels: Record<ResearchOutputType, string> = {
 };
 
 export type ListResearchOutputResponse = ListResponse<ResearchOutputResponse>;
-

--- a/packages/model/src/research-output.ts
+++ b/packages/model/src/research-output.ts
@@ -46,6 +46,7 @@ export type ResearchOutputSubtype =
   | 'Viral Vector';
 
 export type ResearchOutputSharingStatus = 'Public' | 'Network Only';
+export type DecisionOptionSimple = 'Yes' | 'No';
 
 export type ResearchOutputResponse = {
   readonly id: string;
@@ -62,6 +63,7 @@ export type ResearchOutputResponse = {
   readonly lastUpdatedPartial: string;
   readonly accessInstructions?: string;
   readonly sharingStatus: ResearchOutputSharingStatus;
+  readonly asapFunded?: DecisionOptionSimple;
 
   readonly authors: ReadonlyArray<UserResponse>;
   /**
@@ -82,3 +84,4 @@ export const researchOutputLabels: Record<ResearchOutputType, string> = {
 };
 
 export type ListResearchOutputResponse = ListResponse<ResearchOutputResponse>;
+


### PR DESCRIPTION
as per: https://trello.com/c/W40XJ3QT/1233-show-aditional-information-on-an-output-detail-page

Adds the following to research-output endpoint responses:
* usedInPublication
* asapFunded
* sharingStatus

### Notes

* `usedInPublication` was used in the response, omitting the article `a` which is present in the DB