### PR TITLE
feat: removes Algolia record when research output deleted/drafted

### DIFF
--- a/apps/asap-server/src/handlers/research-output/index-handler.ts
+++ b/apps/asap-server/src/handlers/research-output/index-handler.ts
@@ -30,11 +30,7 @@ export const indexResearchOutputHandler = (
   ): Promise<void> => {
     logger.debug(`Event ${event['detail-type']}`);
 
-    if (
-      ['ResearchOutputCreated', 'ResearchOutputUpdated'].includes(
-        event['detail-type'],
-      )
-    ) {
+    try {
       const researchOutput = await researchOutputController.fetchById(
         event.detail.payload.id,
       );
@@ -47,9 +43,9 @@ export const indexResearchOutputHandler = (
       });
 
       logger.debug(`Saved research-output ${researchOutput.id}`);
-    }
+    } catch (e) {
+      logger.debug(JSON.stringify(e));
 
-    if (event['detail-type'] === 'ResearchOutputDeleted') {
       await algoliaIndex.deleteObject(event.detail.payload.id);
       logger.debug(`Deleted research-output ${event.detail.payload.id}`);
     }
@@ -58,7 +54,7 @@ export const indexResearchOutputHandler = (
 
 export type SquidexWebhookResearchOutputPayload = {
   type:
-    | 'ResearchOutputsCreated'
+    | 'ResearchOutputsPublished'
     | 'ResearchOutputsUpdated'
     | 'ResearchOutputsUnpublished'
     | 'ResearchOutputsDeleted';

--- a/apps/asap-server/src/handlers/research-output/index-handler.ts
+++ b/apps/asap-server/src/handlers/research-output/index-handler.ts
@@ -45,15 +45,9 @@ export const indexResearchOutputHandler = (
       logger.debug(`Saved research-output ${researchOutput.id}`);
     } catch (e) {
       if (e?.output?.statusCode === 404) {
-        try {
-          await algoliaIndex.deleteObject(event.detail.payload.id);
-        } catch (err) {
-          logger.debug(JSON.stringify(err));
-          logger.debug(`Deleted research-output ${event.detail.payload.id}`);
-        }
-      } else {
-        throw e;
+        await algoliaIndex.deleteObject(event.detail.payload.id);
       }
+      throw e;
     }
   };
 };

--- a/apps/asap-server/src/handlers/research-output/index-handler.ts
+++ b/apps/asap-server/src/handlers/research-output/index-handler.ts
@@ -44,11 +44,15 @@ export const indexResearchOutputHandler = (
 
       logger.debug(`Saved research-output ${researchOutput.id}`);
     } catch (e) {
-      logger.debug(JSON.stringify(e));
-
-      if (e.output.statusCode === 404) {
-        await algoliaIndex.deleteObject(event.detail.payload.id);
-        logger.debug(`Deleted research-output ${event.detail.payload.id}`);
+      if (e?.output?.statusCode === 404) {
+        try {
+          await algoliaIndex.deleteObject(event.detail.payload.id);
+        } catch (err) {
+          logger.debug(JSON.stringify(err));
+          logger.debug(`Deleted research-output ${event.detail.payload.id}`);
+        }
+      } else {
+        throw e;
       }
     }
   };

--- a/apps/asap-server/src/handlers/research-output/index-handler.ts
+++ b/apps/asap-server/src/handlers/research-output/index-handler.ts
@@ -49,11 +49,7 @@ export const indexResearchOutputHandler = (
       logger.debug(`Saved research-output ${researchOutput.id}`);
     }
 
-    if (
-      ['ResearchOutputUnpublished', 'ResearchOutputDeleted'].includes(
-        event['detail-type'],
-      )
-    ) {
+    if (event['detail-type'] === 'ResearchOutputDeleted') {
       await algoliaIndex.deleteObject(event.detail.payload.id);
       logger.debug(`Deleted research-output ${event.detail.payload.id}`);
     }

--- a/apps/asap-server/src/handlers/research-output/index-handler.ts
+++ b/apps/asap-server/src/handlers/research-output/index-handler.ts
@@ -46,8 +46,10 @@ export const indexResearchOutputHandler = (
     } catch (e) {
       logger.debug(JSON.stringify(e));
 
-      await algoliaIndex.deleteObject(event.detail.payload.id);
-      logger.debug(`Deleted research-output ${event.detail.payload.id}`);
+      if (e.output.statusCode === 404) {
+        await algoliaIndex.deleteObject(event.detail.payload.id);
+        logger.debug(`Deleted research-output ${event.detail.payload.id}`);
+      }
     }
   };
 };

--- a/apps/asap-server/src/handlers/webhooks/webhook-research-output.ts
+++ b/apps/asap-server/src/handlers/webhooks/webhook-research-output.ts
@@ -47,7 +47,6 @@ export const researchOutputWebhookFactory = (
 export type ResearchOutputEventType =
   | 'ResearchOutputCreated'
   | 'ResearchOutputUpdated'
-  | 'ResearchOutputUnpublished'
   | 'ResearchOutputDeleted';
 
 const getEventType = (
@@ -61,7 +60,7 @@ const getEventType = (
       return 'ResearchOutputUpdated';
 
     case 'ResearchOutputsUnpublished':
-      return 'ResearchOutputUnpublished';
+      return 'ResearchOutputDeleted';
 
     case 'ResearchOutputsDeleted':
       return 'ResearchOutputDeleted';

--- a/apps/asap-server/src/handlers/webhooks/webhook-research-output.ts
+++ b/apps/asap-server/src/handlers/webhooks/webhook-research-output.ts
@@ -5,6 +5,7 @@ import { Handler } from '../../utils/types';
 import { http } from '../../utils/instrumented-framework';
 import validateRequest from '../../utils/validate-squidex-request';
 import { eventBus, eventSource } from '../../config';
+import logger from '../../utils/logger';
 
 export const researchOutputWebhookFactory = (
   eventBridge: EventBridge,
@@ -13,10 +14,11 @@ export const researchOutputWebhookFactory = (
     async (
       request: lambda.Request<WebhookPayload<ResearchOutput>>,
     ): Promise<lambda.Response> => {
-      await validateRequest(request);
+      validateRequest(request);
 
       const type = getEventType(request.payload.type);
 
+      logger.debug(`Event type ${type}`);
       if (!type) {
         return {
           statusCode: 204,
@@ -44,20 +46,29 @@ export const researchOutputWebhookFactory = (
 
 export type ResearchOutputEventType =
   | 'ResearchOutputCreated'
-  | 'ResearchOutputUpdated';
+  | 'ResearchOutputUpdated'
+  | 'ResearchOutputUnpublished'
+  | 'ResearchOutputDeleted';
 
 const getEventType = (
   customType: string,
 ): ResearchOutputEventType | undefined => {
-  if (customType === 'ResearchOutputsPublished') {
-    return 'ResearchOutputCreated';
-  }
+  switch (customType) {
+    case 'ResearchOutputsPublished':
+      return 'ResearchOutputCreated';
 
-  if (customType === 'ResearchOutputsUpdated') {
-    return 'ResearchOutputUpdated';
-  }
+    case 'ResearchOutputsUpdated':
+      return 'ResearchOutputUpdated';
 
-  return undefined;
+    case 'ResearchOutputsUnpublished':
+      return 'ResearchOutputUnpublished';
+
+    case 'ResearchOutputsDeleted':
+      return 'ResearchOutputDeleted';
+
+    default:
+      return undefined;
+  }
 };
 
 const eventBridge = new EventBridge();

--- a/apps/asap-server/test/fixtures/research-output.fixtures.ts
+++ b/apps/asap-server/test/fixtures/research-output.fixtures.ts
@@ -323,6 +323,41 @@ export const getResearchOutputEvent = (): WebhookPayload<ResearchOutput> => ({
   },
 });
 
+export const researchOutputEvent = (
+  type:
+    | 'ResearchOutputsPublished'
+    | 'ResearchOutputsUpdated'
+    | 'ResearchOutputsUnpublished'
+    | 'ResearchOutputsDeleted',
+  action: 'Published' | 'Updated' | 'Deleted' | 'Unpublished',
+): WebhookPayload<ResearchOutput> => ({
+  type,
+  timestamp: '2021-02-15T13:11:25Z',
+  payload: {
+    $type: 'EnrichedContentEvent',
+    type: action,
+    id: 'userId',
+    created: '2020-07-31T14:11:58Z',
+    lastModified: '2020-07-31T15:49:41Z',
+    data: {
+      type: { iv: 'Article' },
+      title: { iv: 'Research Output' },
+      description: { iv: 'Description' },
+      sharingStatus: { iv: 'Network Only' },
+      asapFunded: { iv: 'Not Sure' },
+      usedInAPublication: { iv: 'Not Sure' },
+    } as Rest<ResearchOutput>['data'],
+    dataOld: {
+      type: { iv: 'Article' },
+      title: { iv: 'Research Output' },
+      description: { iv: 'Description' },
+      sharingStatus: { iv: 'Network Only' },
+      asapFunded: { iv: 'Not Sure' },
+      usedInAPublication: { iv: 'Not Sure' },
+    } as Rest<ResearchOutput>['data'],
+  },
+});
+
 export const updateResearchOutputEvent: WebhookPayload<ResearchOutput> = {
   type: 'ResearchOutputsUpdated',
   timestamp: '2021-02-15T13:11:25Z',

--- a/apps/asap-server/test/fixtures/research-output.fixtures.ts
+++ b/apps/asap-server/test/fixtures/research-output.fixtures.ts
@@ -11,6 +11,8 @@ import {
 } from '../../src/gql/graphql';
 import { DeepWriteable } from '../../src/utils/types';
 import { fetchExpectation, graphQlResponseFetchUsers } from './users.fixtures';
+import { createEventBridgeEventMock } from '../../test/helpers/events';
+import { ResearchOutputEventType } from '../../src/handlers/webhooks/webhook-research-output';
 
 export const getSquidexResearchOutputsGraphqlResponse =
   (): FetchResearchOutputsQuery => ({
@@ -303,20 +305,20 @@ export const getListResearchOutputResponse =
     items: [getResearchOutputResponse()],
   });
 
-export const researchOutputEvent = (
+export const getResearchOutputWebhookPayload = (
+  id: string,
   type:
     | 'ResearchOutputsPublished'
     | 'ResearchOutputsUpdated'
     | 'ResearchOutputsUnpublished'
     | 'ResearchOutputsDeleted',
-  action: 'Published' | 'Updated' | 'Deleted' | 'Unpublished',
 ): WebhookPayload<ResearchOutput> => ({
   type,
   timestamp: '2021-02-15T13:11:25Z',
   payload: {
     $type: 'EnrichedContentEvent',
-    type: action,
-    id: 'userId',
+    type: '',
+    id,
     created: '2020-07-31T14:11:58Z',
     lastModified: '2020-07-31T15:49:41Z',
     data: {
@@ -338,30 +340,17 @@ export const researchOutputEvent = (
   },
 });
 
-export const updateResearchOutputEvent: WebhookPayload<ResearchOutput> = {
-  type: 'ResearchOutputsUpdated',
-  timestamp: '2021-02-15T13:11:25Z',
-  payload: {
-    $type: 'EnrichedContentEvent',
-    type: 'Updated',
-    id: 'userId',
-    created: '2020-07-31T14:11:58Z',
-    lastModified: '2020-07-31T15:49:41Z',
-    data: {
-      type: { iv: 'Article' },
-      title: { iv: 'Research Output' },
-      description: { iv: 'Description' },
-      sharingStatus: { iv: 'Network Only' },
-      asapFunded: { iv: 'Not Sure' },
-      usedInAPublication: { iv: 'Not Sure' },
-    } as Rest<ResearchOutput>['data'],
-    dataOld: {
-      type: { iv: 'Article' },
-      title: { iv: 'Research Output' },
-      description: { iv: 'Description' },
-      sharingStatus: { iv: 'Network Only' },
-      asapFunded: { iv: 'Not Sure' },
-      usedInAPublication: { iv: 'Not Sure' },
-    } as Rest<ResearchOutput>['data'],
-  },
-};
+export const getResearchOutputEvent = (
+  id: string,
+  squidexEvent:
+    | 'ResearchOutputsPublished'
+    | 'ResearchOutputsUpdated'
+    | 'ResearchOutputsUnpublished'
+    | 'ResearchOutputsDeleted',
+  eventType: ResearchOutputEventType,
+) =>
+  createEventBridgeEventMock(
+    getResearchOutputWebhookPayload(id, squidexEvent),
+    eventType,
+    id,
+  );

--- a/apps/asap-server/test/fixtures/research-output.fixtures.ts
+++ b/apps/asap-server/test/fixtures/research-output.fixtures.ts
@@ -303,26 +303,6 @@ export const getListResearchOutputResponse =
     items: [getResearchOutputResponse()],
   });
 
-export const getResearchOutputEvent = (): WebhookPayload<ResearchOutput> => ({
-  type: 'ResearchOutputsPublished',
-  timestamp: '2021-02-15T13:11:25Z',
-  payload: {
-    $type: 'EnrichedContentEvent',
-    type: 'Published',
-    id: 'researchOutputId',
-    created: '2020-07-31T15:52:33Z',
-    lastModified: '2020-07-31T15:52:33Z',
-    data: {
-      type: { iv: 'Article' },
-      title: { iv: 'Research Output' },
-      description: { iv: 'Description' },
-      sharingStatus: { iv: 'Network Only' },
-      asapFunded: { iv: 'Not Sure' },
-      usedInAPublication: { iv: 'Not Sure' },
-    } as Rest<ResearchOutput>['data'],
-  },
-});
-
 export const researchOutputEvent = (
   type:
     | 'ResearchOutputsPublished'

--- a/apps/asap-server/test/handlers/research-output/index-handler.test.ts
+++ b/apps/asap-server/test/handlers/research-output/index-handler.test.ts
@@ -20,36 +20,102 @@ describe('Research Output index handler', () => {
 
   afterEach(() => jest.clearAllMocks());
 
-  test('Should fetch the research-output and create a record in Algolia when no records exists yet', async () => {
+  test('Should fetch the research-output and create a record in Algolia when research-output is created', async () => {
     const researchOutputResponse = getResearchOutputResponse();
     researchOutputControllerMock.fetchById.mockResolvedValueOnce(
       researchOutputResponse,
     );
 
-    await indexHandler(getEvent());
+    await indexHandler(
+      createEventBridgeEventMock(
+        {
+          type: 'ResearchOutputsCreated',
+          payload: {
+            $type: 'EnrichedContentEvent',
+            type: 'Published',
+            id: '0ecccf93-bd06-4307-90ea-c153fe495580',
+          },
+        },
+        'ResearchOutputCreated',
+      ),
+    );
 
     expect(algoliaIndexMock.saveObject).toHaveBeenCalledWith({
       ...researchOutputResponse,
       objectID: researchOutputResponse.id,
     });
   });
+
+  test('Should fetch the research-output and create a record in Algolia when research-output is updated', async () => {
+    const researchOutputResponse = getResearchOutputResponse();
+    researchOutputControllerMock.fetchById.mockResolvedValueOnce(
+      researchOutputResponse,
+    );
+
+    await indexHandler(
+      createEventBridgeEventMock(
+        {
+          type: 'ResearchOutputsUpdated',
+          payload: {
+            $type: 'EnrichedContentEvent',
+            type: 'Published',
+            id: '0ecccf93-bd06-4307-90ea-c153fe495580',
+          },
+        },
+        'ResearchOutputUpdated',
+      ),
+    );
+
+    expect(algoliaIndexMock.saveObject).toHaveBeenCalledWith({
+      ...researchOutputResponse,
+      objectID: researchOutputResponse.id,
+    });
+  });
+
+  test('Should remove the record Algolia when research-output has been converted to draft', async () => {
+    const event: EventBridgeEvent<
+      ResearchOutputEventType,
+      SquidexWebhookResearchOutputPayload
+    > = createEventBridgeEventMock(
+      {
+        type: 'ResearchOutputsUnpublished',
+        payload: {
+          $type: 'EnrichedContentEvent',
+          type: 'Unpublished',
+          id: '0ecccf93-bd06-4307-90ea-c153fe495580',
+        },
+      },
+      'ResearchOutputUnpublished',
+    );
+    await indexHandler(event);
+
+    expect(researchOutputControllerMock.fetchById).not.toHaveBeenCalled();
+    expect(algoliaIndexMock.deleteObject).toHaveBeenCalledWith(
+      event.detail.payload.id,
+    );
+  });
+
+  test('Should remove the record Algolia when research-output has been converted to draft', async () => {
+    const event: EventBridgeEvent<
+      ResearchOutputEventType,
+      SquidexWebhookResearchOutputPayload
+    > = createEventBridgeEventMock(
+      {
+        type: 'ResearchOutputsDeleted',
+        payload: {
+          $type: 'EnrichedContentEvent',
+          type: 'Unpublished',
+          id: '0ecccf93-bd06-4307-90ea-c153fe495580',
+        },
+      },
+      'ResearchOutputDeleted',
+    );
+
+    await indexHandler(event);
+
+    expect(researchOutputControllerMock.fetchById).not.toHaveBeenCalled();
+    expect(algoliaIndexMock.deleteObject).toHaveBeenCalledWith(
+      event.detail.payload.id,
+    );
+  });
 });
-
-const getEvent = (): EventBridgeEvent<
-  ResearchOutputEventType,
-  SquidexWebhookResearchOutputPayload
-> =>
-  createEventBridgeEventMock(
-    createResearchOutputSquidexWebhookPayload,
-    'ResearchOutputCreated',
-  );
-
-const createResearchOutputSquidexWebhookPayload: SquidexWebhookResearchOutputPayload =
-  {
-    type: 'ResearchOutputsCreated',
-    payload: {
-      $type: 'EnrichedContentEvent',
-      type: 'Created',
-      id: '0ecccf93-bd06-4307-90ea-c153fe495580',
-    },
-  };

--- a/apps/asap-server/test/handlers/research-output/index-handler.test.ts
+++ b/apps/asap-server/test/handlers/research-output/index-handler.test.ts
@@ -72,36 +72,13 @@ describe('Research Output index handler', () => {
     });
   });
 
-  test('Should remove the record Algolia when research-output has been converted to draft', async () => {
+  test('Should remove the record Algolia when research-output has been deleted', async () => {
     const event: EventBridgeEvent<
       ResearchOutputEventType,
       SquidexWebhookResearchOutputPayload
     > = createEventBridgeEventMock(
       {
         type: 'ResearchOutputsUnpublished',
-        payload: {
-          $type: 'EnrichedContentEvent',
-          type: 'Unpublished',
-          id: '0ecccf93-bd06-4307-90ea-c153fe495580',
-        },
-      },
-      'ResearchOutputUnpublished',
-    );
-    await indexHandler(event);
-
-    expect(researchOutputControllerMock.fetchById).not.toHaveBeenCalled();
-    expect(algoliaIndexMock.deleteObject).toHaveBeenCalledWith(
-      event.detail.payload.id,
-    );
-  });
-
-  test('Should remove the record Algolia when research-output has been converted to draft', async () => {
-    const event: EventBridgeEvent<
-      ResearchOutputEventType,
-      SquidexWebhookResearchOutputPayload
-    > = createEventBridgeEventMock(
-      {
-        type: 'ResearchOutputsDeleted',
         payload: {
           $type: 'EnrichedContentEvent',
           type: 'Unpublished',

--- a/apps/asap-server/test/handlers/research-output/index-handler.test.ts
+++ b/apps/asap-server/test/handlers/research-output/index-handler.test.ts
@@ -4,8 +4,10 @@ import {
   SquidexWebhookResearchOutputPayload,
 } from '../../../src/handlers/research-output/index-handler';
 import { ResearchOutputEventType } from '../../../src/handlers/webhooks/webhook-research-output';
-import { getResearchOutputResponse } from '../../fixtures/research-output.fixtures';
-import { createEventBridgeEventMock } from '../../helpers/events';
+import {
+  getResearchOutputResponse,
+  getResearchOutputEvent,
+} from '../../fixtures/research-output.fixtures';
 import {
   algoliaClientMock,
   algoliaIndexMock,
@@ -26,19 +28,7 @@ describe('Research Output index handler', () => {
       researchOutputResponse,
     );
 
-    await indexHandler(
-      createEventBridgeEventMock(
-        {
-          type: 'ResearchOutputsPublished',
-          payload: {
-            $type: 'EnrichedContentEvent',
-            type: 'Published',
-            id: '0ecccf93-bd06-4307-90ea-c153fe495580',
-          },
-        },
-        'ResearchOutputCreated',
-      ),
-    );
+    await indexHandler(createEvent('ro-1234'));
 
     expect(algoliaIndexMock.saveObject).toHaveBeenCalledWith({
       ...researchOutputResponse,
@@ -52,19 +42,7 @@ describe('Research Output index handler', () => {
       researchOutputResponse,
     );
 
-    await indexHandler(
-      createEventBridgeEventMock(
-        {
-          type: 'ResearchOutputsUpdated',
-          payload: {
-            $type: 'EnrichedContentEvent',
-            type: 'Published',
-            id: '0ecccf93-bd06-4307-90ea-c153fe495580',
-          },
-        },
-        'ResearchOutputUpdated',
-      ),
-    );
+    await indexHandler(updateEvent('ro-1234'));
 
     expect(algoliaIndexMock.saveObject).toHaveBeenCalledWith({
       ...researchOutputResponse,
@@ -72,26 +50,8 @@ describe('Research Output index handler', () => {
     });
   });
 
-  test('Should remove the record Algolia when research-output when research-output is not found', async () => {
-    researchOutputControllerMock.fetchById.mockRejectedValueOnce({
-      statusCode: 404,
-    });
-
-    const event: EventBridgeEvent<
-      ResearchOutputEventType,
-      SquidexWebhookResearchOutputPayload
-    > = createEventBridgeEventMock(
-      {
-        type: 'ResearchOutputsUnpublished',
-        payload: {
-          $type: 'EnrichedContentEvent',
-          type: 'Unpublished',
-          id: '0ecccf93-bd06-4307-90ea-c153fe495580',
-        },
-      },
-      'ResearchOutputDeleted',
-    );
-
+  test('Should remove the record Algolia when research-output is unpublished', async () => {
+    const event = unpublishedEvent('ro-1234');
     await indexHandler(event);
 
     expect(algoliaIndexMock.deleteObject).toHaveBeenCalledWith(
@@ -99,48 +59,342 @@ describe('Research Output index handler', () => {
     );
   });
 
-  test('Should not relay on the order of the events, i.e. unpublished and published', async () => {
-    const researchOutputResponse = getResearchOutputResponse();
-    researchOutputControllerMock.fetchById.mockRejectedValueOnce(new Error());
-
-    researchOutputControllerMock.fetchById.mockResolvedValueOnce(
-      researchOutputResponse,
-    );
-
-    await indexHandler(
-      createEventBridgeEventMock(
-        {
-          type: 'ResearchOutputsUnpublished',
-          payload: {
-            $type: 'EnrichedContentEvent',
-            type: 'Unpublished',
-            id: researchOutputResponse.id,
-          },
-        },
-        'ResearchOutputDeleted',
-      ),
-    );
-
-    await indexHandler(
-      createEventBridgeEventMock(
-        {
-          type: 'ResearchOutputsUpdated',
-          payload: {
-            $type: 'EnrichedContentEvent',
-            type: 'Published',
-            id: researchOutputResponse.id,
-          },
-        },
-        'ResearchOutputUpdated',
-      ),
-    );
+  test('Should remove the record Algolia when research-output is deleted', async () => {
+    const event = deleteEvent('ro-1234');
+    await indexHandler(event);
 
     expect(algoliaIndexMock.deleteObject).toHaveBeenCalledWith(
-      researchOutputResponse.id,
+      event.detail.payload.id,
     );
-    expect(algoliaIndexMock.saveObject).toHaveBeenCalledWith({
-      ...researchOutputResponse,
-      objectID: researchOutputResponse.id,
+  });
+
+  describe('Should process all events, and not relay on the order', () => {
+    it('receives on correct order the events created and updated', async () => {
+      const roID = 'ro-1234';
+      const createEv = createEvent(roID);
+      const updateEv = updateEvent(roID);
+      const researchOutputResponse = {
+        ...getResearchOutputResponse(),
+        id: roID,
+      };
+
+      researchOutputControllerMock.fetchById.mockResolvedValueOnce({
+        ...researchOutputResponse,
+        title: 'Original title',
+      });
+
+      await indexHandler(createEv);
+      expect(algoliaIndexMock.deleteObject).not.toHaveBeenCalled();
+      expect(algoliaIndexMock.saveObject).toHaveBeenCalledWith({
+        ...researchOutputResponse,
+        title: 'Original title',
+        objectID: researchOutputResponse.id,
+      });
+
+      researchOutputControllerMock.fetchById.mockResolvedValueOnce({
+        ...researchOutputResponse,
+        title: 'New title',
+      });
+
+      await indexHandler(updateEv);
+      expect(algoliaIndexMock.deleteObject).not.toHaveBeenCalled();
+      expect(algoliaIndexMock.saveObject).toHaveBeenCalledTimes(2);
+      expect(algoliaIndexMock.saveObject).toHaveBeenLastCalledWith({
+        ...researchOutputResponse,
+        title: 'New title',
+        objectID: researchOutputResponse.id,
+      });
+    });
+
+    it('receives on reverse order the events created and updated', async () => {
+      const roID = 'ro-1234';
+      const createEv = createEvent(roID);
+      const updateEv = updateEvent(roID);
+      const researchOutputResponse = {
+        ...getResearchOutputResponse(),
+        id: roID,
+      };
+
+      researchOutputControllerMock.fetchById.mockResolvedValueOnce({
+        ...researchOutputResponse,
+        title: 'Updated title',
+      });
+
+      await indexHandler(updateEv);
+      expect(algoliaIndexMock.deleteObject).not.toHaveBeenCalled();
+      expect(algoliaIndexMock.saveObject).toHaveBeenLastCalledWith({
+        ...researchOutputResponse,
+        title: 'Updated title',
+        objectID: researchOutputResponse.id,
+      });
+
+      researchOutputControllerMock.fetchById.mockResolvedValueOnce({
+        ...researchOutputResponse,
+        title: 'Old title',
+      });
+      await indexHandler(createEv);
+
+      expect(algoliaIndexMock.deleteObject).not.toHaveBeenCalled();
+      expect(algoliaIndexMock.saveObject).toHaveBeenLastCalledWith({
+        ...researchOutputResponse,
+        title: 'Old title',
+        objectID: researchOutputResponse.id,
+      });
+    });
+    it('receives on correct order the events created and unpublished', async () => {
+      const roID = 'ro-1234';
+      const createEv = createEvent(roID);
+      const unpublishedEv = unpublishedEvent(roID);
+
+      const researchOutputResponse = {
+        ...getResearchOutputResponse(),
+        id: roID,
+      };
+
+      researchOutputControllerMock.fetchById.mockResolvedValueOnce(
+        researchOutputResponse,
+      );
+
+      await indexHandler(createEv);
+      expect(algoliaIndexMock.deleteObject).not.toHaveBeenCalled();
+      expect(algoliaIndexMock.saveObject).toHaveBeenCalledWith({
+        ...researchOutputResponse,
+        objectID: researchOutputResponse.id,
+      });
+
+      await indexHandler(unpublishedEv);
+      expect(algoliaIndexMock.saveObject).toHaveBeenCalledTimes(1);
+      expect(algoliaIndexMock.deleteObject).toHaveBeenCalledWith(
+        unpublishedEv.detail.payload.id,
+      );
+    });
+    it('receives on reverser order the events created and unpublished', async () => {
+      const roID = 'ro-1234';
+      const createEv = createEvent(roID);
+      const unpublishedEv = unpublishedEvent(roID);
+      const researchOutputResponse = {
+        ...getResearchOutputResponse(),
+        id: roID,
+      };
+
+      await indexHandler(unpublishedEv);
+      expect(algoliaIndexMock.saveObject).not.toHaveBeenCalled();
+      expect(algoliaIndexMock.deleteObject).toHaveBeenCalledWith(
+        unpublishedEv.detail.payload.id,
+      );
+
+      researchOutputControllerMock.fetchById.mockResolvedValueOnce(
+        researchOutputResponse,
+      );
+
+      await indexHandler(createEv);
+      expect(algoliaIndexMock.deleteObject).toHaveBeenCalledTimes(1);
+      expect(algoliaIndexMock.saveObject).toHaveBeenCalledWith({
+        ...researchOutputResponse,
+        objectID: researchOutputResponse.id,
+      });
+    });
+
+    it('receives on correct order the events created and deleted', async () => {
+      const roID = 'ro-1234';
+      const createEv = createEvent(roID);
+      const deleteEv = deleteEvent(roID);
+
+      const researchOutputResponse = {
+        ...getResearchOutputResponse(),
+        id: roID,
+      };
+
+      researchOutputControllerMock.fetchById.mockResolvedValueOnce(
+        researchOutputResponse,
+      );
+
+      await indexHandler(createEv);
+      expect(algoliaIndexMock.deleteObject).not.toHaveBeenCalled();
+      expect(algoliaIndexMock.saveObject).toHaveBeenCalledWith({
+        ...researchOutputResponse,
+        objectID: researchOutputResponse.id,
+      });
+
+      await indexHandler(deleteEv);
+      expect(algoliaIndexMock.saveObject).toHaveBeenCalledTimes(1);
+      expect(algoliaIndexMock.deleteObject).toHaveBeenCalledWith(
+        deleteEv.detail.payload.id,
+      );
+    });
+
+    it('receives on reverse order the events created and deleted', async () => {
+      const roID = 'ro-1234';
+      const createEv = createEvent(roID);
+      const deleteEv = deleteEvent(roID);
+      const researchOutputResponse = {
+        ...getResearchOutputResponse(),
+        id: roID,
+      };
+
+      await indexHandler(deleteEv);
+      expect(algoliaIndexMock.deleteObject).toHaveBeenCalledWith(
+        deleteEv.detail.payload.id,
+      );
+      expect(algoliaIndexMock.saveObject).not.toHaveBeenCalled();
+
+      researchOutputControllerMock.fetchById.mockResolvedValueOnce(
+        researchOutputResponse,
+      );
+
+      await indexHandler(createEv);
+      expect(algoliaIndexMock.deleteObject).toHaveBeenCalledTimes(1);
+      expect(algoliaIndexMock.saveObject).toHaveBeenCalledWith({
+        ...researchOutputResponse,
+        objectID: researchOutputResponse.id,
+      });
+    });
+
+    it('receives on correct order the events updated and deleted', async () => {
+      const roID = 'ro-1234';
+      const updateEv = updateEvent(roID);
+      const deleteEv = deleteEvent(roID);
+      const researchOutputResponse = {
+        ...getResearchOutputResponse(),
+        id: roID,
+      };
+
+      researchOutputControllerMock.fetchById.mockResolvedValueOnce(
+        researchOutputResponse,
+      );
+
+      await indexHandler(updateEv);
+      expect(algoliaIndexMock.deleteObject).not.toHaveBeenCalled();
+      expect(algoliaIndexMock.saveObject).toHaveBeenCalledWith({
+        ...researchOutputResponse,
+        objectID: researchOutputResponse.id,
+      });
+
+      await indexHandler(deleteEv);
+      expect(algoliaIndexMock.saveObject).toHaveBeenCalledTimes(1);
+      expect(algoliaIndexMock.deleteObject).toHaveBeenCalledWith(
+        deleteEv.detail.payload.id,
+      );
+    });
+    it('receives on reverse order the events updated and deleted', async () => {
+      const roID = 'ro-1234';
+      const updateEv = updateEvent(roID);
+      const deleteEv = deleteEvent(roID);
+      const researchOutputResponse = {
+        ...getResearchOutputResponse(),
+        id: roID,
+      };
+
+      await indexHandler(deleteEv);
+      expect(algoliaIndexMock.saveObject).not.toHaveBeenCalled();
+      expect(algoliaIndexMock.deleteObject).toHaveBeenCalledWith(
+        deleteEv.detail.payload.id,
+      );
+
+      researchOutputControllerMock.fetchById.mockResolvedValueOnce({
+        ...researchOutputResponse,
+        title: 'New title',
+      });
+
+      await indexHandler(updateEv);
+      expect(algoliaIndexMock.deleteObject).toHaveBeenCalledTimes(1);
+      expect(algoliaIndexMock.saveObject).toHaveBeenCalledWith({
+        ...researchOutputResponse,
+        title: 'New title',
+        objectID: researchOutputResponse.id,
+      });
+    });
+    it('receives on correct order the events updated and unpublished', async () => {
+      const roID = 'ro-1234';
+      const updateEv = updateEvent(roID);
+      const unpublishedEv = unpublishedEvent(roID);
+      const researchOutputResponse = {
+        ...getResearchOutputResponse(),
+        id: roID,
+      };
+
+      researchOutputControllerMock.fetchById.mockResolvedValueOnce(
+        researchOutputResponse,
+      );
+
+      await indexHandler(updateEv);
+      expect(algoliaIndexMock.deleteObject).not.toHaveBeenCalled();
+      expect(algoliaIndexMock.saveObject).toHaveBeenCalledWith({
+        ...researchOutputResponse,
+        objectID: researchOutputResponse.id,
+      });
+
+      await indexHandler(unpublishedEv);
+      expect(algoliaIndexMock.saveObject).toHaveBeenCalledTimes(1);
+      expect(algoliaIndexMock.deleteObject).toHaveBeenCalledWith(
+        unpublishedEv.detail.payload.id,
+      );
+    });
+    it('receives on reverse order the events updated and deleted', async () => {
+      const roID = 'ro-1234';
+      const updateEv = updateEvent(roID);
+      const unpublishedEv = unpublishedEvent(roID);
+      const researchOutputResponse = {
+        ...getResearchOutputResponse(),
+        id: roID,
+      };
+
+      await indexHandler(unpublishedEv);
+      expect(algoliaIndexMock.saveObject).not.toHaveBeenCalled();
+      expect(algoliaIndexMock.deleteObject).toHaveBeenCalledWith(
+        unpublishedEv.detail.payload.id,
+      );
+
+      researchOutputControllerMock.fetchById.mockResolvedValueOnce({
+        ...researchOutputResponse,
+      });
+
+      await indexHandler(updateEv);
+      expect(algoliaIndexMock.deleteObject).toHaveBeenCalledTimes(1);
+      expect(algoliaIndexMock.saveObject).toHaveBeenCalledWith({
+        ...researchOutputResponse,
+        objectID: researchOutputResponse.id,
+      });
     });
   });
 });
+
+const unpublishedEvent = (id: string) =>
+  getResearchOutputEvent(
+    id,
+    'ResearchOutputsUnpublished',
+    'ResearchOutputDeleted',
+  ) as EventBridgeEvent<
+    ResearchOutputEventType,
+    SquidexWebhookResearchOutputPayload
+  >;
+
+const deleteEvent = (id: string) =>
+  getResearchOutputEvent(
+    id,
+    'ResearchOutputsDeleted',
+    'ResearchOutputDeleted',
+  ) as EventBridgeEvent<
+    ResearchOutputEventType,
+    SquidexWebhookResearchOutputPayload
+  >;
+
+const createEvent = (id: string) =>
+  getResearchOutputEvent(
+    id,
+    'ResearchOutputsPublished',
+    'ResearchOutputCreated',
+  ) as EventBridgeEvent<
+    ResearchOutputEventType,
+    SquidexWebhookResearchOutputPayload
+  >;
+
+const updateEvent = (id: string) =>
+  getResearchOutputEvent(
+    id,
+    'ResearchOutputsUpdated',
+    'ResearchOutputUpdated',
+  ) as EventBridgeEvent<
+    ResearchOutputEventType,
+    SquidexWebhookResearchOutputPayload
+  >;

--- a/apps/asap-server/test/handlers/research-output/index-handler.test.ts
+++ b/apps/asap-server/test/handlers/research-output/index-handler.test.ts
@@ -50,47 +50,60 @@ describe('Research Output index handler', () => {
     });
   });
 
-  test('Should remove the record Algolia when research-output is unpublished', async () => {
+  test('Should remove the record Algolia and throw a 404 error when research-output is unpublished', async () => {
     const event = unpublishedEvent('ro-1234');
 
     researchOutputControllerMock.fetchById.mockRejectedValue(Boom.notFound());
+    algoliaIndexMock.deleteObject.mockResolvedValue({ taskID: 2 });
 
-    await indexHandler(event);
-
+    await expect(indexHandler(event)).rejects.toThrow(Boom.notFound());
     expect(algoliaIndexMock.deleteObject).toHaveBeenCalledWith(
       event.detail.payload.id,
     );
   });
 
-  test('Should remove the record Algolia when research-output is deleted', async () => {
+  test('Should remove the record Algolia and throw a 404 error when research-output is deleted', async () => {
     const event = deleteEvent('ro-1234');
 
     researchOutputControllerMock.fetchById.mockRejectedValue(Boom.notFound());
-    await indexHandler(event);
 
+    await expect(indexHandler(event)).rejects.toThrow(Boom.notFound());
     expect(algoliaIndexMock.deleteObject).toHaveBeenCalledWith(
       event.detail.payload.id,
     );
   });
 
-  test('Should throw when algolia save method fails', async () => {
-    const error = new Error('nope');
-    researchOutputControllerMock.fetchById.mockResolvedValueOnce({
-      ...getResearchOutputResponse(),
-    });
-    algoliaIndexMock.saveObject.mockRejectedValueOnce(error);
+  test('Should throw an error and do not trigger algolia when the research-output request fails with another error code', async () => {
+    researchOutputControllerMock.fetchById.mockRejectedValue(Boom.badData());
 
-    expect(indexHandler(updateEvent('ro-1234'))).rejects.toThrow(error);
+    await expect(indexHandler(createEvent('ro-1234'))).rejects.toThrow(
+      Boom.badData(),
+    );
+    expect(algoliaIndexMock.deleteObject).not.toHaveBeenCalled();
   });
 
-  test('Should throw when algolia delete method fails', async () => {
-    const error = new Error('nope');
+  test('Should throw the algolia error when algolia save method failed', async () => {
+    const algoliaError = new Error('ERROR');
+    const roID = 'ro-1234';
+    const event = updateEvent(roID);
+
     researchOutputControllerMock.fetchById.mockResolvedValueOnce({
       ...getResearchOutputResponse(),
     });
-    algoliaIndexMock.deleteObject.mockRejectedValueOnce(error);
+    algoliaIndexMock.saveObject.mockRejectedValueOnce(algoliaError);
 
-    expect(indexHandler(updateEvent('ro-1234'))).rejects.toThrow(error);
+    await expect(indexHandler(event)).rejects.toThrow(algoliaError);
+  });
+
+  test("Should throw the algolia error when algolia's delete method failed", async () => {
+    const algoliaError = new Error('ERROR');
+    const roID = 'ro-1234';
+    const event = deleteEvent(roID);
+
+    researchOutputControllerMock.fetchById.mockRejectedValue(Boom.notFound());
+    algoliaIndexMock.deleteObject.mockRejectedValueOnce(algoliaError);
+
+    await expect(indexHandler(event)).rejects.toThrow(algoliaError);
   });
 
   describe('Should process the events, handle race conditions and not rely on the order of the events', () => {
@@ -101,10 +114,7 @@ describe('Research Output index handler', () => {
         id: roID,
       };
 
-      researchOutputControllerMock.fetchById.mockResolvedValueOnce({
-        ...researchOutputResponse,
-      });
-      researchOutputControllerMock.fetchById.mockResolvedValueOnce({
+      researchOutputControllerMock.fetchById.mockResolvedValue({
         ...researchOutputResponse,
       });
 
@@ -126,12 +136,10 @@ describe('Research Output index handler', () => {
         id: roID,
       };
 
-      researchOutputControllerMock.fetchById.mockResolvedValueOnce(
+      researchOutputControllerMock.fetchById.mockResolvedValue(
         researchOutputResponse,
       );
-      researchOutputControllerMock.fetchById.mockResolvedValueOnce(
-        researchOutputResponse,
-      );
+
       await indexHandler(updateEvent(roID));
       await indexHandler(createEvent(roID));
 
@@ -147,11 +155,14 @@ describe('Research Output index handler', () => {
       const roID = 'ro-1234';
       const createEv = createEvent(roID);
       const unpublishedEv = unpublishedEvent(roID);
+      const algoliaError = new Error('ERROR');
 
       researchOutputControllerMock.fetchById.mockRejectedValue(Boom.notFound());
+      algoliaIndexMock.deleteObject.mockResolvedValueOnce({ taskID: 1 });
+      algoliaIndexMock.deleteObject.mockRejectedValue(algoliaError);
 
-      await indexHandler(createEv);
-      await indexHandler(unpublishedEv);
+      await expect(indexHandler(createEv)).rejects.toEqual(Boom.notFound());
+      await expect(indexHandler(unpublishedEv)).rejects.toEqual(algoliaError);
 
       expect(algoliaIndexMock.saveObject).not.toHaveBeenCalled();
       expect(algoliaIndexMock.deleteObject).toHaveBeenCalledTimes(2);
@@ -164,11 +175,16 @@ describe('Research Output index handler', () => {
       const roID = 'ro-1234';
       const createEv = createEvent(roID);
       const unpublishedEv = unpublishedEvent(roID);
+      const algoliaError = new Error('ERROR');
 
       researchOutputControllerMock.fetchById.mockRejectedValue(Boom.notFound());
+      algoliaIndexMock.deleteObject.mockResolvedValueOnce({ taskID: 1 });
+      algoliaIndexMock.deleteObject.mockRejectedValue(algoliaError);
 
-      await indexHandler(unpublishedEv);
-      await indexHandler(createEv);
+      await expect(indexHandler(unpublishedEv)).rejects.toEqual(
+        Boom.notFound(),
+      );
+      await expect(indexHandler(createEv)).rejects.toEqual(algoliaError);
 
       expect(algoliaIndexMock.saveObject).not.toHaveBeenCalled();
       expect(algoliaIndexMock.deleteObject).toHaveBeenCalledTimes(2);
@@ -181,11 +197,14 @@ describe('Research Output index handler', () => {
       const roID = 'ro-1234';
       const createEv = createEvent(roID);
       const deleteEv = deleteEvent(roID);
+      const algoliaError = new Error('ERROR');
 
       researchOutputControllerMock.fetchById.mockRejectedValue(Boom.notFound());
+      algoliaIndexMock.deleteObject.mockResolvedValueOnce({ taskID: 1 });
+      algoliaIndexMock.deleteObject.mockRejectedValue(algoliaError);
 
-      await indexHandler(createEv);
-      await indexHandler(deleteEv);
+      await expect(indexHandler(createEv)).rejects.toEqual(Boom.notFound());
+      await expect(indexHandler(deleteEv)).rejects.toEqual(algoliaError);
 
       expect(algoliaIndexMock.saveObject).not.toHaveBeenCalled();
       expect(algoliaIndexMock.deleteObject).toHaveBeenCalledTimes(2);
@@ -198,11 +217,14 @@ describe('Research Output index handler', () => {
       const roID = 'ro-1234';
       const createEv = createEvent(roID);
       const deleteEv = deleteEvent(roID);
+      const algoliaError = new Error('ERROR');
 
       researchOutputControllerMock.fetchById.mockRejectedValue(Boom.notFound());
+      algoliaIndexMock.deleteObject.mockResolvedValueOnce({ taskID: 1 });
+      algoliaIndexMock.deleteObject.mockRejectedValue(algoliaError);
 
-      await indexHandler(deleteEv);
-      await indexHandler(createEv);
+      await expect(indexHandler(deleteEv)).rejects.toEqual(Boom.notFound());
+      await expect(indexHandler(createEv)).rejects.toEqual(algoliaError);
 
       expect(algoliaIndexMock.saveObject).not.toHaveBeenCalled();
       expect(algoliaIndexMock.deleteObject).toHaveBeenCalledTimes(2);
@@ -215,11 +237,14 @@ describe('Research Output index handler', () => {
       const roID = 'ro-1234';
       const updateEv = updateEvent(roID);
       const deleteEv = deleteEvent(roID);
+      const algoliaError = new Error('ERROR');
 
       researchOutputControllerMock.fetchById.mockRejectedValue(Boom.notFound());
+      algoliaIndexMock.deleteObject.mockResolvedValueOnce({ taskID: 1 });
+      algoliaIndexMock.deleteObject.mockRejectedValue(algoliaError);
 
-      await indexHandler(updateEv);
-      await indexHandler(deleteEv);
+      await expect(indexHandler(updateEv)).rejects.toEqual(Boom.notFound());
+      await expect(indexHandler(deleteEv)).rejects.toEqual(algoliaError);
 
       expect(algoliaIndexMock.saveObject).not.toHaveBeenCalled();
       expect(algoliaIndexMock.deleteObject).toHaveBeenCalledTimes(2);
@@ -232,11 +257,14 @@ describe('Research Output index handler', () => {
       const roID = 'ro-1234';
       const updateEv = updateEvent(roID);
       const deleteEv = deleteEvent(roID);
+      const algoliaError = new Error('ERROR');
 
       researchOutputControllerMock.fetchById.mockRejectedValue(Boom.notFound());
+      algoliaIndexMock.deleteObject.mockResolvedValueOnce({ taskID: 1 });
+      algoliaIndexMock.deleteObject.mockRejectedValue(algoliaError);
 
-      await indexHandler(deleteEv);
-      await indexHandler(updateEv);
+      await expect(indexHandler(deleteEv)).rejects.toEqual(Boom.notFound());
+      await expect(indexHandler(updateEv)).rejects.toEqual(algoliaError);
 
       expect(algoliaIndexMock.saveObject).not.toHaveBeenCalled();
       expect(algoliaIndexMock.deleteObject).toHaveBeenCalledTimes(2);
@@ -248,11 +276,14 @@ describe('Research Output index handler', () => {
       const roID = 'ro-1234';
       const updateEv = updateEvent(roID);
       const unpublishedEv = unpublishedEvent(roID);
+      const algoliaError = new Error('ERROR');
 
       researchOutputControllerMock.fetchById.mockRejectedValue(Boom.notFound());
+      algoliaIndexMock.deleteObject.mockResolvedValueOnce({ taskID: 1 });
+      algoliaIndexMock.deleteObject.mockRejectedValue(algoliaError);
 
-      await indexHandler(updateEv);
-      await indexHandler(unpublishedEv);
+      await expect(indexHandler(updateEv)).rejects.toEqual(Boom.notFound());
+      await expect(indexHandler(unpublishedEv)).rejects.toEqual(algoliaError);
 
       expect(algoliaIndexMock.saveObject).not.toHaveBeenCalled();
       expect(algoliaIndexMock.deleteObject).toHaveBeenCalledTimes(2);
@@ -265,11 +296,16 @@ describe('Research Output index handler', () => {
       const roID = 'ro-1234';
       const updateEv = updateEvent(roID);
       const unpublishedEv = unpublishedEvent(roID);
+      const algoliaError = new Error('ERROR');
 
       researchOutputControllerMock.fetchById.mockRejectedValue(Boom.notFound());
+      algoliaIndexMock.deleteObject.mockResolvedValueOnce({ taskID: 1 });
+      algoliaIndexMock.deleteObject.mockRejectedValue(algoliaError);
 
-      await indexHandler(unpublishedEv);
-      await indexHandler(updateEv);
+      await expect(indexHandler(unpublishedEv)).rejects.toEqual(
+        Boom.notFound(),
+      );
+      await expect(indexHandler(updateEv)).rejects.toEqual(algoliaError);
 
       expect(algoliaIndexMock.saveObject).not.toHaveBeenCalled();
       expect(algoliaIndexMock.deleteObject).toHaveBeenCalledTimes(2);

--- a/apps/asap-server/test/handlers/webhooks/webhook-research-output.test.ts
+++ b/apps/asap-server/test/handlers/webhooks/webhook-research-output.test.ts
@@ -86,27 +86,6 @@ describe('Research output webhook', () => {
     });
   });
 
-  test('Should put the research-output-unpublished event into the event bus and return 200', async () => {
-    const res = (await handler(
-      createSignedPayload(
-        researchOutputEvent('ResearchOutputsUnpublished', 'Unpublished'),
-      ),
-    )) as APIGatewayProxyResult;
-    expect(res.statusCode).toStrictEqual(200);
-    expect(evenBridgeMock.putEvents).toHaveBeenCalledWith({
-      Entries: [
-        {
-          EventBusName: eventBus,
-          Source: eventSource,
-          DetailType: 'ResearchOutputUnpublished',
-          Detail: JSON.stringify(
-            researchOutputEvent('ResearchOutputsUnpublished', 'Unpublished'),
-          ),
-        },
-      ],
-    });
-  });
-
   test('Should put the research-output-deleted event into the event bus and return 200', async () => {
     const res = (await handler(
       createSignedPayload(
@@ -123,6 +102,28 @@ describe('Research output webhook', () => {
           Detail: JSON.stringify(
             researchOutputEvent('ResearchOutputsDeleted', 'Deleted'),
           ),
+        },
+      ],
+    });
+  });
+
+  test('Should treat the research-output-unpublished event as research-output-deleted', async () => {
+    const unpublishedEvent = researchOutputEvent(
+      'ResearchOutputsUnpublished',
+      'Unpublished',
+    );
+
+    const res = (await handler(
+      createSignedPayload(unpublishedEvent),
+    )) as APIGatewayProxyResult;
+    expect(res.statusCode).toStrictEqual(200);
+    expect(evenBridgeMock.putEvents).toHaveBeenCalledWith({
+      Entries: [
+        {
+          EventBusName: eventBus,
+          Source: eventSource,
+          DetailType: 'ResearchOutputDeleted',
+          Detail: JSON.stringify(unpublishedEvent),
         },
       ],
     });

--- a/apps/asap-server/test/handlers/webhooks/webhook-research-output.test.ts
+++ b/apps/asap-server/test/handlers/webhooks/webhook-research-output.test.ts
@@ -5,7 +5,7 @@ import { eventBus, eventSource } from '../../../src/config';
 import { researchOutputWebhookFactory } from '../../../src/handlers/webhooks/webhook-research-output';
 import {
   getResearchOutputEvent,
-  updateResearchOutputEvent,
+  researchOutputEvent,
 } from '../../fixtures/research-output.fixtures';
 import { getApiGatewayEvent } from '../../helpers/events';
 import { createSignedPayload } from '../../helpers/webhooks';
@@ -66,7 +66,9 @@ describe('Research output webhook', () => {
 
   test('Should put the research-output-updated event into the event bus and return 200', async () => {
     const res = (await handler(
-      createSignedPayload(updateResearchOutputEvent),
+      createSignedPayload(
+        researchOutputEvent('ResearchOutputsUpdated', 'Updated'),
+      ),
     )) as APIGatewayProxyResult;
 
     expect(res.statusCode).toStrictEqual(200);
@@ -76,7 +78,51 @@ describe('Research output webhook', () => {
           EventBusName: eventBus,
           Source: eventSource,
           DetailType: 'ResearchOutputUpdated',
-          Detail: JSON.stringify(updateResearchOutputEvent),
+          Detail: JSON.stringify(
+            researchOutputEvent('ResearchOutputsUpdated', 'Updated'),
+          ),
+        },
+      ],
+    });
+  });
+
+  test('Should put the research-output-unpublished event into the event bus and return 200', async () => {
+    const res = (await handler(
+      createSignedPayload(
+        researchOutputEvent('ResearchOutputsUnpublished', 'Unpublished'),
+      ),
+    )) as APIGatewayProxyResult;
+    expect(res.statusCode).toStrictEqual(200);
+    expect(evenBridgeMock.putEvents).toHaveBeenCalledWith({
+      Entries: [
+        {
+          EventBusName: eventBus,
+          Source: eventSource,
+          DetailType: 'ResearchOutputUnpublished',
+          Detail: JSON.stringify(
+            researchOutputEvent('ResearchOutputsUnpublished', 'Unpublished'),
+          ),
+        },
+      ],
+    });
+  });
+
+  test('Should put the research-output-deleted event into the event bus and return 200', async () => {
+    const res = (await handler(
+      createSignedPayload(
+        researchOutputEvent('ResearchOutputsDeleted', 'Deleted'),
+      ),
+    )) as APIGatewayProxyResult;
+    expect(res.statusCode).toStrictEqual(200);
+    expect(evenBridgeMock.putEvents).toHaveBeenCalledWith({
+      Entries: [
+        {
+          EventBusName: eventBus,
+          Source: eventSource,
+          DetailType: 'ResearchOutputDeleted',
+          Detail: JSON.stringify(
+            researchOutputEvent('ResearchOutputsDeleted', 'Deleted'),
+          ),
         },
       ],
     });

--- a/apps/asap-server/test/handlers/webhooks/webhook-research-output.test.ts
+++ b/apps/asap-server/test/handlers/webhooks/webhook-research-output.test.ts
@@ -3,7 +3,7 @@ import { APIGatewayProxyResult } from 'aws-lambda';
 import { EventBridge } from 'aws-sdk';
 import { eventBus, eventSource } from '../../../src/config';
 import { researchOutputWebhookFactory } from '../../../src/handlers/webhooks/webhook-research-output';
-import { researchOutputEvent } from '../../fixtures/research-output.fixtures';
+import { getResearchOutputWebhookPayload } from '../../fixtures/research-output.fixtures';
 import { getApiGatewayEvent } from '../../helpers/events';
 import { createSignedPayload } from '../../helpers/webhooks';
 
@@ -23,7 +23,7 @@ describe('Research output webhook', () => {
         'x-signature': 'XYZ',
       },
       body: JSON.stringify(
-        researchOutputEvent('ResearchOutputsPublished', 'Published'),
+        getResearchOutputWebhookPayload('ro-1234', 'ResearchOutputsPublished'),
       ),
     });
 
@@ -36,7 +36,10 @@ describe('Research output webhook', () => {
   test('Should return 204 and not raise an event when the event type is not supported', async () => {
     const res = (await handler(
       createSignedPayload<ResearchOutput>({
-        ...researchOutputEvent('ResearchOutputsPublished', 'Published'),
+        ...getResearchOutputWebhookPayload(
+          'ro-1234',
+          'ResearchOutputsPublished',
+        ),
         type: 'SomeEvent',
       }),
     )) as APIGatewayProxyResult;
@@ -46,9 +49,9 @@ describe('Research output webhook', () => {
   });
 
   test('Should put the research-output-created event into the event bus and return 200', async () => {
-    const createEvent = researchOutputEvent(
+    const createEvent = getResearchOutputWebhookPayload(
+      'ro-1234',
       'ResearchOutputsPublished',
-      'Published',
     );
 
     const res = (await handler(
@@ -69,9 +72,9 @@ describe('Research output webhook', () => {
   });
 
   test('Should put the research-output-updated event into the event bus and return 200', async () => {
-    const updateEvent = researchOutputEvent(
+    const updateEvent = getResearchOutputWebhookPayload(
+      'ro-1234',
       'ResearchOutputsUpdated',
-      'Updated',
     );
 
     const res = (await handler(
@@ -92,9 +95,9 @@ describe('Research output webhook', () => {
   });
 
   test('Should put the research-output-deleted event into the event bus and return 200', async () => {
-    const deleteEvent = researchOutputEvent(
+    const deleteEvent = getResearchOutputWebhookPayload(
+      'ro-1234',
       'ResearchOutputsDeleted',
-      'Deleted',
     );
 
     const res = (await handler(
@@ -114,9 +117,9 @@ describe('Research output webhook', () => {
   });
 
   test('Should treat the research-output-unpublished event as research-output-deleted', async () => {
-    const unpublishedEvent = researchOutputEvent(
+    const unpublishedEvent = getResearchOutputWebhookPayload(
+      'ro-1234',
       'ResearchOutputsUnpublished',
-      'Unpublished',
     );
 
     const res = (await handler(

--- a/apps/asap-server/test/helpers/events.ts
+++ b/apps/asap-server/test/helpers/events.ts
@@ -66,8 +66,9 @@ export const createEventBridgeScheduledEventMock = (): EventBridgeEvent<
 export const createEventBridgeEventMock = <T, P extends string>(
   detail: T,
   detailType: P,
+  id?: string,
 ): EventBridgeEvent<P, T> => ({
-  id: 'test-id',
+  id: id ?? 'test-id',
   version: '1',
   account: 'test-account',
   time: '3234234234',

--- a/apps/asap-server/test/mocks/algolia-client.mock.ts
+++ b/apps/asap-server/test/mocks/algolia-client.mock.ts
@@ -2,6 +2,7 @@ import { SearchClient, SearchIndex } from 'algoliasearch';
 
 export const algoliaIndexMock = {
   saveObject: jest.fn(),
+  deleteObject: jest.fn(),
 } as unknown as jest.Mocked<SearchIndex>;
 
 export const algoliaClientMock = {

--- a/packages/squidex/schema/rules/rule3.json
+++ b/packages/squidex/schema/rules/rule3.json
@@ -7,7 +7,7 @@
     "schemas": [
       {
         "schemaId": "research-outputs",
-        "condition": "(event.type == 'Updated' || event.type == 'Published') && event.status == 'Published'"
+        "condition": "event.type === 'Published' || event.type === 'Unpublished' || event.type === 'Updated' || event.type === 'Deleted'"
       }
     ],
     "handleAll": false

--- a/serverless.ts
+++ b/serverless.ts
@@ -292,7 +292,6 @@ const serverlessConfig: AWS = {
               'detail-type': [
                 'ResearchOutputCreated',
                 'ResearchOutputUpdated',
-                'ResearchOutputUnpublished',
                 'ResearchOutputDeleted',
               ],
             },

--- a/serverless.ts
+++ b/serverless.ts
@@ -289,7 +289,12 @@ const serverlessConfig: AWS = {
             eventBus: 'asap-events-${self:provider.stage}',
             pattern: {
               source: ['asap.research-output'],
-              'detail-type': ['ResearchOutputCreated', 'ResearchOutputUpdated'],
+              'detail-type': [
+                'ResearchOutputCreated',
+                'ResearchOutputUpdated',
+                'ResearchOutputUnpublished',
+                'ResearchOutputDeleted',
+              ],
             },
           },
         },


### PR DESCRIPTION
https://trello.com/c/UVHhQ6TX/1656-algolia-is-not-receiving-updates-when-research-outputs-is-delete-or-converted-to-draft