### PR TITLE
fix: Calendar subscription 400 error

### DIFF
--- a/apps/asap-server/src/handlers/calendar/subscribe-handler.ts
+++ b/apps/asap-server/src/handlers/calendar/subscribe-handler.ts
@@ -90,6 +90,15 @@ export const calendarCreatedHandlerFactory =
           payload.id,
         );
 
+        logger.debug(
+          {
+            payloadId: payload.id,
+            resourceId,
+            expirationDate: expiration,
+          },
+          'Attempting to save the resource ID and expiration',
+        );
+
         await calendarController.update(payload.id, {
           resourceId,
           expirationDate: expiration,

--- a/packages/squidex/src/squidex.ts
+++ b/packages/squidex/src/squidex.ts
@@ -205,6 +205,10 @@ export class Squidex<
         .json();
       return res as T;
     } catch (err) {
+      // eslint-disable-next-line no-console
+      console.log(err);
+      // eslint-disable-next-line no-console
+      console.log({ response: JSON.stringify(err.response) });
       if (
         err.response?.statusCode === 400 &&
         err.response?.body.includes('invalid_client')


### PR DESCRIPTION
Fixes the bug whereby the subscription handler is not able to store the resourceId after successful subscription due to squidex error.