### PR TITLE
feat: Do not throw on subscription failure

### DIFF
--- a/apps/asap-server/src/handlers/calendar/subscribe-handler.ts
+++ b/apps/asap-server/src/handlers/calendar/subscribe-handler.ts
@@ -30,7 +30,7 @@ export const calendarCreatedHandlerFactory =
   ) =>
   async (
     event: EventBridgeEvent<CalendarEventType, WebhookPayload<Calendar>>,
-  ): Promise<'OK'> => {
+  ): Promise<'OK' | 'ERROR'> => {
     logger.debug(JSON.stringify(event, null, 2), 'Event input');
 
     const bodySchema = Joi.object({
@@ -98,7 +98,7 @@ export const calendarCreatedHandlerFactory =
         logger.error(error, 'Error subscribing to the calendar');
         alerts.error(error);
 
-        throw error;
+        return 'ERROR';
       }
 
       return 'OK';

--- a/apps/asap-server/test/handlers/calendar/subscribe-handler.test.ts
+++ b/apps/asap-server/test/handlers/calendar/subscribe-handler.test.ts
@@ -81,13 +81,15 @@ describe('Calendar Webhook', () => {
       );
     });
 
-    test('Should return 502 and alert when the subscription was unsuccessful', async () => {
+    test('Should return "ERROR" and alert when the subscription was unsuccessful, but should not throw', async () => {
       const errorMessage =
         'Channel id 238c6b46-706e-11eb-9439-0242ac130002 not unique';
       const error = new Error(errorMessage);
       subscribe.mockRejectedValueOnce(error);
 
-      await expect(handler(getEvent())).rejects.toThrow(error);
+      const res = await handler(getEvent());
+
+      expect(res).toBe('ERROR');
       expect(alerts.error).toBeCalledWith(error);
     });
 


### PR DESCRIPTION
Changes the subscription handler to return an error message and never throw - this is because we don't want the eventbridge to retry the subscription.