### PR TITLE
fix: Profile picture upload bug

### DIFF
--- a/apps/asap-server/src/app.ts
+++ b/apps/asap-server/src/app.ts
@@ -111,7 +111,7 @@ export const appFactory = (libs: Libs = {}): Express => {
   app.use(httpLogger);
   app.use(tracingHandler);
   app.use(cors());
-  app.use(express.json());
+  app.use(express.json({ limit: '10MB' }));
 
   /**
    * Public routes --->

--- a/apps/asap-server/test/routes/user.route.test.ts
+++ b/apps/asap-server/test/routes/user.route.test.ts
@@ -1,5 +1,6 @@
 import supertest from 'supertest';
 import Boom from '@hapi/boom';
+import Crypto from 'crypto';
 import { appFactory } from '../../src/app';
 import { FetchOptions } from '../../src/utils/types';
 import {
@@ -400,6 +401,21 @@ describe('/users/ route', () => {
       const response = await supertest(appWithMockedAuth)
         .post(`/users/${userId}/avatar`)
         .send(updateAvatarBody);
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual(userResponse);
+    });
+
+    test('Should upload pictures of 2MB correctly', async () => {
+      userControllerMock.updateAvatar.mockResolvedValueOnce(userResponse);
+      const blob = Crypto.randomBytes(2097152).toString('base64');
+      const updateLargeAvatar = {
+        avatar: `data:image/jpeg;base64,${blob}`,
+      };
+
+      const response = await supertest(appWithMockedAuth)
+        .post(`/users/${userId}/avatar`)
+        .send(updateLargeAvatar);
 
       expect(response.status).toBe(200);
       expect(response.body).toEqual(userResponse);


### PR DESCRIPTION
Extends a global API payload limit to 10MB as per API Gateway limitation: https://docs.aws.amazon.com/apigateway/latest/developerguide/limits.html

see: https://trello.com/c/U5vpkDJP/1264-i-am-not-able-to-upload-a-new-profile-picture