### PR TITLE
feat: Remove external authors legacy

### DIFF
--- a/packages/squidex/schema/schemas/events.json
+++ b/packages/squidex/schema/schemas/events.json
@@ -11,8 +11,8 @@
       "validateOnPublish": false
     },
     "scripts": {},
-    "fieldsInReferences": [],
-    "fieldsInLists": ["title"],
+    "fieldsInReferences": ["title", "startDate"],
+    "fieldsInLists": ["title", "startDate"],
     "fields": [
       {
         "name": "hidden",

--- a/packages/squidex/schema/schemas/external-authors.json
+++ b/packages/squidex/schema/schemas/external-authors.json
@@ -11,8 +11,8 @@
       "validateOnPublish": false
     },
     "scripts": {},
-    "fieldsInReferences": [],
-    "fieldsInLists": [],
+    "fieldsInReferences": ["name", "orcid"],
+    "fieldsInLists": ["name", "orcid"],
     "fields": [
       {
         "name": "name",

--- a/packages/squidex/schema/schemas/labs.json
+++ b/packages/squidex/schema/schemas/labs.json
@@ -11,8 +11,8 @@
       "validateOnPublish": false
     },
     "scripts": {},
-    "fieldsInReferences": [],
-    "fieldsInLists": [],
+    "fieldsInReferences": ["name"],
+    "fieldsInLists": ["name"],
     "fields": [
       {
         "name": "name",

--- a/packages/squidex/schema/schemas/research-outputs.json
+++ b/packages/squidex/schema/schemas/research-outputs.json
@@ -292,7 +292,7 @@
           "placeholder": "",
           "isRequired": false,
           "isRequiredOnPublish": false,
-          "isHalfWidth": true
+          "isHalfWidth": false
         }
       },
       {
@@ -311,7 +311,7 @@
           "label": "Authors",
           "isRequired": false,
           "isRequiredOnPublish": false,
-          "isHalfWidth": true
+          "isHalfWidth": false
         }
       },
       {

--- a/packages/squidex/schema/schemas/research-outputs.json
+++ b/packages/squidex/schema/schemas/research-outputs.json
@@ -285,7 +285,7 @@
           "allowDuplicates": false,
           "resolveReference": false,
           "mustBePublished": true,
-          "editor": "List",
+          "editor": "Tags",
           "schemaIds": ["labs"],
           "label": "Labs",
           "hints": "",

--- a/packages/squidex/schema/schemas/research-outputs.json
+++ b/packages/squidex/schema/schemas/research-outputs.json
@@ -315,56 +315,6 @@
         }
       },
       {
-        "name": "externalAuthors",
-        "isHidden": false,
-        "isLocked": false,
-        "isDisabled": false,
-        "partitioning": "invariant",
-        "properties": {
-          "fieldType": "Array",
-          "label": "External Authors",
-          "isRequired": false,
-          "isRequiredOnPublish": false,
-          "isHalfWidth": false
-        },
-        "nested": [
-          {
-            "name": "name",
-            "isHidden": false,
-            "isLocked": false,
-            "isDisabled": false,
-            "properties": {
-              "fieldType": "String",
-              "isUnique": false,
-              "inlineEditable": false,
-              "contentType": "Unspecified",
-              "editor": "Input",
-              "label": "Name",
-              "isRequired": true,
-              "isRequiredOnPublish": false,
-              "isHalfWidth": true
-            }
-          },
-          {
-            "name": "orcid",
-            "isHidden": false,
-            "isLocked": false,
-            "isDisabled": false,
-            "properties": {
-              "fieldType": "String",
-              "isUnique": false,
-              "inlineEditable": true,
-              "contentType": "Unspecified",
-              "editor": "Input",
-              "label": "ORCID",
-              "isRequired": false,
-              "isRequiredOnPublish": false,
-              "isHalfWidth": true
-            }
-          }
-        ]
-      },
-      {
         "name": "Compliance",
         "isHidden": false,
         "isLocked": false,

--- a/packages/squidex/schema/schemas/teams.json
+++ b/packages/squidex/schema/schemas/teams.json
@@ -12,7 +12,7 @@
     },
     "scripts": {},
     "fieldsInReferences": ["displayName"],
-    "fieldsInLists": [],
+    "fieldsInLists": ["displayName"],
     "fields": [
       {
         "name": "displayName",

--- a/packages/squidex/schema/schemas/users.json
+++ b/packages/squidex/schema/schemas/users.json
@@ -11,8 +11,8 @@
       "validateOnPublish": false
     },
     "scripts": {},
-    "fieldsInReferences": ["email"],
-    "fieldsInLists": ["email", "meta.id"],
+    "fieldsInReferences": ["firstName", "lastName", "orcid"],
+    "fieldsInLists": ["firstName", "lastName", "orcid"],
     "fields": [
       {
         "name": "onboarded",
@@ -139,7 +139,7 @@
           "allowDuplicates": false,
           "resolveReference": false,
           "mustBePublished": true,
-          "editor": "List",
+          "editor": "Tags",
           "schemaIds": ["labs"],
           "label": "Labs",
           "hints": "",

--- a/packages/squidex/src/entities/research-output.ts
+++ b/packages/squidex/src/entities/research-output.ts
@@ -25,10 +25,6 @@ export interface ResearchOutput<TAuthorConnection = string> {
   sharingStatus: ResearchOutputSharingStatus;
   asapFunded: DecisionOption;
   usedInAPublication: DecisionOption;
-  externalAuthors?: {
-    name: string;
-    orcid?: string;
-  }[];
   authors?: TAuthorConnection[];
 }
 


### PR DESCRIPTION
Removes external-authors legacy field in favour of the joint `authors` field.

Also includes the following changes to the schema:
* Events - new fields in references: title, startDate; new fields in lists: startDate
* External Authors - new fields in references: name, orcid; new fields in lists: name, orcid
* Labs - new fields in references: name, new fields in lists: name
* Research Outputs - editor for labs changed from List to Tags
* Teams - new fields in lists: displayName
* Users - new fields in references: firstName, lastName, orcid, removed from references: email, new fields in lists: firstName, lastName, orcid, removed from lists: email, meta.id, editor for labs changed from List to Tags