### PR TITLE
chore: Add google id column to calendar schema

### DIFF
--- a/packages/squidex/schema/schemas/calendars.json
+++ b/packages/squidex/schema/schemas/calendars.json
@@ -84,6 +84,27 @@
         }
       },
       {
+        "name": "googleCalendarId",
+        "isHidden": false,
+        "isLocked": false,
+        "isDisabled": false,
+        "partitioning": "invariant",
+        "properties": {
+          "fieldType": "String",
+          "pattern": "^[a-zA-Z0-9.!#$%&’*+\\/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:.[a-zA-Z0-9-]+)*$",
+          "minLength": 8,
+          "isUnique": true,
+          "inlineEditable": true,
+          "contentType": "Unspecified",
+          "editor": "Input",
+          "label": "Google Calendar ID",
+          "hints": "Make sure this GCal is Public BEFORE adding it. Syncing will NOT work otherwise.",
+          "isRequired": false,
+          "isRequiredOnPublish": false,
+          "isHalfWidth": false
+        }
+      },
+      {
         "name": "color",
         "isHidden": false,
         "isLocked": false,


### PR DESCRIPTION
Re: https://trello.com/c/uTXT3Crm/1412-manage-events-that-belong-to-multiple-calendars
Should go before: https://github.com/yldio/asap-hub/pull/1034