### PR TITLE
Fix: group past events order

### DIFF
--- a/apps/frontend/src/network/groups/GroupProfile.tsx
+++ b/apps/frontend/src/network/groups/GroupProfile.tsx
@@ -88,7 +88,7 @@ const GroupProfile: FC = () => {
               searchQuery={searchQuery}
               onChangeSearchQuery={setSearchQuery}
             >
-              <Frame title="Upcoming Events">
+              <Frame title="Past Events">
                 <EventList
                   past
                   currentTime={currentTime}

--- a/apps/frontend/src/network/groups/events/__tests__/api.test.ts
+++ b/apps/frontend/src/network/groups/events/__tests__/api.test.ts
@@ -19,6 +19,8 @@ describe('getGroupEvents', () => {
         take: '10',
         skip: '0',
         before: new Date('2021-01-01T11:00:00').toISOString(),
+        sortBy: 'endDate',
+        sortOrder: 'desc',
       })
       .reply(200, {});
     await getGroupEvents(

--- a/apps/frontend/src/network/groups/events/api.ts
+++ b/apps/frontend/src/network/groups/events/api.ts
@@ -15,6 +15,11 @@ export const getGroupEvents = async (
   if (options.before) url.searchParams.append('before', options.before);
   else if (options.after) url.searchParams.append('after', options.after);
 
+  if (options.sort) {
+    url.searchParams.set('sortBy', options.sort.sortBy);
+    url.searchParams.set('sortOrder', options.sort.sortOrder);
+  }
+
   const resp = await fetch(url.toString(), {
     headers: { authorization, ...createSentryHeaders() },
   });


### PR DESCRIPTION
https://trello.com/c/yV4Vgd1N/1744-past-events-are-sorted-in-reverse-order-in-group-pages