### PR TITLE
feat: extends dropdown component

### DIFF
--- a/apps/frontend/src/network/users/__tests__/UserProfile.test.tsx
+++ b/apps/frontend/src/network/users/__tests__/UserProfile.test.tsx
@@ -239,7 +239,7 @@ describe('a header edit button', () => {
     const userProfile: UserResponse = {
       ...createUserResponse(),
       city: 'Lon',
-      country: 'UK',
+      country: 'United Kingdom of Great Britain and Northern Ireland',
       id: '42',
     };
 

--- a/apps/storybook/src/LabeledDropdown.stories.tsx
+++ b/apps/storybook/src/LabeledDropdown.stories.tsx
@@ -48,24 +48,15 @@ export const Required = () => (
       { value: 'LCY', label: 'City' },
       { value: 'SEN', label: 'Southend' },
     ]}
-    value={select(
-      'Value',
-      {
-        Heathrow: 'LHR',
-        Gatwick: 'LGW',
-        Stansted: 'STN',
-        Luton: 'LTN',
-        City: 'LCY',
-        Southend: 'SEN',
-      },
-      'LHR',
-    )}
+    value=""
     enabled={boolean('Enabled', true)}
   />
 );
 export const EmptyOption = () => (
   <LabeledDropdown
     title={text('Title', 'Airport')}
+    placeholder={text('Empty Label', 'Select airport')}
+    subtitle={text('Subtitle', '')}
     options={[
       { value: '', label: text('Empty Label', 'Select airport') },
       { value: 'LHR', label: 'Heathrow' },
@@ -82,7 +73,7 @@ export const EmptyOption = () => (
 export const Invalid = () => (
   <LabeledDropdown
     title={text('Title', 'Airport')}
-    subtitle={text('Subtitle', '(Required)')}
+    subtitle={text('Subtitle', '')}
     required={true}
     options={[
       { value: 'LHR', label: 'Heathrow' },
@@ -92,10 +83,10 @@ export const Invalid = () => (
       { value: 'LCY', label: 'City' },
       { value: 'SEN', label: 'Southend' },
     ]}
-    value=""
+    value="LHR"
     customValidationMessage={text(
       'Validation Error Message',
-      'Choose something',
+      'This airport is currently closed.',
     )}
     enabled={boolean('Enabled', true)}
   />

--- a/apps/storybook/src/LabeledDropdown.stories.tsx
+++ b/apps/storybook/src/LabeledDropdown.stories.tsx
@@ -10,7 +10,36 @@ export default {
 export const Normal = () => (
   <LabeledDropdown
     title={text('Title', 'Airport')}
+    subtitle={text('Subtitle', '(Optional)')}
+    options={[
+      { value: 'LHR', label: 'Heathrow' },
+      { value: 'LGW', label: 'Gatwick' },
+      { value: 'STN', label: 'Stansted' },
+      { value: 'LTN', label: 'Luton' },
+      { value: 'LCY', label: 'City' },
+      { value: 'SEN', label: 'Southend' },
+    ]}
+    value={select(
+      'Value',
+      {
+        Heathrow: 'LHR',
+        Gatwick: 'LGW',
+        Stansted: 'STN',
+        Luton: 'LTN',
+        City: 'LCY',
+        Southend: 'SEN',
+      },
+      'LHR',
+    )}
+    enabled={boolean('Enabled', true)}
+  />
+);
+
+export const Required = () => (
+  <LabeledDropdown
+    title={text('Title', 'Airport')}
     subtitle={text('Subtitle', '(Required)')}
+    required={true}
     options={[
       { value: 'LHR', label: 'Heathrow' },
       { value: 'LGW', label: 'Gatwick' },
@@ -37,7 +66,6 @@ export const Normal = () => (
 export const EmptyOption = () => (
   <LabeledDropdown
     title={text('Title', 'Airport')}
-    subtitle={text('Subtitle', '(Required)')}
     options={[
       { value: '', label: text('Empty Label', 'Select airport') },
       { value: 'LHR', label: 'Heathrow' },
@@ -55,6 +83,7 @@ export const Invalid = () => (
   <LabeledDropdown
     title={text('Title', 'Airport')}
     subtitle={text('Subtitle', '(Required)')}
+    required={true}
     options={[
       { value: 'LHR', label: 'Heathrow' },
       { value: 'LGW', label: 'Gatwick' },
@@ -63,10 +92,10 @@ export const Invalid = () => (
       { value: 'LCY', label: 'City' },
       { value: 'SEN', label: 'Southend' },
     ]}
-    value="LHR"
+    value=""
     customValidationMessage={text(
       'Validation Error Message',
-      'This airport is currently closed.',
+      'Choose something',
     )}
     enabled={boolean('Enabled', true)}
   />

--- a/packages/react-components/src/atoms/Dropdown.tsx
+++ b/packages/react-components/src/atoms/Dropdown.tsx
@@ -1,51 +1,132 @@
-import { FC } from 'react';
-import Select, { OptionTypeBase } from 'react-select';
+import {
+  ComponentProps,
+  createContext,
+  createRef,
+  FC,
+  useContext,
+  useState,
+} from 'react';
+import Select, {
+  OptionTypeBase,
+  InputActionMeta,
+  components,
+} from 'react-select';
 import { css } from '@emotion/react';
 
 import { noop } from '../utils';
-import { validationMessageStyles } from '../form';
 import { dropdownChevronIcon } from '../icons';
 import { Option, reactSelectStyles } from '../select';
+import { useValidation, validationMessageStyles } from '../form';
 
 const containerStyles = css({
   flexBasis: '100%',
 });
 const DropdownIndicator: FC = () => dropdownChevronIcon;
 
-export interface DropdownProps<V extends string> {
+const InputContext = createContext<
+  ReturnType<typeof useValidation>['validationTargetProps'] &
+    Pick<DropdownProps, 'required'>
+>({
+  ref: createRef(),
+  onBlur: noop,
+  onInvalid: noop,
+});
+
+const Input: React.FC<ComponentProps<typeof components.Input>> = (props) => {
+  const { ref, onBlur, ...inputProps } = useContext(InputContext);
+
+  return (
+    <components.Input
+      {...props}
+      {...inputProps}
+      onBlur={(event) => {
+        props.onBlur?.(event);
+        onBlur(event);
+      }}
+      style={{ display: 'unset' }}
+      autoComplete="off"
+      isHidden={false}
+      innerRef={(element) => {
+        ref.current = element;
+        props.innerRef(element);
+      }}
+    />
+  );
+};
+
+type DropdownProps = {
   readonly customValidationMessage?: string;
+  readonly getValidationMessage?: Parameters<typeof useValidation>[1];
 
   readonly id?: string;
-  readonly options: ReadonlyArray<Option<V>>;
+  readonly options: ReadonlyArray<Option<string>>;
   readonly enabled?: boolean;
+  readonly required?: boolean;
 
-  readonly value: V;
-  readonly onChange?: (newValue: V) => void;
-}
-export default function Dropdown<V extends string>({
+  readonly value: string;
+  readonly onChange?: (newValue: string) => void;
+  readonly noOptionsMessage?: (value: { inputValue: string }) => string | null;
+};
+
+const Dropdown: FC<DropdownProps> = ({
   customValidationMessage = '',
+  getValidationMessage,
+  noOptionsMessage = () => null,
 
   id,
   options,
   enabled = true,
+  required = false,
 
   value,
   onChange = noop,
-}: DropdownProps<V>): ReturnType<FC> {
+}) => {
+  const [inputValue, setInputValue] = useState(value);
+
+  const { validationMessage, validationTargetProps } =
+    useValidation<HTMLInputElement>(
+      customValidationMessage,
+      getValidationMessage,
+    );
+
+  const onNewValue = (newValue: string) => {
+    setInputValue(newValue);
+    onChange(newValue);
+    // Hack to re-validate once the selected value has been put in the state of the input field
+    setTimeout(validationTargetProps.onBlur, 0);
+  };
   return (
     <div css={containerStyles}>
-      <Select<OptionTypeBase>
-        inputId={id}
-        isDisabled={!enabled}
-        options={options.filter((option) => option.value !== '')}
-        value={options.find((option) => option.value === value)}
-        onChange={(option) => {
-          onChange((option as Option<V>).value);
-        }}
-        components={{ DropdownIndicator }}
-        styles={reactSelectStyles(!!customValidationMessage)}
-      />
-      <div css={validationMessageStyles}>{customValidationMessage}</div>
+      <InputContext.Provider value={{ ...validationTargetProps, required }}>
+        <Select<OptionTypeBase>
+          inputId={id}
+          isDisabled={!enabled}
+          inputValue={inputValue}
+          value={{ value, label: value }}
+          options={options.filter((option) => option.value !== '')}
+          components={{ DropdownIndicator, Input }}
+          styles={reactSelectStyles(!!validationMessage)}
+          noOptionsMessage={noOptionsMessage}
+          tabSelectsValue={false}
+          controlShouldRenderValue={false}
+          onChange={(option: OptionTypeBase | null) => {
+            onNewValue(option?.value || '');
+          }}
+          onInputChange={(
+            newInputValue: string,
+            { action }: InputActionMeta,
+          ) => {
+            switch (action) {
+              case 'input-change':
+                onNewValue(newInputValue);
+                break;
+            }
+          }}
+        />
+      </InputContext.Provider>
+      <div css={validationMessageStyles}>{validationMessage}</div>
     </div>
   );
-}
+};
+
+export default Dropdown;

--- a/packages/react-components/src/atoms/Dropdown.tsx
+++ b/packages/react-components/src/atoms/Dropdown.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react';
 import Select, { OptionTypeBase, components } from 'react-select';
 import { css } from '@emotion/react';
+import { v4 as uuidV4 } from 'uuid';
 
 import { noop } from '../utils';
 import { dropdownChevronIcon } from '../icons';
@@ -40,7 +41,7 @@ const Input: React.FC<ComponentProps<typeof components.Input>> = (props) => {
         onBlur(event);
       }}
       style={{ display: 'unset' }}
-      autoComplete="off"
+      autoComplete={uuidV4()}
       isHidden={false}
       innerRef={(element) => {
         ref.current = element;
@@ -79,6 +80,14 @@ export default function Dropdown<V extends string>({
   const [inputValue, setInputValue] = useState<string>(value);
   const [lastValidValue, setLastInputValue] = useState<V>(value);
 
+  const handleInputValue = (newValue: string) => {
+    const isValidValue =
+      options.filter((option: OptionTypeBase) => option.value === newValue)
+        .length > 0;
+
+    return isValidValue ? lastValidValue : '';
+  };
+
   const { validationMessage, validationTargetProps } =
     useValidation<HTMLInputElement>(
       customValidationMessage,
@@ -94,8 +103,8 @@ export default function Dropdown<V extends string>({
           inputValue={inputValue}
           value={{ value, label: value }}
           options={options.filter((option) => option.value !== '')}
-          onBlur={() => {
-            setInputValue(lastValidValue);
+          onBlur={(option: OptionTypeBase) => {
+            setInputValue(handleInputValue(option.target.value));
             setTimeout(validationTargetProps.onBlur, 0);
           }}
           controlShouldRenderValue={false}
@@ -107,6 +116,7 @@ export default function Dropdown<V extends string>({
             onChange(option?.value);
             setLastInputValue(option?.value);
             setInputValue(option?.value);
+            setTimeout(validationTargetProps.onBlur, 0);
           }}
           onInputChange={(newInputValue, { action }) => {
             switch (action) {

--- a/packages/react-components/src/atoms/Dropdown.tsx
+++ b/packages/react-components/src/atoms/Dropdown.tsx
@@ -80,19 +80,23 @@ export default function Dropdown<V extends string>({
   const [inputValue, setInputValue] = useState<string>(value);
   const [lastValidValue, setLastInputValue] = useState<V>(value);
 
-  const handleInputValue = (newValue: string) => {
-    const isValidValue =
-      options.filter((option: OptionTypeBase) => option.value === newValue)
-        .length > 0;
-
-    return isValidValue ? lastValidValue : '';
-  };
-
   const { validationMessage, validationTargetProps } =
     useValidation<HTMLInputElement>(
       customValidationMessage,
       getValidationMessage,
     );
+
+  const handleInputValidation = (currentValue: string) => {
+    const updatedValue =
+      options.filter((option: OptionTypeBase) => option.value === currentValue)
+        .length > 0
+        ? lastValidValue
+        : ('' as V);
+
+    setInputValue(updatedValue);
+    onChange(updatedValue);
+    setTimeout(validationTargetProps.onBlur, 0);
+  };
 
   return (
     <div css={containerStyles}>
@@ -102,16 +106,24 @@ export default function Dropdown<V extends string>({
           isDisabled={!enabled}
           inputValue={inputValue}
           value={{ value, label: value }}
-          options={options.filter((option) => option.value !== '')}
+          options={options.filter(
+            (option) => option.label.length > 0 && option.label.length > 0,
+          )}
           onBlur={(option: OptionTypeBase) => {
-            setInputValue(handleInputValue(option.target.value));
-            setTimeout(validationTargetProps.onBlur, 0);
+            handleInputValidation(option.target.value);
           }}
           controlShouldRenderValue={false}
           components={{ DropdownIndicator, Input }}
           styles={reactSelectStyles(!!validationMessage)}
           noOptionsMessage={noOptionsMessage}
           tabSelectsValue={false}
+          onKeyDown={(option) => {
+            switch (option.keyCode) {
+              case 13:
+                handleInputValidation(inputValue);
+                break;
+            }
+          }}
           onChange={(option) => {
             onChange(option?.value);
             setLastInputValue(option?.value);

--- a/packages/react-components/src/atoms/Dropdown.tsx
+++ b/packages/react-components/src/atoms/Dropdown.tsx
@@ -109,9 +109,7 @@ export default function Dropdown<V extends string>({
           isDisabled={!enabled}
           inputValue={inputValue}
           value={{ value, label: value }}
-          options={options.filter(
-            (option) => option.label.length > 0 && option.label.length > 0,
-          )}
+          options={options.filter((option) => option.value !== '')}
           onBlur={(option: OptionTypeBase) => {
             handleInputValidation(option.target.value);
           }}

--- a/packages/react-components/src/atoms/Dropdown.tsx
+++ b/packages/react-components/src/atoms/Dropdown.tsx
@@ -15,6 +15,8 @@ import { dropdownChevronIcon } from '../icons';
 import { Option, reactSelectStyles } from '../select';
 import { useValidation, validationMessageStyles } from '../form';
 
+export const ENTER_KEYCODE = 13;
+
 const containerStyles = css({
   flexBasis: '100%',
 });
@@ -117,7 +119,8 @@ export default function Dropdown<V extends string>({
           noOptionsMessage={noOptionsMessage}
           tabSelectsValue={false}
           onKeyDown={(option) => {
-            if (option.keyCode === 13) handleInputValidation(inputValue);
+            if (option.keyCode === ENTER_KEYCODE)
+              handleInputValidation(inputValue);
           }}
           onChange={(option) => {
             onChange(option?.value);

--- a/packages/react-components/src/atoms/Dropdown.tsx
+++ b/packages/react-components/src/atoms/Dropdown.tsx
@@ -79,8 +79,9 @@ export default function Dropdown<V extends string>({
   onChange = noop,
   noOptionsMessage,
 }: DropdownProps<V>): ReturnType<FC> {
-  const [inputValue, setInputValue] = useState<string>(value);
-  const [lastValidValue, setLastInputValue] = useState<V>(value);
+  const [inputValue, setInputValue] = useState<string>(
+    options.find((opt) => value.length > 0 && opt.value === value)?.label ?? '',
+  );
 
   const { validationMessage, validationTargetProps } =
     useValidation<HTMLInputElement>(
@@ -89,14 +90,12 @@ export default function Dropdown<V extends string>({
     );
 
   const handleInputValidation = (currentValue: string) => {
-    const updatedValue =
-      options.filter((option: OptionTypeBase) => option.value === currentValue)
-        .length > 0
-        ? lastValidValue
-        : ('' as V);
+    const optionSelected = options.find(
+      (option: OptionTypeBase) => option.label === currentValue,
+    );
 
-    setInputValue(updatedValue);
-    onChange(updatedValue);
+    setInputValue(optionSelected?.label ?? '');
+    onChange(optionSelected?.value ?? ('' as V));
     setTimeout(validationTargetProps.onBlur, 0);
   };
 
@@ -108,7 +107,6 @@ export default function Dropdown<V extends string>({
           inputId={id}
           isDisabled={!enabled}
           inputValue={inputValue}
-          value={{ value, label: value }}
           options={options.filter((option) => option.value !== '')}
           onBlur={(option: OptionTypeBase) => {
             handleInputValidation(option.target.value);
@@ -127,8 +125,7 @@ export default function Dropdown<V extends string>({
           }}
           onChange={(option) => {
             onChange(option?.value);
-            setLastInputValue(option?.value);
-            setInputValue(option?.value);
+            setInputValue(option?.label);
             setTimeout(validationTargetProps.onBlur, 0);
           }}
           onInputChange={(newInputValue, { action }) => {

--- a/packages/react-components/src/atoms/Dropdown.tsx
+++ b/packages/react-components/src/atoms/Dropdown.tsx
@@ -59,6 +59,7 @@ export interface DropdownProps<V extends string> {
   readonly options: ReadonlyArray<Option<V>>;
   readonly enabled?: boolean;
   readonly required?: boolean;
+  readonly placeholder?: string;
 
   readonly value: V;
   readonly onChange?: (newValue: V) => void;
@@ -72,6 +73,7 @@ export default function Dropdown<V extends string>({
   options,
   enabled = true,
   required = false,
+  placeholder = 'Select',
 
   value,
   onChange = noop,
@@ -102,6 +104,7 @@ export default function Dropdown<V extends string>({
     <div css={containerStyles}>
       <InputContext.Provider value={{ ...validationTargetProps, required }}>
         <Select<OptionTypeBase>
+          placeholder={placeholder}
           inputId={id}
           isDisabled={!enabled}
           inputValue={inputValue}

--- a/packages/react-components/src/atoms/Dropdown.tsx
+++ b/packages/react-components/src/atoms/Dropdown.tsx
@@ -73,7 +73,7 @@ export default function Dropdown<V extends string>({
   options,
   enabled = true,
   required = false,
-  placeholder = 'Select',
+  placeholder = 'Start Typing...',
 
   value,
   onChange = noop,
@@ -117,11 +117,7 @@ export default function Dropdown<V extends string>({
           noOptionsMessage={noOptionsMessage}
           tabSelectsValue={false}
           onKeyDown={(option) => {
-            switch (option.keyCode) {
-              case 13:
-                handleInputValidation(inputValue);
-                break;
-            }
+            if (option.keyCode === 13) handleInputValidation(inputValue);
           }}
           onChange={(option) => {
             onChange(option?.value);

--- a/packages/react-components/src/atoms/__tests__/Dropdown.test.tsx
+++ b/packages/react-components/src/atoms/__tests__/Dropdown.test.tsx
@@ -14,17 +14,33 @@ it('shows the selected value', () => {
   expect(getByDisplayValue('LHR')).toBeVisible();
 });
 
+it('without selection shows a placeholder', () => {
+  const { getByText, rerender } = render(
+    <Dropdown
+      options={[{ value: 'LHR', label: 'Heathrow' }]}
+      value=""
+      placeholder="Choose something"
+    />,
+  );
+  expect(getByText('Choose something')).toBeVisible();
+
+  rerender(
+    <Dropdown options={[{ value: 'LHR', label: 'Heathrow' }]} value="" />,
+  );
+  expect(getByText('Select')).toBeVisible();
+});
+
 it('without options shows a placeholder message that can be customized', () => {
   const { getByText, rerender } = render(<Dropdown options={[]} value="" />);
-  userEvent.click(getByText('Select...'));
+  userEvent.click(getByText('Select'));
   expect(getByText(/no.+options/i)).toBeVisible();
 
   rerender(
     <Dropdown options={[]} value="" noOptionsMessage={(a) => 'Not found LL'} />,
   );
 
-  userEvent.click(getByText('Select...'));
-  userEvent.type(getByText('Select...'), 'll');
+  userEvent.click(getByText('Select'));
+  userEvent.type(getByText('Select'), 'll');
   expect(getByText('Not found LL')).toBeVisible();
 });
 
@@ -41,11 +57,11 @@ it('allows selecting from a menu with available options', () => {
     />,
   );
 
-  userEvent.click(getByText('Select...'));
+  userEvent.click(getByText('Select'));
   userEvent.click(getByText('Heathrow'));
   expect(handleChange).toHaveBeenCalledWith('LHR');
 
-  userEvent.click(getByText('Select...'));
+  userEvent.click(getByText('Select'));
   userEvent.click(getByText('Gatwick'));
   expect(handleChange).toHaveBeenCalledWith('LGW');
 });
@@ -61,7 +77,7 @@ it('shows the focused option in green', () => {
     />,
   );
 
-  userEvent.click(getByText('Select...'));
+  userEvent.click(getByText('Select'));
 
   fireEvent.mouseOver(getByText('Gatwick'));
   expect(
@@ -79,7 +95,7 @@ it('shows a list of valid values', () => {
     <Dropdown options={[{ value: '', label: '' }]} value="" />,
   );
 
-  userEvent.click(getByText('Select...'));
+  userEvent.click(getByText('Select'));
   expect(queryByText('No options')).toBeVisible();
 });
 
@@ -152,7 +168,7 @@ it('shows an error message when required field not filled', () => {
       required
     />,
   );
-  userEvent.click(getByText('Select...'));
+  userEvent.click(getByText('Select'));
   userEvent.tab();
 
   expect(getByText('Please fill out this field.')).toBeVisible();
@@ -171,8 +187,8 @@ it('shows an error message  when required field has invalid value', async () => 
 
   expect(getByRole('textbox')).toBeRequired();
 
-  userEvent.click(getByText('Select...'));
-  userEvent.type(getByText('Select...'), 'xxx');
+  userEvent.click(getByText('Select'));
+  userEvent.type(getByText('Select'), 'xxx');
   fireEvent.focusOut(getByText('xxx'));
 
   await waitFor(() => {
@@ -186,16 +202,37 @@ it('clears invalid values, when it looses focus', async () => {
     <Dropdown options={[{ value: 'LHR', label: 'Heathrow' }]} value="" />,
   );
 
-  userEvent.click(getByText('Select...'));
-  userEvent.type(getByText('Select...'), 'xxx');
+  userEvent.click(getByText('Select'));
+  userEvent.type(getByText('Select'), 'xxx');
 
-  expect(queryByText('Select...')).toBeNull();
+  expect(queryByText('Select')).toBeNull();
   expect(getByRole('textbox')).toHaveValue('xxx');
 
   userEvent.tab();
 
   await waitFor(() => {
-    expect(getByText('Select...')).toBeVisible();
+    expect(getByText('Select')).toBeVisible();
+    expect(getByRole('textbox')).toHaveValue('');
+  });
+});
+
+it('clears invalid values, when enter', async () => {
+  const { getByText, getByRole, queryByText } = render(
+    <Dropdown options={[{ value: 'LHR', label: 'Heathrow' }]} value="" />,
+  );
+
+  userEvent.click(getByText('Select'));
+  userEvent.type(getByText('Select'), 'xxx');
+
+  expect(queryByText('Select')).toBeNull();
+  expect(getByRole('textbox')).toHaveValue('xxx');
+
+  fireEvent.keyDown(getByRole('textbox'), {
+    keyCode: 13,
+  });
+
+  await waitFor(() => {
+    expect(getByText('Select')).toBeVisible();
     expect(getByRole('textbox')).toHaveValue('');
   });
 });

--- a/packages/react-components/src/atoms/__tests__/Dropdown.test.tsx
+++ b/packages/react-components/src/atoms/__tests__/Dropdown.test.tsx
@@ -3,7 +3,7 @@ import { waitFor } from '@testing-library/dom';
 import userEvent from '@testing-library/user-event';
 import { findParentWithStyle } from '@asap-hub/dom-test-utils';
 
-import Dropdown from '../Dropdown';
+import Dropdown, { ENTER_KEYCODE } from '../Dropdown';
 import { ember, fern, pine, lead, silver } from '../../colors';
 
 it('shows the selected value', () => {
@@ -273,7 +273,7 @@ it('clears invalid values, when enter', async () => {
   expect(getByRole('textbox')).toHaveValue('xxx');
 
   fireEvent.keyDown(getByRole('textbox'), {
-    keyCode: 13,
+    keyCode: ENTER_KEYCODE,
   });
 
   await waitFor(() => {

--- a/packages/react-components/src/atoms/__tests__/Dropdown.test.tsx
+++ b/packages/react-components/src/atoms/__tests__/Dropdown.test.tsx
@@ -16,7 +16,11 @@ it('shows the selected value', () => {
 
 it('shows a placeholder without a selection', () => {
   const { getByText, rerender } = render(
-    <Dropdown options={[{ value: 'LHR', label: 'Heathrow' }]} value="" />,
+    <Dropdown
+      options={[{ value: 'LHR', label: 'Heathrow' }]}
+      value=""
+      placeholder="Select"
+    />,
   );
   expect(getByText('Select')).toBeVisible();
   expect(getComputedStyle(getByText('Select')).color).toBe(lead.rgb);
@@ -34,12 +38,15 @@ it('shows a placeholder without a selection', () => {
 });
 
 it('shows no options message when there are no matching options', () => {
-  const { getByText, rerender } = render(<Dropdown options={[]} value="" />);
+  const { getByText, rerender } = render(
+    <Dropdown options={[]} value="" placeholder="Select" />,
+  );
   userEvent.click(getByText('Select'));
   expect(getByText(/no.+options/i)).toBeVisible();
 
   rerender(
     <Dropdown
+      placeholder="Select"
       options={[]}
       value=""
       noOptionsMessage={(value) => `Not found ${value.inputValue}`}
@@ -54,6 +61,7 @@ it('allows selecting from a menu with available options', () => {
   const handleChange = jest.fn();
   const { getByText } = render(
     <Dropdown
+      placeholder="Select"
       options={[
         { value: 'LHR', label: 'Heathrow' },
         { value: 'LGW', label: 'Gatwick' },
@@ -75,6 +83,7 @@ it('allows selecting from a menu with available options', () => {
 it('only shows valid options', () => {
   const { getByText, queryByText } = render(
     <Dropdown
+      placeholder="Select"
       options={[
         { value: '', label: '-' },
         { value: 'Heathrow', label: 'Heathrow' },
@@ -91,6 +100,7 @@ it('only shows valid options', () => {
 it('shows the focused option in green', () => {
   const { getByText } = render(
     <Dropdown
+      placeholder="Select"
       options={[
         { value: 'LHR', label: 'Heathrow' },
         { value: 'LGW', label: 'Gatwick' },
@@ -114,7 +124,11 @@ it('shows the focused option in green', () => {
 
 it('gets a green border when focused', () => {
   const { getByText } = render(
-    <Dropdown options={[{ value: 'LHR', label: 'Heathrow' }]} value="" />,
+    <Dropdown
+      placeholder="Select"
+      options={[{ value: 'LHR', label: 'Heathrow' }]}
+      value=""
+    />,
   );
 
   userEvent.click(getByText('Select'));
@@ -131,6 +145,7 @@ it('gets a green border when focused', () => {
 it('gets greyed out when disabled', () => {
   const { getByRole, getByText, rerender } = render(
     <Dropdown
+      placeholder="Select"
       options={[{ value: 'LHR', label: 'Heathrow' }]}
       enabled={false}
       value="LHR"
@@ -160,6 +175,7 @@ it('gets greyed out when disabled', () => {
 it('shows the field in red when required field not filled', async () => {
   const { getByText, getByRole, rerender } = render(
     <Dropdown
+      placeholder="Select"
       options={[{ value: 'LHR', label: 'Heathrow' }]}
       required={true}
       value=""
@@ -173,7 +189,11 @@ it('shows the field in red when required field not filled', async () => {
   );
 
   rerender(
-    <Dropdown options={[{ value: 'LHR', label: 'Heathrow' }]} value="" />,
+    <Dropdown
+      options={[{ value: 'LHR', label: 'Heathrow' }]}
+      value=""
+      placeholder="Select"
+    />,
   );
   userEvent.click(getByText('Select'));
   userEvent.tab();
@@ -185,6 +205,7 @@ it('shows the field in red when required field not filled', async () => {
 it('shows an error message when required field not filled', () => {
   const { getByText, getByRole, rerender } = render(
     <Dropdown
+      placeholder="Select"
       options={[{ value: 'LHR', label: 'Heathrow' }]}
       value=""
       required
@@ -198,6 +219,7 @@ it('shows an error message when required field not filled', () => {
 
   rerender(
     <Dropdown
+      placeholder="Select"
       options={[{ value: 'LHR', label: 'Heathrow' }]}
       value=""
       required
@@ -214,7 +236,11 @@ it('shows an error message when required field not filled', () => {
 
 it('clears invalid values, when it looses focus', async () => {
   const { getByText, getByRole, queryByText } = render(
-    <Dropdown options={[{ value: 'LHR', label: 'Heathrow' }]} value="" />,
+    <Dropdown
+      placeholder="Select"
+      options={[{ value: 'LHR', label: 'Heathrow' }]}
+      value=""
+    />,
   );
 
   userEvent.click(getByText('Select'));
@@ -233,7 +259,11 @@ it('clears invalid values, when it looses focus', async () => {
 
 it('clears invalid values, when enter', async () => {
   const { getByText, getByRole, queryByText } = render(
-    <Dropdown options={[{ value: 'LHR', label: 'Heathrow' }]} value="" />,
+    <Dropdown
+      placeholder="Select"
+      options={[{ value: 'LHR', label: 'Heathrow' }]}
+      value=""
+    />,
   );
 
   userEvent.click(getByText('Select'));

--- a/packages/react-components/src/atoms/__tests__/Dropdown.test.tsx
+++ b/packages/react-components/src/atoms/__tests__/Dropdown.test.tsx
@@ -23,11 +23,13 @@ it('without selection shows a placeholder', () => {
     />,
   );
   expect(getByText('Choose something')).toBeVisible();
+  expect(getComputedStyle(getByText('Choose something')).color).toBe(lead.rgb);
 
   rerender(
     <Dropdown options={[{ value: 'LHR', label: 'Heathrow' }]} value="" />,
   );
   expect(getByText('Select')).toBeVisible();
+  expect(getComputedStyle(getByText('Select')).color).toBe(lead.rgb);
 });
 
 it('without options shows a placeholder message that can be customized', () => {
@@ -64,6 +66,22 @@ it('allows selecting from a menu with available options', () => {
   userEvent.click(getByText('Select'));
   userEvent.click(getByText('Gatwick'));
   expect(handleChange).toHaveBeenCalledWith('LGW');
+});
+
+it('only shows valid options', () => {
+  const { getByText, queryByText } = render(
+    <Dropdown
+      options={[
+        { value: '', label: '-' },
+        { value: 'Heathrow', label: 'Heathrow' },
+      ]}
+      value=""
+    />,
+  );
+
+  userEvent.click(getByText('Select'));
+  expect(getByText('Heathrow')).toBeDefined();
+  expect(queryByText('-')).toBeNull();
 });
 
 it('shows the focused option in green', () => {

--- a/packages/react-components/src/atoms/__tests__/Dropdown.test.tsx
+++ b/packages/react-components/src/atoms/__tests__/Dropdown.test.tsx
@@ -33,10 +33,8 @@ it('shows a placeholder without a selection', () => {
   expect(getComputedStyle(getByText('Choose something')).color).toBe(lead.rgb);
 });
 
-it('shows a placeholder message without options', () => {
-  const { getByText, queryByText, rerender } = render(
-    <Dropdown options={[]} value="" />,
-  );
+it('shows no options message when there are no matching options', () => {
+  const { getByText, rerender } = render(<Dropdown options={[]} value="" />);
   userEvent.click(getByText('Select'));
   expect(getByText(/no.+options/i)).toBeVisible();
 
@@ -48,9 +46,8 @@ it('shows a placeholder message without options', () => {
     />,
   );
 
-  userEvent.click(getByText('Select'));
   userEvent.type(getByText('Select'), 'll');
-  expect(queryByText('Not found LL')).toBeDefined();
+  expect(getByText('Not found ll')).toBeVisible();
 });
 
 it('allows selecting from a menu with available options', () => {
@@ -87,7 +84,7 @@ it('only shows valid options', () => {
   );
 
   userEvent.click(getByText('Select'));
-  expect(getByText('Heathrow')).toBeDefined();
+  expect(getByText('Heathrow')).toBeVisible();
   expect(queryByText('-')).toBeNull();
 });
 

--- a/packages/react-components/src/molecules/__tests__/LabeledDropdown.test.tsx
+++ b/packages/react-components/src/molecules/__tests__/LabeledDropdown.test.tsx
@@ -3,7 +3,7 @@ import { render } from '@testing-library/react';
 import LabeledDropdown from '../LabeledDropdown';
 
 it('renders a labeled dropdown, passing through props', () => {
-  const { getByText, getByLabelText } = render(
+  const { getByLabelText } = render(
     <LabeledDropdown
       title="Title"
       subtitle="Optional"
@@ -14,5 +14,5 @@ it('renders a labeled dropdown, passing through props', () => {
 
   expect(getByLabelText(/Title/i)).toBeVisible();
   expect(getByLabelText(/Optional/i)).toBeVisible();
-  expect(getByText('Value')).toBeVisible();
+  expect(getByLabelText(/Title/i)).toHaveValue('val');
 });

--- a/packages/react-components/src/molecules/__tests__/LabeledDropdown.test.tsx
+++ b/packages/react-components/src/molecules/__tests__/LabeledDropdown.test.tsx
@@ -14,5 +14,5 @@ it('renders a labeled dropdown, passing through props', () => {
 
   expect(getByLabelText(/Title/i)).toBeVisible();
   expect(getByLabelText(/Optional/i)).toBeVisible();
-  expect(getByLabelText(/Title/i)).toHaveValue('val');
+  expect(getByLabelText(/Title/i)).toHaveValue('Value');
 });

--- a/packages/react-components/src/select.ts
+++ b/packages/react-components/src/select.ts
@@ -123,6 +123,10 @@ export const reactSelectStyles = (
     padding: 0,
     paddingRight: `${indicatorPadding / perRem}em`,
   }),
+  placeholder: (provided) => ({
+    ...provided,
+    color: lead.rgb,
+  }),
 });
 
 export const reactMultiSelectStyles = (

--- a/packages/react-components/src/templates/PersonalInfoModal.tsx
+++ b/packages/react-components/src/templates/PersonalInfoModal.tsx
@@ -175,15 +175,21 @@ const PersonalInfoModal: React.FC<PersonalInfoModalProps> = ({
               value={newJobTitle}
               enabled={!isSaving}
             />
-            <LabeledTypeahead
+            <LabeledDropdown
               title="Country"
               subtitle="(Required)"
               required
               getValidationMessage={() => 'Please add your country'}
-              suggestions={countrySuggestions}
+              options={countrySuggestions.map((countryName) => ({
+                label: countryName,
+                value: countryName,
+              }))}
               onChange={setNewCountry}
               value={newCountry}
               enabled={!isSaving}
+              noOptionsMessage={(value: { inputValue: string }) =>
+                `No countries match "${value.inputValue}"`
+              }
             />
             <LabeledTextField
               title="City"

--- a/packages/react-components/src/templates/PersonalInfoModal.tsx
+++ b/packages/react-components/src/templates/PersonalInfoModal.tsx
@@ -116,8 +116,8 @@ const PersonalInfoModal: React.FC<PersonalInfoModalProps> = ({
               title="Degree"
               subtitle="(Optional)"
               onChange={setNewDegree}
+              placeholder="Choose a degree"
               options={[
-                { label: 'Choose a degree', value: '' },
                 { label: 'BA', value: 'BA' },
                 { label: 'BSc', value: 'BSc' },
                 { label: 'MSc', value: 'MSc' },

--- a/packages/react-components/src/templates/__tests__/PersonalInfoModal.test.tsx
+++ b/packages/react-components/src/templates/__tests__/PersonalInfoModal.test.tsx
@@ -9,7 +9,7 @@ import PersonalInfoModal from '../PersonalInfoModal';
 
 const props: ComponentProps<typeof PersonalInfoModal> = {
   ...createUserResponse(),
-  countrySuggestions: ['United States', 'Mexico'],
+  countrySuggestions: [],
   loadInstitutionOptions: () => Promise.resolve([]),
   backHref: '/wrong',
 };
@@ -56,6 +56,7 @@ it('renders default values into text inputs', () => {
   const { queryAllByRole } = render(
     <PersonalInfoModal
       {...props}
+      countrySuggestions={['United States', 'Mexico']}
       firstName="firstName"
       lastName="lastName"
       country="United States"
@@ -77,6 +78,27 @@ it('renders default values into text inputs', () => {
       "city",
     ]
   `);
+});
+
+it('renders a country selector', () => {
+  const { getByText, queryByText } = render(
+    <PersonalInfoModal
+      {...props}
+      countrySuggestions={['United States', 'Mexico']}
+      country=""
+    />,
+    {
+      wrapper: StaticRouter,
+    },
+  );
+
+  userEvent.click(getByText('Select'));
+  expect(queryByText('United States')).toBeVisible();
+  expect(queryByText('Mexico')).toBeVisible();
+
+  userEvent.click(getByText('Select'));
+  userEvent.type(getByText('Select'), 'xx');
+  expect(queryByText(new RegExp(/no+countries/, 'i'))).toBeDefined();
 });
 
 it.each`
@@ -107,6 +129,7 @@ it('triggers the save function', async () => {
   const { getByText } = render(
     <PersonalInfoModal
       {...props}
+      countrySuggestions={['United States', 'Mexico']}
       firstName="firstName"
       lastName="lastName"
       country="United States"
@@ -142,7 +165,12 @@ it('disables the form elements while submitting', async () => {
       resolveSubmit = resolve;
     });
   const { getByText, getAllByRole } = render(
-    <PersonalInfoModal {...props} country="Mexico" onSave={handleSave} />,
+    <PersonalInfoModal
+      {...props}
+      countrySuggestions={['United States', 'Mexico']}
+      country="Mexico"
+      onSave={handleSave}
+    />,
     { wrapper: StaticRouter },
   );
 

--- a/packages/react-components/src/templates/__tests__/PersonalInfoModal.test.tsx
+++ b/packages/react-components/src/templates/__tests__/PersonalInfoModal.test.tsx
@@ -27,6 +27,26 @@ it('renders the title', () => {
   expect(getByText('Your details', { selector: 'h3' })).toBeVisible();
 });
 
+it('renders a country selector', async () => {
+  const { getByText } = render(
+    <PersonalInfoModal
+      country=""
+      countrySuggestions={['United States', 'Australia', 'Canada']}
+      loadInstitutionOptions={() => Promise.resolve([])}
+      backHref="/wrong"
+    />,
+    {
+      wrapper: StaticRouter,
+    },
+  );
+
+  userEvent.click(getByText('Select'));
+
+  expect(getByText('United States')).toBeVisible();
+  expect(getByText('Australia')).toBeVisible();
+  expect(getByText('Canada')).toBeVisible();
+});
+
 it('indicates which fields are required or optional', () => {
   const { getByText } = render(
     <PersonalInfoModal

--- a/packages/react-components/src/templates/__tests__/PersonalInfoModal.test.tsx
+++ b/packages/react-components/src/templates/__tests__/PersonalInfoModal.test.tsx
@@ -164,22 +164,24 @@ it('disables the form elements while submitting', async () => {
     new Promise<void>((resolve) => {
       resolveSubmit = resolve;
     });
-  const { getByText, getAllByRole } = render(
+  const { getByText } = render(
     <PersonalInfoModal
       {...props}
+      onSave={handleSave}
       countrySuggestions={['United States', 'Mexico']}
       country="Mexico"
-      onSave={handleSave}
     />,
     { wrapper: StaticRouter },
   );
 
   userEvent.click(getByText(/save/i));
-  getAllByRole('textbox').forEach((field) => expect(field).toBeDisabled());
+
+  const form = getByText(/save/i).closest('form')!;
+  expect(form.elements.length).toBeGreaterThan(1);
+  [...form.elements].forEach((element) => expect(element).toBeDisabled());
 
   act(resolveSubmit);
-
   await waitFor(() =>
-    getAllByRole('textbox').forEach((field) => expect(field).toBeEnabled()),
+    expect(getByText(/save/i).closest('button')).toBeEnabled(),
   );
 });

--- a/packages/react-components/src/templates/__tests__/PersonalInfoModal.test.tsx
+++ b/packages/react-components/src/templates/__tests__/PersonalInfoModal.test.tsx
@@ -9,14 +9,14 @@ import PersonalInfoModal from '../PersonalInfoModal';
 
 const props: ComponentProps<typeof PersonalInfoModal> = {
   ...createUserResponse(),
-  countrySuggestions: [],
+  countrySuggestions: ['United States', 'Mexico'],
   loadInstitutionOptions: () => Promise.resolve([]),
   backHref: '/wrong',
 };
 it('renders the title', () => {
   const { getByText } = render(
     <PersonalInfoModal
-      countrySuggestions={[]}
+      {...props}
       loadInstitutionOptions={() => Promise.resolve([])}
       backHref="/wrong"
     />,
@@ -25,26 +25,6 @@ it('renders the title', () => {
     },
   );
   expect(getByText('Your details', { selector: 'h3' })).toBeVisible();
-});
-
-it('renders a country selector', async () => {
-  const { getByText } = render(
-    <PersonalInfoModal
-      country=""
-      countrySuggestions={['United States', 'Australia', 'Canada']}
-      loadInstitutionOptions={() => Promise.resolve([])}
-      backHref="/wrong"
-    />,
-    {
-      wrapper: StaticRouter,
-    },
-  );
-
-  userEvent.click(getByText('Select'));
-
-  expect(getByText('United States')).toBeVisible();
-  expect(getByText('Australia')).toBeVisible();
-  expect(getByText('Canada')).toBeVisible();
 });
 
 it('indicates which fields are required or optional', () => {
@@ -78,7 +58,7 @@ it('renders default values into text inputs', () => {
       {...props}
       firstName="firstName"
       lastName="lastName"
-      country="country"
+      country="United States"
       city="city"
       jobTitle="jobTitle"
       institution="institution"
@@ -93,7 +73,7 @@ it('renders default values into text inputs', () => {
       "",
       "institution",
       "jobTitle",
-      "country",
+      "United States",
       "city",
     ]
   `);
@@ -109,7 +89,9 @@ it.each`
   async ({ label, value, message }) => {
     const { getByLabelText, findByText } = render(
       <PersonalInfoModal {...props} />,
-      { wrapper: StaticRouter },
+      {
+        wrapper: StaticRouter,
+      },
     );
     const input = getByLabelText(label);
     fireEvent.change(input, {
@@ -127,7 +109,7 @@ it('triggers the save function', async () => {
       {...props}
       firstName="firstName"
       lastName="lastName"
-      country="country"
+      country="United States"
       city="city"
       jobTitle="jobTitle"
       institution="institution"
@@ -141,7 +123,7 @@ it('triggers the save function', async () => {
   expect(jestFn).toHaveBeenCalledWith({
     firstName: 'firstName',
     lastName: 'lastName',
-    country: 'country',
+    country: 'United States',
     city: 'city',
     degree: 'MPH',
     jobTitle: 'jobTitle',
@@ -159,19 +141,17 @@ it('disables the form elements while submitting', async () => {
     new Promise<void>((resolve) => {
       resolveSubmit = resolve;
     });
-  const { getByText } = render(
-    <PersonalInfoModal {...props} onSave={handleSave} />,
+  const { getByText, getAllByRole } = render(
+    <PersonalInfoModal {...props} country="Mexico" onSave={handleSave} />,
     { wrapper: StaticRouter },
   );
 
   userEvent.click(getByText(/save/i));
-
-  const form = getByText(/save/i).closest('form')!;
-  expect(form.elements.length).toBeGreaterThan(1);
-  [...form.elements].forEach((element) => expect(element).toBeDisabled());
+  getAllByRole('textbox').forEach((field) => expect(field).toBeDisabled());
 
   act(resolveSubmit);
+
   await waitFor(() =>
-    expect(getByText(/save/i).closest('button')).toBeEnabled(),
+    getAllByRole('textbox').forEach((field) => expect(field).toBeEnabled()),
   );
 });

--- a/packages/react-components/src/templates/__tests__/PersonalInfoModal.test.tsx
+++ b/packages/react-components/src/templates/__tests__/PersonalInfoModal.test.tsx
@@ -92,12 +92,12 @@ it('renders a country selector', () => {
     },
   );
 
-  userEvent.click(getByText('Select'));
+  userEvent.click(getByText('Start Typing...'));
   expect(queryByText('United States')).toBeVisible();
   expect(queryByText('Mexico')).toBeVisible();
 
-  userEvent.click(getByText('Select'));
-  userEvent.type(getByText('Select'), 'xx');
+  userEvent.click(getByText('Start Typing...'));
+  userEvent.type(getByText('Start Typing...'), 'xx');
   expect(queryByText(new RegExp(/no+countries/, 'i'))).toBeDefined();
 });
 

--- a/packages/react-components/src/templates/__tests__/TeamMembershipModal.test.tsx
+++ b/packages/react-components/src/templates/__tests__/TeamMembershipModal.test.tsx
@@ -33,29 +33,28 @@ it('indicates which fields are required or optional', () => {
   );
 });
 
-it('renders default values into text inputs', () => {
-  const { getByLabelText, getAllByLabelText, getByDisplayValue, getByText } =
-    render(
-      <TeamMembershipModal
-        {...props}
-        approach="approach"
-        responsibilities="responsibilities"
-        role="Collaborating PI"
-        displayName="Team Name"
-        labs={[
-          { name: 'Lab 1', id: '1' },
-          { name: 'Lab 2', id: '2' },
-        ]}
-      />,
-      { wrapper: StaticRouter },
-    );
+it('renders default values into text inputs', async () => {
+  const { getByLabelText, getAllByLabelText } = render(
+    <TeamMembershipModal
+      {...props}
+      approach="approach"
+      responsibilities="responsibilities"
+      role="Collaborating PI"
+      displayName="Team Name"
+      labs={[
+        { name: 'Lab 1', id: '1' },
+        { name: 'Lab 2', id: '2' },
+      ]}
+    />,
+    { wrapper: StaticRouter },
+  );
   expect(getByLabelText(/team/i)).toHaveValue('Team Name');
-  expect(getByText('Collaborating PI')).toBeVisible();
+  expect(getByLabelText(/role/i)).toHaveValue('Collaborating PI');
   expect(getByLabelText(/main.+interests/i)).toHaveValue('approach');
   expect(getByLabelText(/responsibilities/i)).toHaveValue('responsibilities');
   expect(getAllByLabelText(/lab/i)).toHaveLength(2);
-  expect(getByDisplayValue('Lab 1')).toBeVisible();
-  expect(getByDisplayValue('Lab 2')).toBeVisible();
+  expect(getAllByLabelText(/lab/i)[0]).toHaveValue('Lab 1');
+  expect(getAllByLabelText(/lab/i)[1]).toHaveValue('Lab 2');
 });
 
 it('triggers the save function', async () => {

--- a/packages/squidex/schema/rules/rule4.json
+++ b/packages/squidex/schema/rules/rule4.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "./../__json/rule.json",
+  "isEnabled": true,
+  "name": "Teams upated",
+  "trigger": {
+    "triggerType": "ContentChanged",
+    "schemas": [
+      {
+        "schemaId": "teams",
+        "condition": "event.type == 'Created' || event.type == 'Updated'"
+      }
+    ],
+    "handleAll": false
+  },
+  "action": {
+    "url": "ASAP_API_URL/webhook/teams",
+    "method": "POST",
+    "sharedSecret": "SQUIDEX_SHARED_SECRET",
+    "actionType": "Webhook"
+  }
+}


### PR DESCRIPTION
https://trello.com/c/27dUYTjL/1566-disable-custom-values-for-country-only-accept-allowed-values

- Updates Personal Info Modal, so the country selector only allow the selection of valid values
- Updates Dropdown component to support validation
