### PR TITLE
Updating TextField to support both right and left indicators

### DIFF
--- a/apps/storybook/src/LabeledTextField.stories.tsx
+++ b/apps/storybook/src/LabeledTextField.stories.tsx
@@ -51,13 +51,6 @@ export const Invalid = () => (
     hint={text('Hint', 'Hint')}
   />
 );
-export const Loading = () => (
-  <LabeledTextField
-    title={text('Title', 'Full Name')}
-    value={text('Value', 'John Doe')}
-    loading
-  />
-);
 
 export const LabelIndicator = () => (
   <LabeledTextField

--- a/packages/react-components/src/atoms/TextField.tsx
+++ b/packages/react-components/src/atoms/TextField.tsx
@@ -97,17 +97,11 @@ const containerStyles = css({
   position: 'relative',
 });
 
-const getIndicatorPadding = (aspectRatio: number, position: Position) => {
-  const padding = `${
+const getIndicatorPadding = (icon: React.ReactElement) => {
+  const aspectRatio = getSvgAspectRatio(icon);
+  return `${
     (paddingLeftRight + indicatorSize * aspectRatio + indicatorPadding) / perRem
   }em`;
-  return position === 'right'
-    ? css({
-        paddingRight: padding,
-      })
-    : css({
-        paddingLeft: padding,
-      });
 };
 
 const getIndicatorStyles = (aspectRatio: number, position: Position) =>
@@ -139,7 +133,7 @@ type TextFieldProps = {
   readonly customValidationMessage?: string;
 
   readonly leftIndicator?: React.ReactElement;
-  readonly rightIndicator?: React.ReactElement | null;
+  readonly rightIndicator?: React.ReactElement;
 
   readonly labelIndicator?: React.ReactElement | string;
   readonly getValidationMessage?: Parameters<typeof useValidation>[1];
@@ -200,10 +194,13 @@ const TextField: React.FC<TextFieldProps> = ({
           validationMessage && invalidStyles,
           !labelIndicator && { gridColumn: '1 / span 2' },
 
-          leftIndicator &&
-            getIndicatorPadding(getSvgAspectRatio(leftIndicator), 'left'),
-          rightIndicator &&
-            getIndicatorPadding(getSvgAspectRatio(rightIndicator), 'right'),
+          leftIndicator && {
+            paddingLeft: getIndicatorPadding(leftIndicator),
+          },
+
+          rightIndicator && {
+            paddingRight: getIndicatorPadding(rightIndicator),
+          },
         ]}
       />
 

--- a/packages/react-components/src/atoms/TextField.tsx
+++ b/packages/react-components/src/atoms/TextField.tsx
@@ -1,12 +1,9 @@
-import { InputHTMLAttributes, useState } from 'react';
+import { InputHTMLAttributes } from 'react';
 import { css } from '@emotion/react';
-import { useDebounce } from 'use-debounce';
 
 import { perRem } from '../pixels';
 import { lead, silver, ember, rose, tin, pine, steel, paper } from '../colors';
 import { noop, getSvgAspectRatio } from '../utils';
-import { loadingImage, validTickGreenImage } from '../images';
-import { useGifReplay } from '../hooks';
 import {
   useValidation,
   styles,
@@ -31,6 +28,7 @@ const disabledStyles = css({
   color: lead.rgb,
   backgroundColor: silver.rgb,
 });
+
 const LABEL_INDICATOR_CLASS_NAME = 'labelIndicator';
 const labelIndicatorStyles = css({
   padding: `${15 / perRem}em ${18 / perRem}em`,
@@ -41,34 +39,7 @@ const labelIndicatorStyles = css({
   color: lead.rgb,
   order: -1,
 });
-const customIndicatorPadding = (aspectRatio: number, position: Position) => {
-  const padding = `${
-    (paddingLeftRight + indicatorSize * aspectRatio + indicatorPadding) / perRem
-  }em`;
-  return position === 'right'
-    ? css({
-        paddingRight: padding,
-      })
-    : css({
-        paddingLeft: padding,
-      });
-};
 
-const loadingStyles = css({
-  paddingRight: `${
-    (paddingLeftRight + indicatorSize + indicatorPadding) / perRem
-  }em`,
-  backgroundImage: `url(${loadingImage})`,
-});
-const validStyles = (gifUrl: string) =>
-  css({
-    ':valid': {
-      paddingRight: `${
-        (paddingLeftRight + indicatorSize + indicatorPadding) / perRem
-      }em`,
-      backgroundImage: `url(${gifUrl})`,
-    },
-  });
 const invalidStyles = css({
   ':invalid': {
     color: ember.rgb,
@@ -118,15 +89,33 @@ const textFieldStyles = css({
     stroke: pine.rgb,
   },
 });
+
 const containerStyles = css({
   flexBasis: '100%',
   display: 'grid',
   gridTemplateColumns: 'max-content 1fr',
   position: 'relative',
 });
-const customIndicatorStyles = (aspectRatio: number, position: Position) =>
+
+const getIndicatorPadding = (aspectRatio: number, position: Position) => {
+  const padding = `${
+    (paddingLeftRight + indicatorSize * aspectRatio + indicatorPadding) / perRem
+  }em`;
+  return position === 'right'
+    ? css({
+        paddingRight: padding,
+      })
+    : css({
+        paddingLeft: padding,
+      });
+};
+
+const getIndicatorStyles = (aspectRatio: number, position: Position) =>
   css({
     position: 'absolute',
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
 
     top: `${paddingTopBottom / perRem}em`,
     [position]: `${paddingLeftRight / perRem}em`,
@@ -134,13 +123,6 @@ const customIndicatorStyles = (aspectRatio: number, position: Position) =>
     height: `${indicatorSize / perRem}em`,
     width: `${(indicatorSize * aspectRatio) / perRem}em`,
   });
-
-const showValidationType: Set<FieldType> = new Set([
-  'date',
-  'email',
-  'tel',
-  'url',
-]);
 
 type TextFieldProps = {
   readonly type?: FieldType;
@@ -156,9 +138,9 @@ type TextFieldProps = {
   readonly indicateValid?: boolean;
   readonly customValidationMessage?: string;
 
-  readonly loading?: boolean;
-  readonly customIndicator?: React.ReactElement;
-  readonly customIndicatorPosition?: Position;
+  readonly leftIndicator?: React.ReactElement;
+  readonly rightIndicator?: React.ReactElement | null;
+
   readonly labelIndicator?: React.ReactElement | string;
   readonly getValidationMessage?: Parameters<typeof useValidation>[1];
 
@@ -178,11 +160,9 @@ const TextField: React.FC<TextFieldProps> = ({
 
   customValidationMessage = '',
 
-  customIndicator,
-  customIndicatorPosition = 'right',
-  loading = false,
-  indicateValid = customIndicator === undefined &&
-    (pattern !== undefined || showValidationType.has(type)),
+  leftIndicator,
+  rightIndicator,
+
   labelIndicator,
 
   getValidationMessage,
@@ -198,11 +178,6 @@ const TextField: React.FC<TextFieldProps> = ({
       getValidationMessage,
     );
 
-  const validGifUrl = useGifReplay(validTickGreenImage, [indicateValid, value]);
-  const [debouncedValue] = useDebounce(value, 500);
-  const [isDirty, setIsDirty] = useState(false);
-  const debouncedIndicateValid =
-    isDirty && indicateValid && value === debouncedValue;
   return (
     <div css={containerStyles}>
       <input
@@ -214,41 +189,44 @@ const TextField: React.FC<TextFieldProps> = ({
         maxLength={maxLength}
         pattern={pattern}
         value={value}
-        onChange={({ currentTarget: { value: newValue } }) => {
-          setIsDirty(true);
-          return onChange(newValue);
-        }}
+        onChange={({ currentTarget: { value: newValue } }) =>
+          onChange(newValue)
+        }
         css={[
           styles,
           textFieldStyles,
           enabled || disabledStyles,
 
-          debouncedIndicateValid && validStyles(validGifUrl),
           validationMessage && invalidStyles,
           !labelIndicator && { gridColumn: '1 / span 2' },
-          customIndicator &&
-            customIndicatorPadding(
-              getSvgAspectRatio(customIndicator),
-              customIndicatorPosition,
-            ),
-          loading && loadingStyles,
+
+          leftIndicator &&
+            getIndicatorPadding(getSvgAspectRatio(leftIndicator), 'left'),
+          rightIndicator &&
+            getIndicatorPadding(getSvgAspectRatio(rightIndicator), 'right'),
         ]}
       />
+
       {labelIndicator && (
         <div className={LABEL_INDICATOR_CLASS_NAME} css={labelIndicatorStyles}>
           {labelIndicator}
         </div>
       )}
-      {customIndicator && (
-        <div
-          css={customIndicatorStyles(
-            getSvgAspectRatio(customIndicator),
-            customIndicatorPosition,
-          )}
-        >
-          {customIndicator}
+
+      {leftIndicator && (
+        <div css={getIndicatorStyles(getSvgAspectRatio(leftIndicator), 'left')}>
+          {leftIndicator}
         </div>
       )}
+
+      {rightIndicator && (
+        <div
+          css={getIndicatorStyles(getSvgAspectRatio(rightIndicator), 'right')}
+        >
+          {rightIndicator}
+        </div>
+      )}
+
       <div css={[validationMessageStyles, { gridColumn: '1 / span 2' }]}>
         {validationMessage}
       </div>

--- a/packages/react-components/src/atoms/__tests__/TextField.test.tsx
+++ b/packages/react-components/src/atoms/__tests__/TextField.test.tsx
@@ -1,8 +1,7 @@
 import { render, fireEvent } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 
 import TextField from '../TextField';
-import { silver, ember } from '../../colors';
+import { silver } from '../../colors';
 import { perRem } from '../../pixels';
 import { indicatorPadding } from '../../form';
 
@@ -42,19 +41,12 @@ it('with the label indicator prop prop shows a react node', () => {
   expect(getByText(/github/)).toBeVisible();
 });
 
-it('with the loading prop shows a loading indicator', () => {
-  const { getByRole } = render(<TextField value="" loading />);
-  expect(getComputedStyle(getByRole('textbox')).backgroundImage).toMatch(
-    /^url\(.*loading.*\.gif.*\)$/,
-  );
-});
-
-describe('with a custom indicator positioned right', () => {
+describe('with a right indicator', () => {
   it('shows the indicator', () => {
     const { getByRole } = render(
       <TextField
         value=""
-        customIndicator={<svg role="img" viewBox="0 0 2 1" />}
+        rightIndicator={<svg role="img" viewBox="0 0 2 1" />}
       />,
     );
     const { width, height } = getComputedStyle(getByRole('img').parentElement!);
@@ -72,7 +64,7 @@ describe('with a custom indicator positioned right', () => {
     rerender(
       <TextField
         value=""
-        customIndicator={<svg role="img" viewBox="0 0 2 1" />}
+        rightIndicator={<svg role="img" viewBox="0 0 2 1" />}
       />,
     );
     const customIndicatorPaddingRight = Number(
@@ -91,13 +83,12 @@ describe('with a custom indicator positioned right', () => {
   });
 });
 
-describe('with a custom indicator positioned left', () => {
+describe('with a left indicator', () => {
   it('shows the indicator', () => {
     const { getByRole } = render(
       <TextField
-        customIndicatorPosition="left"
         value=""
-        customIndicator={<svg role="img" viewBox="0 0 2 1" />}
+        leftIndicator={<svg role="img" viewBox="0 0 2 1" />}
       />,
     );
     const { width, height } = getComputedStyle(getByRole('img').parentElement!);
@@ -114,9 +105,8 @@ describe('with a custom indicator positioned left', () => {
 
     rerender(
       <TextField
-        customIndicatorPosition="left"
         value=""
-        customIndicator={<svg role="img" viewBox="0 0 2 1" />}
+        leftIndicator={<svg role="img" viewBox="0 0 2 1" />}
       />,
     );
     const customIndicatorPaddingLeft = Number(
@@ -132,112 +122,5 @@ describe('with a custom indicator positioned left', () => {
     expect(customIndicatorPaddingLeft).toBeCloseTo(
       normalPaddingLeft + indicatorWidth + indicatorPadding / perRem,
     );
-  });
-});
-
-describe('when valid', () => {
-  beforeAll(() => {
-    jest.useFakeTimers('modern');
-  });
-  afterAll(() => {
-    jest.useRealTimers();
-  });
-
-  it('does not by default show an indicator', () => {
-    const { getByRole } = render(<TextField value="" />);
-    expect(getComputedStyle(getByRole('textbox')).backgroundImage).toBe('');
-  });
-
-  describe('when the type is set to a validated type', () => {
-    it('does not show indicator on unchanged field', () => {
-      const { getByRole } = render(
-        <TextField value="test@example.com" type="email" />,
-      );
-      expect(getComputedStyle(getByRole('textbox')).backgroundImage).toBe('');
-    });
-    it('show indicator on changed field', async () => {
-      const { getByRole } = render(
-        <TextField value="test@example.co" type="email" />,
-      );
-      await userEvent.type(getByRole('textbox'), 'a');
-      expect(getComputedStyle(getByRole('textbox')).backgroundImage).toMatch(
-        /^url\(.*tick.*\.gif.*\)$/,
-      );
-    });
-  });
-
-  describe('when a validation prop is set', () => {
-    it('Does not show an indicator when field is unchanged', () => {
-      const { getByRole } = render(<TextField value="a" pattern=".*" />);
-      expect(getComputedStyle(getByRole('textbox')).backgroundImage).toEqual(
-        '',
-      );
-    });
-
-    it('shows an indicator on changed field', async () => {
-      const { getByRole } = render(<TextField value="" pattern=".*" />);
-      await userEvent.type(getByRole('textbox'), 'a');
-      expect(getComputedStyle(getByRole('textbox')).backgroundImage).toMatch(
-        /^url\(.*tick.*\.gif.*\)$/,
-      );
-    });
-
-    describe('but also a custom indicator', () => {
-      it('does not show a valid indicator', () => {
-        const { getByRole } = render(
-          <TextField
-            value=""
-            pattern=".*"
-            customIndicator={<svg role="img" viewBox="0 0 2 1" />}
-          />,
-        );
-        expect(getComputedStyle(getByRole('textbox')).backgroundImage).toBe('');
-      });
-    });
-
-    it('removes the indicator while the value is changing', () => {
-      const { getByRole, rerender } = render(
-        <TextField value="val" pattern=".*" />,
-      );
-      rerender(<TextField value="changed" pattern=".*" />);
-      expect(getComputedStyle(getByRole('textbox')).backgroundImage).toBe('');
-    });
-  });
-
-  describe('with the indicateValid prop', () => {
-    it('Does not shows an indicator when field unchanged', () => {
-      const { getByRole } = render(<TextField value="" indicateValid />);
-      expect(getComputedStyle(getByRole('textbox')).backgroundImage).toBe('');
-    });
-
-    it('Shows an indicator when field changed', async () => {
-      const { getByRole } = render(<TextField value="" indicateValid />);
-      await userEvent.type(getByRole('textbox'), 'a');
-      expect(getComputedStyle(getByRole('textbox')).backgroundImage).toMatch(
-        /^url\(.*tick.*\.gif.*\)$/,
-      );
-    });
-  });
-});
-
-describe('when invalid', () => {
-  it('shows a validation error message only after losing focus', () => {
-    const { getByRole, getByText, queryByText } = render(
-      <TextField value="wrong" pattern="^val$" />,
-    );
-    expect(queryByText(/match/i)).not.toBeInTheDocument();
-
-    fireEvent.blur(getByRole('textbox'));
-    expect(getByText(/match/i)).toBeVisible();
-    expect(getComputedStyle(getByText(/match/i)).color).toBe(ember.rgb);
-  });
-
-  it('shows a custom validation message', () => {
-    const { getByRole, getByText } = render(
-      <TextField value="wrong" customValidationMessage="Wrong!" />,
-    );
-    fireEvent.blur(getByRole('textbox'));
-    expect(getByText('Wrong!')).toBeVisible();
-    expect(getComputedStyle(getByText('Wrong!')).color).toBe(ember.rgb);
   });
 });

--- a/packages/react-components/src/molecules/LabeledPasswordField.tsx
+++ b/packages/react-components/src/molecules/LabeledPasswordField.tsx
@@ -51,7 +51,7 @@ const LabeledPasswordField: React.FC<LabeledPasswordFieldProps> = ({
             id={id}
             value={value}
             type={showPassword ? 'text' : 'password'}
-            customIndicator={
+            rightIndicator={
               value ? (
                 <div css={showPasswordIndicatorStyles}>
                   <Button

--- a/packages/react-components/src/molecules/SearchField.tsx
+++ b/packages/react-components/src/molecules/SearchField.tsx
@@ -12,6 +12,17 @@ import { searchIcon, crossIcon } from '../icons';
 import { perRem } from '../pixels';
 
 const clearButtonStyles = css({
+  padding: `${18 / perRem}em 0`,
+  // removing input's clear/cancel pseudo-element
+  // from webkit based browsers
+  'input[type="search"]::-webkit-search-cancel-button': {
+    appearance: 'none',
+  },
+  // and from IE
+  'input[type=text]::-ms-clear': { display: 'none', width: 0, height: 0 },
+});
+
+const rightIndicatorStyles = css({
   button: {
     display: 'flex',
     justifyContent: 'center',
@@ -45,25 +56,14 @@ const SearchField: React.FC<SearchProps> = (props) => {
   }, [debouncedValue, props.placeholder, props.value]);
 
   return (
-    <div
-      css={{
-        padding: `${18 / perRem}em 0`,
-        // removing input's clear/cancel pseudo-element
-        // from webkit based browsers
-        'input[type="search"]::-webkit-search-cancel-button': {
-          appearance: 'none',
-        },
-        // and from IE
-        'input[type=text]::-ms-clear': { display: 'none', width: 0, height: 0 },
-      }}
-    >
+    <div css={clearButtonStyles}>
       <TextField
         {...props}
         type="search"
         leftIndicator={searchIcon}
         rightIndicator={
           props.value ? (
-            <div css={clearButtonStyles}>
+            <div css={rightIndicatorStyles}>
               <Button
                 linkStyle
                 onClick={() => props.onChange && props.onChange('')}

--- a/packages/react-components/src/molecules/SearchField.tsx
+++ b/packages/react-components/src/molecules/SearchField.tsx
@@ -1,14 +1,23 @@
 import { ComponentProps, useEffect } from 'react';
 import { useDebounce } from 'use-debounce';
+import { css } from '@emotion/react';
 
 import {
   SEARCH_EVENT,
   SEARCH_PLACEHOLDER_KEY,
   SEARCH_QUERY_KEY,
 } from '../analytics';
-import { TextField } from '../atoms';
-import { searchIcon } from '../icons';
+import { TextField, Button } from '../atoms';
+import { searchIcon, crossIcon } from '../icons';
 import { perRem } from '../pixels';
+
+const clearButtonStyles = css({
+  button: {
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});
 
 type SearchProps = Pick<
   ComponentProps<typeof TextField>,
@@ -17,6 +26,7 @@ type SearchProps = Pick<
   Required<Pick<ComponentProps<typeof TextField>, 'placeholder'>>;
 const SearchField: React.FC<SearchProps> = (props) => {
   const [debouncedValue] = useDebounce(props.value, 5000);
+
   useEffect(() => {
     if (props.value && props.value === debouncedValue) {
       window.dataLayer?.push({
@@ -35,12 +45,34 @@ const SearchField: React.FC<SearchProps> = (props) => {
   }, [debouncedValue, props.placeholder, props.value]);
 
   return (
-    <div css={{ padding: `${18 / perRem}em 0` }}>
+    <div
+      css={{
+        padding: `${18 / perRem}em 0`,
+        // removing input's clear/cancel pseudo-element
+        // from webkit based browsers
+        'input[type="search"]::-webkit-search-cancel-button': {
+          appearance: 'none',
+        },
+        // and from IE
+        'input[type=text]::-ms-clear': { display: 'none', width: 0, height: 0 },
+      }}
+    >
       <TextField
         {...props}
         type="search"
-        customIndicator={searchIcon}
-        customIndicatorPosition="left"
+        leftIndicator={searchIcon}
+        rightIndicator={
+          props.value ? (
+            <div css={clearButtonStyles}>
+              <Button
+                linkStyle
+                onClick={() => props.onChange && props.onChange('')}
+              >
+                {crossIcon}
+              </Button>
+            </div>
+          ) : undefined
+        }
       />
     </div>
   );

--- a/packages/react-components/src/molecules/__tests__/SearchField.test.tsx
+++ b/packages/react-components/src/molecules/__tests__/SearchField.test.tsx
@@ -36,23 +36,22 @@ describe('GTM data', () => {
     );
   });
   it('shows an custom X to clear the query', () => {
-    const { getByRole } = render(<SearchField placeholder="p" value="q" />);
+    const { rerender, queryByRole, getByRole } = render(
+      <SearchField placeholder="p" value="" />,
+    );
+    expect(queryByRole('button')).not.toBeInTheDocument();
+
+    rerender(<SearchField placeholder="p" value="q" />);
     expect(getByRole('button')).toBeVisible();
   });
   it('clears the query after the custom X is pushed', () => {
     const onChange = jest.fn();
-    const { getByRole } = render(
-      <SearchField placeholder="p" value="q" onChange={onChange} />,
+    const { rerender, getByRole } = render(
+      <SearchField placeholder="p" value="" onChange={onChange} />,
     );
+    rerender(<SearchField placeholder="p" value="q" onChange={onChange} />);
     fireEvent.click(getByRole('button'));
     expect(onChange).toHaveBeenCalledWith('');
-
-    act(() => {
-      jest.advanceTimersByTime(30 * 1000);
-    });
-    expect(window.dataLayer?.reduce(Object.assign)).not.toHaveProperty(
-      SEARCH_EVENT,
-    );
   });
   it('is pushed after changing the query and waiting for a debounce', () => {
     const { rerender } = render(<SearchField placeholder="p" value="" />);

--- a/packages/react-components/src/molecules/__tests__/SearchField.test.tsx
+++ b/packages/react-components/src/molecules/__tests__/SearchField.test.tsx
@@ -35,7 +35,7 @@ describe('GTM data', () => {
       expect.anything(),
     );
   });
-  it('shows an custom X to clear the query', () => {
+  it('shows a clear query button when there is a value', () => {
     const { rerender, queryByRole, getByRole } = render(
       <SearchField placeholder="p" value="" />,
     );

--- a/packages/react-components/src/molecules/__tests__/SearchField.test.tsx
+++ b/packages/react-components/src/molecules/__tests__/SearchField.test.tsx
@@ -1,4 +1,4 @@
-import { act, render } from '@testing-library/react';
+import { act, fireEvent, render } from '@testing-library/react';
 
 import SearchField from '../SearchField';
 import { SEARCH_EVENT, SEARCH_QUERY_KEY } from '../../analytics';
@@ -33,6 +33,25 @@ describe('GTM data', () => {
     expect(window.dataLayer?.reduce(Object.assign)).not.toHaveProperty(
       SEARCH_QUERY_KEY,
       expect.anything(),
+    );
+  });
+  it('shows an custom X to clear the query', () => {
+    const { getByRole } = render(<SearchField placeholder="p" value="q" />);
+    expect(getByRole('button')).toBeVisible();
+  });
+  it('clears the query after the custom X is pushed', () => {
+    const onChange = jest.fn();
+    const { getByRole } = render(
+      <SearchField placeholder="p" value="q" onChange={onChange} />,
+    );
+    fireEvent.click(getByRole('button'));
+    expect(onChange).toHaveBeenCalledWith('');
+
+    act(() => {
+      jest.advanceTimersByTime(30 * 1000);
+    });
+    expect(window.dataLayer?.reduce(Object.assign)).not.toHaveProperty(
+      SEARCH_EVENT,
     );
   });
   it('is pushed after changing the query and waiting for a debounce', () => {


### PR DESCRIPTION
The following changes were introduced:
- As discussed with @kmaid, we used the custom indicator of the text field input, and made it work for both the right and left sides concurrently, which wasn't the case before.
- The loading and validity check icons were removed, as requested by product.
- The Password field had to be updated to reflect the changes and use the new interface for the Text Field input.

(Requirements: https://trello.com/c/P6AT7U22/1120-add-a-custom-icon-for-x-on-all-search-bars)