### PR TITLE
chore: Add extra info to logs

### DIFF
--- a/serverless.ts
+++ b/serverless.ts
@@ -49,7 +49,7 @@ const serverlessConfig: AWS = {
     logs: {
       httpApi: {
         format:
-          '{ "requestId":"$context.requestId", "ip": "$context.identity.sourceIp", "requestTime":"$context.requestTime", "httpMethod":"$context.httpMethod", "path":"$context.path", "routeKey":"$context.routeKey", "status":"$context.status","protocol":"$context.protocol", "responseLength":"$context.responseLength" }',
+          '{ "requestId":"$context.requestId", "ip": "$context.identity.sourceIp", "requestTime":"$context.requestTime", "httpMethod":"$context.httpMethod", "path":"$context.path", "routeKey":"$context.routeKey", "status":"$context.status","protocol":"$context.protocol", "responseLength":"$context.responseLength", "integrationRequestId": "$context.integration.requestId", "functionResponseStatus": "$context.integration.status" }',
       },
     },
     tracing: {


### PR DESCRIPTION
This PR enables extra cloudwatch logs for the API Gateway.

It will make it possible for us to link the lambda logs and the API gateway logs by printing the request ID in log groups of both resources.

see:
![image](https://user-images.githubusercontent.com/11645956/138659435-b426837b-e42a-4942-9fe4-7946c7a05fef.png)
