### PR TITLE
fix: Onboarded default state and lab editor type

### DIFF
--- a/packages/squidex/schema/schemas/research-outputs.json
+++ b/packages/squidex/schema/schemas/research-outputs.json
@@ -285,7 +285,7 @@
           "allowDuplicates": false,
           "resolveReference": false,
           "mustBePublished": true,
-          "editor": "Tags",
+          "editor": "List",
           "schemaIds": ["labs"],
           "label": "Labs",
           "hints": "",

--- a/packages/squidex/schema/schemas/users.json
+++ b/packages/squidex/schema/schemas/users.json
@@ -703,7 +703,7 @@
         "partitioning": "invariant",
         "properties": {
           "fieldType": "Boolean",
-          "defaultValue": false,
+          "defaultValue": true,
           "inlineEditable": false,
           "editor": "Toggle",
           "label": "Onboarding complete",

--- a/packages/squidex/schema/schemas/users.json
+++ b/packages/squidex/schema/schemas/users.json
@@ -121,7 +121,7 @@
           "allowDuplicates": false,
           "resolveReference": false,
           "mustBePublished": true,
-          "editor": "Tags",
+          "editor": "List",
           "schemaIds": ["labs"],
           "label": "Labs",
           "hints": "Mandatory for grantees. They cannot publish profile without a lab.",


### PR DESCRIPTION
fixes:
* https://trello.com/c/7iVw9yZb/1445-%F0%9F%90%9B-bug-not-all-labs-are-showing-on-user-profiles-cms
* https://trello.com/c/zANJCbn7/1465-default-value-for-onboarding-is-false