### PR TITLE
feat: update required fields on OpenQuestions and Biography modals

### DIFF
--- a/packages/react-components/src/templates/BiographyModal.tsx
+++ b/packages/react-components/src/templates/BiographyModal.tsx
@@ -35,6 +35,7 @@ const BiographyModal: React.FC<BiographyModalProps> = ({
           title="Summarize your background and highlight any past achievements."
           tip="Tip: refer to yourself in the third person."
           placeholder="Example: Randy is a Professor in the Department of Molecular and Cell Biology, University of California, and an Investigator of the Howard Hughes Medical Institute. He studied the enzymology of DNA replication as a graduate student with Arthur Kornberg at Stanford University. Among his awards is the Nobel Prize in Physiology or Medicine, which he shared with James Rothman and Thomas Südhof."
+          getValidationMessage={() => 'Please add your biography'}
         />
       )}
     </EditModal>

--- a/packages/react-components/src/templates/OpenQuestionsModal.tsx
+++ b/packages/react-components/src/templates/OpenQuestionsModal.tsx
@@ -46,8 +46,10 @@ const OpenQuestionsModal: React.FC<OpenQuestionsModalProps> = ({
           </Paragraph>
           <div css={[fieldsContainerStyles]}>
             <LabeledTextArea
+              required
               title="Open Question 1"
               placeholder="Example: Are alpha-synuclein deposits the cause or consequence of something deeper wrong with neurons?"
+              getValidationMessage={() => 'Please add your first Open Question'}
               maxLength={200}
               enabled={!isSaving}
               onChange={(newValue) =>
@@ -58,8 +60,18 @@ const OpenQuestionsModal: React.FC<OpenQuestionsModalProps> = ({
               value={newQuestions[0] || ''}
             />
             <LabeledTextArea
+              required
               title="Open Question 2"
               placeholder="Does alpha-synuclein represent a pathologically relevant stimulator of microglial activation?"
+              getValidationMessage={() =>
+               
+               
+               
+                'Please add your second Open Question'
+              
+              
+              
+              }
               maxLength={200}
               enabled={!isSaving}
               onChange={(newValue) =>

--- a/packages/react-components/src/templates/OpenQuestionsModal.tsx
+++ b/packages/react-components/src/templates/OpenQuestionsModal.tsx
@@ -64,13 +64,7 @@ const OpenQuestionsModal: React.FC<OpenQuestionsModalProps> = ({
               title="Open Question 2"
               placeholder="Does alpha-synuclein represent a pathologically relevant stimulator of microglial activation?"
               getValidationMessage={() =>
-               
-               
-               
                 'Please add your second Open Question'
-              
-              
-              
               }
               maxLength={200}
               enabled={!isSaving}

--- a/packages/react-components/src/templates/__tests__/OpenQuestionsModal.test.tsx
+++ b/packages/react-components/src/templates/__tests__/OpenQuestionsModal.test.tsx
@@ -39,7 +39,9 @@ describe('triggers the save function', () => {
 
     const answerQuestion = (index: number) =>
       userEvent.type(
-        getByLabelText(`Open Question ${index}`),
+        getByLabelText(
+          `Open Question ${index}${index === 1 || index === 2 ? '*' : ''}`,
+        ),
         questions[index],
       );
 
@@ -54,14 +56,21 @@ describe('triggers the save function', () => {
     );
   };
 
-  it('sends an empty array when no questions are entered and saved', async () => {
+  it('does not save if no questions are set', async () => {
     await testSave({});
-    expect(jestFn).toHaveBeenCalledWith({ questions: [] });
+    expect(jestFn).not.toHaveBeenCalled();
   });
-  it('sends questions when a question is skipped', async () => {
-    await testSave({ 1: 'a', 4: 'b' });
-    expect(jestFn).toHaveBeenCalledWith({ questions: ['a', 'b'] });
+
+  it('does not save if required questions 1 and 2 are empty', async () => {
+    await testSave({ 3: 'c', 4: 'd' });
+    expect(jestFn).not.toHaveBeenCalled();
   });
+
+  it('sends questions when a non required question is skipped', async () => {
+    await testSave({ 1: 'a', 2: 'b', 4: 'd' });
+    expect(jestFn).toHaveBeenCalledWith({ questions: ['a', 'b', 'd'] });
+  });
+
   it('sends all questions', async () => {
     await testSave({ 1: 'a', 2: 'b', 3: 'c', 4: 'd' });
     expect(jestFn).toHaveBeenCalledWith({ questions: ['a', 'b', 'c', 'd'] });
@@ -75,7 +84,11 @@ it('disables the form elements while submitting', async () => {
       resolveSubmit = resolve;
     });
   const { getByText } = render(
-    <OpenQuestionsModal {...props} onSave={handleSave} />,
+    <OpenQuestionsModal
+      {...props}
+      onSave={handleSave}
+      questions={['a', 'b']}
+    />,
     { wrapper: StaticRouter },
   );
 


### PR DESCRIPTION
This PR introduces the following changes:
- The first and second questions on Open Questions Modal are now required
- Both have new custom error messages
- Add custom error message to Biography textArea on it's editing modal