### PR TITLE
feat: disable nav bar items for not onboarded users with incomplete profile

### DIFF
--- a/apps/frontend/src/AuthenticatedApp.tsx
+++ b/apps/frontend/src/AuthenticatedApp.tsx
@@ -63,6 +63,7 @@ const AuthenticatedApp: FC<Record<string, never>> = () => {
     <Onboardable>
       {({ isOnboardable }) => (
         <Layout
+          userOnboarded={user.onboarded}
           isOnboardable={isOnboardable}
           userProfileHref={network({}).users({}).user({ userId: user.id }).$}
           teams={user.teams.map(({ id, displayName = '' }) => ({

--- a/apps/storybook/src/Layout.stories.tsx
+++ b/apps/storybook/src/Layout.stories.tsx
@@ -12,6 +12,7 @@ export default {
 };
 
 const props: Omit<ComponentProps<typeof Layout>, 'children'> = {
+  userOnboarded: true,
   userProfileHref: '/profile',
   teams: [
     { name: '1', href: '/team-1' },

--- a/apps/storybook/src/MainNavigation.stories.tsx
+++ b/apps/storybook/src/MainNavigation.stories.tsx
@@ -25,7 +25,9 @@ export const Normal = () => {
   );
   return (
     <StaticRouter key={path} location={path}>
-      <MainNavigation />
+      <MainNavigation userOnboarded={true} />
     </StaticRouter>
   );
 };
+
+export const Disabled = () => <MainNavigation userOnboarded={false} />;

--- a/apps/storybook/src/UserNavigation.stories.tsx
+++ b/apps/storybook/src/UserNavigation.stories.tsx
@@ -1,5 +1,5 @@
 import { StaticRouter } from 'react-router-dom';
-import { array, select } from '@storybook/addon-knobs';
+import { select } from '@storybook/addon-knobs';
 import { UserNavigation } from '@asap-hub/react-components';
 
 import { NoPaddingDecorator } from './layout';
@@ -10,29 +10,41 @@ export default {
   decorators: [NoPaddingDecorator],
 };
 
-export const Normal = () => {
-  const path = `/${select(
-    'Active Section',
-    {
-      Profile: 'profile',
-      'First Team': 'team-1',
-      Settings: 'settings',
-      Feedback: 'feedback',
-      None: 'none',
-    },
-    'profile',
-  )}`;
-  return (
-    <StaticRouter key={path} location={path}>
-      <UserNavigation
-        userOnboarded={true}
-        userProfileHref="/profile"
-        teams={array('Teams', ['Team 1', 'Team 2']).map((name, i) => ({
-          name,
-          href: `/team-${i + 1}`,
-        }))}
-        aboutHref="/about"
-      />
-    </StaticRouter>
-  );
-};
+const teams = ['Team 1', 'Team 2'].map((name, i) => ({
+  name,
+  href: `/team-${i + 1}`,
+}));
+
+const path = `/${select(
+  'Active Section',
+  {
+    Profile: 'profile',
+    'First Team': 'team-1',
+    Settings: 'settings',
+    Feedback: 'feedback',
+    None: 'none',
+  },
+  'profile',
+)}`;
+
+export const Normal = () => (
+  <StaticRouter key={path} location={path}>
+    <UserNavigation
+      userOnboarded={true}
+      userProfileHref="/profile"
+      teams={teams}
+      aboutHref="/about"
+    />
+  </StaticRouter>
+);
+
+export const Disabled = () => (
+  <StaticRouter key={path} location={path}>
+    <UserNavigation
+      userOnboarded={false}
+      userProfileHref="/profile"
+      teams={teams}
+      aboutHref="/about"
+    />
+  </StaticRouter>
+);

--- a/apps/storybook/src/UserNavigation.stories.tsx
+++ b/apps/storybook/src/UserNavigation.stories.tsx
@@ -25,6 +25,7 @@ export const Normal = () => {
   return (
     <StaticRouter key={path} location={path}>
       <UserNavigation
+        userOnboarded={true}
         userProfileHref="/profile"
         teams={array('Teams', ['Team 1', 'Team 2']).map((name, i) => ({
           name,

--- a/apps/storybook/src/layout.tsx
+++ b/apps/storybook/src/layout.tsx
@@ -33,6 +33,7 @@ export const LayoutDecorator: DecoratorFn = (storyFn, context) =>
   NoPaddingDecorator(
     () => (
       <Layout
+        userOnboarded={true}
         userProfileHref="/profile"
         teams={[
           { name: '1', href: '/team-1' },

--- a/packages/react-components/src/atoms/NavigationLink.tsx
+++ b/packages/react-components/src/atoms/NavigationLink.tsx
@@ -35,7 +35,6 @@ const styles = css({
     15 - 1,
     'px',
   ),
-
   color: 'unset',
   textDecoration: 'none',
   outline: 'none',
@@ -50,7 +49,6 @@ const textStyles = css({
   margin: 0,
   display: 'flex',
   alignItems: 'center',
-
   fontSize: `${18 / perRem}em`,
 });
 const iconStyles = css({
@@ -60,24 +58,35 @@ const iconStyles = css({
   paddingRight: `${14 / perRem}em`,
 });
 
+const disableStyles = css({
+  opacity: 0.3,
+  pointerEvents: 'none',
+});
+
 interface NavigationLinkProps {
   readonly href: string;
-
+  readonly enabled?: boolean;
   readonly icon: JSX.Element;
   readonly children: TextChildren;
 }
 const NavigationLink: React.FC<NavigationLinkProps> = ({
   href,
+  enabled = true,
   icon,
   children,
 }) => {
   const [internal, url] = isInternalLink(href);
+
   if (useHasRouter() && internal) {
     return (
       <NavHashLink
         to={url}
         activeClassName={activeClassName}
-        css={[styles, { [`&.${activeClassName}`]: activePrimaryStyles }]}
+        css={[
+          styles,
+          { [`&.${activeClassName}`]: activePrimaryStyles },
+          !enabled && disableStyles,
+        ]}
         smooth
         isActive={(match, _) => !!match}
       >
@@ -92,7 +101,10 @@ const NavigationLink: React.FC<NavigationLinkProps> = ({
   const active =
     new URL(href, window.location.href).pathname === window.location.pathname;
   return (
-    <a href={url} css={[styles, active && activePrimaryStyles]}>
+    <a
+      href={url}
+      css={[styles, active && activePrimaryStyles, !enabled && disableStyles]}
+    >
       <p css={textStyles}>
         <span css={iconStyles}>{icon}</span>
         {children}

--- a/packages/react-components/src/molecules/Header.tsx
+++ b/packages/react-components/src/molecules/Header.tsx
@@ -6,15 +6,16 @@ import { Link } from '../atoms';
 
 const height = '72px';
 
-const containerStyles = css({
-  height,
-  flexGrow: 1,
-  boxSizing: 'border-box',
-  padding: '0 24px',
-
-  display: 'flex',
-  justifyContent: 'center',
-});
+const containerStyles = (enabled: boolean) =>
+  css({
+    height,
+    flexGrow: 1,
+    boxSizing: 'border-box',
+    padding: '0 24px',
+    display: 'flex',
+    justifyContent: 'center',
+    cursor: enabled ? 'pointer' : 'cursor',
+  });
 const containerOpaqueStyles = css({
   backgroundColor: paper.rgb,
 });
@@ -24,23 +25,37 @@ const logoStyles = css({
 });
 
 type HeaderProps = {
+  readonly enabled?: boolean;
   readonly transparent?: boolean;
   readonly logoHref?: string;
 };
 
 const Header: React.FC<HeaderProps> = ({
+  enabled = true,
   transparent = false,
   logoHref = '/',
-}) => (
-  <header css={[containerStyles, transparent || containerOpaqueStyles]}>
-    <Link href={logoHref}>
-      <img
-        alt="ASAP logo"
-        src={transparent ? asapPaddedWhiteImage : asapPaddedImage}
-        css={logoStyles}
-      />
-    </Link>
-  </header>
-);
+}) => {
+  const Logo = () => (
+    <img
+      alt="ASAP logo"
+      src={transparent ? asapPaddedWhiteImage : asapPaddedImage}
+      css={logoStyles}
+    />
+  );
+
+  return (
+    <header
+      css={[containerStyles(enabled), transparent || containerOpaqueStyles]}
+    >
+      {enabled ? (
+        <Link href={logoHref}>
+          <Logo />
+        </Link>
+      ) : (
+        <Logo />
+      )}
+    </header>
+  );
+};
 
 export default Header;

--- a/packages/react-components/src/molecules/Header.tsx
+++ b/packages/react-components/src/molecules/Header.tsx
@@ -14,7 +14,6 @@ const containerStyles = (enabled: boolean) =>
     padding: '0 24px',
     display: 'flex',
     justifyContent: 'center',
-    cursor: enabled ? 'pointer' : 'cursor',
   });
 const containerOpaqueStyles = css({
   backgroundColor: paper.rgb,
@@ -35,25 +34,17 @@ const Header: React.FC<HeaderProps> = ({
   transparent = false,
   logoHref = '/',
 }) => {
-  const Logo = () => (
-    <img
-      alt="ASAP logo"
-      src={transparent ? asapPaddedWhiteImage : asapPaddedImage}
-      css={logoStyles}
-    />
-  );
-
   return (
     <header
       css={[containerStyles(enabled), transparent || containerOpaqueStyles]}
     >
-      {enabled ? (
-        <Link href={logoHref}>
-          <Logo />
-        </Link>
-      ) : (
-        <Logo />
-      )}
+      <Link href={enabled ? logoHref : undefined}>
+        <img
+          alt="ASAP logo"
+          src={transparent ? asapPaddedWhiteImage : asapPaddedImage}
+          css={logoStyles}
+        />
+      </Link>
     </header>
   );
 };

--- a/packages/react-components/src/molecules/__tests__/Header.test.tsx
+++ b/packages/react-components/src/molecules/__tests__/Header.test.tsx
@@ -37,3 +37,11 @@ it('does not render an opaque background when set to transparent', () => {
     findParentWithStyle(getByAltText(/asap.+logo/i), 'backgroundColor'),
   ).toBe(null);
 });
+
+it('enables the header link when user is onboarded', () => {
+  const { container, rerender } = render(<Header enabled={true} />);
+  expect(container.querySelector('a')).toBeDefined();
+
+  rerender(<Header enabled={false} />);
+  expect(container.querySelector('a')).toBeNull();
+});

--- a/packages/react-components/src/molecules/__tests__/Header.test.tsx
+++ b/packages/react-components/src/molecules/__tests__/Header.test.tsx
@@ -40,8 +40,8 @@ it('does not render an opaque background when set to transparent', () => {
 
 it('enables the header link when user is onboarded', () => {
   const { container, rerender } = render(<Header enabled={true} />);
-  expect(container.querySelector('a')).toBeDefined();
+  expect(container.querySelector('a')).toHaveAttribute('href', '/');
 
   rerender(<Header enabled={false} />);
-  expect(container.querySelector('a')).toBeNull();
+  expect(container.querySelector('a')).not.toHaveAttribute('href', '');
 });

--- a/packages/react-components/src/organisms/MainNavigation.tsx
+++ b/packages/react-components/src/organisms/MainNavigation.tsx
@@ -42,7 +42,6 @@ const containerStyles = css({
 const listStyles = css({
   listStyle: 'none',
   margin: 0,
-
   boxSizing: 'border-box',
   padding: `${12 / perRem}em`,
   paddingTop: `max(${12 / perRem}em, ${vminLinearCalc(
@@ -54,31 +53,55 @@ const listStyles = css({
   )})`,
 });
 
-const MainNavigation: React.FC = () => (
+export interface MainNavigationProps {
+  readonly userOnboarded: boolean;
+}
+
+const MainNavigation: React.FC<MainNavigationProps> = ({ userOnboarded }) => (
   <nav css={containerStyles}>
     <ul css={listStyles}>
       <li>
-        <NavigationLink href={network({}).$} icon={networkIcon}>
+        <NavigationLink
+          href={network({}).$}
+          icon={networkIcon}
+          enabled={userOnboarded}
+        >
           Network
         </NavigationLink>
       </li>
       <li>
-        <NavigationLink href={sharedResearch({}).$} icon={libraryIcon}>
+        <NavigationLink
+          href={sharedResearch({}).$}
+          icon={libraryIcon}
+          enabled={userOnboarded}
+        >
           Shared Research
         </NavigationLink>
       </li>
       <li>
-        <NavigationLink href={news({}).$} icon={newsIcon}>
+        <NavigationLink
+          href={news({}).$}
+          icon={newsIcon}
+          enabled={userOnboarded}
+        >
           News
         </NavigationLink>
       </li>
       <li>
-        <NavigationLink href={events({}).$} icon={calendarIcon}>
+        <NavigationLink
+          href={events({}).$}
+          icon={calendarIcon}
+          enabled={userOnboarded}
+        >
           Calendar and Events
         </NavigationLink>
       </li>
       <li>
-        <NavigationLink href={discover({}).$} icon={discoverIcon}>
+        <NavigationLink
+          href={discover({}).$}
+          icon={discoverIcon}
+          enabled={userOnboarded}
+        >
           Discover ASAP
         </NavigationLink>
       </li>

--- a/packages/react-components/src/organisms/MenuHeader.tsx
+++ b/packages/react-components/src/organisms/MenuHeader.tsx
@@ -36,10 +36,12 @@ const headerSpaceStyles = css({
 });
 
 interface MenuHeaderProps {
+  enabled?: boolean;
   menuOpen?: boolean;
   onToggleMenu?: () => void;
 }
 const MenuHeader: React.FC<MenuHeaderProps> = ({
+  enabled = true,
   menuOpen = false,
   onToggleMenu = noop,
 }) => (
@@ -47,7 +49,7 @@ const MenuHeader: React.FC<MenuHeaderProps> = ({
     <div css={[menuButtonStyles]}>
       <MenuButton open={menuOpen} onClick={() => onToggleMenu()} />
     </div>
-    <Header />
+    <Header enabled={enabled} />
     <div role="presentation" css={[headerSpaceStyles]} />
   </div>
 );

--- a/packages/react-components/src/organisms/UserNavigation.tsx
+++ b/packages/react-components/src/organisms/UserNavigation.tsx
@@ -48,6 +48,7 @@ export interface UserNavigationProps {
   readonly teams: ReadonlyArray<{ name: string; href: string }>;
   readonly aboutHref: string;
 }
+
 const UserNavigation: React.FC<UserNavigationProps> = ({
   userOnboarded = true,
   userProfileHref,

--- a/packages/react-components/src/organisms/UserNavigation.tsx
+++ b/packages/react-components/src/organisms/UserNavigation.tsx
@@ -43,11 +43,13 @@ const bottomLinksStyles = css({
 });
 
 export interface UserNavigationProps {
+  readonly userOnboarded: boolean;
   readonly userProfileHref: string;
   readonly teams: ReadonlyArray<{ name: string; href: string }>;
   readonly aboutHref: string;
 }
 const UserNavigation: React.FC<UserNavigationProps> = ({
+  userOnboarded,
   userProfileHref,
   teams,
   aboutHref,
@@ -61,7 +63,7 @@ const UserNavigation: React.FC<UserNavigationProps> = ({
       </li>
       {teams.map(({ name, href }) => (
         <li key={href}>
-          <NavigationLink href={href} icon={teamIcon}>
+          <NavigationLink href={href} icon={teamIcon} enabled={userOnboarded}>
             My Team: {name}
           </NavigationLink>
         </li>

--- a/packages/react-components/src/organisms/UserNavigation.tsx
+++ b/packages/react-components/src/organisms/UserNavigation.tsx
@@ -43,13 +43,13 @@ const bottomLinksStyles = css({
 });
 
 export interface UserNavigationProps {
-  readonly userOnboarded: boolean;
+  readonly userOnboarded?: boolean;
   readonly userProfileHref: string;
   readonly teams: ReadonlyArray<{ name: string; href: string }>;
   readonly aboutHref: string;
 }
 const UserNavigation: React.FC<UserNavigationProps> = ({
-  userOnboarded,
+  userOnboarded = true,
   userProfileHref,
   teams,
   aboutHref,

--- a/packages/react-components/src/organisms/__tests__/MainNavigation.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/MainNavigation.test.tsx
@@ -6,9 +6,12 @@ import { findParentWithStyle } from '@asap-hub/dom-test-utils';
 import MainNavigation from '../MainNavigation';
 
 it('renders the navigation items', () => {
-  const { getAllByRole } = render(<MainNavigation />);
+  const { getAllByRole } = render(<MainNavigation userOnboarded={true} />);
   expect(
-    getAllByRole('listitem').map(({ textContent }) => textContent),
+    getAllByRole('listitem').map((item) => {
+      expect(item).toHaveStyle('opacity:');
+      return item.textContent;
+    }),
   ).toEqual([
     expect.stringMatching(/network/i),
     expect.stringMatching(/research/i),
@@ -22,7 +25,7 @@ describe('a navigation item', () => {
   it('is highlighted when it links to the current page', () => {
     const { getByTitle, rerender } = render(
       <StaticRouter key={1} location="/somewhere-else">
-        <MainNavigation />
+        <MainNavigation userOnboarded={true} />
       </StaticRouter>,
     );
     expect(
@@ -32,7 +35,7 @@ describe('a navigation item', () => {
 
     rerender(
       <StaticRouter key={2} location={network({}).$}>
-        <MainNavigation />
+        <MainNavigation userOnboarded={true} />
       </StaticRouter>,
     );
     expect(
@@ -44,7 +47,7 @@ describe('a navigation item', () => {
   it('is highlighted when the current page is in the section it links to', () => {
     const { getByTitle, rerender } = render(
       <StaticRouter key={1} location="/somewhere-else">
-        <MainNavigation />
+        <MainNavigation userOnboarded={true} />
       </StaticRouter>,
     );
     expect(
@@ -54,12 +57,20 @@ describe('a navigation item', () => {
 
     rerender(
       <StaticRouter key={2} location={network({}).groups({}).$}>
-        <MainNavigation />
+        <MainNavigation userOnboarded={true} />
       </StaticRouter>,
     );
     expect(
       findParentWithStyle(getByTitle(/network/i), 'backgroundColor')
         ?.backgroundColor,
     ).toMatchInlineSnapshot(`"rgba(122, 210, 169, 0.18)"`);
+  });
+
+  it('is disabled when the current user is not onboarded', () => {
+    const { getAllByRole } = render(<MainNavigation userOnboarded={false} />);
+
+    getAllByRole('listitem').map((item) =>
+      expect(item).toHaveStyle('opacity: 0,3'),
+    );
   });
 });

--- a/packages/react-components/src/organisms/__tests__/MenuHeader.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/MenuHeader.test.tsx
@@ -17,3 +17,11 @@ it('triggers the menu toggle event', () => {
   userEvent.click(getByLabelText(/toggle menu/i));
   expect(handleToggleMenu).toHaveBeenCalledTimes(1);
 });
+
+it('enables the header link when user is onboarded', () => {
+  const { container, rerender } = render(<MenuHeader enabled={true} />);
+  expect(container.querySelector('a')).toBeDefined();
+
+  rerender(<MenuHeader enabled={false} />);
+  expect(container.querySelector('a')).toBeNull();
+});

--- a/packages/react-components/src/organisms/__tests__/UserNavigation.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/UserNavigation.test.tsx
@@ -4,6 +4,7 @@ import { render } from '@testing-library/react';
 import UserNavigation from '../UserNavigation';
 
 const props: ComponentProps<typeof UserNavigation> = {
+  userOnboarded: false,
   userProfileHref: '/profile',
   teams: [
     { name: 'Team 1', href: '/team-1' },
@@ -41,4 +42,18 @@ it('applies the passed href', () => {
       /profile/i.test(textContent ?? ''),
     ),
   ).toHaveAttribute('href', '/profile');
+});
+
+it('enables My team link when user is onboarded', () => {
+  const { getAllByText, rerender } = render(
+    <UserNavigation {...props} userOnboarded={false} />,
+  );
+  getAllByText(/^My team:/i).map((groupItem) =>
+    expect(groupItem).toHaveStyle('opacity: 0,3'),
+  );
+
+  rerender(<UserNavigation {...props} userOnboarded={true} />);
+  getAllByText(/^My team:/i).map((groupItem) =>
+    expect(groupItem).toHaveStyle('opacity:'),
+  );
 });

--- a/packages/react-components/src/organisms/__tests__/UserNavigation.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/UserNavigation.test.tsx
@@ -46,7 +46,11 @@ it('applies the passed href', () => {
 
 it('enables My team link when user is onboarded', () => {
   const { getAllByText, rerender } = render(
-    <UserNavigation {...props} userOnboarded={false} />,
+    <UserNavigation
+      {...props}
+      userOnboarded={false}
+      teams={[{ name: 'Team 1', href: '/team-1' }]}
+    />,
   );
   getAllByText(/^My team:/i).map((groupItem) =>
     expect(groupItem).toHaveStyle('opacity: 0,3'),

--- a/packages/react-components/src/templates/Layout.tsx
+++ b/packages/react-components/src/templates/Layout.tsx
@@ -222,7 +222,7 @@ const Layout: FC<LayoutProps> = ({
           css={[menuStyles, menuShown && menuMenuShownStyles, mainMenuStyles]}
         >
           <Suspense fallback={<Loading />}>
-            <MainNavigation />
+            <MainNavigation userOnboarded={userNavProps.userOnboarded} />
           </Suspense>
         </div>
         <div
@@ -234,7 +234,11 @@ const Layout: FC<LayoutProps> = ({
           ]}
         >
           <Suspense fallback={<Loading />}>
-            <UserNavigation {...userNavProps} />
+            <UserNavigation
+              userProfileHref={userNavProps.userProfileHref}
+              teams={userNavProps.teams}
+              aboutHref={userNavProps.aboutHref}
+            />
           </Suspense>
         </div>
       </article>

--- a/packages/react-components/src/templates/Layout.tsx
+++ b/packages/react-components/src/templates/Layout.tsx
@@ -235,11 +235,7 @@ const Layout: FC<LayoutProps> = ({
           ]}
         >
           <Suspense fallback={<Loading />}>
-            <UserNavigation
-              userProfileHref={userNavProps.userProfileHref}
-              teams={userNavProps.teams}
-              aboutHref={userNavProps.aboutHref}
-            />
+            <UserNavigation {...userNavProps} />
           </Suspense>
         </div>
       </article>

--- a/packages/react-components/src/templates/Layout.tsx
+++ b/packages/react-components/src/templates/Layout.tsx
@@ -200,6 +200,7 @@ const Layout: FC<LayoutProps> = ({
         {/* order relevant for overlap */}
         <div css={[headerStyles, menuShown && headerMenuShownStyles]}>
           <MenuHeader
+            enabled={userNavProps.userOnboarded}
             menuOpen={menuShown}
             onToggleMenu={() => setMenuShown(!menuShown)}
           />

--- a/packages/react-components/src/templates/__tests__/Layout.browser-test.tsx
+++ b/packages/react-components/src/templates/__tests__/Layout.browser-test.tsx
@@ -8,7 +8,7 @@ import { largeDesktopScreen } from '../../pixels';
 
 const props: ComponentProps<typeof Layout> = {
   children: 'Content',
-
+  userOnboarded: true,
   userProfileHref: '/profile',
   teams: [],
   aboutHref: '/about',

--- a/packages/react-components/src/templates/__tests__/Layout.test.tsx
+++ b/packages/react-components/src/templates/__tests__/Layout.test.tsx
@@ -7,7 +7,7 @@ import Layout from '../Layout';
 
 const props: ComponentProps<typeof Layout> = {
   children: 'Content',
-
+  userOnboarded: true,
   userProfileHref: '/profile',
   teams: [],
   aboutHref: '/about',


### PR DESCRIPTION
https://trello.com/c/Udf2NtaX/1302-disable-nav-bar-items-for-not-onboarded-users-with-incomplete-profile
## Requirements
- [x] main navbar items are disabled and show no interaction
- [x] there is no link cursor in the ASAP logo
- [x] on the user's nav bar "My team" button should be disabled