### PR TITLE
fix: update link styles

### DIFF
--- a/packages/react-components/src/atoms/Link.tsx
+++ b/packages/react-components/src/atoms/Link.tsx
@@ -8,9 +8,15 @@ import { Anchor } from '.';
 
 const styles = css({
   textDecoration: 'underline',
+  ':hover': {
+    textDecoration: 'none',
+  },
 });
 export const themeStyles: Record<ThemeVariant, SerializedStyles> = {
-  light: css({ color: fern.rgb, ':active': { color: pine.rgb } }),
+  light: css({
+    color: fern.rgb,
+    ':active, :hover': { color: pine.rgb },
+  }),
   grey: css({ color: fern.rgb, ':active': { color: pine.rgb } }),
   dark: css({ color: paper.rgb, ':active': { color: paper.rgb } }),
 };

--- a/packages/react-components/src/atoms/Link.tsx
+++ b/packages/react-components/src/atoms/Link.tsx
@@ -12,6 +12,7 @@ const styles = css({
     textDecoration: 'none',
   },
 });
+
 export const themeStyles: Record<ThemeVariant, SerializedStyles> = {
   light: css({
     color: fern.rgb,

--- a/packages/react-components/src/molecules/ExternalLink.tsx
+++ b/packages/react-components/src/molecules/ExternalLink.tsx
@@ -4,6 +4,7 @@ import { Anchor } from '../atoms';
 import { externalLinkIcon } from '../icons';
 import { fern, pine } from '../colors';
 import { mobileScreen, perRem } from '../pixels';
+import { themeStyles as linkStyles } from '../atoms/Link';
 
 const containerStyles = css({
   display: 'flex',
@@ -45,6 +46,10 @@ const textStyles = css({
   [`@media (max-width: ${mobileScreen.max}px)`]: {
     display: 'none',
   },
+  textDecoration: 'underline',
+  ':hover': {
+    textDecoration: 'none',
+  },
 });
 
 type ExternalLinkProps = {
@@ -61,7 +66,7 @@ const ExternalLink: React.FC<ExternalLinkProps> = ({
     <Anchor href={href}>
       <div css={styles}>
         {icon}
-        <div css={textStyles}>{label}</div>
+        <div css={[textStyles, linkStyles]}>{label}</div>
       </div>
     </Anchor>
   </div>


### PR DESCRIPTION
https://trello.com/c/gWaDbP7V/880-as-a-user-i-want-to-better-identify-links-states-hover-visited-clicked

This only updates the link's colours and text-decoration. There's an inconsistency regarding the icon placement between the components External Links and External Link on Card (see below) that will be tackled on a different ticket. 

![image (1)](https://user-images.githubusercontent.com/87698274/127291148-b38eab44-fd2d-4170-be3b-cdf06b42ed17.png)
![image](https://user-images.githubusercontent.com/87698274/127291155-7b5cf83b-8f72-438a-9bb8-3ad7d6a0baf8.png)
