### PR TITLE
fix: Hide tools and non-onboarded users

### DIFF
--- a/apps/asap-server/src/controllers/teams.ts
+++ b/apps/asap-server/src/controllers/teams.ts
@@ -102,6 +102,7 @@ export type FetchTeamsOptions = {
   search?: string;
   filter?: string | string[];
   // select team IDs of which tools should be returned
+  // leave undefined to return all teams' tools
   showTeamTools?: string[];
 };
 
@@ -181,7 +182,7 @@ export default class Teams implements TeamController {
 
         return {
           ...parsedTeam,
-          tools: [],
+          tools: undefined,
         };
       }),
     };
@@ -208,7 +209,7 @@ export default class Teams implements TeamController {
     if (options?.showTools === false) {
       return {
         ...parsedTeam,
-        tools: [],
+        tools: undefined,
       };
     }
 

--- a/apps/asap-server/src/controllers/teams.ts
+++ b/apps/asap-server/src/controllers/teams.ts
@@ -44,7 +44,7 @@ flatData {
     url
   }
 }
-referencingUsersContents {
+referencingUsersContents(filter: "data/onboarded/iv eq true") {
     ${GraphQLQueryUser}
 }`;
 

--- a/apps/asap-server/src/controllers/teams.ts
+++ b/apps/asap-server/src/controllers/teams.ts
@@ -67,7 +67,7 @@ export const buildGraphQLQueryFetchTeam = (): string => `
       ${getGraphQLQueryTeam({
         researchOutputsWithTeams: false,
       })}
-      
+
     }
   }
 `;
@@ -91,7 +91,10 @@ export interface TeamController {
     search?: string;
     filter?: string | string[];
   }) => Promise<ListTeamResponse>;
-  fetchById: (teamId: string) => Promise<TeamResponse>;
+  fetchById: (
+    teamId: string,
+    options?: FetchTeamOptions,
+  ) => Promise<TeamResponse>;
 }
 
 export default class Teams implements TeamController {
@@ -166,7 +169,10 @@ export default class Teams implements TeamController {
     };
   }
 
-  async fetchById(teamId: string): Promise<TeamResponse> {
+  async fetchById(
+    teamId: string,
+    options?: FetchTeamOptions,
+  ): Promise<TeamResponse> {
     const query = buildGraphQLQueryFetchTeam();
     const teamResponse = await this.client.request<
       ResponseFetchTeam,
@@ -179,6 +185,19 @@ export default class Teams implements TeamController {
       throw Boom.notFound();
     }
 
-    return parseGraphQLTeam(team);
+    const parsedTeam = parseGraphQLTeam(team);
+
+    if (options?.showTools === false) {
+      return {
+        ...parsedTeam,
+        tools: [],
+      };
+    }
+
+    return parsedTeam;
   }
 }
+
+type FetchTeamOptions = {
+  showTools: boolean;
+};

--- a/apps/asap-server/src/controllers/teams.ts
+++ b/apps/asap-server/src/controllers/teams.ts
@@ -96,7 +96,7 @@ type FetchTeamOptions = {
   showTools: boolean;
 };
 
-type FetchTeamsOptions = {
+export type FetchTeamsOptions = {
   take: number;
   skip: number;
   search?: string;

--- a/apps/asap-server/src/entities/team.ts
+++ b/apps/asap-server/src/entities/team.ts
@@ -79,12 +79,12 @@ export const parseGraphQLTeam = (team: GraphqlTeam): TeamResponse => {
       parseGraphQLTeamMember(user, team.id),
     ) || [];
 
-  // const tools =
-  //   team?.flatData?.tools?.map(({ name, description, url }) => ({
-  //     name,
-  //     url,
-  //     description: description ?? undefined,
-  //   })) || [];
+  const tools =
+    team?.flatData?.tools?.map(({ name, description, url }) => ({
+      name,
+      url,
+      description: description ?? undefined,
+    })) || [];
 
   const outputs: ResearchOutputResponse[] = flatOutputs
     .map((o) => {
@@ -113,7 +113,7 @@ export const parseGraphQLTeam = (team: GraphqlTeam): TeamResponse => {
     lastModifiedDate: parseDate(team.lastModified).toISOString(),
     skills: team.flatData?.skills || [],
     outputs,
-    tools: undefined,
+    tools,
     pointOfContact: members.find(({ role }) => role === 'Project Manager'),
     members: members.sort((a, b) => priorities[a.role] - priorities[b.role]),
     projectTitle: team.flatData?.projectTitle || '',

--- a/apps/asap-server/src/entities/team.ts
+++ b/apps/asap-server/src/entities/team.ts
@@ -80,7 +80,7 @@ export const parseGraphQLTeam = (team: GraphqlTeam): TeamResponse => {
     ) || [];
 
   const tools =
-    team?.flatData?.tools?.map(({ name, description, url }) => ({
+    team.flatData?.tools?.map(({ name, description, url }) => ({
       name,
       url,
       description: description ?? undefined,

--- a/apps/asap-server/src/routes/teams.route.ts
+++ b/apps/asap-server/src/routes/teams.route.ts
@@ -30,7 +30,10 @@ export const teamRouteFactory = (
       filter?: string[] | string;
     };
 
-    const result = await teamsController.fetch(options);
+    const result = await teamsController.fetch({
+      ...options,
+      showTeamTools: req.loggedInUser?.teams.map((team) => team.id),
+    });
 
     res.json(result);
   });

--- a/apps/asap-server/src/routes/teams.route.ts
+++ b/apps/asap-server/src/routes/teams.route.ts
@@ -39,7 +39,11 @@ export const teamRouteFactory = (
     const { params } = req;
     const { teamId } = framework.validate('parameters', params, paramSchema);
 
-    const result = await teamsController.fetchById(teamId);
+    const showTools = !!req.loggedInUser?.teams.find(
+      (team) => team.id === teamId,
+    );
+
+    const result = await teamsController.fetchById(teamId, { showTools });
 
     res.json(result);
   });

--- a/apps/asap-server/src/routes/teams.route.ts
+++ b/apps/asap-server/src/routes/teams.route.ts
@@ -1,9 +1,14 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import { Router } from 'express';
+import { Router, Response } from 'express';
 import { framework } from '@asap-hub/services-common';
 import Joi from '@hapi/joi';
 import Boom from '@hapi/boom';
-import { TeamPatchRequest } from '@asap-hub/model';
+import {
+  ListGroupResponse,
+  ListTeamResponse,
+  TeamPatchRequest,
+  TeamResponse,
+} from '@asap-hub/model';
 
 import { TeamController } from '../controllers/teams';
 import { teamUpdateSchema } from '../entities/team';
@@ -16,7 +21,7 @@ export const teamRouteFactory = (
 ): Router => {
   const teamRoutes = Router();
 
-  teamRoutes.get('/teams', async (req, res) => {
+  teamRoutes.get('/teams', async (req, res: Response<ListTeamResponse>) => {
     const { query } = req;
 
     const options = framework.validate(
@@ -38,7 +43,7 @@ export const teamRouteFactory = (
     res.json(result);
   });
 
-  teamRoutes.get('/teams/:teamId', async (req, res) => {
+  teamRoutes.get('/teams/:teamId', async (req, res: Response<TeamResponse>) => {
     const { params } = req;
     const { teamId } = framework.validate('parameters', params, paramSchema);
 
@@ -51,39 +56,45 @@ export const teamRouteFactory = (
     res.json(result);
   });
 
-  teamRoutes.patch('/teams/:teamId', async (req, res) => {
-    const { body, params } = req;
+  teamRoutes.patch(
+    '/teams/:teamId',
+    async (req, res: Response<TeamResponse>) => {
+      const { body, params } = req;
 
-    const { teamId } = framework.validate('parameters', params, paramSchema);
-    const { tools } = framework.validate(
-      'payload',
-      body,
-      teamUpdateSchema,
-    ) as TeamPatchRequest;
+      const { teamId } = framework.validate('parameters', params, paramSchema);
+      const { tools } = framework.validate(
+        'payload',
+        body,
+        teamUpdateSchema,
+      ) as TeamPatchRequest;
 
-    if (!req.loggedInUser!.teams.find(({ id }) => id === teamId)) {
-      throw Boom.forbidden();
-    }
+      if (!req.loggedInUser!.teams.find(({ id }) => id === teamId)) {
+        throw Boom.forbidden();
+      }
 
-    const result = await teamsController.update(teamId, tools);
+      const result = await teamsController.update(teamId, tools);
 
-    res.json(result);
-  });
+      res.json(result);
+    },
+  );
 
-  teamRoutes.get('/teams/:teamId/groups', async (req, res) => {
-    const { query, params } = req;
+  teamRoutes.get(
+    '/teams/:teamId/groups',
+    async (req, res: Response<ListGroupResponse>) => {
+      const { query, params } = req;
 
-    const { teamId } = framework.validate('parameters', params, paramSchema);
-    const options = framework.validate(
-      'query',
-      query,
-      querySchema,
-    ) as unknown as FetchOptions;
+      const { teamId } = framework.validate('parameters', params, paramSchema);
+      const options = framework.validate(
+        'query',
+        query,
+        querySchema,
+      ) as unknown as FetchOptions;
 
-    const result = await groupsController.fetchByTeamId(teamId, options);
+      const result = await groupsController.fetchByTeamId(teamId, options);
 
-    res.json(result);
-  });
+      res.json(result);
+    },
+  );
 
   return teamRoutes;
 };

--- a/apps/asap-server/test/controllers/teams.test.ts
+++ b/apps/asap-server/test/controllers/teams.test.ts
@@ -309,6 +309,28 @@ describe('Team controller', () => {
     });
 
     describe('Tools', () => {
+      test('Should return the tools as an empty array when they are defined as null in squidex', async () => {
+        const teamId = 'team-id-1';
+
+        const tools = null;
+
+        nock(config.baseUrl)
+          .post(`/api/content/${config.appName}/graphql`, {
+            query: buildGraphQLQueryFetchTeam(),
+            variables: {
+              id: teamId,
+            },
+          })
+          .reply(200, getGraphQlTeamResponse(tools));
+
+        const result = await teams.fetchById(teamId);
+
+        expect(result).toEqual({
+          ...fetchTeamByIdExpectation,
+          tools: [],
+        });
+      });
+
       test('Should return the tools when the showTools parameter is missing', async () => {
         const teamId = 'team-id-1';
 

--- a/apps/asap-server/test/controllers/teams.test.ts
+++ b/apps/asap-server/test/controllers/teams.test.ts
@@ -246,7 +246,7 @@ describe('Team controller', () => {
       expect(result).toEqual(fetchTeamByIdExpectation);
     });
 
-    test.skip('Should return team information when user is part of the team', async () => {
+    test('Should return team information when user is part of the team', async () => {
       const teamId = 'team-id-1';
 
       const tools = [
@@ -390,7 +390,7 @@ describe('Team controller', () => {
       expect(result).toEqual(updateExpectation);
     });
 
-    test.skip('Should remove a field are return the team', async () => {
+    test('Should remove a field are return the team', async () => {
       const teamId = 'team-id-1';
       const tools = [
         {

--- a/apps/asap-server/test/controllers/teams.test.ts
+++ b/apps/asap-server/test/controllers/teams.test.ts
@@ -246,37 +246,65 @@ describe('Team controller', () => {
       expect(result).toEqual(fetchTeamByIdExpectation);
     });
 
-    test('Should return team information when user is part of the team', async () => {
-      const teamId = 'team-id-1';
+    describe('Tools', () => {
+      test('Should return the tools when the showTools parameter is missing', async () => {
+        const teamId = 'team-id-1';
 
-      const tools = [
-        {
-          url: 'https://example.com',
-          name: 'good link',
-          // squidex graphql api typings aren't perfect
-          description: null as unknown as undefined,
-        },
-      ];
-
-      nock(config.baseUrl)
-        .post(`/api/content/${config.appName}/graphql`, {
-          query: buildGraphQLQueryFetchTeam(),
-          variables: {
-            id: teamId,
-          },
-        })
-        .reply(200, getGraphQlTeamResponse(tools));
-
-      const result = await teams.fetchById(teamId);
-
-      expect(result).toEqual({
-        ...fetchTeamByIdExpectation,
-        tools: [
+        const tools = [
           {
             url: 'https://example.com',
             name: 'good link',
+            // squidex graphql api typings aren't perfect
+            description: null as unknown as undefined,
           },
-        ],
+        ];
+
+        nock(config.baseUrl)
+          .post(`/api/content/${config.appName}/graphql`, {
+            query: buildGraphQLQueryFetchTeam(),
+            variables: {
+              id: teamId,
+            },
+          })
+          .reply(200, getGraphQlTeamResponse(tools));
+
+        const result = await teams.fetchById(teamId);
+
+        expect(result).toEqual({
+          ...fetchTeamByIdExpectation,
+          tools: [
+            {
+              url: 'https://example.com',
+              name: 'good link',
+            },
+          ],
+        });
+      });
+
+      test('Should NOT return the tools when the "showTools" parameter is set to false', async () => {
+        const teamId = 'team-id-1';
+
+        const tools = [
+          {
+            url: 'https://example.com',
+            name: 'good link',
+            // squidex graphql api typings aren't perfect
+            description: null as unknown as undefined,
+          },
+        ];
+
+        nock(config.baseUrl)
+          .post(`/api/content/${config.appName}/graphql`, {
+            query: buildGraphQLQueryFetchTeam(),
+            variables: {
+              id: teamId,
+            },
+          })
+          .reply(200, getGraphQlTeamResponse(tools));
+
+        const result = await teams.fetchById(teamId, { showTools: false });
+
+        expect(result.tools).toEqual([]);
       });
     });
 

--- a/apps/asap-server/test/fixtures/groups.fixtures.ts
+++ b/apps/asap-server/test/fixtures/groups.fixtures.ts
@@ -59,7 +59,12 @@ export const queryGroupsResponse: { data: ResponseFetchGroups } = {
                       id: 'output-id-1',
                     },
                   ],
-                  tools: undefined,
+                  tools: [
+                    {
+                      name: 'dropbox',
+                      url: '  https://example.com/secure-comms',
+                    },
+                  ],
                 },
               },
             ],
@@ -243,7 +248,12 @@ export const listGroupsResponse: ListGroupResponse = {
           projectTitle:
             'Senescence in Parkinson’s disease and related disorders',
           proposalURL: 'output-id-1',
-          tools: undefined,
+          tools: [
+            {
+              name: 'dropbox',
+              url: '  https://example.com/secure-comms',
+            },
+          ],
         },
       ],
       leaders: [

--- a/apps/asap-server/test/fixtures/teams.fixtures.ts
+++ b/apps/asap-server/test/fixtures/teams.fixtures.ts
@@ -53,7 +53,7 @@ export const referencingUsersContentsResponse = ({
   },
 ];
 
-export const graphQlTeamsResponse: { data: ResponseFetchTeams } = {
+export const getGraphQlTeamsResponse = (): { data: ResponseFetchTeams } => ({
   data: {
     queryTeamsContentsWithTotal: {
       total: 3,
@@ -322,18 +322,20 @@ export const graphQlTeamsResponse: { data: ResponseFetchTeams } = {
       ],
     },
   },
-};
+});
 
 export const graphQlTeamsResponseSingle: { data: ResponseFetchTeams } = {
   data: {
     queryTeamsContentsWithTotal: {
       total: 1,
-      items: [graphQlTeamsResponse.data.queryTeamsContentsWithTotal.items[0]],
+      items: [
+        getGraphQlTeamsResponse().data.queryTeamsContentsWithTotal.items[0],
+      ],
     },
   },
 };
 
-export const listTeamResponse: ListTeamResponse = {
+export const getListTeamResponse = (): ListTeamResponse => ({
   total: 3,
   items: [
     {
@@ -478,7 +480,7 @@ export const listTeamResponse: ListTeamResponse = {
       lastModifiedDate: '2020-09-23T20:29:52.000Z',
     },
   ],
-};
+});
 
 export const graphQlTeamResponse: { data: ResponseFetchTeam } = {
   data: {

--- a/apps/asap-server/test/fixtures/teams.fixtures.ts
+++ b/apps/asap-server/test/fixtures/teams.fixtures.ts
@@ -704,7 +704,7 @@ export const getUpdateTeamResponse = (tools: TeamTool[] = []): RestTeam => ({
 });
 
 export const getGraphQlTeamResponse = (
-  tools: TeamTool[] = [],
+  tools: TeamTool[] | null = [],
 ): { data: ResponseFetchTeam } => ({
   data: {
     findTeamsContent: {

--- a/apps/asap-server/test/fixtures/teams.fixtures.ts
+++ b/apps/asap-server/test/fixtures/teams.fixtures.ts
@@ -112,7 +112,13 @@ export const graphQlTeamsResponse: { data: ResponseFetchTeams } = {
                 id: '4cfb1b7b-bafe-4fca-b2ab-197e84d98996',
               },
             ],
-            tools: undefined,
+            tools: [
+              {
+                url: 'testUrl',
+                name: 'slack',
+                description: 'this is a test',
+              },
+            ],
           },
           referencingUsersContents: [
             {
@@ -172,7 +178,7 @@ export const graphQlTeamsResponse: { data: ResponseFetchTeams } = {
               'Mapping the LRRK2 signalling pathway and its interplay with other Parkinson’s disease components',
             skills: [],
             proposal: null,
-            tools: undefined,
+            tools: null,
           },
           referencingUsersContents: [
             {
@@ -266,7 +272,7 @@ export const graphQlTeamsResponse: { data: ResponseFetchTeams } = {
             projectTitle: 'This is good',
             skills: [],
             proposal: null,
-            tools: undefined,
+            tools: null,
           },
           referencingUsersContents: [
             {
@@ -406,7 +412,13 @@ export const listTeamResponse: ListTeamResponse = {
       projectTitle:
         'The genome-microbiome axis in the cause of Parkinson disease: Mechanistic insights and therapeutic implications from experimental models and a genetically stratified patient population.',
       proposalURL: '4cfb1b7b-bafe-4fca-b2ab-197e84d98996',
-      tools: undefined,
+      tools: [
+        {
+          url: 'testUrl',
+          name: 'slack',
+          description: 'this is a test',
+        },
+      ],
     },
     {
       id: 'team-id-2',
@@ -438,7 +450,7 @@ export const listTeamResponse: ListTeamResponse = {
         },
       ],
       lastModifiedDate: '2020-10-26T20:54:00.000Z',
-      tools: undefined,
+      tools: [],
     },
     {
       id: 'team-id-3',
@@ -460,7 +472,7 @@ export const listTeamResponse: ListTeamResponse = {
           ],
         },
       ],
-      tools: undefined,
+      tools: [],
       projectTitle: 'This is good',
       projectSummary: 'Its good',
       lastModifiedDate: '2020-09-23T20:29:52.000Z',
@@ -537,7 +549,7 @@ export const graphQlTeamResponse: { data: ResponseFetchTeam } = {
             id: '4cfb1b7b-bafe-4fca-b2ab-197e84d98996',
           },
         ],
-        tools: undefined,
+        tools: [],
       },
       referencingUsersContents: [
         {
@@ -566,7 +578,7 @@ export const graphQlTeamResponse: { data: ResponseFetchTeam } = {
                     lastModified: '2020-11-26T11:56:04Z',
                     flatData: {
                       displayName: 'Schipa, A',
-                      tools: undefined,
+                      tools: [],
                     },
                   },
                 ],
@@ -667,7 +679,7 @@ export const fetchTeamByIdExpectation: TeamResponse = {
   projectTitle:
     'The genome-microbiome axis in the cause of Parkinson disease: Mechanistic insights and therapeutic implications from experimental models and a genetically stratified patient population.',
   proposalURL: '4cfb1b7b-bafe-4fca-b2ab-197e84d98996',
-  tools: undefined,
+  tools: [],
 };
 
 export const getUpdateTeamResponse = (tools: TeamTool[] = []): RestTeam => ({
@@ -942,7 +954,7 @@ export const updateExpectation: TeamResponse = {
   projectTitle:
     'The genome-microbiome axis in the cause of Parkinson disease: Mechanistic insights and therapeutic implications from experimental models and a genetically stratified patient population.',
   proposalURL: '4cfb1b7b-bafe-4fca-b2ab-197e84d98996',
-  tools: undefined,
+  tools: [],
 };
 
 export const teamResponse: TeamResponse = updateExpectation;

--- a/apps/asap-server/test/routes/teams.route.test.ts
+++ b/apps/asap-server/test/routes/teams.route.test.ts
@@ -5,7 +5,7 @@ import { FetchOptions } from '../../src/utils/types';
 import * as fixtures from '../fixtures/groups.fixtures';
 import { groupControllerMock } from '../mocks/group-controller.mock';
 import { teamControllerMock } from '../mocks/team-controller.mock';
-import { listTeamResponse, teamResponse } from '../fixtures/teams.fixtures';
+import { getListTeamResponse, teamResponse } from '../fixtures/teams.fixtures';
 import { AuthHandler } from '../../src/middleware/auth-handler';
 import { userMock } from '../../src/utils/__mocks__/validate-token';
 import { User } from '@asap-hub/auth';
@@ -114,15 +114,15 @@ describe('/teams/ route', () => {
     });
 
     test('Should return the results correctly', async () => {
-      teamControllerMock.fetch.mockResolvedValueOnce(listTeamResponse);
+      teamControllerMock.fetch.mockResolvedValueOnce(getListTeamResponse());
 
       const response = await supertest(app).get('/teams');
 
-      expect(response.body).toEqual(listTeamResponse);
+      expect(response.body).toEqual(getListTeamResponse());
     });
 
     test('Should call the controller with the right parameters', async () => {
-      teamControllerMock.fetch.mockResolvedValueOnce(listTeamResponse);
+      teamControllerMock.fetch.mockResolvedValueOnce(getListTeamResponse());
 
       const expectedParams: FetchOptions = {
         take: 15,


### PR DESCRIPTION
see: https://trello.com/c/ehQe5myf/1547-private-team-tab-team-workspace-is-being-exposed-to-all-users

This PR moves the auth logic to the route layer keeping the controller libraries unaware of the logged-user state.