### PR TITLE
chore: Add vars to graphql queries

### DIFF
--- a/apps/asap-server/src/controllers/events.ts
+++ b/apps/asap-server/src/controllers/events.ts
@@ -6,7 +6,7 @@ import {
   InstrumentedSquidexGraphql,
   InstrumentedSquidex,
 } from '../utils/instrumented-client';
-import { FetchOptions, AllOrNone } from '../utils/types';
+import { FetchOptions, AllOrNone, GraphqlFetchOptions } from '../utils/types';
 import { parseGraphQLEvent } from '../entities/event';
 import { ResponseFetchGroup, GraphQLQueryGroup } from './groups';
 import { sanitiseForSquidex } from '../utils/squidex';
@@ -30,8 +30,16 @@ export default class Events implements EventController {
   }
 
   async fetch(options: FetchEventsOptions): Promise<ListEventResponse> {
-    const { take, skip, before, after, groupId, search, sortBy, sortOrder } =
-      options;
+    const {
+      take = 10,
+      skip = 0,
+      before,
+      after,
+      groupId,
+      search,
+      sortBy,
+      sortOrder,
+    } = options;
 
     const filters = (search || '')
       .split(' ')
@@ -67,8 +75,8 @@ export default class Events implements EventController {
     if (groupId) {
       const { findGroupsContent } = await this.client.request<
         ResponseFetchGroup,
-        unknown
-      >(buildGraphQLQueryFetchGroup(groupId));
+        { id: string }
+      >(buildGraphQLQueryFetchGroup(), { id: groupId });
 
       if (!findGroupsContent) {
         throw Boom.notFound();
@@ -82,17 +90,17 @@ export default class Events implements EventController {
       filters.push(`data/calendar/iv in [${calendarIds.join(', ')}]`);
     }
 
-    const query = buildGraphQLQueryFetchEvents(
-      filters.join(' and '),
-      take,
-      skip,
-      orderby,
-    );
+    const query = buildGraphQLQueryFetchEvents();
 
     const { queryEventsContentsWithTotal } = await this.client.request<
       ResponseFetchEvents,
-      unknown
-    >(query);
+      GraphqlFetchOptions
+    >(query, {
+      filter: filters.join(' and '),
+      top: take,
+      skip,
+      order: orderby,
+    });
 
     const { total, items: events } = queryEventsContentsWithTotal;
 
@@ -105,11 +113,11 @@ export default class Events implements EventController {
   }
 
   async fetchById(eventId: string): Promise<EventResponse> {
-    const query = buildGraphQLQueryFetchEvent(eventId);
+    const query = buildGraphQLQueryFetchEvent();
     const { findEventsContent: event } = await this.client.request<
       ResponseFetchEvent,
-      unknown
-    >(query);
+      { id: string }
+    >(query, { id: eventId });
 
     if (!event) {
       throw Boom.notFound();
@@ -196,32 +204,28 @@ flatData{
   }
 }`;
 
-export const buildGraphQLQueryFetchEvents = (
-  filter: string,
-  top = 10,
-  skip = 0,
-  orderby = '',
-): string =>
-  `{
-  queryEventsContentsWithTotal(top: ${top}, skip: ${skip}, filter: "${filter}", orderby: "${orderby}"){
-    total,
-    items{
-      ${GraphQLQueryEvent}
-    }
-  }
-}`;
-
-export const buildGraphQLQueryFetchEvent = (eventId: string): string => `
-  {
-    findEventsContent(id: "${eventId}") {
+export const buildGraphQLQueryFetchEvents = (): string => `
+  query FetchEvents($top: Int, $skip: Int, $filter: String, $order: String) {
+    queryEventsContentsWithTotal(top: $top, skip: $skip, filter: $filter, orderby: $order){
+      total,
+      items {
         ${GraphQLQueryEvent}
+      }
     }
   }
 `;
 
-export const buildGraphQLQueryFetchGroup = (groupId: string): string => `
-  {
-    findGroupsContent(id: "${groupId}") {
+export const buildGraphQLQueryFetchEvent = (): string => `
+  query FetchEvent($id: String) {
+    findEventsContent(id: $id) {
+      ${GraphQLQueryEvent}
+    }
+  }
+`;
+
+export const buildGraphQLQueryFetchGroup = (): string => `
+  query FetchGroup($id: String) {
+    findGroupsContent(id: $id) {
       flatData {
         calendars {
           id

--- a/apps/asap-server/src/controllers/users.ts
+++ b/apps/asap-server/src/controllers/users.ts
@@ -16,7 +16,7 @@ import {
 } from '../utils/instrumented-client';
 import { parseUser, parseGraphQLUser } from '../entities';
 import { fetchOrcidProfile, transformOrcidWorks } from '../utils/fetch-orcid';
-import { FetchOptions } from '../utils/types';
+import { FetchOptions, GraphqlFetchOptions } from '../utils/types';
 import { sanitiseForSquidex } from '../utils/squidex';
 
 export const GraphQLQueryUser = `
@@ -85,26 +85,24 @@ flatData {
   reachOut
 }`;
 
-export const buildGraphQLQueryFetchUsers = (
-  filter = '',
-  top = 8,
-  skip = 0,
-): string =>
-  `{
-  queryUsersContentsWithTotal(top: ${top}, skip: ${skip}, filter: "${filter}", orderby: "data/firstName/iv,data/lastName/iv") {
-    total
-    items {
+export const buildGraphQLQueryFetchUsers = (): string => `
+  query FetchUsers($top: Int, $skip: Int, $filter: String) {
+    queryUsersContentsWithTotal(top: $top, skip: $skip, filter: $filter, orderby: "data/firstName/iv,data/lastName/iv") {
+      total
+      items {
+        ${GraphQLQueryUser}
+      }
+    }
+  }
+`;
+
+export const buildGraphQLQueryFetchUser = (): string => `
+  query FetchUser($id: String) {
+    findUsersContent(id: $id) {
       ${GraphQLQueryUser}
     }
   }
-}`;
-
-export const buildGraphQLQueryFetchUser = (id: string): string =>
-  `{
-  findUsersContent(id: "${id}") {
-    ${GraphQLQueryUser}
-  }
-}`;
+`;
 
 export interface ResponseFetchUsers {
   queryUsersContentsWithTotal: {
@@ -246,7 +244,7 @@ export default class Users {
   }
 
   async fetch(options: FetchOptions): Promise<ListUserResponse> {
-    const { take, skip, search, filter } = options;
+    const { take = 8, skip = 0, search, filter } = options;
 
     const searchFilter = [
       ...(search || '')
@@ -290,12 +288,12 @@ export default class Users {
       .join(' and ')
       .trim();
 
-    const query = buildGraphQLQueryFetchUsers(queryFilter, take, skip);
+    const query = buildGraphQLQueryFetchUsers();
 
     const { queryUsersContentsWithTotal } = await this.client.request<
       ResponseFetchUsers,
-      unknown
-    >(query);
+      GraphqlFetchOptions
+    >(query, { filter: queryFilter, top: take, skip });
     const { total, items } = queryUsersContentsWithTotal;
 
     return {
@@ -305,11 +303,11 @@ export default class Users {
   }
 
   async fetchById(id: string): Promise<UserResponse> {
-    const query = buildGraphQLQueryFetchUser(id);
+    const query = buildGraphQLQueryFetchUser();
     const { findUsersContent } = await this.client.request<
       ResponseFetchUser,
-      unknown
-    >(query);
+      { id: string }
+    >(query, { id });
     if (!findUsersContent) {
       throw Boom.notFound();
     }
@@ -322,15 +320,15 @@ export default class Users {
   }
 
   async fetchByCode(code: string): Promise<UserResponse> {
-    const query = buildGraphQLQueryFetchUsers(
-      `data/connections/iv/code eq '${code}'`,
-      1,
-      0,
-    );
+    const query = buildGraphQLQueryFetchUsers();
     const { queryUsersContentsWithTotal } = await this.client.request<
       ResponseFetchUsers,
-      unknown
-    >(query);
+      GraphqlFetchOptions
+    >(query, {
+      filter: `data/connections/iv/code eq '${code}'`,
+      top: 1,
+      skip: 0,
+    });
 
     const { total, items } = queryUsersContentsWithTotal;
     if (total !== 1) {

--- a/apps/asap-server/src/utils/instrumented-client.ts
+++ b/apps/asap-server/src/utils/instrumented-client.ts
@@ -41,12 +41,12 @@ export class InstrumentedSquidexGraphql extends SquidexGraphql {
       tracer.extract(opentracing.FORMAT_HTTP_HEADERS, ctxHeaders) || undefined;
   }
 
-  async request<T, V>(query: string): Promise<T> {
+  async request<T, V>(query: string, variables?: V): Promise<T> {
     const queryName = getQueryName(query) || 'Graphql Request';
     const span = startSpan(queryName, this.tracingContext);
     span.log({ event: 'request_started', query });
 
-    const res = await super.request<T, V>(query).catch((err) => {
+    const res = await super.request<T, V>(query, variables).catch((err) => {
       span.setTag(opentracing.Tags.ERROR, true);
       span.log({ event: 'error', 'error.object': err, message: err.message });
       throw err;

--- a/apps/asap-server/src/utils/types.ts
+++ b/apps/asap-server/src/utils/types.ts
@@ -21,6 +21,13 @@ export type FetchOptions = {
   filter?: string[];
 } & FetchPaginationOptions;
 
+export type GraphqlFetchOptions = {
+  top?: number;
+  skip?: number;
+  filter?: string;
+  order?: string;
+};
+
 export type AllOrNone<T> = T | { [K in keyof T]?: never };
 
 export type ScheduledHandlerAsync = (

--- a/apps/asap-server/test/controllers/events.test.ts
+++ b/apps/asap-server/test/controllers/events.test.ts
@@ -38,7 +38,15 @@ describe('Event controller', () => {
   describe('Fetch method', () => {
     test('Should return an empty result when the client returns an empty array of data', async () => {
       nock(config.baseUrl)
-        .post(`/api/content/${config.appName}/graphql`, (body) => body.query)
+        .post(`/api/content/${config.appName}/graphql`, {
+          query: buildGraphQLQueryFetchEvents(),
+          variables: {
+            filter: 'data/hidden/iv ne true and data/endDate/iv lt before',
+            order: '',
+            top: 10,
+            skip: 0,
+          },
+        })
         .reply(200, {
           data: {
             queryEventsContentsWithTotal: {
@@ -62,7 +70,15 @@ describe('Event controller', () => {
 
     test('Should return a list of events', async () => {
       nock(config.baseUrl)
-        .post(`/api/content/${config.appName}/graphql`, (body) => body.query)
+        .post(`/api/content/${config.appName}/graphql`, {
+          query: buildGraphQLQueryFetchEvents(),
+          variables: {
+            filter: 'data/hidden/iv ne true and data/endDate/iv lt before',
+            order: '',
+            top: 10,
+            skip: 0,
+          },
+        })
         .reply(200, fetchEventsResponse);
 
       const result = await events.fetch({
@@ -74,7 +90,15 @@ describe('Event controller', () => {
 
     test('Should return event thumbnail', async () => {
       nock(config.baseUrl)
-        .post(`/api/content/${config.appName}/graphql`, (body) => body.query)
+        .post(`/api/content/${config.appName}/graphql`, {
+          query: buildGraphQLQueryFetchEvents(),
+          variables: {
+            filter: 'data/hidden/iv ne true and data/endDate/iv lt before',
+            order: '',
+            top: 10,
+            skip: 0,
+          },
+        })
         .reply(200, fetchEventsResponse);
 
       const result = await events.fetch({
@@ -87,9 +111,13 @@ describe('Event controller', () => {
     test('Should apply the filter to remove hidden events by default', async () => {
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryFetchEvents(
-            'data/hidden/iv ne true and data/endDate/iv gt after-date',
-          ),
+          query: buildGraphQLQueryFetchEvents(),
+          variables: {
+            filter: 'data/hidden/iv ne true and data/endDate/iv gt after-date',
+            order: '',
+            top: 10,
+            skip: 0,
+          },
         })
         .reply(200, fetchEventsResponse);
 
@@ -102,9 +130,14 @@ describe('Event controller', () => {
       test('Should apply the "after" filter to the end-date', async () => {
         nock(config.baseUrl)
           .post(`/api/content/${config.appName}/graphql`, {
-            query: buildGraphQLQueryFetchEvents(
-              'data/hidden/iv ne true and data/endDate/iv gt after-date',
-            ),
+            query: buildGraphQLQueryFetchEvents(),
+            variables: {
+              filter:
+                'data/hidden/iv ne true and data/endDate/iv gt after-date',
+              order: '',
+              top: 10,
+              skip: 0,
+            },
           })
           .reply(200, fetchEventsResponse);
 
@@ -116,9 +149,14 @@ describe('Event controller', () => {
       test('Should apply the "before" filter to the end-date', async () => {
         nock(config.baseUrl)
           .post(`/api/content/${config.appName}/graphql`, {
-            query: buildGraphQLQueryFetchEvents(
-              'data/hidden/iv ne true and data/endDate/iv lt before-date',
-            ),
+            query: buildGraphQLQueryFetchEvents(),
+            variables: {
+              filter:
+                'data/hidden/iv ne true and data/endDate/iv lt before-date',
+              order: '',
+              top: 10,
+              skip: 0,
+            },
           })
           .reply(200, fetchEventsResponse);
 
@@ -133,7 +171,13 @@ describe('Event controller', () => {
 
         nock(config.baseUrl)
           .post(`/api/content/${config.appName}/graphql`, {
-            query: buildGraphQLQueryFetchEvents(expectedFilter),
+            query: buildGraphQLQueryFetchEvents(),
+            variables: {
+              filter: expectedFilter,
+              order: '',
+              top: 10,
+              skip: 0,
+            },
           })
           .reply(200, fetchEventsResponse);
 
@@ -149,7 +193,13 @@ describe('Event controller', () => {
 
         nock(config.baseUrl)
           .post(`/api/content/${config.appName}/graphql`, {
-            query: buildGraphQLQueryFetchEvents(expectedFilter),
+            query: buildGraphQLQueryFetchEvents(),
+            variables: {
+              filter: expectedFilter,
+              order: '',
+              top: 10,
+              skip: 0,
+            },
           })
           .reply(200, fetchEventsResponse);
 
@@ -165,7 +215,13 @@ describe('Event controller', () => {
 
         nock(config.baseUrl)
           .post(`/api/content/${config.appName}/graphql`, {
-            query: buildGraphQLQueryFetchEvents(expectedFilter),
+            query: buildGraphQLQueryFetchEvents(),
+            variables: {
+              filter: expectedFilter,
+              order: '',
+              top: 10,
+              skip: 0,
+            },
           })
           .reply(200, fetchEventsResponse);
 
@@ -181,7 +237,13 @@ describe('Event controller', () => {
 
         nock(config.baseUrl)
           .post(`/api/content/${config.appName}/graphql`, {
-            query: buildGraphQLQueryFetchEvents(expectedFilter),
+            query: buildGraphQLQueryFetchEvents(),
+            variables: {
+              filter: expectedFilter,
+              order: '',
+              top: 10,
+              skip: 0,
+            },
           })
           .reply(200, fetchEventsResponse);
 
@@ -229,7 +291,10 @@ describe('Event controller', () => {
 
         nock(config.baseUrl)
           .post(`/api/content/${config.appName}/graphql`, {
-            query: buildGraphQLQueryFetchGroup(groupId),
+            query: buildGraphQLQueryFetchGroup(),
+            variables: {
+              id: groupId,
+            },
           })
           .reply(200, findGroupResponse);
 
@@ -238,7 +303,13 @@ describe('Event controller', () => {
 
         nock(config.baseUrl)
           .post(`/api/content/${config.appName}/graphql`, {
-            query: buildGraphQLQueryFetchEvents(expectedFilter),
+            query: buildGraphQLQueryFetchEvents(),
+            variables: {
+              filter: expectedFilter,
+              order: '',
+              top: 10,
+              skip: 0,
+            },
           })
           .reply(200, fetchEventsResponse);
 
@@ -258,12 +329,13 @@ describe('Event controller', () => {
 
         nock(config.baseUrl)
           .post(`/api/content/${config.appName}/graphql`, {
-            query: buildGraphQLQueryFetchEvents(
-              expectedFilter,
-              undefined,
-              undefined,
-              expectedOrder,
-            ),
+            query: buildGraphQLQueryFetchEvents(),
+            variables: {
+              filter: expectedFilter,
+              order: expectedOrder,
+              top: 10,
+              skip: 0,
+            },
           })
           .reply(200, fetchEventsResponse);
 
@@ -279,12 +351,13 @@ describe('Event controller', () => {
 
         nock(config.baseUrl)
           .post(`/api/content/${config.appName}/graphql`, {
-            query: buildGraphQLQueryFetchEvents(
-              expectedFilter,
-              undefined,
-              undefined,
-              expectedOrder,
-            ),
+            query: buildGraphQLQueryFetchEvents(),
+            variables: {
+              filter: expectedFilter,
+              order: expectedOrder,
+              top: 10,
+              skip: 0,
+            },
           })
           .reply(200, fetchEventsResponse);
 
@@ -300,12 +373,13 @@ describe('Event controller', () => {
 
         nock(config.baseUrl)
           .post(`/api/content/${config.appName}/graphql`, {
-            query: buildGraphQLQueryFetchEvents(
-              expectedFilter,
-              undefined,
-              undefined,
-              expectedOrder,
-            ),
+            query: buildGraphQLQueryFetchEvents(),
+            variables: {
+              filter: expectedFilter,
+              order: expectedOrder,
+              top: 10,
+              skip: 0,
+            },
           })
           .reply(200, fetchEventsResponse);
 
@@ -447,7 +521,10 @@ describe('Event controller', () => {
 
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryFetchEvent(eventId),
+          query: buildGraphQLQueryFetchEvent(),
+          variables: {
+            id: eventId,
+          },
         })
         .reply(200, {
           data: { findEventsContent: pUnavailableEventRes },
@@ -476,7 +553,10 @@ describe('Event controller', () => {
 
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryFetchEvent(eventId),
+          query: buildGraphQLQueryFetchEvent(),
+          variables: {
+            id: eventId,
+          },
         })
         .reply(200, { data: { findEventsContent: emptyEvent } });
 
@@ -505,7 +585,10 @@ describe('Event controller', () => {
 
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryFetchEvent(eventId),
+          query: buildGraphQLQueryFetchEvent(),
+          variables: {
+            id: eventId,
+          },
         })
         .reply(200, { data: { findEventsContent: emptyEvent } });
 
@@ -538,7 +621,10 @@ describe('Event controller', () => {
 
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryFetchEvent(eventId),
+          query: buildGraphQLQueryFetchEvent(),
+          variables: {
+            id: eventId,
+          },
         })
         .reply(200, { data: { findEventsContent: eventResponse } });
 
@@ -583,7 +669,10 @@ describe('Event controller', () => {
 
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryFetchEvent(eventId),
+          query: buildGraphQLQueryFetchEvent(),
+          variables: {
+            id: eventId,
+          },
         })
         .reply(200, findEventResponse);
 
@@ -702,7 +791,10 @@ describe('Event controller', () => {
 
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryFetchEvent(eventId),
+          query: buildGraphQLQueryFetchEvent(),
+          variables: {
+            id: eventId,
+          },
         })
         .reply(200, findEventResponseMultiRef);
 
@@ -722,7 +814,10 @@ describe('Event controller', () => {
 
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryFetchEvent(eventId),
+          query: buildGraphQLQueryFetchEvent(),
+          variables: {
+            id: eventId,
+          },
         })
         .reply(200, findEventResponseSingleRef);
 
@@ -742,7 +837,10 @@ describe('Event controller', () => {
 
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryFetchEvent(eventId),
+          query: buildGraphQLQueryFetchEvent(),
+          variables: {
+            id: eventId,
+          },
         })
         .reply(200, findEventResponse);
 

--- a/apps/asap-server/test/controllers/groups.test.ts
+++ b/apps/asap-server/test/controllers/groups.test.ts
@@ -29,7 +29,12 @@ describe('Group controller', () => {
     test('Should return an empty result', async () => {
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryFetchGroups(''),
+          query: buildGraphQLQueryFetchGroups(),
+          variables: {
+            filter: '',
+            top: 50,
+            skip: 0,
+          },
         })
         .reply(200, {
           data: {
@@ -51,7 +56,7 @@ describe('Group controller', () => {
         search: 'first last',
       };
 
-      const filterQuery =
+      const expetedFilter =
         "(contains(data/name/iv, 'first')" +
         " or contains(data/description/iv, 'first')" +
         " or contains(data/tags/iv, 'first'))" +
@@ -62,7 +67,12 @@ describe('Group controller', () => {
 
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryFetchGroups(filterQuery, 12, 2),
+          query: buildGraphQLQueryFetchGroups(),
+          variables: {
+            filter: expetedFilter,
+            top: 12,
+            skip: 2,
+          },
         })
         .reply(200, fixtures.queryGroupsResponse);
 
@@ -84,7 +94,12 @@ describe('Group controller', () => {
 
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryFetchGroups(expectedFilter, 12, 2),
+          query: buildGraphQLQueryFetchGroups(),
+          variables: {
+            filter: expectedFilter,
+            top: 12,
+            skip: 2,
+          },
         })
         .reply(200, fixtures.queryGroupsResponse);
 
@@ -107,7 +122,12 @@ describe('Group controller', () => {
 
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryFetchGroups(expectedFilter, 12, 2),
+          query: buildGraphQLQueryFetchGroups(),
+          variables: {
+            filter: expectedFilter,
+            top: 12,
+            skip: 2,
+          },
         })
         .reply(200, fixtures.queryGroupsResponse);
 
@@ -122,7 +142,10 @@ describe('Group controller', () => {
       const groupId = 'not-found';
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryFetchGroup(groupId),
+          query: buildGraphQLQueryFetchGroup(),
+          variables: {
+            id: groupId,
+          },
         })
         .reply(200, {
           data: {
@@ -137,7 +160,10 @@ describe('Group controller', () => {
       const groupId = 'group-id-1';
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryFetchGroup(groupId),
+          query: buildGraphQLQueryFetchGroup(),
+          variables: {
+            id: groupId,
+          },
         })
         .reply(200, fixtures.findGroupResponse);
 
@@ -149,11 +175,16 @@ describe('Group controller', () => {
   describe('Fetch-by-team-ID method', () => {
     test('Should return an empty result', async () => {
       const teamUUID = 'eb531b6e-195c-46e2-b347-58fb86715033';
-      const filter = `data/teams/iv eq '${teamUUID}'`;
+      const expectedFilter = `data/teams/iv eq '${teamUUID}'`;
 
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryFetchGroups(filter),
+          query: buildGraphQLQueryFetchGroups(),
+          variables: {
+            filter: expectedFilter,
+            top: 50,
+            skip: 0,
+          },
         })
         .reply(200, {
           data: {
@@ -176,11 +207,16 @@ describe('Group controller', () => {
       };
 
       const teamUUID = 'eb531b6e-195c-46e2-b347-58fb86715033';
-      const filterQuery = `data/teams/iv eq '${teamUUID}'`;
+      const expectedFilter = `data/teams/iv eq '${teamUUID}'`;
 
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryFetchGroups(filterQuery, 12, 2),
+          query: buildGraphQLQueryFetchGroups(),
+          variables: {
+            filter: expectedFilter,
+            top: 12,
+            skip: 2,
+          },
         })
         .reply(200, fixtures.queryGroupsResponse);
 
@@ -198,7 +234,12 @@ describe('Group controller', () => {
 
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryFetchGroups(userFilter),
+          query: buildGraphQLQueryFetchGroups(),
+          variables: {
+            filter: userFilter,
+            top: 50,
+            skip: 0,
+          },
         })
         .reply(200, {
           data: {
@@ -209,7 +250,12 @@ describe('Group controller', () => {
           },
         })
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryFetchGroups(teamFilter),
+          query: buildGraphQLQueryFetchGroups(),
+          variables: {
+            filter: teamFilter,
+            top: 50,
+            skip: 0,
+          },
         })
         .reply(200, {
           data: {
@@ -237,11 +283,21 @@ describe('Group controller', () => {
       // same response since the user is group leader and member a team
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryFetchGroups(userFilter),
+          query: buildGraphQLQueryFetchGroups(),
+          variables: {
+            filter: userFilter,
+            top: 50,
+            skip: 0,
+          },
         })
         .reply(200, fixtures.queryGroupsResponse)
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryFetchGroups(teamFilter),
+          query: buildGraphQLQueryFetchGroups(),
+          variables: {
+            filter: teamFilter,
+            top: 50,
+            skip: 0,
+          },
         })
         .reply(200, fixtures.queryGroupsResponse);
 

--- a/apps/asap-server/test/controllers/research-outputs.test.ts
+++ b/apps/asap-server/test/controllers/research-outputs.test.ts
@@ -36,6 +36,11 @@ describe('ResearchOutputs controller', () => {
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {
           query: buildGraphQLQueryFetchResearchOutputs(),
+          variables: {
+            top: 10,
+            skip: 5,
+            filter: '',
+          },
         })
         .reply(200, {
           data: {
@@ -46,7 +51,7 @@ describe('ResearchOutputs controller', () => {
           },
         });
 
-      const result = await researchOutputs.fetch({ take: 8, skip: 0 });
+      const result = await researchOutputs.fetch({ take: 10, skip: 5 });
 
       expect(result).toEqual({ total: 0, items: [] });
     });
@@ -55,6 +60,11 @@ describe('ResearchOutputs controller', () => {
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {
           query: buildGraphQLQueryFetchResearchOutputs(),
+          variables: {
+            top: 8,
+            skip: 0,
+            filter: '',
+          },
         })
         .reply(200, {
           data: getSquidexResearchOutputsGraphqlResponse(),
@@ -71,7 +81,12 @@ describe('ResearchOutputs controller', () => {
 
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryFetchResearchOutputs(expectedFilter),
+          query: buildGraphQLQueryFetchResearchOutputs(),
+          variables: {
+            filter: expectedFilter,
+            top: 8,
+            skip: 0,
+          },
         })
         .reply(200, {
           data: getSquidexResearchOutputsGraphqlResponse(),
@@ -93,7 +108,12 @@ describe('ResearchOutputs controller', () => {
 
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryFetchResearchOutputs(expectedFilter),
+          query: buildGraphQLQueryFetchResearchOutputs(),
+          variables: {
+            filter: expectedFilter,
+            top: 8,
+            skip: 0,
+          },
         })
         .reply(200, {
           data: getSquidexResearchOutputsGraphqlResponse(),
@@ -113,7 +133,12 @@ describe('ResearchOutputs controller', () => {
 
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryFetchResearchOutputs(expectedFilter),
+          query: buildGraphQLQueryFetchResearchOutputs(),
+          variables: {
+            filter: expectedFilter,
+            top: 8,
+            skip: 0,
+          },
         })
         .reply(200, {
           data: getSquidexResearchOutputsGraphqlResponse(),
@@ -134,7 +159,12 @@ describe('ResearchOutputs controller', () => {
 
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryFetchResearchOutputs(expectedFilter),
+          query: buildGraphQLQueryFetchResearchOutputs(),
+          variables: {
+            filter: expectedFilter,
+            top: 8,
+            skip: 0,
+          },
         })
         .reply(200, {
           data: getSquidexResearchOutputsGraphqlResponse(),
@@ -156,7 +186,10 @@ describe('ResearchOutputs controller', () => {
     test('Should throw a Not Found error when the research output is not found', async () => {
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryResearchOutput(researchOutputId),
+          query: buildGraphQLQueryResearchOutput(),
+          variables: {
+            id: researchOutputId,
+          },
         })
         .reply(200, {
           data: {
@@ -172,7 +205,10 @@ describe('ResearchOutputs controller', () => {
     test('Should return the research output and the team', async () => {
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryResearchOutput(researchOutputId),
+          query: buildGraphQLQueryResearchOutput(),
+          variables: {
+            id: researchOutputId,
+          },
         })
         .reply(200, { data: getSquidexResearchOutputGraphqlResponse() });
 
@@ -189,7 +225,10 @@ describe('ResearchOutputs controller', () => {
 
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryResearchOutput(researchOutputId),
+          query: buildGraphQLQueryResearchOutput(),
+          variables: {
+            id: researchOutputId,
+          },
         })
         .reply(200, { data: squidexGraphqlResponse });
 
@@ -205,7 +244,10 @@ describe('ResearchOutputs controller', () => {
 
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryResearchOutput(researchOutputId),
+          query: buildGraphQLQueryResearchOutput(),
+          variables: {
+            id: researchOutputId,
+          },
         })
         .reply(200, { data: squidexGraphqlResponse });
 
@@ -222,7 +264,10 @@ describe('ResearchOutputs controller', () => {
 
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryResearchOutput(researchOutputId),
+          query: buildGraphQLQueryResearchOutput(),
+          variables: {
+            id: researchOutputId,
+          },
         })
         .reply(200, { data: squidexGraphqlResponse });
 
@@ -238,7 +283,10 @@ describe('ResearchOutputs controller', () => {
 
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryResearchOutput(researchOutputId),
+          query: buildGraphQLQueryResearchOutput(),
+          variables: {
+            id: researchOutputId,
+          },
         })
         .reply(200, { data: squidexGraphqlResponse });
 
@@ -254,7 +302,10 @@ describe('ResearchOutputs controller', () => {
 
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryResearchOutput(researchOutputId),
+          query: buildGraphQLQueryResearchOutput(),
+          variables: {
+            id: researchOutputId,
+          },
         })
         .reply(200, { data: squidexGraphqlResponse });
 
@@ -270,7 +321,10 @@ describe('ResearchOutputs controller', () => {
 
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryResearchOutput(researchOutputId),
+          query: buildGraphQLQueryResearchOutput(),
+          variables: {
+            id: researchOutputId,
+          },
         })
         .reply(200, { data: squidexGraphqlResponse });
 
@@ -286,7 +340,10 @@ describe('ResearchOutputs controller', () => {
 
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryResearchOutput(researchOutputId),
+          query: buildGraphQLQueryResearchOutput(),
+          variables: {
+            id: researchOutputId,
+          },
         })
         .reply(200, { data: squidexGraphqlResponse });
 
@@ -302,7 +359,10 @@ describe('ResearchOutputs controller', () => {
 
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryResearchOutput(researchOutputId),
+          query: buildGraphQLQueryResearchOutput(),
+          variables: {
+            id: researchOutputId,
+          },
         })
         .reply(200, { data: squidexGraphqlResponse });
 
@@ -318,7 +378,10 @@ describe('ResearchOutputs controller', () => {
 
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryResearchOutput(researchOutputId),
+          query: buildGraphQLQueryResearchOutput(),
+          variables: {
+            id: researchOutputId,
+          },
         })
         .reply(200, { data: researchOutputResponse });
 
@@ -363,7 +426,10 @@ describe('ResearchOutputs controller', () => {
 
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryResearchOutput(researchOutputId),
+          query: buildGraphQLQueryResearchOutput(),
+          variables: {
+            id: researchOutputId,
+          },
         })
         .reply(200, { data: researchOutputResponse });
 
@@ -411,7 +477,10 @@ describe('ResearchOutputs controller', () => {
 
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryResearchOutput(researchOutputId),
+          query: buildGraphQLQueryResearchOutput(),
+          variables: {
+            id: researchOutputId,
+          },
         })
         .reply(200, { data: researchOutputResponse });
 
@@ -431,7 +500,10 @@ describe('ResearchOutputs controller', () => {
       const researchOutputResponse = getSquidexResearchOutputGraphqlResponse();
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryResearchOutput(researchOutputId),
+          query: buildGraphQLQueryResearchOutput(),
+          variables: {
+            id: researchOutputId,
+          },
         })
         .reply(200, { data: researchOutputResponse });
 
@@ -447,7 +519,10 @@ describe('ResearchOutputs controller', () => {
       const researchOutputResponse = getSquidexResearchOutputGraphqlResponse();
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryResearchOutput(researchOutputId),
+          query: buildGraphQLQueryResearchOutput(),
+          variables: {
+            id: researchOutputId,
+          },
         })
         .reply(200, { data: researchOutputResponse });
 
@@ -471,7 +546,10 @@ describe('ResearchOutputs controller', () => {
 
         nock(config.baseUrl)
           .post(`/api/content/${config.appName}/graphql`, {
-            query: buildGraphQLQueryResearchOutput(researchOutputId),
+            query: buildGraphQLQueryResearchOutput(),
+            variables: {
+              id: researchOutputId,
+            },
           })
           .reply(200, { data: researchOutputResponse });
 
@@ -492,7 +570,10 @@ describe('ResearchOutputs controller', () => {
 
         nock(config.baseUrl)
           .post(`/api/content/${config.appName}/graphql`, {
-            query: buildGraphQLQueryResearchOutput(researchOutputId),
+            query: buildGraphQLQueryResearchOutput(),
+            variables: {
+              id: researchOutputId,
+            },
           })
           .reply(200, { data: researchOutputResponse });
 

--- a/apps/asap-server/test/controllers/teams.test.ts
+++ b/apps/asap-server/test/controllers/teams.test.ts
@@ -64,7 +64,12 @@ describe('Team controller', () => {
     test('Should return an empty result', async () => {
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryFetchTeams('', 8, 8),
+          query: buildGraphQLQueryFetchTeams(),
+          variables: {
+            filter: '',
+            top: 10,
+            skip: 8,
+          },
         })
         .reply(200, {
           data: {
@@ -75,7 +80,7 @@ describe('Team controller', () => {
           },
         });
 
-      const result = await teams.fetch({ take: 8, skip: 8 }, mockUser);
+      const result = await teams.fetch({ take: 10, skip: 8 }, mockUser);
       expect(result).toEqual({ items: [], total: 0 });
     });
 
@@ -91,7 +96,12 @@ describe('Team controller', () => {
 
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryFetchTeams(searchQ),
+          query: buildGraphQLQueryFetchTeams(),
+          variables: {
+            filter: searchQ,
+            top: 8,
+            skip: 0,
+          },
         })
         .reply(200, graphQlTeamsResponseSingle)
         .get(`/api/content/${config.appName}/users`)
@@ -119,7 +129,12 @@ describe('Team controller', () => {
 
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryFetchTeams(expectedSearchFilter),
+          query: buildGraphQLQueryFetchTeams(),
+          variables: {
+            filter: expectedSearchFilter,
+            top: 8,
+            skip: 0,
+          },
         })
         .reply(200, graphQlTeamsResponseSingle)
         .get(`/api/content/${config.appName}/users`)
@@ -147,7 +162,12 @@ describe('Team controller', () => {
 
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryFetchTeams(expectedSearchFilter),
+          query: buildGraphQLQueryFetchTeams(),
+          variables: {
+            filter: expectedSearchFilter,
+            top: 8,
+            skip: 0,
+          },
         })
         .reply(200, graphQlTeamsResponseSingle)
         .get(`/api/content/${config.appName}/users`)
@@ -171,6 +191,11 @@ describe('Team controller', () => {
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {
           query: buildGraphQLQueryFetchTeams(),
+          variables: {
+            filter: '',
+            top: 8,
+            skip: 0,
+          },
         })
         .reply(200, graphQlTeamsResponse)
         .get(`/api/content/${config.appName}/users`)
@@ -201,7 +226,10 @@ describe('Team controller', () => {
 
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryFetchTeam(teamId),
+          query: buildGraphQLQueryFetchTeam(),
+          variables: {
+            id: teamId,
+          },
         })
         .reply(200, {
           data: {
@@ -219,7 +247,10 @@ describe('Team controller', () => {
 
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryFetchTeam(teamId),
+          query: buildGraphQLQueryFetchTeam(),
+          variables: {
+            id: teamId,
+          },
         })
         .reply(200, graphQlTeamResponse)
         .get(`/api/content/${config.appName}/users`)
@@ -238,7 +269,10 @@ describe('Team controller', () => {
 
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryFetchTeam(teamId),
+          query: buildGraphQLQueryFetchTeam(),
+          variables: {
+            id: teamId,
+          },
         })
         .reply(200, graphQlTeamResponse)
         .get(`/api/content/${config.appName}/users`)
@@ -257,7 +291,10 @@ describe('Team controller', () => {
 
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryFetchTeam(teamId),
+          query: buildGraphQLQueryFetchTeam(),
+          variables: {
+            id: teamId,
+          },
         })
         .reply(200, graphQlTeamResponse)
         .get(`/api/content/${config.appName}/users`)
@@ -285,7 +322,10 @@ describe('Team controller', () => {
 
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryFetchTeam(teamId),
+          query: buildGraphQLQueryFetchTeam(),
+          variables: {
+            id: teamId,
+          },
         })
         .reply(200, getGraphQlTeamResponse(tools))
         .get(`/api/content/${config.appName}/users`)
@@ -328,7 +368,10 @@ describe('Team controller', () => {
 
         nock(config.baseUrl)
           .post(`/api/content/${config.appName}/graphql`, {
-            query: buildGraphQLQueryFetchTeam(teamId),
+            query: buildGraphQLQueryFetchTeam(),
+            variables: {
+              id: teamId,
+            },
           })
           .reply(200, graphQlTeamResponse)
           .get(`/api/content/${config.appName}/users`)
@@ -364,7 +407,10 @@ describe('Team controller', () => {
 
         nock(config.baseUrl)
           .post(`/api/content/${config.appName}/graphql`, {
-            query: buildGraphQLQueryFetchTeam(teamId),
+            query: buildGraphQLQueryFetchTeam(),
+            variables: {
+              id: teamId,
+            },
           })
           .reply(200, graphQlTeamResponse)
           .get(`/api/content/${config.appName}/users`)
@@ -411,7 +457,10 @@ describe('Team controller', () => {
         })
         .reply(200, getUpdateTeamResponse()) // response is not used
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryFetchTeam(teamId),
+          query: buildGraphQLQueryFetchTeam(),
+          variables: {
+            id: teamId,
+          },
         })
         .reply(200, getGraphQlTeamResponse())
         .get(`/api/content/${config.appName}/users`)
@@ -440,7 +489,10 @@ describe('Team controller', () => {
         })
         .reply(200, getUpdateTeamResponse(tools)) // response is not used
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryFetchTeam(teamId),
+          query: buildGraphQLQueryFetchTeam(),
+          variables: {
+            id: teamId,
+          },
         })
         .reply(200, getGraphQlTeamResponse(tools))
         .get(`/api/content/${config.appName}/users`)

--- a/apps/asap-server/test/controllers/users.test.ts
+++ b/apps/asap-server/test/controllers/users.test.ts
@@ -39,9 +39,12 @@ describe('Users controller', () => {
     test('Should return an empty result', async () => {
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryFetchUsers(
-            "data/onboarded/iv eq true and data/role/iv ne 'Hidden'",
-          ),
+          query: buildGraphQLQueryFetchUsers(),
+          variables: {
+            filter: "data/onboarded/iv eq true and data/role/iv ne 'Hidden'",
+            top: 8,
+            skip: 0,
+          },
         })
         .reply(200, {
           data: {
@@ -83,7 +86,12 @@ describe('Users controller', () => {
 
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryFetchUsers(filterQuery, 12, 2),
+          query: buildGraphQLQueryFetchUsers(),
+          variables: {
+            filter: filterQuery,
+            top: 12,
+            skip: 2,
+          },
         })
         .reply(200, graphQlResponseFetchUsers);
 
@@ -107,7 +115,12 @@ describe('Users controller', () => {
 
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryFetchUsers(expectedFilter, 12, 2),
+          query: buildGraphQLQueryFetchUsers(),
+          variables: {
+            filter: expectedFilter,
+            top: 12,
+            skip: 2,
+          },
         })
         .reply(200, graphQlResponseFetchUsers);
 
@@ -132,7 +145,12 @@ describe('Users controller', () => {
 
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryFetchUsers(expectedFilter, 12, 2),
+          query: buildGraphQLQueryFetchUsers(),
+          variables: {
+            filter: expectedFilter,
+            top: 12,
+            skip: 2,
+          },
         })
         .reply(200, graphQlResponseFetchUsers);
 
@@ -146,7 +164,10 @@ describe('Users controller', () => {
     test('Should throw when user is not found', async () => {
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryFetchUser('not-found'),
+          query: buildGraphQLQueryFetchUser(),
+          variables: {
+            id: 'not-found',
+          },
         })
         .reply(200, {
           data: {
@@ -164,7 +185,10 @@ describe('Users controller', () => {
 
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryFetchUser('not-found'),
+          query: buildGraphQLQueryFetchUser(),
+          variables: {
+            id: 'not-found',
+          },
         })
         .reply(200, nonOnboardedUserResponse);
 
@@ -174,7 +198,10 @@ describe('Users controller', () => {
     test('Should return the user when it finds it', async () => {
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryFetchUser('user-id'),
+          query: buildGraphQLQueryFetchUser(),
+          variables: {
+            id: 'user-id',
+          },
         })
         .reply(200, getGraphQlResponseFetchUser());
 
@@ -189,7 +216,10 @@ describe('Users controller', () => {
 
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryFetchUser('user-id'),
+          query: buildGraphQLQueryFetchUser(),
+          variables: {
+            id: 'user-id',
+          },
         })
         .reply(200, userWithNoOnboardedFlagResponse);
 
@@ -206,7 +236,12 @@ describe('Users controller', () => {
     test('Should throw 403 when no user is found', async () => {
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryFetchUsers(filter, 1, 0),
+          query: buildGraphQLQueryFetchUsers(),
+          variables: {
+            filter,
+            top: 1,
+            skip: 0,
+          },
         })
         .reply(200, {
           data: {
@@ -223,7 +258,12 @@ describe('Users controller', () => {
     test('Should throw when it finds more than one user', async () => {
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryFetchUsers(filter, 1, 0),
+          query: buildGraphQLQueryFetchUsers(),
+          variables: {
+            filter,
+            top: 1,
+            skip: 0,
+          },
         })
         .reply(200, graphQlResponseFetchUsers);
 
@@ -233,7 +273,12 @@ describe('Users controller', () => {
     test('Should return user when it finds it', async () => {
       nock(config.baseUrl)
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryFetchUsers(filter, 1, 0),
+          query: buildGraphQLQueryFetchUsers(),
+          variables: {
+            filter,
+            top: 1,
+            skip: 0,
+          },
         })
         .reply(200, {
           data: {
@@ -271,7 +316,10 @@ describe('Users controller', () => {
         })
         .reply(200, fetchUserResponse)
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryFetchUser(userId),
+          query: buildGraphQLQueryFetchUser(),
+          variables: {
+            id: userId,
+          },
         })
         .reply(200, buildUserGraphqlResponse());
 
@@ -288,7 +336,10 @@ describe('Users controller', () => {
         })
         .reply(200, fetchUserResponse)
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryFetchUser(userId),
+          query: buildGraphQLQueryFetchUser(),
+          variables: {
+            id: userId,
+          },
         })
         .reply(200, buildUserGraphqlResponse());
 
@@ -310,7 +361,10 @@ describe('Users controller', () => {
         } as { [k: string]: any })
         .reply(200, fetchUserResponse) // this response is ignored
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryFetchUser(userId),
+          query: buildGraphQLQueryFetchUser(),
+          variables: {
+            id: userId,
+          },
         })
         .reply(
           200,
@@ -333,7 +387,10 @@ describe('Users controller', () => {
         } as { [k: string]: any })
         .reply(200, fetchUserResponse)
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryFetchUser(userId),
+          query: buildGraphQLQueryFetchUser(),
+          variables: {
+            id: userId,
+          },
         })
         .reply(
           200,
@@ -392,7 +449,10 @@ describe('Users controller', () => {
         } as { [k: string]: any })
         .reply(200, fetchUserResponse) // this response is ignored
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryFetchUser(userId),
+          query: buildGraphQLQueryFetchUser(),
+          variables: {
+            id: userId,
+          },
         })
         .reply(
           200,
@@ -512,7 +572,10 @@ describe('Users controller', () => {
         })
         .reply(200, patchResponse)
         .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryFetchUser('user-id'),
+          query: buildGraphQLQueryFetchUser(),
+          variables: {
+            id: 'user-id',
+          },
         })
         .reply(200, getGraphQlResponseFetchUser());
 

--- a/apps/asap-server/test/handlers/webhooks/webhook-fetch-by-code.test.ts
+++ b/apps/asap-server/test/handlers/webhooks/webhook-fetch-by-code.test.ts
@@ -77,11 +77,12 @@ describe('GET /webhook/users/{code}', () => {
   test("returns 403 when code doesn't exist", async () => {
     nock(config.baseUrl)
       .post(`/api/content/${config.appName}/graphql`, {
-        query: buildGraphQLQueryFetchUsers(
-          `data/connections/iv/code eq 'notFound'`,
-          1,
-          0,
-        ),
+        query: buildGraphQLQueryFetchUsers(),
+        variables: {
+          filter: `data/connections/iv/code eq 'notFound'`,
+          top: 1,
+          skip: 0,
+        },
       })
       .reply(200, {
         data: {
@@ -109,11 +110,12 @@ describe('GET /webhook/users/{code}', () => {
   test('returns 200 when user exists', async () => {
     nock(config.baseUrl)
       .post(`/api/content/${config.appName}/graphql`, {
-        query: buildGraphQLQueryFetchUsers(
-          `data/connections/iv/code eq 'welcomeCode'`,
-          1,
-          0,
-        ),
+        query: buildGraphQLQueryFetchUsers(),
+        variables: {
+          filter: `data/connections/iv/code eq 'welcomeCode'`,
+          top: 1,
+          skip: 0,
+        },
       })
       .reply(200, fetchUserResponse);
 

--- a/apps/asap-server/test/utils/instrumentation.test.ts
+++ b/apps/asap-server/test/utils/instrumentation.test.ts
@@ -39,11 +39,12 @@ describe('Instrumentation', () => {
   test('marks span as ERROR, when statusCode is >= 400', async () => {
     nock(config.baseUrl)
       .post(`/api/content/${config.appName}/graphql`, {
-        query: buildGraphQLQueryFetchUsers(
-          `data/connections/iv/code eq 'notFound'`,
-          1,
-          0,
-        ),
+        query: buildGraphQLQueryFetchUsers(),
+        variables: {
+          filter: `data/connections/iv/code eq 'notFound'`,
+          top: 1,
+          skip: 0,
+        },
       })
       .reply(200, {
         data: {
@@ -72,11 +73,12 @@ describe('Instrumentation', () => {
   test('returns 200 when user exists', async () => {
     nock(config.baseUrl)
       .post(`/api/content/${config.appName}/graphql`, {
-        query: buildGraphQLQueryFetchUsers(
-          `data/connections/iv/code eq 'welcomeCode'`,
-          1,
-          0,
-        ),
+        query: buildGraphQLQueryFetchUsers(),
+        variables: {
+          filter: `data/connections/iv/code eq 'welcomeCode'`,
+          top: 1,
+          skip: 0,
+        },
       })
       .reply(200, fetchUserResponse);
 

--- a/packages/squidex/src/graphql.ts
+++ b/packages/squidex/src/graphql.ts
@@ -12,9 +12,9 @@ export class SquidexGraphql {
     );
   }
 
-  async request<T, V>(query: string): Promise<T> {
+  async request<T, V>(query: string, variables?: V): Promise<T> {
     const tk = await getAccessToken();
     this.client.setHeaders({ authorization: `Bearer ${tk}` });
-    return this.client.request<T, V>(query);
+    return this.client.request<T, V>(query, variables);
   }
 }


### PR DESCRIPTION
Moves all query parameters in the graphql queries to Squidex into the dedicated `variables` section of the request body.

See: https://trello.com/c/Ahlq8rgV/1259-move-graphql-query-parameters-to-the-variables