### PR TITLE
fix: User search with special characters

### DIFF
--- a/apps/asap-server/src/utils/squidex.ts
+++ b/apps/asap-server/src/utils/squidex.ts
@@ -14,7 +14,16 @@ export const parseDate = (date: string): Date =>
   DateTime.fromISO(date).toJSDate();
 
 export const sanitiseForSquidex = (text: string): string =>
-  escape(text.replace(/'/g, "''"));
+  text
+    .replace(/'/g, "''")
+    .replace(/%/g, '%25')
+    .replace(/"/g, '%22')
+    .replace(/'/g, '%27')
+    .replace(/\+/g, '%2B')
+    .replace(/\//g, '%2F')
+    .replace(/\?/g, '%3F')
+    .replace(/#/g, '%23')
+    .replace(/&/g, '%26');
 
 export const validatePropertiesRequired = <
   T extends { [key: string]: unknown },

--- a/apps/asap-server/src/utils/squidex.ts
+++ b/apps/asap-server/src/utils/squidex.ts
@@ -15,10 +15,8 @@ export const parseDate = (date: string): Date =>
 
 export const sanitiseForSquidex = (text: string): string =>
   text
-    .replace(/'/g, "''")
-    .replace(/%/g, '%25')
+    .replace(/'/g, '%27%27')
     .replace(/"/g, '%22')
-    .replace(/'/g, '%27')
     .replace(/\+/g, '%2B')
     .replace(/\//g, '%2F')
     .replace(/\?/g, '%3F')

--- a/apps/asap-server/test/controllers/users.test.ts
+++ b/apps/asap-server/test/controllers/users.test.ts
@@ -158,6 +158,36 @@ describe('Users controller', () => {
 
       expect(result).toEqual(fetchExpectation);
     });
+
+    test('Should search with special characters', async () => {
+      const fetchOptions: FetchOptions = {
+        take: 12,
+        skip: 2,
+        search: 'Solène',
+      };
+
+      const expectedFilter =
+        "data/onboarded/iv eq true and data/role/iv ne 'Hidden' and" +
+        " ((contains(data/firstName/iv, 'Solène')" +
+        " or contains(data/lastName/iv, 'Solène')" +
+        " or contains(data/institution/iv, 'Solène')" +
+        " or contains(data/skills/iv, 'Solène')))";
+
+      nock(config.baseUrl)
+        .post(`/api/content/${config.appName}/graphql`, {
+          query: buildGraphQLQueryFetchUsers(),
+          variables: {
+            filter: expectedFilter,
+            top: 12,
+            skip: 2,
+          },
+        })
+        .reply(200, graphQlResponseFetchUsers);
+
+      const result = await users.fetch(fetchOptions);
+
+      expect(result).toEqual(fetchExpectation);
+    });
   });
 
   describe('fetchById', () => {


### PR DESCRIPTION
Replace the native escape function with a custom sanitisation function for odata support

see: https://trello.com/c/IHU7bWU2/1525-search-does-not-work-on-terms-with-odd-characters-such-as-%C3%A8