### PR TITLE
fix: Onboarded always shown as 'true'

### DIFF
--- a/apps/asap-server/src/controllers/users.ts
+++ b/apps/asap-server/src/controllers/users.ts
@@ -37,6 +37,7 @@ flatData {
   lastModifiedDate
   lastName
   location
+  onboarded
   orcid
   orcidLastModifiedDate
   orcidLastSyncDate

--- a/apps/asap-server/src/entities/user.ts
+++ b/apps/asap-server/src/entities/user.ts
@@ -92,7 +92,10 @@ export const parseGraphQLUser = (item: GraphqlUser): UserResponse => {
 
   return {
     id: item.id,
-    onboarded: item.flatData?.onboarded || true,
+    onboarded:
+      item.flatData && typeof item.flatData.onboarded === 'boolean'
+        ? item.flatData.onboarded
+        : true,
     createdDate,
     displayName,
     orcid, // TODO: remove once edit social is added

--- a/apps/asap-server/test/controllers/users.test.ts
+++ b/apps/asap-server/test/controllers/users.test.ts
@@ -154,6 +154,31 @@ describe('Users controller', () => {
       const result = await users.fetchById('user-id');
       expect(result).toEqual(fixtures.fetchUserExpectation);
     });
+
+    test('Should return onboarded flag when its false', async () => {
+      const response = {
+        data: {
+          findUsersContent: {
+            ...fixtures.graphQlResponseFetchUser.data.findUsersContent,
+            flatData: {
+              ...fixtures.graphQlResponseFetchUser.data.findUsersContent
+                .flatData,
+              onboarded: false,
+            },
+          },
+        },
+      };
+
+      nock(config.baseUrl)
+        .post(`/api/content/${config.appName}/graphql`, {
+          query: buildGraphQLQueryFetchUser('user-id'),
+        })
+        .reply(200, response);
+
+      const result = await users.fetchById('user-id');
+
+      expect(result.onboarded).toEqual(false);
+    });
   });
 
   describe('fetchByCode', () => {

--- a/apps/asap-server/test/controllers/users.test.ts
+++ b/apps/asap-server/test/controllers/users.test.ts
@@ -179,6 +179,31 @@ describe('Users controller', () => {
 
       expect(result.onboarded).toEqual(false);
     });
+
+    test('Should default onboarded flag to true when its null', async () => {
+      const response = {
+        data: {
+          findUsersContent: {
+            ...fixtures.graphQlResponseFetchUser.data.findUsersContent,
+            flatData: {
+              ...fixtures.graphQlResponseFetchUser.data.findUsersContent
+                .flatData,
+              onboarded: null,
+            },
+          },
+        },
+      };
+
+      nock(config.baseUrl)
+        .post(`/api/content/${config.appName}/graphql`, {
+          query: buildGraphQLQueryFetchUser('user-id'),
+        })
+        .reply(200, response);
+
+      const result = await users.fetchById('user-id');
+
+      expect(result.onboarded).toEqual(true);
+    });
   });
 
   describe('fetchByCode', () => {


### PR DESCRIPTION
Fixes the bug whereby even non-onboarded users are shown as onboarded. 
The fix adds the property to the graphql query and also adds proper boolean defaulting

## Notes
Without proper integration testing the missing query parameter would be impossible to trace with our current unit tests