### PR TITLE
feat: Mark new events as hidden when the status is: cancelled

### DIFF
--- a/apps/asap-server/src/utils/sync-google-event.ts
+++ b/apps/asap-server/src/utils/sync-google-event.ts
@@ -87,6 +87,10 @@ export const syncEventFactory = (
         return await eventsController.update(existingEvent.id, newEvent);
       }
 
+      if (newEvent.status === 'Cancelled') {
+        newEvent.hidden = true;
+      }
+
       logger.info(
         { id: googleEvent.id, event: newEvent },
         'Event not found. Creating.',


### PR DESCRIPTION
see: https://trello.com/c/u0fsA81Z/1383-new-cancelled-events-should-be-hidden-by-default