### PR TITLE
feat: Block non-onboarded users

### DIFF
--- a/apps/asap-server/src/middleware/auth-handler.ts
+++ b/apps/asap-server/src/middleware/auth-handler.ts
@@ -31,6 +31,10 @@ export const authHandlerFactory =
       throw Boom.unauthorized();
     }
 
+    if (user.onboarded !== true) {
+      throw Boom.forbidden('User is not onboarded');
+    }
+
     req.loggedUser = user;
     req.span?.setBaggageItem('user.id', user.id);
 


### PR DESCRIPTION
Second stage of: https://trello.com/c/CyzhVfx5/1299-8-add-user-state-to-cms-and-block-api-calls

This will effectively block all private endpoints from accessing by non-onboarded users.

Should not affect our current or new users as they should be automatically set to `onboarded: true` as per the migration in https://github.com/yldio/asap-hub/pull/887