### PR TITLE
feat: Remove team outputs from group request

### DIFF
--- a/apps/asap-server/src/controllers/groups.ts
+++ b/apps/asap-server/src/controllers/groups.ts
@@ -23,7 +23,7 @@ flatData {
     googleDrive
   }
   teams {
-    ${getGraphQLQueryTeam({ researchOutputsWithTeams: false })}
+    ${getGraphQLQueryTeam({ withResearchOutputs: false })}
   }
   leaders{
     role

--- a/apps/asap-server/src/controllers/teams.ts
+++ b/apps/asap-server/src/controllers/teams.ts
@@ -21,9 +21,11 @@ import { createURL, sanitiseForSquidex } from '../utils/squidex';
 import { GraphqlFetchOptions } from '../utils/types';
 
 export const getGraphQLQueryTeam = ({
-  researchOutputsWithTeams,
+  withResearchOutputs = true,
+  researchOutputsWithTeams = true,
 }: {
-  researchOutputsWithTeams: boolean;
+  withResearchOutputs?: boolean;
+  researchOutputsWithTeams?: boolean;
 }): string => `
 id
 created
@@ -31,8 +33,12 @@ lastModified
 flatData {
   applicationNumber
   displayName
-  outputs {
+  ${
+    withResearchOutputs
+      ? `outputs {
     ${getGraphQLQueryResearchOutput({ withTeams: researchOutputsWithTeams })}
+  }`
+      : ''
   }
   projectSummary
   projectTitle

--- a/apps/asap-server/test/fixtures/groups.fixtures.ts
+++ b/apps/asap-server/test/fixtures/groups.fixtures.ts
@@ -4,7 +4,6 @@ import {
   ResponseFetchGroups,
   ResponseFetchGroup,
 } from '../../src/controllers/groups';
-import { getSquidexResearchOutputGraphqlResponseAuthors } from './research-output.fixtures';
 
 export const queryGroupsResponse: { data: ResponseFetchGroups } = {
   data: {
@@ -51,26 +50,6 @@ export const queryGroupsResponse: { data: ResponseFetchGroups } = {
                 flatData: {
                   applicationNumber: 'ASAP-000592',
                   displayName: 'Lee, M',
-                  outputs: [
-                    {
-                      id: 'output-id-1',
-                      created: '2020-12-11T14:33:18.000Z',
-                      flatData: {
-                        link: null,
-                        publishDate: null,
-                        addedDate: null,
-                        title: 'Proposal',
-                        type: 'Proposal',
-                        tags: ['test', 'tag'],
-                        accessInstructions: 'some access instructions',
-                        sharingStatus: 'Network Only',
-                        asapFunded: 'No',
-                        usedInAPublication: 'No',
-                        authors:
-                          getSquidexResearchOutputGraphqlResponseAuthors(),
-                      },
-                    },
-                  ],
                   projectSummary: null,
                   projectTitle:
                     'Senescence in Parkinson’s disease and related disorders',


### PR DESCRIPTION
After the team outputs have been removed from group response (see: https://github.com/yldio/asap-hub/pull/931) this PR removes the outputs from the request to the data store (squidex) as the data is no longer used.