### PR TITLE
fix: set sentry error boundary as default

### DIFF
--- a/apps/frontend/src/structure/ErrorBoundary.tsx
+++ b/apps/frontend/src/structure/ErrorBoundary.tsx
@@ -12,7 +12,7 @@ type ErrorBoundaryProps = { children: ReactNode } & Partial<
 
 const ErrorBoundary: React.FC<ErrorBoundaryProps> = ({
   children,
-  sentryReporting = false,
+  sentryReporting = true,
   ...errorCardProps
 }) => {
   let pathname = '';

--- a/apps/frontend/src/structure/ErrorBoundary.tsx
+++ b/apps/frontend/src/structure/ErrorBoundary.tsx
@@ -6,13 +6,13 @@ import { ErrorBoundary as SentryErrorBoundary } from '@sentry/react';
 
 type ErrorBoundaryProps = { children: ReactNode } & Partial<
   ComponentProps<typeof ErrorCard> & {
-    sentryReporting: boolean;
+    disableSentryReporting: boolean;
   }
 >;
 
 const ErrorBoundary: React.FC<ErrorBoundaryProps> = ({
   children,
-  sentryReporting = true,
+  disableSentryReporting = false,
   ...errorCardProps
 }) => {
   let pathname = '';
@@ -25,13 +25,7 @@ const ErrorBoundary: React.FC<ErrorBoundaryProps> = ({
     // no routing, no way to get out of the error state
   }
 
-  return sentryReporting ? (
-    <SentryErrorBoundary
-      fallback={({ error }) => <ErrorCard error={error} {...errorCardProps} />}
-    >
-      {children}
-    </SentryErrorBoundary>
-  ) : (
+  return disableSentryReporting ? (
     <ReactErrorBoundary
       fallbackRender={({ error }) => (
         <ErrorCard error={error} {...errorCardProps} />
@@ -40,6 +34,12 @@ const ErrorBoundary: React.FC<ErrorBoundaryProps> = ({
     >
       {children}
     </ReactErrorBoundary>
+  ) : (
+    <SentryErrorBoundary
+      fallback={({ error }) => <ErrorCard error={error} {...errorCardProps} />}
+    >
+      {children}
+    </SentryErrorBoundary>
   );
 };
 

--- a/apps/frontend/src/structure/Frame.tsx
+++ b/apps/frontend/src/structure/Frame.tsx
@@ -45,7 +45,6 @@ export const SearchFrame: React.FC<Omit<FrameBoundaryProps, 'boundaryProps'>> =
       title={'Something went wrong'}
       description={'There was a problem with your search, please try again.'}
       error={new Error()}
-      sentryReporting={true}
     >
       <Frame title={title} fallback={fallback}>
         {children}

--- a/apps/frontend/src/structure/__tests__/ErrorBoundary.test.tsx
+++ b/apps/frontend/src/structure/__tests__/ErrorBoundary.test.tsx
@@ -14,7 +14,7 @@ const Throw: React.FC<Record<string, never>> = () => {
 describe('error boundary', () => {
   it('catches child errors', async () => {
     const { container } = render(
-      <ErrorBoundary sentryReporting={false}>
+      <ErrorBoundary disableSentryReporting={true}>
         <Throw />
       </ErrorBoundary>,
     );
@@ -24,7 +24,7 @@ describe('error boundary', () => {
   it('Overrides title and description when error thrown', async () => {
     const { container } = render(
       <ErrorBoundary
-        sentryReporting={false}
+        disableSentryReporting={true}
         title="Something went wrong"
         description="There was a problem with your request"
       >
@@ -42,7 +42,7 @@ describe('error boundary', () => {
     const history = createMemoryHistory({ initialEntries: ['/throw'] });
     const { container } = render(
       <Router history={history}>
-        <ErrorBoundary sentryReporting={false}>
+        <ErrorBoundary disableSentryReporting={true}>
           <Route path="/home">at home</Route>
           <Route path="/throw">
             <Throw />

--- a/apps/frontend/src/structure/__tests__/ErrorBoundary.test.tsx
+++ b/apps/frontend/src/structure/__tests__/ErrorBoundary.test.tsx
@@ -14,7 +14,7 @@ const Throw: React.FC<Record<string, never>> = () => {
 describe('error boundary', () => {
   it('catches child errors', async () => {
     const { container } = render(
-      <ErrorBoundary>
+      <ErrorBoundary sentryReporting={false}>
         <Throw />
       </ErrorBoundary>,
     );
@@ -24,6 +24,7 @@ describe('error boundary', () => {
   it('Overrides title and description when error thrown', async () => {
     const { container } = render(
       <ErrorBoundary
+        sentryReporting={false}
         title="Something went wrong"
         description="There was a problem with your request"
       >
@@ -41,7 +42,7 @@ describe('error boundary', () => {
     const history = createMemoryHistory({ initialEntries: ['/throw'] });
     const { container } = render(
       <Router history={history}>
-        <ErrorBoundary>
+        <ErrorBoundary sentryReporting={false}>
           <Route path="/home">at home</Route>
           <Route path="/throw">
             <Throw />
@@ -59,7 +60,7 @@ describe('error boundary', () => {
 describe('sentry error boundary', () => {
   it('catches child errors', async () => {
     const { container } = render(
-      <ErrorBoundary sentryReporting={true}>
+      <ErrorBoundary>
         <Throw />
       </ErrorBoundary>,
     );
@@ -69,7 +70,6 @@ describe('sentry error boundary', () => {
   it('Overrides title and description when error thrown', async () => {
     const { container } = render(
       <ErrorBoundary
-        sentryReporting={true}
         title="Something went wrong"
         description="There was a problem with your request"
       >


### PR DESCRIPTION
https://trello.com/c/DfezNKBy/1739-change-error-boundaries-to-report-into-sentry

See https://sentry.io/organizations/yld/issues/2848318280/?referrer=slack
https://sentry.io/organizations/yld/issues/2848318280/?project=5893160