### PR TITLE
fix: Teardown job

### DIFF
--- a/serverless.ts
+++ b/serverless.ts
@@ -120,8 +120,17 @@ const serverlessConfig: AWS = {
       {
         Effect: 'Allow',
         Action: 'events:*',
-        Resource:
-          'arn:aws:events:${aws:region}:${aws:accountId}:event-bus/asap-events-${self:provider.stage}',
+        Resource: {
+          'Fn::Join': [
+            ':',
+            [
+              'arn:aws:events',
+              { Ref: 'AWS::Region' },
+              { Ref: 'AWS::AccountId' },
+              'event-bus/asap-events-${self:provider.stage}',
+            ],
+          ],
+        },
       },
     ],
   },


### PR DESCRIPTION
fixes https://trello.com/c/QjGxpJW1/1579-environment-teardown-does-not-work

Replace the `aws:region` and `aws:accountId` references which do not work in teardown command with an old syntax.