### PR TITLE
feat: Forward invitation e-mail bounce

### DIFF
--- a/apps/asap-server/src/config.ts
+++ b/apps/asap-server/src/config.ts
@@ -25,6 +25,7 @@ const {
   EVENT_SOURCE,
   EMAIL_SENDER,
   EMAIL_BCC,
+  EMAIL_RETURN,
 } = process.env;
 
 export const origin = APP_ORIGIN || 'https://dev.hub.asap.science';
@@ -55,5 +56,6 @@ export const algoliaApiKeyTtl = 36060;
 export const sesRegion = SES_REGION || 'eu-west-1';
 export const userInviteSender = EMAIL_SENDER || `"ASAP Hub" <hub@asap.science>`;
 export const userInviteBcc = EMAIL_BCC || 'hub.invites.dev@asap.science';
+export const userInviteReturn = EMAIL_RETURN || 'hub.invites.dev@asap.science';
 export const eventBus = EVENT_BUS || 'asap-events-dev';
 export const eventSource = EVENT_SOURCE || '';

--- a/apps/asap-server/src/gql/graphql.ts
+++ b/apps/asap-server/src/gql/graphql.ts
@@ -1359,23 +1359,23 @@ export type AppQueriesQueryUsersContentsWithTotalArgs = {
 
 /** An asset */
 export type Asset = {
-  /** The date and time when the asset has been created. */
+  /** The timestamp when the object was created. */
   created: Scalars['Instant'];
-  /** The user that has created the asset. */
+  /** The user who created the object. */
   createdBy: Scalars['String'];
-  /** The full info of the user that has created the asset. */
+  /** The user who created the object. */
   createdByUser: User;
   /** The hash of the file. Can be null for old files. */
   fileHash: Scalars['String'];
-  /** The file name. */
+  /** The file name of the asset. */
   fileName: Scalars['String'];
   /** The size of the file in bytes. */
   fileSize: Scalars['Int'];
-  /** The file type. */
+  /** The file type (file extension) of the asset. */
   fileType: Scalars['String'];
   /** The version of the file. */
   fileVersion: Scalars['Int'];
-  /** The id of the asset. */
+  /** The ID of the object. */
   id: Scalars['String'];
   /**
    * Determines if the uploaded file is an image.
@@ -1384,15 +1384,15 @@ export type Asset = {
   isImage: Scalars['Boolean'];
   /** True, when the asset is not public. */
   isProtected: Scalars['Boolean'];
-  /** The date and time when the asset has been modified last. */
+  /** The timestamp when the object was updated the last time. */
   lastModified: Scalars['Instant'];
-  /** The user that has updated the asset last. */
+  /** The user who updated the object the last time. */
   lastModifiedBy: Scalars['String'];
-  /** The full info of the user that has created the asset. */
+  /** The user who updated the object the last time. */
   lastModifiedByUser: User;
   /** The asset metadata. */
   metadata: Maybe<Scalars['JsonScalar']>;
-  /** The text representation of the metadata. */
+  /** The type of the image. */
   metadataText: Scalars['String'];
   /** The mime type. */
   mimeType: Scalars['String'];
@@ -1410,13 +1410,13 @@ export type Asset = {
   slug: Scalars['String'];
   /** The asset tags. */
   tags: Array<Scalars['String']>;
-  /** The thumbnail url to the asset. */
+  /** The thumbnail URL to the asset. */
   thumbnailUrl: Maybe<Scalars['String']>;
   /** The type of the image. */
   type: AssetType;
-  /** The url to the asset. */
+  /** The URL to the asset. */
   url: Scalars['String'];
-  /** The version of the asset. */
+  /** The version of the object (usually GUID). */
   version: Scalars['Int'];
 };
 
@@ -1442,27 +1442,27 @@ export enum AssetType {
 
 /** The structure of a Calendars content type. */
 export type Calendars = Content & {
-  /** The date and time when the content has been created. */
+  /** The timestamp when the object was created. */
   created: Scalars['Instant'];
-  /** The user that has created the content. */
+  /** The user who created the object. */
   createdBy: Scalars['String'];
-  /** The full info of the user that has created the content. */
+  /** The user who created the object. */
   createdByUser: User;
   /** The data of the content. */
   data: CalendarsDataDto;
   /** The flat data of the content. */
   flatData: CalendarsFlatDataDto;
-  /** The id of the content. */
+  /** The ID of the object. */
   id: Scalars['String'];
-  /** The date and time when the content has been modified last. */
+  /** The timestamp when the object was updated the last time. */
   lastModified: Scalars['Instant'];
-  /** The user that has updated the content last. */
+  /** The user who updated the object the last time. */
   lastModifiedBy: Scalars['String'];
-  /** The full info of the user that has updated the content last. */
+  /** The user who updated the object the last time. */
   lastModifiedByUser: User;
   /** The new status of the content. */
   newStatus: Maybe<Scalars['String']>;
-  /** The new status color of the content. */
+  /** The status color of the content. */
   newStatusColor: Maybe<Scalars['String']>;
   /** Query Events content items. */
   referencingEventsContents: Maybe<Array<Events>>;
@@ -1476,9 +1476,9 @@ export type Calendars = Content & {
   status: Scalars['String'];
   /** The status color of the content. */
   statusColor: Scalars['String'];
-  /** The url to the content. */
+  /** The URL to the content. */
   url: Scalars['String'];
-  /** The version of the content. */
+  /** The version of the object (usually GUID). */
   version: Scalars['Int'];
 };
 
@@ -1613,75 +1613,75 @@ export type CalendarsFlatDataDto = {
 
 /** List of Calendars items and total count. */
 export type CalendarsResultDto = {
-  /** The Calendars items. */
+  /** The contents. */
   items: Maybe<Array<Calendars>>;
-  /** The total number of Calendars items. */
+  /** The total count of  contents. */
   total: Scalars['Int'];
 };
 
 /** The structure of all content types. */
 export type Component = {
-  /** The id of the schema. */
+  /** The ID of the schema. */
   schemaId: Scalars['String'];
 };
 
 /** The structure of all content types. */
 export type Content = {
-  /** The date and time when the content has been created. */
+  /** The timestamp when the object was created. */
   created: Scalars['Instant'];
-  /** The user that has created the content. */
+  /** The user who created the object. */
   createdBy: Scalars['String'];
-  /** The id of the content. */
+  /** The ID of the object. */
   id: Scalars['String'];
-  /** The date and time when the content has been modified last. */
+  /** The timestamp when the object was updated the last time. */
   lastModified: Scalars['Instant'];
-  /** The user that has updated the content last. */
+  /** The user who updated the object the last time. */
   lastModifiedBy: Scalars['String'];
   /** The new status of the content. */
   newStatus: Maybe<Scalars['String']>;
-  /** The new status color of the content. */
+  /** The status color of the content. */
   newStatusColor: Maybe<Scalars['String']>;
   /** The status of the content. */
   status: Scalars['String'];
   /** The status color of the content. */
   statusColor: Scalars['String'];
-  /** The url to the content. */
+  /** The URL to the content. */
   url: Scalars['String'];
-  /** The version of the content. */
+  /** The version of the object (usually GUID). */
   version: Scalars['Int'];
 };
 
 /** The structure of a Dashboard content type. */
 export type Dashboard = Content & {
-  /** The date and time when the content has been created. */
+  /** The timestamp when the object was created. */
   created: Scalars['Instant'];
-  /** The user that has created the content. */
+  /** The user who created the object. */
   createdBy: Scalars['String'];
-  /** The full info of the user that has created the content. */
+  /** The user who created the object. */
   createdByUser: User;
   /** The data of the content. */
   data: DashboardDataDto;
   /** The flat data of the content. */
   flatData: DashboardFlatDataDto;
-  /** The id of the content. */
+  /** The ID of the object. */
   id: Scalars['String'];
-  /** The date and time when the content has been modified last. */
+  /** The timestamp when the object was updated the last time. */
   lastModified: Scalars['Instant'];
-  /** The user that has updated the content last. */
+  /** The user who updated the object the last time. */
   lastModifiedBy: Scalars['String'];
-  /** The full info of the user that has updated the content last. */
+  /** The user who updated the object the last time. */
   lastModifiedByUser: User;
   /** The new status of the content. */
   newStatus: Maybe<Scalars['String']>;
-  /** The new status color of the content. */
+  /** The status color of the content. */
   newStatusColor: Maybe<Scalars['String']>;
   /** The status of the content. */
   status: Scalars['String'];
   /** The status color of the content. */
   statusColor: Scalars['String'];
-  /** The url to the content. */
+  /** The URL to the content. */
   url: Scalars['String'];
-  /** The version of the content. */
+  /** The version of the object (usually GUID). */
   version: Scalars['Int'];
 };
 
@@ -1725,43 +1725,43 @@ export type DashboardFlatDataDto = {
 
 /** List of Dashboard items and total count. */
 export type DashboardResultDto = {
-  /** The Dashboard items. */
+  /** The contents. */
   items: Maybe<Array<Dashboard>>;
-  /** The total number of Dashboard items. */
+  /** The total count of  contents. */
   total: Scalars['Int'];
 };
 
 /** The structure of a Discover ASAP content type. */
 export type Discover = Content & {
-  /** The date and time when the content has been created. */
+  /** The timestamp when the object was created. */
   created: Scalars['Instant'];
-  /** The user that has created the content. */
+  /** The user who created the object. */
   createdBy: Scalars['String'];
-  /** The full info of the user that has created the content. */
+  /** The user who created the object. */
   createdByUser: User;
   /** The data of the content. */
   data: DiscoverDataDto;
   /** The flat data of the content. */
   flatData: DiscoverFlatDataDto;
-  /** The id of the content. */
+  /** The ID of the object. */
   id: Scalars['String'];
-  /** The date and time when the content has been modified last. */
+  /** The timestamp when the object was updated the last time. */
   lastModified: Scalars['Instant'];
-  /** The user that has updated the content last. */
+  /** The user who updated the object the last time. */
   lastModifiedBy: Scalars['String'];
-  /** The full info of the user that has updated the content last. */
+  /** The user who updated the object the last time. */
   lastModifiedByUser: User;
   /** The new status of the content. */
   newStatus: Maybe<Scalars['String']>;
-  /** The new status color of the content. */
+  /** The status color of the content. */
   newStatusColor: Maybe<Scalars['String']>;
   /** The status of the content. */
   status: Scalars['String'];
   /** The status color of the content. */
   statusColor: Scalars['String'];
-  /** The url to the content. */
+  /** The URL to the content. */
   url: Scalars['String'];
-  /** The version of the content. */
+  /** The version of the object (usually GUID). */
   version: Scalars['Int'];
 };
 
@@ -1831,9 +1831,9 @@ export type DiscoverFlatDataDto = {
 
 /** List of Discover ASAP items and total count. */
 export type DiscoverResultDto = {
-  /** The Discover ASAP items. */
+  /** The contents. */
   items: Maybe<Array<Discover>>;
-  /** The total number of Discover ASAP items. */
+  /** The total count of  contents. */
   total: Scalars['Int'];
 };
 
@@ -1845,35 +1845,35 @@ export type EntitySavedResultDto = {
 
 /** The structure of a Events content type. */
 export type Events = Content & {
-  /** The date and time when the content has been created. */
+  /** The timestamp when the object was created. */
   created: Scalars['Instant'];
-  /** The user that has created the content. */
+  /** The user who created the object. */
   createdBy: Scalars['String'];
-  /** The full info of the user that has created the content. */
+  /** The user who created the object. */
   createdByUser: User;
   /** The data of the content. */
   data: EventsDataDto;
   /** The flat data of the content. */
   flatData: EventsFlatDataDto;
-  /** The id of the content. */
+  /** The ID of the object. */
   id: Scalars['String'];
-  /** The date and time when the content has been modified last. */
+  /** The timestamp when the object was updated the last time. */
   lastModified: Scalars['Instant'];
-  /** The user that has updated the content last. */
+  /** The user who updated the object the last time. */
   lastModifiedBy: Scalars['String'];
-  /** The full info of the user that has updated the content last. */
+  /** The user who updated the object the last time. */
   lastModifiedByUser: User;
   /** The new status of the content. */
   newStatus: Maybe<Scalars['String']>;
-  /** The new status color of the content. */
+  /** The status color of the content. */
   newStatusColor: Maybe<Scalars['String']>;
   /** The status of the content. */
   status: Scalars['String'];
   /** The status color of the content. */
   statusColor: Scalars['String'];
-  /** The url to the content. */
+  /** The URL to the content. */
   url: Scalars['String'];
-  /** The version of the content. */
+  /** The version of the object (usually GUID). */
   version: Scalars['Int'];
 };
 
@@ -2216,35 +2216,35 @@ export type EventsFlatDataDto = {
 
 /** List of Events items and total count. */
 export type EventsResultDto = {
-  /** The Events items. */
+  /** The contents. */
   items: Maybe<Array<Events>>;
-  /** The total number of Events items. */
+  /** The total count of  contents. */
   total: Scalars['Int'];
 };
 
 /** The structure of a External authors content type. */
 export type ExternalAuthors = Content & {
-  /** The date and time when the content has been created. */
+  /** The timestamp when the object was created. */
   created: Scalars['Instant'];
-  /** The user that has created the content. */
+  /** The user who created the object. */
   createdBy: Scalars['String'];
-  /** The full info of the user that has created the content. */
+  /** The user who created the object. */
   createdByUser: User;
   /** The data of the content. */
   data: ExternalAuthorsDataDto;
   /** The flat data of the content. */
   flatData: ExternalAuthorsFlatDataDto;
-  /** The id of the content. */
+  /** The ID of the object. */
   id: Scalars['String'];
-  /** The date and time when the content has been modified last. */
+  /** The timestamp when the object was updated the last time. */
   lastModified: Scalars['Instant'];
-  /** The user that has updated the content last. */
+  /** The user who updated the object the last time. */
   lastModifiedBy: Scalars['String'];
-  /** The full info of the user that has updated the content last. */
+  /** The user who updated the object the last time. */
   lastModifiedByUser: User;
   /** The new status of the content. */
   newStatus: Maybe<Scalars['String']>;
-  /** The new status color of the content. */
+  /** The status color of the content. */
   newStatusColor: Maybe<Scalars['String']>;
   /** Query Research Outputs content items. */
   referencingResearchOutputsContents: Maybe<Array<ResearchOutputs>>;
@@ -2254,9 +2254,9 @@ export type ExternalAuthors = Content & {
   status: Scalars['String'];
   /** The status color of the content. */
   statusColor: Scalars['String'];
-  /** The url to the content. */
+  /** The URL to the content. */
   url: Scalars['String'];
-  /** The version of the content. */
+  /** The version of the object (usually GUID). */
   version: Scalars['Int'];
 };
 
@@ -2318,43 +2318,43 @@ export type ExternalAuthorsFlatDataDto = {
 
 /** List of External authors items and total count. */
 export type ExternalAuthorsResultDto = {
-  /** The External authors items. */
+  /** The contents. */
   items: Maybe<Array<ExternalAuthors>>;
-  /** The total number of External authors items. */
+  /** The total count of  contents. */
   total: Scalars['Int'];
 };
 
 /** The structure of a Groups content type. */
 export type Groups = Content & {
-  /** The date and time when the content has been created. */
+  /** The timestamp when the object was created. */
   created: Scalars['Instant'];
-  /** The user that has created the content. */
+  /** The user who created the object. */
   createdBy: Scalars['String'];
-  /** The full info of the user that has created the content. */
+  /** The user who created the object. */
   createdByUser: User;
   /** The data of the content. */
   data: GroupsDataDto;
   /** The flat data of the content. */
   flatData: GroupsFlatDataDto;
-  /** The id of the content. */
+  /** The ID of the object. */
   id: Scalars['String'];
-  /** The date and time when the content has been modified last. */
+  /** The timestamp when the object was updated the last time. */
   lastModified: Scalars['Instant'];
-  /** The user that has updated the content last. */
+  /** The user who updated the object the last time. */
   lastModifiedBy: Scalars['String'];
-  /** The full info of the user that has updated the content last. */
+  /** The user who updated the object the last time. */
   lastModifiedByUser: User;
   /** The new status of the content. */
   newStatus: Maybe<Scalars['String']>;
-  /** The new status color of the content. */
+  /** The status color of the content. */
   newStatusColor: Maybe<Scalars['String']>;
   /** The status of the content. */
   status: Scalars['String'];
   /** The status color of the content. */
   statusColor: Scalars['String'];
-  /** The url to the content. */
+  /** The URL to the content. */
   url: Scalars['String'];
-  /** The version of the content. */
+  /** The version of the object (usually GUID). */
   version: Scalars['Int'];
 };
 
@@ -2500,35 +2500,35 @@ export type GroupsFlatDataDto = {
 
 /** List of Groups items and total count. */
 export type GroupsResultDto = {
-  /** The Groups items. */
+  /** The contents. */
   items: Maybe<Array<Groups>>;
-  /** The total number of Groups items. */
+  /** The total count of  contents. */
   total: Scalars['Int'];
 };
 
 /** The structure of a Labs content type. */
 export type Labs = Content & {
-  /** The date and time when the content has been created. */
+  /** The timestamp when the object was created. */
   created: Scalars['Instant'];
-  /** The user that has created the content. */
+  /** The user who created the object. */
   createdBy: Scalars['String'];
-  /** The full info of the user that has created the content. */
+  /** The user who created the object. */
   createdByUser: User;
   /** The data of the content. */
   data: LabsDataDto;
   /** The flat data of the content. */
   flatData: LabsFlatDataDto;
-  /** The id of the content. */
+  /** The ID of the object. */
   id: Scalars['String'];
-  /** The date and time when the content has been modified last. */
+  /** The timestamp when the object was updated the last time. */
   lastModified: Scalars['Instant'];
-  /** The user that has updated the content last. */
+  /** The user who updated the object the last time. */
   lastModifiedBy: Scalars['String'];
-  /** The full info of the user that has updated the content last. */
+  /** The user who updated the object the last time. */
   lastModifiedByUser: User;
   /** The new status of the content. */
   newStatus: Maybe<Scalars['String']>;
-  /** The new status color of the content. */
+  /** The status color of the content. */
   newStatusColor: Maybe<Scalars['String']>;
   /** Query Research Outputs content items. */
   referencingResearchOutputsContents: Maybe<Array<ResearchOutputs>>;
@@ -2542,9 +2542,9 @@ export type Labs = Content & {
   status: Scalars['String'];
   /** The status color of the content. */
   statusColor: Scalars['String'];
-  /** The url to the content. */
+  /** The URL to the content. */
   url: Scalars['String'];
-  /** The version of the content. */
+  /** The version of the object (usually GUID). */
   version: Scalars['Int'];
 };
 
@@ -2611,43 +2611,43 @@ export type LabsFlatDataDto = {
 
 /** List of Labs items and total count. */
 export type LabsResultDto = {
-  /** The Labs items. */
+  /** The contents. */
   items: Maybe<Array<Labs>>;
-  /** The total number of Labs items. */
+  /** The total count of  contents. */
   total: Scalars['Int'];
 };
 
 /** The structure of a Migrations content type. */
 export type Migrations = Content & {
-  /** The date and time when the content has been created. */
+  /** The timestamp when the object was created. */
   created: Scalars['Instant'];
-  /** The user that has created the content. */
+  /** The user who created the object. */
   createdBy: Scalars['String'];
-  /** The full info of the user that has created the content. */
+  /** The user who created the object. */
   createdByUser: User;
   /** The data of the content. */
   data: MigrationsDataDto;
   /** The flat data of the content. */
   flatData: MigrationsFlatDataDto;
-  /** The id of the content. */
+  /** The ID of the object. */
   id: Scalars['String'];
-  /** The date and time when the content has been modified last. */
+  /** The timestamp when the object was updated the last time. */
   lastModified: Scalars['Instant'];
-  /** The user that has updated the content last. */
+  /** The user who updated the object the last time. */
   lastModifiedBy: Scalars['String'];
-  /** The full info of the user that has updated the content last. */
+  /** The user who updated the object the last time. */
   lastModifiedByUser: User;
   /** The new status of the content. */
   newStatus: Maybe<Scalars['String']>;
-  /** The new status color of the content. */
+  /** The status color of the content. */
   newStatusColor: Maybe<Scalars['String']>;
   /** The status of the content. */
   status: Scalars['String'];
   /** The status color of the content. */
   statusColor: Scalars['String'];
-  /** The url to the content. */
+  /** The URL to the content. */
   url: Scalars['String'];
-  /** The version of the content. */
+  /** The version of the object (usually GUID). */
   version: Scalars['Int'];
 };
 
@@ -2678,35 +2678,35 @@ export type MigrationsFlatDataDto = {
 
 /** List of Migrations items and total count. */
 export type MigrationsResultDto = {
-  /** The Migrations items. */
+  /** The contents. */
   items: Maybe<Array<Migrations>>;
-  /** The total number of Migrations items. */
+  /** The total count of  contents. */
   total: Scalars['Int'];
 };
 
 /** The structure of a News and Events content type. */
 export type NewsAndEvents = Content & {
-  /** The date and time when the content has been created. */
+  /** The timestamp when the object was created. */
   created: Scalars['Instant'];
-  /** The user that has created the content. */
+  /** The user who created the object. */
   createdBy: Scalars['String'];
-  /** The full info of the user that has created the content. */
+  /** The user who created the object. */
   createdByUser: User;
   /** The data of the content. */
   data: NewsAndEventsDataDto;
   /** The flat data of the content. */
   flatData: NewsAndEventsFlatDataDto;
-  /** The id of the content. */
+  /** The ID of the object. */
   id: Scalars['String'];
-  /** The date and time when the content has been modified last. */
+  /** The timestamp when the object was updated the last time. */
   lastModified: Scalars['Instant'];
-  /** The user that has updated the content last. */
+  /** The user who updated the object the last time. */
   lastModifiedBy: Scalars['String'];
-  /** The full info of the user that has updated the content last. */
+  /** The user who updated the object the last time. */
   lastModifiedByUser: User;
   /** The new status of the content. */
   newStatus: Maybe<Scalars['String']>;
-  /** The new status color of the content. */
+  /** The status color of the content. */
   newStatusColor: Maybe<Scalars['String']>;
   /** Query Dashboard content items. */
   referencingDashboardContents: Maybe<Array<Dashboard>>;
@@ -2720,9 +2720,9 @@ export type NewsAndEvents = Content & {
   status: Scalars['String'];
   /** The status color of the content. */
   statusColor: Scalars['String'];
-  /** The url to the content. */
+  /** The URL to the content. */
   url: Scalars['String'];
-  /** The version of the content. */
+  /** The version of the object (usually GUID). */
   version: Scalars['Int'];
 };
 
@@ -2889,35 +2889,35 @@ export type NewsAndEventsFlatDataDto = {
 
 /** List of News and Events items and total count. */
 export type NewsAndEventsResultDto = {
-  /** The News and Events items. */
+  /** The contents. */
   items: Maybe<Array<NewsAndEvents>>;
-  /** The total number of News and Events items. */
+  /** The total count of  contents. */
   total: Scalars['Int'];
 };
 
 /** The structure of a Pages content type. */
 export type Pages = Content & {
-  /** The date and time when the content has been created. */
+  /** The timestamp when the object was created. */
   created: Scalars['Instant'];
-  /** The user that has created the content. */
+  /** The user who created the object. */
   createdBy: Scalars['String'];
-  /** The full info of the user that has created the content. */
+  /** The user who created the object. */
   createdByUser: User;
   /** The data of the content. */
   data: PagesDataDto;
   /** The flat data of the content. */
   flatData: PagesFlatDataDto;
-  /** The id of the content. */
+  /** The ID of the object. */
   id: Scalars['String'];
-  /** The date and time when the content has been modified last. */
+  /** The timestamp when the object was updated the last time. */
   lastModified: Scalars['Instant'];
-  /** The user that has updated the content last. */
+  /** The user who updated the object the last time. */
   lastModifiedBy: Scalars['String'];
-  /** The full info of the user that has updated the content last. */
+  /** The user who updated the object the last time. */
   lastModifiedByUser: User;
   /** The new status of the content. */
   newStatus: Maybe<Scalars['String']>;
-  /** The new status color of the content. */
+  /** The status color of the content. */
   newStatusColor: Maybe<Scalars['String']>;
   /** Query Dashboard content items. */
   referencingDashboardContents: Maybe<Array<Dashboard>>;
@@ -2931,9 +2931,9 @@ export type Pages = Content & {
   status: Scalars['String'];
   /** The status color of the content. */
   statusColor: Scalars['String'];
-  /** The url to the content. */
+  /** The URL to the content. */
   url: Scalars['String'];
-  /** The version of the content. */
+  /** The version of the object (usually GUID). */
   version: Scalars['Int'];
 };
 
@@ -3065,35 +3065,35 @@ export type PagesFlatDataDto = {
 
 /** List of Pages items and total count. */
 export type PagesResultDto = {
-  /** The Pages items. */
+  /** The contents. */
   items: Maybe<Array<Pages>>;
-  /** The total number of Pages items. */
+  /** The total count of  contents. */
   total: Scalars['Int'];
 };
 
 /** The structure of a Research Outputs content type. */
 export type ResearchOutputs = Content & {
-  /** The date and time when the content has been created. */
+  /** The timestamp when the object was created. */
   created: Scalars['Instant'];
-  /** The user that has created the content. */
+  /** The user who created the object. */
   createdBy: Scalars['String'];
-  /** The full info of the user that has created the content. */
+  /** The user who created the object. */
   createdByUser: User;
   /** The data of the content. */
   data: ResearchOutputsDataDto;
   /** The flat data of the content. */
   flatData: ResearchOutputsFlatDataDto;
-  /** The id of the content. */
+  /** The ID of the object. */
   id: Scalars['String'];
-  /** The date and time when the content has been modified last. */
+  /** The timestamp when the object was updated the last time. */
   lastModified: Scalars['Instant'];
-  /** The user that has updated the content last. */
+  /** The user who updated the object the last time. */
   lastModifiedBy: Scalars['String'];
-  /** The full info of the user that has updated the content last. */
+  /** The user who updated the object the last time. */
   lastModifiedByUser: User;
   /** The new status of the content. */
   newStatus: Maybe<Scalars['String']>;
-  /** The new status color of the content. */
+  /** The status color of the content. */
   newStatusColor: Maybe<Scalars['String']>;
   /** Query Teams content items. */
   referencingTeamsContents: Maybe<Array<Teams>>;
@@ -3103,9 +3103,9 @@ export type ResearchOutputs = Content & {
   status: Scalars['String'];
   /** The status color of the content. */
   statusColor: Scalars['String'];
-  /** The url to the content. */
+  /** The URL to the content. */
   url: Scalars['String'];
-  /** The version of the content. */
+  /** The version of the object (usually GUID). */
   version: Scalars['Int'];
 };
 
@@ -3439,35 +3439,35 @@ export type ResearchOutputsFlatDataDto = {
 
 /** List of Research Outputs items and total count. */
 export type ResearchOutputsResultDto = {
-  /** The Research Outputs items. */
+  /** The contents. */
   items: Maybe<Array<ResearchOutputs>>;
-  /** The total number of Research Outputs items. */
+  /** The total count of  contents. */
   total: Scalars['Int'];
 };
 
 /** The structure of a Teams content type. */
 export type Teams = Content & {
-  /** The date and time when the content has been created. */
+  /** The timestamp when the object was created. */
   created: Scalars['Instant'];
-  /** The user that has created the content. */
+  /** The user who created the object. */
   createdBy: Scalars['String'];
-  /** The full info of the user that has created the content. */
+  /** The user who created the object. */
   createdByUser: User;
   /** The data of the content. */
   data: TeamsDataDto;
   /** The flat data of the content. */
   flatData: TeamsFlatDataDto;
-  /** The id of the content. */
+  /** The ID of the object. */
   id: Scalars['String'];
-  /** The date and time when the content has been modified last. */
+  /** The timestamp when the object was updated the last time. */
   lastModified: Scalars['Instant'];
-  /** The user that has updated the content last. */
+  /** The user who updated the object the last time. */
   lastModifiedBy: Scalars['String'];
-  /** The full info of the user that has updated the content last. */
+  /** The user who updated the object the last time. */
   lastModifiedByUser: User;
   /** The new status of the content. */
   newStatus: Maybe<Scalars['String']>;
-  /** The new status color of the content. */
+  /** The status color of the content. */
   newStatusColor: Maybe<Scalars['String']>;
   /** Query Groups content items. */
   referencingGroupsContents: Maybe<Array<Groups>>;
@@ -3481,9 +3481,9 @@ export type Teams = Content & {
   status: Scalars['String'];
   /** The status color of the content. */
   statusColor: Scalars['String'];
-  /** The url to the content. */
+  /** The URL to the content. */
   url: Scalars['String'];
-  /** The version of the content. */
+  /** The version of the object (usually GUID). */
   version: Scalars['Int'];
 };
 
@@ -3655,9 +3655,9 @@ export type TeamsFlatDataDto = {
 
 /** List of Teams items and total count. */
 export type TeamsResultDto = {
-  /** The Teams items. */
+  /** The contents. */
   items: Maybe<Array<Teams>>;
-  /** The total number of Teams items. */
+  /** The total count of  contents. */
   total: Scalars['Int'];
 };
 
@@ -3665,35 +3665,35 @@ export type TeamsResultDto = {
 export type User = {
   /** The display name of the user. */
   displayName: Maybe<Scalars['String']>;
-  /** The email of the user. */
+  /** The email address of the current user. */
   email: Maybe<Scalars['String']>;
-  /** The id of the user. */
+  /** The ID of the user. */
   id: Scalars['String'];
 };
 
 /** The structure of a Users content type. */
 export type Users = Content & {
-  /** The date and time when the content has been created. */
+  /** The timestamp when the object was created. */
   created: Scalars['Instant'];
-  /** The user that has created the content. */
+  /** The user who created the object. */
   createdBy: Scalars['String'];
-  /** The full info of the user that has created the content. */
+  /** The user who created the object. */
   createdByUser: User;
   /** The data of the content. */
   data: UsersDataDto;
   /** The flat data of the content. */
   flatData: UsersFlatDataDto;
-  /** The id of the content. */
+  /** The ID of the object. */
   id: Scalars['String'];
-  /** The date and time when the content has been modified last. */
+  /** The timestamp when the object was updated the last time. */
   lastModified: Scalars['Instant'];
-  /** The user that has updated the content last. */
+  /** The user who updated the object the last time. */
   lastModifiedBy: Scalars['String'];
-  /** The full info of the user that has updated the content last. */
+  /** The user who updated the object the last time. */
   lastModifiedByUser: User;
   /** The new status of the content. */
   newStatus: Maybe<Scalars['String']>;
-  /** The new status color of the content. */
+  /** The status color of the content. */
   newStatusColor: Maybe<Scalars['String']>;
   /** Query Discover ASAP content items. */
   referencingDiscoverContents: Maybe<Array<Discover>>;
@@ -3711,9 +3711,9 @@ export type Users = Content & {
   status: Scalars['String'];
   /** The status color of the content. */
   statusColor: Scalars['String'];
-  /** The url to the content. */
+  /** The URL to the content. */
   url: Scalars['String'];
-  /** The version of the content. */
+  /** The version of the object (usually GUID). */
   version: Scalars['Int'];
 };
 
@@ -4254,9 +4254,9 @@ export type UsersFlatDataDto = {
 
 /** List of Users items and total count. */
 export type UsersResultDto = {
-  /** The Users items. */
+  /** The contents. */
   items: Maybe<Array<Users>>;
-  /** The total number of Users items. */
+  /** The total count of  contents. */
   total: Scalars['Int'];
 };
 

--- a/apps/asap-server/src/utils/send-email.ts
+++ b/apps/asap-server/src/utils/send-email.ts
@@ -26,6 +26,7 @@ export const sendEmailFactory =
       Template: template,
       TemplateData: JSON.stringify(values),
       Source: userInviteSender,
+      ReturnPath: 'piotr.szpak@yld.io',
     };
 
     return ses.sendTemplatedEmail(params).promise();

--- a/apps/asap-server/src/utils/send-email.ts
+++ b/apps/asap-server/src/utils/send-email.ts
@@ -2,7 +2,7 @@ import { welcome } from '@asap-hub/message-templates';
 import { AWSError } from 'aws-sdk';
 import SES, { SendTemplatedEmailResponse } from 'aws-sdk/clients/ses';
 import { PromiseResult } from 'aws-sdk/lib/request';
-import { userInviteBcc, userInviteSender } from '../config';
+import { userInviteBcc, userInviteSender, userInviteReturn } from '../config';
 
 export interface Welcome {
   displayName: string;
@@ -26,7 +26,7 @@ export const sendEmailFactory =
       Template: template,
       TemplateData: JSON.stringify(values),
       Source: userInviteSender,
-      ReturnPath: 'piotr.szpak@yld.io',
+      ReturnPath: userInviteReturn,
     };
 
     return ses.sendTemplatedEmail(params).promise();

--- a/apps/asap-server/test/utils/send-email.test.ts
+++ b/apps/asap-server/test/utils/send-email.test.ts
@@ -29,6 +29,7 @@ describe('Send Email helper', () => {
       Template: 'Invite',
       TemplateData: JSON.stringify(params),
       Source: userInviteSender,
+      ReturnPath: 'piotr.szpak@yld.io',
     });
   });
 });

--- a/apps/asap-server/test/utils/send-email.test.ts
+++ b/apps/asap-server/test/utils/send-email.test.ts
@@ -1,5 +1,9 @@
 import { SES } from 'aws-sdk';
-import { userInviteBcc, userInviteSender } from '../../src/config';
+import {
+  userInviteBcc,
+  userInviteReturn,
+  userInviteSender,
+} from '../../src/config';
 import { sendEmailFactory } from '../../src/utils/send-email';
 
 describe('Send Email helper', () => {
@@ -29,7 +33,7 @@ describe('Send Email helper', () => {
       Template: 'Invite',
       TemplateData: JSON.stringify(params),
       Source: userInviteSender,
-      ReturnPath: 'piotr.szpak@yld.io',
+      ReturnPath: userInviteReturn,
     });
   });
 });

--- a/serverless.ts
+++ b/serverless.ts
@@ -300,6 +300,9 @@ const serverlessConfig: AWS = {
         EMAIL_BCC: `\${ssm:email-invite-bcc-${
           SLS_STAGE === 'production' ? 'prod' : 'dev'
         }}`,
+        EMAIL_RETURN: `\${ssm:email-invite-return-${
+          SLS_STAGE === 'production' ? 'prod' : 'dev'
+        }}`,
       },
     },
     indexResearchOutput: {


### PR DESCRIPTION
see: https://trello.com/c/Oi7Y6kTL/1369-forward-invitation-email-bounce-must

Adds a `return-to` parameter to the send-email function call which, in case of an email bounce, is automatically used for forwarding the bounced email. 

Requires a manual step of activating e-mail feedback forwarding in both SES regions we use (done)