### PR TITLE
feat: Add user onboarded state

### DIFF
--- a/apps/asap-cli/src/import/users/insert.ts
+++ b/apps/asap-cli/src/import/users/insert.ts
@@ -166,6 +166,9 @@ const insertUser = async (
     role: {
       iv: asapRole,
     },
+    onboarded: {
+      iv: true,
+    },
   };
 
   if (location) {

--- a/apps/asap-cli/test/import/protocols.fixture.ts
+++ b/apps/asap-cli/test/import/protocols.fixture.ts
@@ -46,6 +46,9 @@ export const fetchUserResponse: RestUser = {
     questions: { iv: [] },
     skills: { iv: [] },
     role: { iv: 'Grantee' },
+    onboarded: {
+      iv: true,
+    },
   },
 };
 

--- a/apps/asap-cli/test/import/users.test.ts
+++ b/apps/asap-cli/test/import/users.test.ts
@@ -57,6 +57,9 @@ const body = {
       },
     ],
   },
+  onboarded: {
+    iv: true,
+  },
 };
 
 describe('Import user', () => {

--- a/apps/asap-cli/test/invite.fixtures.ts
+++ b/apps/asap-cli/test/invite.fixtures.ts
@@ -22,6 +22,9 @@ export const fetchUsersResponse: { total: number; items: RestUser[] } = {
         questions: { iv: [] },
         skills: { iv: [] },
         role: { iv: 'Grantee' },
+        onboarded: {
+          iv: true,
+        },
       },
     },
     {
@@ -43,6 +46,9 @@ export const fetchUsersResponse: { total: number; items: RestUser[] } = {
         teams: { iv: [] },
         skills: { iv: [] },
         role: { iv: 'Grantee' },
+        onboarded: {
+          iv: true,
+        },
       },
     },
     {
@@ -70,6 +76,9 @@ export const fetchUsersResponse: { total: number; items: RestUser[] } = {
         teams: { iv: [] },
         skills: { iv: [] },
         role: { iv: 'Grantee' },
+        onboarded: {
+          iv: true,
+        },
       },
     },
   ],

--- a/apps/asap-server/src/entities/user.ts
+++ b/apps/asap-server/src/entities/user.ts
@@ -92,6 +92,7 @@ export const parseGraphQLUser = (item: GraphqlUser): UserResponse => {
 
   return {
     id: item.id,
+    onboarded: item.flatData?.onboarded || true,
     createdDate,
     displayName,
     orcid, // TODO: remove once edit social is added

--- a/apps/asap-server/src/migrations/1622036244-add-default-onboarded-field-to-users.ts
+++ b/apps/asap-server/src/migrations/1622036244-add-default-onboarded-field-to-users.ts
@@ -1,0 +1,23 @@
+/* istanbul ignore file */
+import { RestUser } from '@asap-hub/squidex';
+import { Migration } from '../handlers/webhooks/webhook-run-migrations';
+import { applyToAllItemsInCollection } from '../utils/migrations';
+
+export default class AddDefaultOnboardedFieldsToUser extends Migration {
+  up = async (): Promise<void> => {
+    await applyToAllItemsInCollection<RestUser>(
+      'users',
+      async (user, squidexClient) => {
+        await squidexClient.patch(user.id, { onboarded: { iv: true } });
+      },
+    );
+  };
+  down = async (): Promise<void> => {
+    await applyToAllItemsInCollection<RestUser>(
+      'users',
+      async (user, squidexClient) => {
+        await squidexClient.patch(user.id, { onboarded: undefined });
+      },
+    );
+  };
+}

--- a/apps/asap-server/src/utils/__mocks__/validate-token.ts
+++ b/apps/asap-server/src/utils/__mocks__/validate-token.ts
@@ -3,6 +3,7 @@ import { origin } from '../../config';
 
 export const userMock: User = {
   id: 'userId',
+  onboarded: true,
   displayName: 'JT',
   email: 'joao.tiago@asap.science',
   firstName: 'Joao',

--- a/apps/asap-server/src/utils/migrations.ts
+++ b/apps/asap-server/src/utils/migrations.ts
@@ -1,7 +1,9 @@
 import { Results, Squidex } from '@asap-hub/squidex';
 import { Entity, Rest } from '@asap-hub/squidex/src/entities/common';
 
-export const applyToAllItemsInCollection = async <T extends Entity & Rest<unknown>>(
+export const applyToAllItemsInCollection = async <
+  T extends Entity & Rest<unknown>,
+>(
   entityName: string,
   processEntity: (entity: T, squidexClient: Squidex<T>) => Promise<void>,
 ): Promise<void> => {

--- a/apps/asap-server/src/utils/migrations.ts
+++ b/apps/asap-server/src/utils/migrations.ts
@@ -1,0 +1,28 @@
+import { Results, Squidex } from '@asap-hub/squidex';
+import { Entity, Rest } from '@asap-hub/squidex/src/entities/common';
+
+export const applyToAllItemsInCollection = async <T extends Entity & Rest<unknown>>(
+  entityName: string,
+  processEntity: (entity: T, squidexClient: Squidex<T>) => Promise<void>,
+): Promise<void> => {
+  const squidexClient = new Squidex<T>(entityName, {
+    unpublished: true,
+  });
+
+  let pointer = 0;
+  let result: Results<T>;
+
+  do {
+    result = await squidexClient.fetch({
+      $top: 10,
+      $skip: pointer,
+      $orderby: 'created asc',
+    });
+
+    for (const item of result.items) {
+      await processEntity(item, squidexClient);
+    }
+
+    pointer += 10;
+  } while (pointer < result.total);
+};

--- a/apps/asap-server/test/controllers/teams.test.ts
+++ b/apps/asap-server/test/controllers/teams.test.ts
@@ -26,6 +26,7 @@ describe('Team controller', () => {
   const teams = new Teams();
   const mockUser: User = {
     id: 'userId',
+    onboarded: true,
     displayName: 'JT',
     email: 'joao.tiago@asap.science',
     firstName: 'Joao',

--- a/apps/asap-server/test/fixtures/discover.fixtures.ts
+++ b/apps/asap-server/test/fixtures/discover.fixtures.ts
@@ -117,6 +117,7 @@ export const discoverResponse: DiscoverResponse = {
   members: [
     {
       id: 'uuid-1',
+      onboarded: true,
       createdDate: '2020-10-15T17:55:21.000Z',
       displayName: 'John Doe',
       email: 'john@example.com',
@@ -133,6 +134,7 @@ export const discoverResponse: DiscoverResponse = {
     },
     {
       id: 'uuid-2',
+      onboarded: true,
       createdDate: '2020-10-14T17:55:21.000Z',
       displayName: 'Jon Do',
       email: '',

--- a/apps/asap-server/test/fixtures/groups.fixtures.ts
+++ b/apps/asap-server/test/fixtures/groups.fixtures.ts
@@ -284,6 +284,7 @@ export const queryGroupsExpectation: ListGroupResponse = {
         {
           user: {
             id: 'user-id-1',
+            onboarded: true,
             createdDate: '2020-12-11T14:33:50.000Z',
             displayName: 'Filipe Pinheiro',
             firstName: 'Filipe',
@@ -320,7 +321,8 @@ export const queryGroupsExpectation: ListGroupResponse = {
         {
           user: {
             id: 'user-id-2',
-            createdDate: '2020-12-11T14:33:50.000Z',
+    onboarded: true,
+    createdDate: '2020-12-11T14:33:50.000Z',
             displayName: 'João Tiago',
             firstName: 'João',
             lastName: 'Tiago',

--- a/apps/asap-server/test/fixtures/groups.fixtures.ts
+++ b/apps/asap-server/test/fixtures/groups.fixtures.ts
@@ -321,8 +321,8 @@ export const queryGroupsExpectation: ListGroupResponse = {
         {
           user: {
             id: 'user-id-2',
-    onboarded: true,
-    createdDate: '2020-12-11T14:33:50.000Z',
+            onboarded: true,
+            createdDate: '2020-12-11T14:33:50.000Z',
             displayName: 'João Tiago',
             firstName: 'João',
             lastName: 'Tiago',

--- a/apps/asap-server/test/fixtures/orcid.fixtures.ts
+++ b/apps/asap-server/test/fixtures/orcid.fixtures.ts
@@ -37,6 +37,9 @@ export const updateUserEvent: WebhookPayload<User> = {
       skills: { iv: [] },
       questions: { iv: [] },
       teams: { iv: [] },
+      onboarded: {
+        iv: true,
+      },
     },
     dataOld: {
       firstName: { iv: 'Bill' },
@@ -64,6 +67,9 @@ export const updateUserEvent: WebhookPayload<User> = {
       skills: { iv: [] },
       questions: { iv: [] },
       teams: { iv: [] },
+      onboarded: {
+        iv: true,
+      },
     },
   },
 };
@@ -102,6 +108,9 @@ export const createUserEvent: WebhookPayload<User> = {
       },
       email: {
         iv: 'webhokk@ola.io',
+      },
+      onboarded: {
+        iv: true,
       },
     },
   },

--- a/apps/asap-server/test/fixtures/teams.fixtures.ts
+++ b/apps/asap-server/test/fixtures/teams.fixtures.ts
@@ -149,6 +149,9 @@ export const usersResponseTeam1: { total: number; items: RestUser[] } = {
         connections: { iv: [] },
         questions: { iv: [] },
         skills: { iv: [] },
+        onboarded: {
+          iv: true,
+        },
       },
       created: '2020-09-25T09:42:51Z',
       lastModified: '2020-09-25T09:42:51Z',
@@ -184,6 +187,9 @@ export const usersResponseTeam2: { total: number; items: RestUser[] } = {
         connections: { iv: [] },
         skills: { iv: [] },
         questions: { iv: [] },
+        onboarded: {
+          iv: true,
+        },
       },
       created: '2020-09-25T09:42:51Z',
       lastModified: '2020-09-25T09:42:51Z',
@@ -213,6 +219,9 @@ export const usersResponseTeam2: { total: number; items: RestUser[] } = {
         connections: { iv: [] },
         skills: { iv: [] },
         questions: { iv: [] },
+        onboarded: {
+          iv: true,
+        },
       },
       created: '2020-09-25T09:42:51Z',
       lastModified: '2020-09-25T09:42:51Z',
@@ -248,6 +257,9 @@ export const usersResponseTeam3: { total: number; items: RestUser[] } = {
         connections: { iv: [] },
         skills: { iv: [] },
         questions: { iv: [] },
+        onboarded: {
+          iv: true,
+        },
       },
       created: '2020-09-25T09:42:51Z',
       lastModified: '2020-09-25T09:42:51Z',
@@ -476,6 +488,9 @@ export const fetchByIdUserResponse: { total: number; items: RestUser[] } = {
       data: {
         role: {
           iv: 'Grantee',
+        },
+        onboarded: {
+          iv: true,
         },
         lastModifiedDate: {
           iv: '2020-09-25T09:42:51.132Z',
@@ -745,6 +760,9 @@ export const updateResponseTeam: { total: number; items: RestUser[] } = {
         },
         connections: { iv: [] },
         questions: { iv: [] },
+        onboarded: {
+          iv: true,
+        },
       },
       created: '2020-09-25T09:42:51Z',
       lastModified: '2020-09-25T09:42:51Z',

--- a/apps/asap-server/test/fixtures/users.fixtures.ts
+++ b/apps/asap-server/test/fixtures/users.fixtures.ts
@@ -121,6 +121,7 @@ export const graphQlResponseFetchUser: { data: ResponseFetchUser } = {
       lastModified: '2020-09-25T09:42:51Z',
       data: null,
       flatData: {
+        onboarded: true,
         degree: 'MPH',
         email: 'cristiano@ronaldo.com',
         contactEmail: 'cristiano@ronaldo.com',
@@ -274,6 +275,7 @@ export const buildUserGraphqlResponse = (
 export const patchResponse: RestUser = {
   id: 'userId',
   data: {
+    onboarded: { iv: true },
     role: { iv: 'Grantee' },
     lastModifiedDate: { iv: '2020-09-25T09:42:51.132Z' },
     email: { iv: 'cristiano@ronaldo.com' },
@@ -315,6 +317,7 @@ export const updateAvatarBody: { avatar: string } = {
 
 export const updateUserExpectation: UserResponse = {
   id: 'userId',
+  onboarded: true,
   displayName: 'Cristiano Ronaldo',
   createdDate: '2020-09-25T09:42:51.000Z',
   lastModifiedDate: '2020-09-25T09:42:51.132Z',
@@ -359,6 +362,7 @@ export const fetchExpectation: ListUserResponse = {
   items: [
     {
       id: 'userId1',
+      onboarded: true,
       createdDate: '2020-09-23T20:45:22.000Z',
       questions: [],
       skills: ['React'],
@@ -386,6 +390,7 @@ export const fetchExpectation: ListUserResponse = {
     },
     {
       id: 'userId2',
+      onboarded: true,
       createdDate: '2020-09-23T20:45:22.000Z',
       questions: [],
       skills: [],

--- a/apps/asap-server/test/fixtures/users.fixtures.ts
+++ b/apps/asap-server/test/fixtures/users.fixtures.ts
@@ -417,3 +417,5 @@ export const fetchExpectation: ListUserResponse = {
     },
   ],
 };
+
+export const restUserMock = patchResponse;

--- a/apps/asap-server/test/handlers/webhooks/cronjob-sync-orcid.fixtures.ts
+++ b/apps/asap-server/test/handlers/webhooks/cronjob-sync-orcid.fixtures.ts
@@ -26,6 +26,9 @@ export const fetchUsersResponse: { total: number; items: RestUser[] } = {
         skills: { iv: [] },
         questions: { iv: [] },
         teams: { iv: [] },
+        onboarded: {
+          iv: true,
+        },
       },
       created: '2020-08-27T13:20:57Z',
       lastModified: '2020-08-31T13:57:51Z',
@@ -52,6 +55,9 @@ export const fetchUsersResponse: { total: number; items: RestUser[] } = {
         skills: { iv: [] },
         questions: { iv: [] },
         teams: { iv: [] },
+        onboarded: {
+          iv: true,
+        },
       },
       created: '2020-08-27T13:20:57Z',
       lastModified: '2020-08-31T13:57:51Z',

--- a/apps/asap-server/test/handlers/webhooks/webhook-connect.test.ts
+++ b/apps/asap-server/test/handlers/webhooks/webhook-connect.test.ts
@@ -29,6 +29,9 @@ const user: RestUser = {
     skills: { iv: [] },
     questions: { iv: [] },
     teams: { iv: [] },
+    onboarded: {
+      iv: true,
+    },
   },
 };
 

--- a/apps/asap-server/test/handlers/webhooks/webhook-sync-orcid.fixtures.ts
+++ b/apps/asap-server/test/handlers/webhooks/webhook-sync-orcid.fixtures.ts
@@ -23,6 +23,9 @@ export const fetchUserResponse: RestUser = {
     role: {
       iv: 'Grantee',
     },
+    onboarded: {
+      iv: true,
+    },
   },
   created: '2020-08-27T13:20:57Z',
   lastModified: '2020-08-31T13:57:51Z',
@@ -63,6 +66,9 @@ export const updateUserEvent: WebhookPayload<User> = {
       skills: { iv: [] },
       questions: { iv: [] },
       teams: { iv: [] },
+      onboarded: {
+        iv: true,
+      },
     },
     dataOld: {
       firstName: { iv: 'Bill' },
@@ -90,6 +96,9 @@ export const updateUserEvent: WebhookPayload<User> = {
       skills: { iv: [] },
       questions: { iv: [] },
       teams: { iv: [] },
+      onboarded: {
+        iv: true,
+      },
     },
   },
 };
@@ -128,6 +137,9 @@ export const createUserEvent: WebhookPayload<User> = {
       },
       email: {
         iv: 'webhokk@ola.io',
+      },
+      onboarded: {
+        iv: true,
       },
     },
   },

--- a/apps/asap-server/test/helpers/users.ts
+++ b/apps/asap-server/test/helpers/users.ts
@@ -20,6 +20,7 @@ function transform(user: RestUser): TestUserResponse {
 
 export const createUser = (overwrites?: Partial<User>): Promise<RestUser> => {
   const userData: User = {
+    onboarded: true,
     firstName: chance.first(),
     lastName: chance.last(),
     jobTitle: chance.suffix({ full: true }),

--- a/apps/asap-server/test/middleware/auth-handler.test.ts
+++ b/apps/asap-server/test/middleware/auth-handler.test.ts
@@ -50,6 +50,7 @@ describe('Authentication middleware', () => {
     decodeToken.mockResolvedValueOnce({
       [`some-other-origin/user`]: {
         id: 'userId',
+        onboarded: true,
         displayName: 'JT',
         email: 'joao.tiago@asap.science',
         firstName: 'Joao',

--- a/apps/asap-server/test/utils/migrations.test.ts
+++ b/apps/asap-server/test/utils/migrations.test.ts
@@ -1,0 +1,84 @@
+import { RestUser, Results, Squidex } from '@asap-hub/squidex';
+import { applyToAllItemsInCollection } from '../../src/utils/migrations';
+
+const mockFetch: jest.MockedFunction<Squidex<RestUser>['fetch']> = jest.fn();
+const mockConstructor = jest.fn();
+
+jest.mock('@asap-hub/squidex', () => ({
+  Squidex: class Squidex {
+    constructor(collection: string) {
+      mockConstructor(collection);
+    }
+    fetch = mockFetch;
+  },
+}));
+
+const restUserMock = {
+  id: 'userId',
+  onboarded: true,
+  displayName: 'Cristiano Ronaldo',
+  created: '',
+  lastModified: '',
+  data: {},
+} as any as RestUser;
+
+describe('Migration utils', () => {
+  describe('applyToAllItemsInCollection helper method', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    test('Should invoke the client as expected', async () => {
+      const mockFetchResult: Results<RestUser> = {
+        items: [],
+        total: 0,
+      };
+
+      mockFetch.mockResolvedValueOnce(mockFetchResult);
+
+      await applyToAllItemsInCollection('user', jest.fn());
+
+      expect(mockConstructor).toBeCalledWith('user');
+    });
+
+    test('Should invoke the given processing function for every item in the result', async () => {
+      const mockFetchResult: Results<RestUser> = {
+        items: [restUserMock, restUserMock],
+        total: 2,
+      };
+
+      mockFetch.mockResolvedValueOnce(mockFetchResult);
+
+      const processingFunction = jest.fn();
+
+      await applyToAllItemsInCollection('user', processingFunction);
+
+      expect(processingFunction).toBeCalledTimes(2);
+      expect(processingFunction).toBeCalledWith(
+        restUserMock,
+        expect.any(Squidex),
+      );
+    });
+
+    test('Should invoke the given processing function with the results from each iteration', async () => {
+      const mockFetchResult: Results<RestUser> = {
+        items: [restUserMock],
+        total: 11,
+      };
+
+      // resolve twice
+      mockFetch.mockResolvedValueOnce(mockFetchResult);
+      mockFetch.mockResolvedValueOnce(mockFetchResult);
+
+      const processingFunction = jest.fn();
+
+      await applyToAllItemsInCollection('user', processingFunction);
+
+      expect(processingFunction).toBeCalledTimes(2);
+      expect(processingFunction).toBeCalledWith(
+        restUserMock,
+        expect.any(Squidex),
+      );
+    });
+  });
+});

--- a/apps/asap-server/test/utils/migrations.test.ts
+++ b/apps/asap-server/test/utils/migrations.test.ts
@@ -1,10 +1,12 @@
 import { RestUser, Results, Squidex } from '@asap-hub/squidex';
 import { applyToAllItemsInCollection } from '../../src/utils/migrations';
+import { restUserMock } from '../fixtures/users.fixtures';
 
 const mockFetch: jest.MockedFunction<Squidex<RestUser>['fetch']> = jest.fn();
 const mockConstructor = jest.fn();
 
 jest.mock('@asap-hub/squidex', () => ({
+  ...jest.requireActual('@asap-hub/squidex'),
   Squidex: class Squidex {
     constructor(collection: string) {
       mockConstructor(collection);
@@ -12,15 +14,6 @@ jest.mock('@asap-hub/squidex', () => ({
     fetch = mockFetch;
   },
 }));
-
-const restUserMock = {
-  id: 'userId',
-  onboarded: true,
-  displayName: 'Cristiano Ronaldo',
-  created: '',
-  lastModified: '',
-  data: {},
-} as any as RestUser;
 
 describe('Migration utils', () => {
   describe('applyToAllItemsInCollection helper method', () => {

--- a/apps/auth0-rules/src/__tests__/add-user-metadata.test.ts
+++ b/apps/auth0-rules/src/__tests__/add-user-metadata.test.ts
@@ -78,6 +78,7 @@ const context: RuleContext = {
 };
 
 const apiUser: UserResponse = {
+  onboarded: true,
   displayName: 'Joao Tiago',
   firstName: 'Joao',
   lastName: 'Tiago',
@@ -164,6 +165,7 @@ describe('Auth0 Rule - Add User Metadata', () => {
       displayName: 'Joao Tiago',
       email: 'joao.tiago@yld.io',
       id: 'myRandomId123',
+      onboarded: true,
       firstName: 'Joao',
       lastName: 'Tiago',
       avatarUrl: undefined,
@@ -210,6 +212,7 @@ describe('Auth0 Rule - Add User Metadata', () => {
       displayName: 'Joao Tiago',
       email: 'joao.tiago@yld.io',
       id: 'myRandomId123',
+      onboarded: true,
       firstName: 'Joao',
       lastName: 'Tiago',
       avatarUrl: undefined,

--- a/apps/auth0-rules/src/add-user-metadata.ts
+++ b/apps/auth0-rules/src/add-user-metadata.ts
@@ -22,13 +22,21 @@ const addUserMetadata: Rule<{ invitationCode: string }> = async (
   }
 
   try {
-    const { id, onboarded, displayName, email, firstName, lastName, avatarUrl, teams } =
-      await got(`${apiURL}/webhook/users/${auth0User.user_id}`, {
-        headers: {
-          Authorization: `Basic ${apiSharedSecret}`,
-        },
-        timeout: 10000,
-      }).json<UserResponse>();
+    const {
+      id,
+      onboarded,
+      displayName,
+      email,
+      firstName,
+      lastName,
+      avatarUrl,
+      teams,
+    } = await got(`${apiURL}/webhook/users/${auth0User.user_id}`, {
+      headers: {
+        Authorization: `Basic ${apiSharedSecret}`,
+      },
+      timeout: 10000,
+    }).json<UserResponse>();
 
     const user: User = {
       id,

--- a/apps/auth0-rules/src/add-user-metadata.ts
+++ b/apps/auth0-rules/src/add-user-metadata.ts
@@ -22,7 +22,7 @@ const addUserMetadata: Rule<{ invitationCode: string }> = async (
   }
 
   try {
-    const { id, displayName, email, firstName, lastName, avatarUrl, teams } =
+    const { id, onboarded, displayName, email, firstName, lastName, avatarUrl, teams } =
       await got(`${apiURL}/webhook/users/${auth0User.user_id}`, {
         headers: {
           Authorization: `Basic ${apiSharedSecret}`,
@@ -32,6 +32,7 @@ const addUserMetadata: Rule<{ invitationCode: string }> = async (
 
     const user: User = {
       id,
+      onboarded,
       displayName,
       email,
       firstName,

--- a/apps/frontend/src/auth/test-utils.tsx
+++ b/apps/frontend/src/auth/test-utils.tsx
@@ -26,6 +26,7 @@ const createAuth0 = (
   if (user) {
     const completeUser: User = {
       id: 'testuserid',
+      onboarded: true,
       email: 'john.doe@example.com',
       displayName: 'John Doe',
       firstName: 'John',

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -27,7 +27,6 @@ export interface Auth0User {
   readonly given_name?: string;
   readonly family_name?: string;
   readonly orcid?: string;
-  readonly onboarded: boolean;
   readonly aud: string;
   readonly [customUserClaim: string]: string | undefined | User;
 }

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -8,7 +8,13 @@ export { config, auth0PubKeys };
 
 export type User = Pick<
   UserResponse,
-  'id' | 'displayName' | 'email' | 'firstName' | 'lastName' | 'avatarUrl'
+  | 'id'
+  | 'onboarded'
+  | 'displayName'
+  | 'email'
+  | 'firstName'
+  | 'lastName'
+  | 'avatarUrl'
 > & {
   teams: ReadonlyArray<
     Omit<UserResponse['teams'][0], 'approach' | 'responsibilities'>
@@ -21,6 +27,7 @@ export interface Auth0User {
   readonly given_name?: string;
   readonly family_name?: string;
   readonly orcid?: string;
+  readonly onboarded: boolean;
   readonly aud: string;
   readonly [customUserClaim: string]: string | undefined | User;
 }

--- a/packages/fixtures/src/users.ts
+++ b/packages/fixtures/src/users.ts
@@ -8,6 +8,7 @@ const listUserResponseTeam: Omit<UserTeam, 'id'> = {
 export const listUserResponseItem: Omit<ListUserResponse['items'][0], 'id'> = {
   createdDate: '2020-09-07T17:36:54Z',
   lastModifiedDate: '2020-09-07T17:36:54Z',
+  onboarded: true,
   displayName: 'Person A',
   email: 'agnete.kirkeby@sund.ku.dk',
   firstName: 'Agnete',

--- a/packages/model/src/user.ts
+++ b/packages/model/src/user.ts
@@ -103,6 +103,7 @@ export interface UserSocialLinks {
 
 export interface UserResponse extends Invitee {
   id: string;
+  onboarded: boolean;
   contactEmail?: string;
   displayName: string;
   lastModifiedDate: string;

--- a/packages/react-components/src/auth-test-utils.tsx
+++ b/packages/react-components/src/auth-test-utils.tsx
@@ -84,6 +84,7 @@ export const LoggedIn: React.FC<{
   if (user) {
     const completeUser: User = {
       id: 'testuserid',
+      onboarded: true,
       email: 'john.doe@example.com',
       displayName: 'John Doe',
       firstName: 'John',

--- a/packages/react-context/src/__tests__/auth.test.tsx
+++ b/packages/react-context/src/__tests__/auth.test.tsx
@@ -71,6 +71,7 @@ describe('useCurrentUser', () => {
         aud: 'Av2psgVspAN00Kez9v1vR2c496a9zCW3',
         [`${window.location.origin}/user`]: {
           id: 'testuser',
+          onboarded: true,
           email: 'john.doe@example.com',
           firstName: 'John',
           lastName: 'Doe',

--- a/packages/squidex/schema/schemas/users.json
+++ b/packages/squidex/schema/schemas/users.json
@@ -15,6 +15,24 @@
     "fieldsInLists": ["email", "meta.id"],
     "fields": [
       {
+        "name": "onboarded",
+        "isHidden": false,
+        "isLocked": false,
+        "isDisabled": true,
+        "partitioning": "invariant",
+        "properties": {
+          "fieldType": "Boolean",
+          "defaultValue": true,
+          "inlineEditable": false,
+          "editor": "Toggle",
+          "label": "Onboarding complete",
+          "hints": "Users that have NOT completed onboarding can only see their profile and are hidden from the Hub.",
+          "isRequired": true,
+          "isRequiredOnPublish": false,
+          "isHalfWidth": false
+        }
+      },
+      {
         "name": "separatorBasicData",
         "isHidden": false,
         "isLocked": false,

--- a/packages/squidex/src/entities/user.ts
+++ b/packages/squidex/src/entities/user.ts
@@ -29,6 +29,7 @@ export interface User<
   TConnection = UserTeamConnection,
   TSocial = Omit<UserSocialLinks, 'orcid'>,
 > {
+  onboarded: boolean;
   avatar: TAvatar[];
   biography?: string;
   connections: { code: string }[];


### PR DESCRIPTION
First stage of https://trello.com/c/CyzhVfx5/1299-8-add-user-state-to-cms-and-block-api-calls

Adds the `onboarded` flag to the `User`. Once the migration is run and all the existing as well as new users have got the flag set to `true` we can then implement the auth rule to reject the ones with a `false` value

## Notable changes
* adds a modification to auth0 rule which needs to be manually deployed
