### PR TITLE
feat: Create external-authors/authors mixed relationship for ROs

### DIFF
--- a/apps/asap-server/.eslintrc.js
+++ b/apps/asap-server/.eslintrc.js
@@ -11,5 +11,6 @@ module.exports = {
       'LabeledStatement',
       'WithStatement',
     ],
+    'no-underscore-dangle': ['error', { allow: ['__typename'] }],
   },
 };

--- a/apps/asap-server/src/controllers/research-outputs.ts
+++ b/apps/asap-server/src/controllers/research-outputs.ts
@@ -33,7 +33,19 @@ flatData{
   asapFunded
   usedInAPublication
   authors {
-    ${GraphQLQueryUser}
+    __typename
+    ... on Users {
+      ${GraphQLQueryUser}
+    }
+    ... on ExternalAuthors {
+      id
+      created
+      lastModified
+      flatData {
+        name
+        orcid
+      }
+    }
   }
 }
 ${

--- a/apps/asap-server/src/entities/research-output.ts
+++ b/apps/asap-server/src/entities/research-output.ts
@@ -15,8 +15,16 @@ export const parseGraphQLResearchOutput = (
   const optionalAuthors = options?.includeAuthors
     ? {
         authors:
-          output.flatData?.authors?.map((author) => parseGraphQLUser(author)) ||
-          [],
+          output.flatData?.authors?.map((author) => {
+            if (author.__typename === 'Users') {
+              return parseGraphQLUser(author);
+            }
+
+            return {
+              displayName: author.flatData?.name,
+              orcid: author.flatData?.orcid,
+            };
+          }) || [],
       }
     : {};
 

--- a/apps/asap-server/test/fixtures/groups.fixtures.ts
+++ b/apps/asap-server/test/fixtures/groups.fixtures.ts
@@ -4,7 +4,8 @@ import {
   ResponseFetchGroups,
   ResponseFetchGroup,
 } from '../../src/controllers/groups';
-import { fetchExpectation, graphQlResponseFetchUsers } from './users.fixtures';
+import { getSquidexResearchOutputGrapqlResponseAuthors } from './research-output.fixtures';
+import { fetchExpectation } from './users.fixtures';
 
 export const queryGroupsResponse: { data: ResponseFetchGroups } = {
   data: {
@@ -67,8 +68,7 @@ export const queryGroupsResponse: { data: ResponseFetchGroups } = {
                         asapFunded: 'No',
                         usedInAPublication: 'No',
                         authors:
-                          graphQlResponseFetchUsers.data
-                            .queryUsersContentsWithTotal.items,
+                          getSquidexResearchOutputGrapqlResponseAuthors(),
                       },
                     },
                   ],

--- a/apps/asap-server/test/fixtures/groups.fixtures.ts
+++ b/apps/asap-server/test/fixtures/groups.fixtures.ts
@@ -4,7 +4,7 @@ import {
   ResponseFetchGroups,
   ResponseFetchGroup,
 } from '../../src/controllers/groups';
-import { getSquidexResearchOutputGrapqlResponseAuthors } from './research-output.fixtures';
+import { getSquidexResearchOutputGraphqlResponseAuthors } from './research-output.fixtures';
 import { fetchExpectation } from './users.fixtures';
 
 export const queryGroupsResponse: { data: ResponseFetchGroups } = {
@@ -68,7 +68,7 @@ export const queryGroupsResponse: { data: ResponseFetchGroups } = {
                         asapFunded: 'No',
                         usedInAPublication: 'No',
                         authors:
-                          getSquidexResearchOutputGrapqlResponseAuthors(),
+                          getSquidexResearchOutputGraphqlResponseAuthors(),
                       },
                     },
                   ],

--- a/apps/asap-server/test/fixtures/research-output.fixtures.ts
+++ b/apps/asap-server/test/fixtures/research-output.fixtures.ts
@@ -23,7 +23,7 @@ export const getSquidexResearchOutputsGraphqlResponse =
     },
   });
 
-export const getSquidexResearchOutputGrapqlResponseAuthors =
+export const getSquidexResearchOutputGraphqlResponseAuthors =
   (): GraphqlResearchOutputAuthors[] =>
     graphQlResponseFetchUsers.data.queryUsersContentsWithTotal.items.map(
       (item): GraphqlUserAssoc => ({
@@ -50,7 +50,7 @@ export const getSquidexGraphqlResearchOutput = (): GraphqlResearchOutput => ({
     publishDate: '2021-05-21T13:18:31Z',
     tags: ['tag', 'test'],
     lastUpdatedPartial: '2020-09-23T16:34:26.842Z',
-    authors: getSquidexResearchOutputGrapqlResponseAuthors(),
+    authors: getSquidexResearchOutputGraphqlResponseAuthors(),
     accessInstructions: 'some access instructions',
     sharingStatus: 'Network Only',
     asapFunded: 'Yes',

--- a/apps/asap-server/test/fixtures/research-output.fixtures.ts
+++ b/apps/asap-server/test/fixtures/research-output.fixtures.ts
@@ -3,7 +3,11 @@ import {
   ListUserResponse,
   ResearchOutputResponse,
 } from '@asap-hub/model';
-import { GraphqlResearchOutput } from '@asap-hub/squidex';
+import {
+  GraphqlResearchOutputAuthors,
+  GraphqlResearchOutput,
+  GraphqlUserAssoc,
+} from '@asap-hub/squidex';
 import {
   ResponseFetchResearchOutput,
   ResponseFetchResearchOutputs,
@@ -18,6 +22,15 @@ export const getSquidexResearchOutputsGraphqlResponse =
       items: [getSquidexGraphqlResearchOutput()],
     },
   });
+
+export const getSquidexResearchOutputGrapqlResponseAuthors =
+  (): GraphqlResearchOutputAuthors[] =>
+    graphQlResponseFetchUsers.data.queryUsersContentsWithTotal.items.map(
+      (item): GraphqlUserAssoc => ({
+        __typename: 'Users',
+        ...item,
+      }),
+    );
 
 export const getSquidexResearchOutputGraphqlResponse =
   (): ResponseFetchResearchOutput => ({
@@ -37,7 +50,7 @@ export const getSquidexGraphqlResearchOutput = (): GraphqlResearchOutput => ({
     publishDate: '2021-05-21T13:18:31Z',
     tags: ['tag', 'test'],
     lastUpdatedPartial: '2020-09-23T16:34:26.842Z',
-    authors: graphQlResponseFetchUsers.data.queryUsersContentsWithTotal.items,
+    authors: getSquidexResearchOutputGrapqlResponseAuthors(),
     accessInstructions: 'some access instructions',
     sharingStatus: 'Network Only',
     asapFunded: 'Yes',

--- a/apps/asap-server/test/fixtures/teams.fixtures.ts
+++ b/apps/asap-server/test/fixtures/teams.fixtures.ts
@@ -5,7 +5,8 @@ import {
   ResponseFetchTeams,
   ResponseFetchTeam,
 } from '../../src/controllers/teams';
-import { fetchExpectation, graphQlResponseFetchUsers } from './users.fixtures';
+import { getSquidexResearchOutputGrapqlResponseAuthors } from './research-output.fixtures';
+import { fetchExpectation } from './users.fixtures';
 
 export const graphQlTeamsResponse: { data: ResponseFetchTeams } = {
   data: {
@@ -31,10 +32,7 @@ export const graphQlTeamsResponse: { data: ResponseFetchTeams } = {
                   title: 'Proposal',
                   type: 'Proposal',
                   tags: ['test', 'tag'],
-                  authors: [
-                    graphQlResponseFetchUsers.data.queryUsersContentsWithTotal
-                      .items[0],
-                  ],
+                  authors: [getSquidexResearchOutputGrapqlResponseAuthors()[0]],
                   sharingStatus: 'Network Only',
                   asapFunded: 'No',
                 },
@@ -51,10 +49,7 @@ export const graphQlTeamsResponse: { data: ResponseFetchTeams } = {
                   type: 'Presentation',
                   tags: ['test', 'tag'],
                   accessInstructions: 'some access instructions',
-                  authors: [
-                    graphQlResponseFetchUsers.data.queryUsersContentsWithTotal
-                      .items[1],
-                  ],
+                  authors: [getSquidexResearchOutputGrapqlResponseAuthors()[1]],
                 },
               },
             ],
@@ -423,10 +418,7 @@ export const graphQlTeamResponse: { data: ResponseFetchTeam } = {
               tags: ['test', 'tag'],
               sharingStatus: 'Network Only',
               asapFunded: 'No',
-              authors: [
-                graphQlResponseFetchUsers.data.queryUsersContentsWithTotal
-                  .items[0],
-              ],
+              authors: [getSquidexResearchOutputGrapqlResponseAuthors()[0]],
             },
           },
           {
@@ -439,10 +431,7 @@ export const graphQlTeamResponse: { data: ResponseFetchTeam } = {
               addedDate: null,
               title: "Team Salzer's intro slide deck",
               type: 'Presentation',
-              authors: [
-                graphQlResponseFetchUsers.data.queryUsersContentsWithTotal
-                  .items[1],
-              ],
+              authors: [getSquidexResearchOutputGrapqlResponseAuthors()[1]],
               usedInAPublication: 'No',
             },
             referencingTeamsContents: [
@@ -663,10 +652,7 @@ export const getGraphQlTeamResponse = (
               title: 'Proposal',
               type: 'Proposal',
               tags: ['test', 'tag'],
-              authors: [
-                graphQlResponseFetchUsers.data.queryUsersContentsWithTotal
-                  .items[0],
-              ],
+              authors: [getSquidexResearchOutputGrapqlResponseAuthors()[0]],
               sharingStatus: 'Network Only',
               asapFunded: 'No',
             },
@@ -691,10 +677,7 @@ export const getGraphQlTeamResponse = (
               addedDate: null,
               title: "Team Salzer's intro slide deck",
               type: 'Presentation',
-              authors: [
-                graphQlResponseFetchUsers.data.queryUsersContentsWithTotal
-                  .items[1],
-              ],
+              authors: [getSquidexResearchOutputGrapqlResponseAuthors()[1]],
               usedInAPublication: 'No',
             },
             referencingTeamsContents: [

--- a/apps/asap-server/test/fixtures/teams.fixtures.ts
+++ b/apps/asap-server/test/fixtures/teams.fixtures.ts
@@ -5,7 +5,7 @@ import {
   ResponseFetchTeams,
   ResponseFetchTeam,
 } from '../../src/controllers/teams';
-import { getSquidexResearchOutputGrapqlResponseAuthors } from './research-output.fixtures';
+import { getSquidexResearchOutputGraphqlResponseAuthors } from './research-output.fixtures';
 import { fetchExpectation } from './users.fixtures';
 
 export const graphQlTeamsResponse: { data: ResponseFetchTeams } = {
@@ -32,7 +32,9 @@ export const graphQlTeamsResponse: { data: ResponseFetchTeams } = {
                   title: 'Proposal',
                   type: 'Proposal',
                   tags: ['test', 'tag'],
-                  authors: [getSquidexResearchOutputGrapqlResponseAuthors()[0]],
+                  authors: [
+                    getSquidexResearchOutputGraphqlResponseAuthors()[0],
+                  ],
                   sharingStatus: 'Network Only',
                   asapFunded: 'No',
                 },
@@ -49,7 +51,9 @@ export const graphQlTeamsResponse: { data: ResponseFetchTeams } = {
                   type: 'Presentation',
                   tags: ['test', 'tag'],
                   accessInstructions: 'some access instructions',
-                  authors: [getSquidexResearchOutputGrapqlResponseAuthors()[1]],
+                  authors: [
+                    getSquidexResearchOutputGraphqlResponseAuthors()[1],
+                  ],
                 },
               },
             ],
@@ -418,7 +422,7 @@ export const graphQlTeamResponse: { data: ResponseFetchTeam } = {
               tags: ['test', 'tag'],
               sharingStatus: 'Network Only',
               asapFunded: 'No',
-              authors: [getSquidexResearchOutputGrapqlResponseAuthors()[0]],
+              authors: [getSquidexResearchOutputGraphqlResponseAuthors()[0]],
             },
           },
           {
@@ -431,7 +435,7 @@ export const graphQlTeamResponse: { data: ResponseFetchTeam } = {
               addedDate: null,
               title: "Team Salzer's intro slide deck",
               type: 'Presentation',
-              authors: [getSquidexResearchOutputGrapqlResponseAuthors()[1]],
+              authors: [getSquidexResearchOutputGraphqlResponseAuthors()[1]],
               usedInAPublication: 'No',
             },
             referencingTeamsContents: [
@@ -652,7 +656,7 @@ export const getGraphQlTeamResponse = (
               title: 'Proposal',
               type: 'Proposal',
               tags: ['test', 'tag'],
-              authors: [getSquidexResearchOutputGrapqlResponseAuthors()[0]],
+              authors: [getSquidexResearchOutputGraphqlResponseAuthors()[0]],
               sharingStatus: 'Network Only',
               asapFunded: 'No',
             },
@@ -677,7 +681,7 @@ export const getGraphQlTeamResponse = (
               addedDate: null,
               title: "Team Salzer's intro slide deck",
               type: 'Presentation',
-              authors: [getSquidexResearchOutputGrapqlResponseAuthors()[1]],
+              authors: [getSquidexResearchOutputGraphqlResponseAuthors()[1]],
               usedInAPublication: 'No',
             },
             referencingTeamsContents: [

--- a/packages/squidex/schema/schemas/external-authors.json
+++ b/packages/squidex/schema/schemas/external-authors.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "./../__json/schema.json",
+  "name": "external-authors",
+  "isSingleton": false,
+  "isPublished": false,
+  "schema": {
+    "noFieldDeletion": false,
+    "noFieldRecreation": false,
+    "properties": {
+      "label": "External authors",
+      "validateOnPublish": false
+    },
+    "scripts": {},
+    "fieldsInReferences": [],
+    "fieldsInLists": [],
+    "fields": [
+      {
+        "name": "name",
+        "isHidden": false,
+        "isLocked": false,
+        "isDisabled": false,
+        "partitioning": "invariant",
+        "properties": {
+          "fieldType": "String",
+          "isUnique": false,
+          "inlineEditable": false,
+          "contentType": "Unspecified",
+          "editor": "Input",
+          "label": "Name",
+          "isRequired": true,
+          "isRequiredOnPublish": false,
+          "isHalfWidth": false
+        }
+      },
+      {
+        "name": "orcid",
+        "isHidden": false,
+        "isLocked": false,
+        "isDisabled": false,
+        "partitioning": "invariant",
+        "properties": {
+          "fieldType": "String",
+          "isUnique": false,
+          "inlineEditable": false,
+          "contentType": "Unspecified",
+          "editor": "Input",
+          "label": "Orcid",
+          "isRequired": false,
+          "isRequiredOnPublish": false,
+          "isHalfWidth": false
+        }
+      }
+    ],
+    "previewUrls": {},
+    "category": "Storage",
+    "isPublished": true
+  }
+}

--- a/packages/squidex/schema/schemas/research-outputs.json
+++ b/packages/squidex/schema/schemas/research-outputs.json
@@ -307,7 +307,7 @@
           "resolveReference": false,
           "mustBePublished": false,
           "editor": "List",
-          "schemaIds": ["users"],
+          "schemaIds": ["users", "external-authors"],
           "label": "Authors",
           "isRequired": false,
           "isRequiredOnPublish": false,

--- a/packages/squidex/src/entities/common.ts
+++ b/packages/squidex/src/entities/common.ts
@@ -31,6 +31,6 @@ export interface Graphql<T> {
     | null;
 }
 
-export type GraphqlWithTypename<T extends Graphql<any>, Y> = T & {
+export type GraphqlWithTypename<T extends Graphql<unknown>, Y> = T & {
   __typename: Y;
 };

--- a/packages/squidex/src/entities/common.ts
+++ b/packages/squidex/src/entities/common.ts
@@ -30,3 +30,7 @@ export interface Graphql<T> {
       }
     | null;
 }
+
+export type GraphqlWithTypename<T extends Graphql<any>, Y> = T & {
+  __typename: Y;
+};

--- a/packages/squidex/src/entities/external-author.ts
+++ b/packages/squidex/src/entities/external-author.ts
@@ -1,0 +1,10 @@
+import { Entity, Graphql } from './common';
+
+export interface ExternalAuthor {
+  name: string;
+  orcid?: string;
+}
+
+export interface GraphqlExternalAuthor
+  extends Entity,
+    Graphql<ExternalAuthor> {}

--- a/packages/squidex/src/entities/research-output.ts
+++ b/packages/squidex/src/entities/research-output.ts
@@ -5,7 +5,8 @@ import {
   DecisionOption,
 } from '@asap-hub/model';
 
-import { Rest, Entity, Graphql } from './common';
+import { Rest, Entity, Graphql, GraphqlWithTypename } from './common';
+import { GraphqlExternalAuthor } from './external-author';
 import { GraphqlTeam } from './team';
 import { GraphqlUser } from './user';
 
@@ -34,6 +35,11 @@ export interface ResearchOutput<TAuthorConnection = string> {
 export interface RestResearchOutput extends Entity, Rest<ResearchOutput> {}
 export interface GraphqlResearchOutput
   extends Entity,
-    Graphql<ResearchOutput<GraphqlUser>> {
+    Graphql<
+      ResearchOutput<
+        | GraphqlWithTypename<GraphqlUser, 'Users'>
+        | GraphqlWithTypename<GraphqlExternalAuthor, 'ExternalAuthors'>
+      >
+    > {
   referencingTeamsContents?: GraphqlTeam[];
 }

--- a/packages/squidex/src/entities/research-output.ts
+++ b/packages/squidex/src/entities/research-output.ts
@@ -8,7 +8,7 @@ import {
 import { Rest, Entity, Graphql, GraphqlWithTypename } from './common';
 import { GraphqlExternalAuthor } from './external-author';
 import { GraphqlTeam } from './team';
-import { GraphqlUser } from './user';
+import { GraphqlUserAssoc } from './user';
 
 export interface ResearchOutput<TAuthorConnection = string> {
   type: ResearchOutputType;
@@ -33,13 +33,17 @@ export interface ResearchOutput<TAuthorConnection = string> {
 }
 
 export interface RestResearchOutput extends Entity, Rest<ResearchOutput> {}
+
+export type GraphqlExternalAuthorAssoc = GraphqlWithTypename<
+  GraphqlExternalAuthor,
+  'ExternalAuthors'
+>;
+
+export type GraphqlResearchOutputAuthors =
+  | GraphqlUserAssoc
+  | GraphqlExternalAuthorAssoc;
 export interface GraphqlResearchOutput
   extends Entity,
-    Graphql<
-      ResearchOutput<
-        | GraphqlWithTypename<GraphqlUser, 'Users'>
-        | GraphqlWithTypename<GraphqlExternalAuthor, 'ExternalAuthors'>
-      >
-    > {
+    Graphql<ResearchOutput<GraphqlResearchOutputAuthors>> {
   referencingTeamsContents?: GraphqlTeam[];
 }

--- a/packages/squidex/src/entities/user.ts
+++ b/packages/squidex/src/entities/user.ts
@@ -5,7 +5,7 @@ import {
   UserSocialLinks,
   Role,
 } from '@asap-hub/model';
-import { Rest, Entity, Graphql } from './common';
+import { Rest, Entity, Graphql, GraphqlWithTypename } from './common';
 import { GraphqlTeam } from './team';
 
 export type UserTeamConnection<T = string> = T extends string
@@ -66,3 +66,5 @@ export interface GraphqlUser
         OrNull<Omit<UserSocialLinks, 'orcid'>>
       >
     > {}
+
+export type GraphqlUserAssoc = GraphqlWithTypename<GraphqlUser, 'Users'>;


### PR DESCRIPTION
Creates a new external-authors entity and modifies the research-output author list to point to the new entity as well as existing user entity.
This then enables us to apply a custom order the author list being a mix of users and external authors 

see: https://trello.com/c/60v7kM95/1334-list-of-ordered-authors-external-authors-users