### PR TITLE
fix: Team pagination bug

### DIFF
--- a/apps/asap-cli/src/invite/index.ts
+++ b/apps/asap-cli/src/invite/index.ts
@@ -45,7 +45,7 @@ const inviteUsersFactory = (
     const query: Query = {
       skip,
       take,
-      sort: [{ path: 'created', order: 'ascending' }],
+      sort: [{ path: 'created', order: 'descending' }],
     };
 
     if (role) {
@@ -77,13 +77,14 @@ const inviteUsersFactory = (
     const userTeamIds = usersToInvite
       .flatMap((user) => user.data.teams.iv)
       .flatMap((team) => team?.id)
-      .filter(Boolean) as string[];
+      .filter(Boolean)
+      .filter((team, pos, self) => self.indexOf(team) === pos) as string[];
 
     let teamMap: { [key: string]: string };
     if (userTeamIds.length > 0) {
       const teamQuery: Query = {
-        skip,
-        take,
+        skip: 0,
+        take: 20, // Dont expect a user to have more than 20 teams
         filter: {
           path: 'id',
           op: 'in',

--- a/apps/asap-cli/test/invite.test.ts
+++ b/apps/asap-cli/test/invite.test.ts
@@ -47,7 +47,7 @@ describe('Invite user', () => {
         q: JSON.stringify({
           take: 20,
           skip: 0,
-          sort: [{ path: 'created', order: 'ascending' }],
+          sort: [{ path: 'created', order: 'descending' }],
           filter: {
             path: 'data.role.iv',
             op: 'eq',
@@ -70,7 +70,7 @@ describe('Invite user', () => {
         q: JSON.stringify({
           take: 20,
           skip: 0,
-          sort: [{ path: 'created', order: 'ascending' }],
+          sort: [{ path: 'created', order: 'descending' }],
           filter: {
             path: 'data.role.iv',
             op: 'eq',
@@ -115,7 +115,7 @@ describe('Invite user', () => {
         q: JSON.stringify({
           take: 20,
           skip: 0,
-          sort: [{ path: 'created', order: 'ascending' }],
+          sort: [{ path: 'created', order: 'descending' }],
         }),
       })
       .reply(200, fetchUsersResponse)
@@ -159,7 +159,7 @@ describe('Invite user', () => {
         q: JSON.stringify({
           take: 20,
           skip: 0,
-          sort: [{ path: 'created', order: 'ascending' }],
+          sort: [{ path: 'created', order: 'descending' }],
         }),
       })
       .reply(200, fetchUsersWithTeamsResponse)
@@ -225,7 +225,7 @@ describe('Invite user', () => {
         q: JSON.stringify({
           take: 20,
           skip: 0,
-          sort: [{ path: 'created', order: 'ascending' }],
+          sort: [{ path: 'created', order: 'descending' }],
         }),
       })
       .reply(200, fetchUserMultipleTeamsResponse)
@@ -259,7 +259,7 @@ describe('Invite user', () => {
         q: JSON.stringify({
           take: 20,
           skip: 0,
-          sort: [{ path: 'created', order: 'ascending' }],
+          sort: [{ path: 'created', order: 'descending' }],
           filter: {
             path: 'data.role.iv',
             op: 'eq',
@@ -291,7 +291,7 @@ describe('Invite user', () => {
         q: JSON.stringify({
           take: 20,
           skip: 0,
-          sort: [{ path: 'created', order: 'ascending' }],
+          sort: [{ path: 'created', order: 'descending' }],
           filter: {
             path: 'data.role.iv',
             op: 'eq',


### PR DESCRIPTION
Fixes the bug with team pagination - the number of teams for each user should be fixed - this PR sets it to maximum 20.