### PR TITLE
fix: link styles

### DIFF
--- a/packages/react-components/src/atoms/Anchor.tsx
+++ b/packages/react-components/src/atoms/Anchor.tsx
@@ -8,13 +8,7 @@ import { useHasRouter } from '../routing';
 const resetStyles = css({
   outline: 'none',
   textDecoration: 'none',
-  ':hover, :focus': {
-    textDecoration: 'none',
-  },
   color: 'unset',
-  ':active': {
-    color: 'unset',
-  },
 });
 
 // Lint rules don't understand abstractions ...

--- a/packages/react-components/src/atoms/Link.tsx
+++ b/packages/react-components/src/atoms/Link.tsx
@@ -8,11 +8,15 @@ import { Anchor } from '.';
 
 const styles = css({
   textDecoration: 'underline',
+  ':hover': {
+    textDecoration: 'none',
+  },
 });
 export const themeStyles: Record<ThemeVariant, SerializedStyles> = {
   light: css({
     color: fern.rgb,
-    ':active, :hover': { color: pine.rgb },
+    ':hover': { color: pine.rgb },
+    ':active': { color: fern.rgb },
   }),
   grey: css({ color: fern.rgb, ':active': { color: pine.rgb } }),
   dark: css({ color: paper.rgb, ':active': { color: paper.rgb } }),


### PR DESCRIPTION
https://trello.com/c/gWaDbP7V/880-as-a-user-i-want-to-better-identify-links-states-hover-visited-clicked
- hover: dark green and underline
- active: light green
