### PR TITLE
fix: Invalid Algolia App ID in production

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -275,6 +275,7 @@ verify:development:
 deploy:sls:production:
   <<: *tmpl_master
   <<: *tmpl_deploy
+  image: $INTEGRATION_DOCKER_IMAGE
   artifacts:
     paths:
       - 'apps/*/build*'


### PR DESCRIPTION
Use the integration image with aws cli to deploy prod