### PR TITLE
Hotfix/Revert the proposal type

### DIFF
--- a/packages/squidex/schema/schemas/research-outputs.json
+++ b/packages/squidex/schema/schemas/research-outputs.json
@@ -90,7 +90,8 @@
             "Dataset",
             "Bioinformatics",
             "Lab Resource",
-            "Article"
+            "Article",
+            "Proposal"
           ],
           "isUnique": false,
           "inlineEditable": true,


### PR DESCRIPTION
The Proposal type must be in the list of RO types.
Currently, we cannot import the RO with Proposal type into the PR environment.