### PR TITLE
fix: Enable algolia index deletion on teardown

### DIFF
--- a/.github/workflows/env-teardown.yml
+++ b/.github/workflows/env-teardown.yml
@@ -48,4 +48,4 @@ jobs:
         run: |
           cd apps/asap-server
           export ALGOLIA_INDEX=asap-hub_research_outputs_CI-$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
-          yarn workspace @asap-hub/asap-server run algolia deleteindicespattern -a $ALGOLIA_APP_ID -k $ALGOLIA_API_KEY -r "^$ALGOLIA_INDEX$" -x true
+          yarn workspace @asap-hub/asap-server run algolia deleteindicespattern -a $ALGOLIA_APP_ID -k $ALGOLIA_API_KEY -r "^$ALGOLIA_INDEX$" -x false


### PR DESCRIPTION
Disables the dry-run so that the index actually gets deleted when the environment is removed