### PR TITLE
feat: Add RRID to research outputs

### DIFF
--- a/packages/squidex/schema/schemas/research-outputs.json
+++ b/packages/squidex/schema/schemas/research-outputs.json
@@ -410,6 +410,27 @@
         }
       },
       {
+        "name": "rrid",
+        "isHidden": false,
+        "isLocked": false,
+        "isDisabled": false,
+        "partitioning": "invariant",
+        "properties": {
+          "fieldType": "String",
+          "pattern": "^RRID:[a-zA-Z]+.+$",
+          "isUnique": false,
+          "inlineEditable": false,
+          "contentType": "Unspecified",
+          "editor": "Input",
+          "label": "Identifier (RRID)",
+          "hints": "This must start with \"RRID:\"",
+          "placeholder": "",
+          "isRequired": false,
+          "isRequiredOnPublish": false,
+          "isHalfWidth": false
+        }
+      },
+      {
         "name": "labCatalogNumber",
         "isHidden": false,
         "isLocked": false,

--- a/packages/squidex/src/entities/research-output.ts
+++ b/packages/squidex/src/entities/research-output.ts
@@ -28,6 +28,7 @@ export interface ResearchOutput<TAuthorConnection = string> {
   usedInAPublication: DecisionOption;
   authors?: TAuthorConnection[];
   pmsEmails: string[];
+  rrid?: string;
 }
 
 export interface RestResearchOutput extends Entity, Rest<ResearchOutput> {}


### PR DESCRIPTION
https://trello.com/c/wJMIFi2p/1397-store-rrid-for-each-roms-output

no tests as there is not much point of writing any for just the CMS work - i expect integration tests to be added once the field is surfaced to the FE