### PR TITLE
Feat: Speedup production pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,10 +41,8 @@ stages:
   - build
   - test
   - check
-  - prepare-dev
   - deploy-dev
   - verify-dev
-  - prepare-prod
   - deploy-prod
   - verify-prod
 
@@ -245,7 +243,6 @@ deploy:sls:development:
   needs:
     - build:ts
     - build:native
-    - sync:squidex:dev
 
 ####################
 # stage verify-dev #

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,9 +15,7 @@ include:
   variables: &tmpl_branch_variables
     SLS_STAGE: $CI_EXTERNAL_PULL_REQUEST_IID
 
-.tmpl:deploy: &tmpl_deploy
-  script:
-    - yarn sls deploy --verbose
+.tmpl:deploy:
   variables: &tmpl_deploy_variables
     NODE_ENV: production
     NODE_OPTIONS: '--max_old_space_size=4096'
@@ -63,7 +61,6 @@ stages:
     - export REACT_APP_SENTRY_DSN=$REACT_APP_SENTRY_DSN
   script:
     - yarn run build
-  needs: []
   stage: build
 
 build:ts:branch:
@@ -127,22 +124,15 @@ prepare:squidex:branch:
     - echo "Caching successful import"
     - mkdir -p first_run
     - touch first_run/squidex_app_create
-  needs: []
 
 .build:sls:package:
   image: $INTEGRATION_DOCKER_IMAGE
   stage: build
-  variables:
-    <<: *tmpl_branch_variables
-    <<: *tmpl_deploy_variables
   artifacts:
     expire_in: 2 weeks
     paths:
       - '.serverless'
   script:
-    - export SQUIDEX_APP_NAME=${CI_EXTERNAL_PULL_REQUEST_IID}
-    - export SQUIDEX_CLIENT_ID=$SQUIDEX_TEST_CLIENT_ID
-    - export SQUIDEX_CLIENT_SECRET=$SQUIDEX_TEST_CLIENT_SECRET
     - source ci/env-setup.sh
     - yarn rebuild # Duplicated for performance
     - yarn build:typecheck # Duplicated for performance
@@ -151,18 +141,37 @@ prepare:squidex:branch:
 
 build:sls:package:branch:
   extends: .build:sls:package
+  variables:
+    <<: *tmpl_branch_variables
+    <<: *tmpl_deploy_variables
   rules:
     - if: $CI_EXTERNAL_PULL_REQUEST_IID
+  before_script:
+    - export SQUIDEX_APP_NAME=${CI_EXTERNAL_PULL_REQUEST_IID}
+    - export SQUIDEX_CLIENT_ID=$SQUIDEX_TEST_CLIENT_ID
+    - export SQUIDEX_CLIENT_SECRET=$SQUIDEX_TEST_CLIENT_SECRET
 
 build:sls:package:dev:
   extends: .build:sls:package
   rules:
     - if: $CI_COMMIT_BRANCH == 'master'
+  environment:
+    name: dev
+    url: $ASAP_APP_URL
+  variables:
+    <<: *tmpl_deploy_variables
+    SLS_STAGE: 'dev'
 
 build:sls:package:prod:
   extends: .build:sls:package
   rules:
     - if: $CI_COMMIT_BRANCH == 'master'
+  environment:
+    name: production
+    url: $ASAP_APP_URL
+  variables:
+    <<: *tmpl_deploy_variables
+    SLS_STAGE: production
 
 build:native:
   artifacts:
@@ -171,7 +180,6 @@ build:native:
       - '.yarn/unplugged'
   script:
     - yarn rebuild
-  needs: []
   stage: build
 
 ##############
@@ -249,38 +257,45 @@ check:bundlewatch:
 # stage deploy-dev #
 ####################
 
-deploy:sls:branch:
+.deploy:sls:
   <<: *tmpl_branch
   image: $INTEGRATION_DOCKER_IMAGE
   stage: deploy-dev
+  script:
+    - source ci/env-setup.sh
+    - yarn sls deploy --package .serverless --verbose
+
+deploy:sls:branch:
+  extends: .deploy:sls
+  rules:
+    - if: $CI_EXTERNAL_PULL_REQUEST_IID
   variables:
     <<: *tmpl_branch_variables
     <<: *tmpl_deploy_variables
-  script:
+  before_script:
     - export SQUIDEX_APP_NAME=${CI_EXTERNAL_PULL_REQUEST_IID}
     - export SQUIDEX_CLIENT_ID=$SQUIDEX_TEST_CLIENT_ID
     - export SQUIDEX_CLIENT_SECRET=$SQUIDEX_TEST_CLIENT_SECRET
-    - source ci/env-setup.sh
-    - yarn sls deploy --package .serverless --verbose
   dependencies:
     - build:native
-    - build:sls:package
+    - build:sls:package:branch
     - build:ts:branch
 
-deploy:sls:development:
-  <<: *tmpl_master
-  <<: *tmpl_deploy
+deploy:sls:dev:
+  extends: .deploy:sls
+  rules:
+    - if: $CI_COMMIT_BRANCH == 'master'
+  stage: deploy-dev
   environment:
     name: dev
     url: $ASAP_APP_URL
   variables:
-    <<: *tmpl_master_variables
     <<: *tmpl_deploy_variables
     SLS_STAGE: 'dev'
-  stage: deploy-dev
-  needs:
-    - build:ts:dev
+  dependencies:
     - build:native
+    - build:sls:package:dev
+    - build:ts:dev
 
 ####################
 # stage verify-dev #
@@ -344,20 +359,21 @@ verify:development:
 # stage deploy-prod #
 #####################
 
-deploy:sls:production:
-  <<: *tmpl_master
-  <<: *tmpl_deploy
-  image: $INTEGRATION_DOCKER_IMAGE
+deploy:sls:prod:
+  extends: .deploy:sls
+  rules:
+    - if: $CI_COMMIT_BRANCH == 'master'
+  stage: deploy-prod
+  variables:
+    <<: *tmpl_deploy_variables
+    SLS_STAGE: production
   environment:
     name: production
     url: $ASAP_APP_URL
-  variables:
-    <<: *tmpl_master_variables
-    <<: *tmpl_deploy_variables
-  stage: deploy-prod
   dependencies:
-    - build:ts:prod
     - build:native
+    - build:sls:package:prod
+    - build:ts:prod
 
 #####################
 # stage verify-prod #

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -110,10 +110,6 @@ build:ts:
     - export REACT_APP_SENTRY_DSN=$REACT_APP_SENTRY_DSN
     - export REACT_APP_ENVIRONMENT="development"
     - yarn run build
-    - export CI_REPO_OWNER="$CI_PROJECT_NAMESPACE"
-    - export CI_REPO_NAME="$CI_PROJECT_NAME"
-    - export CI_BRANCH="$CI_COMMIT_BRANCH"
-    - yarn bundlewatch
   needs: []
   stage: build
 
@@ -203,6 +199,19 @@ check:format:
     - yarn run lint:format
   stage: check
   needs: []
+
+check:bundlewatch:
+  <<: *tmpl_branch
+  script:
+    - export CI_REPO_OWNER="$CI_PROJECT_NAMESPACE"
+    - export CI_REPO_NAME="$CI_PROJECT_NAME"
+    - export CI_BRANCH="$CI_COMMIT_BRANCH"
+    - yarn bundlewatch
+  stage: check
+  needs:
+    - build:ts
+  dependencies:
+    - build:ts
 
 ####################
 # stage deploy-dev #

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -150,15 +150,7 @@ build:native:
 ##############
 # stage test #
 ##############
-
-.tmpl:test: &tmpl_test
-  script:
-    - echo "no script property found"
-  needs: []
-  stage: test
-
 test:unit:
-  <<: *tmpl_test
   cache:
     key: jest-cache
     paths:
@@ -170,21 +162,23 @@ test:unit:
   script:
     - yarn run test --coverage
     - yarn codecov
+  needs: []
+  stage: test
 
 test:browser:
-  <<: *tmpl_test
   image: mcr.microsoft.com/playwright:bionic
   script:
     - yarn run test:browser
   needs:
     - build:native
+  stage: test
 
 test:build-output:
-  <<: *tmpl_test
   script:
     - yarn run test:build-output
   needs:
     - build:ts
+  stage: test
 
 ##############
 # stage check #

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,6 +49,7 @@ stages:
 ###############
 # stage build #
 ###############
+
 prepare:squidex:branch:
   <<: *tmpl_branch
   image: $INTEGRATION_DOCKER_IMAGE
@@ -150,6 +151,7 @@ build:native:
 ##############
 # stage test #
 ##############
+
 test:unit:
   cache:
     key: jest-cache
@@ -205,6 +207,7 @@ check:format:
 ####################
 # stage deploy-dev #
 ####################
+
 deploy:sls:branch:
   <<: *tmpl_branch
   image: $INTEGRATION_DOCKER_IMAGE

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,9 +21,6 @@ include:
   variables: &tmpl_deploy_variables
     NODE_ENV: production
     NODE_OPTIONS: '--max_old_space_size=4096'
-  dependencies:
-    - build:ts
-    - build:native
 
 variables:
   ASAP_HOSTNAME: hub.asap.science
@@ -49,6 +46,51 @@ stages:
 ###############
 # stage build #
 ###############
+.build:ts:
+  image: $INTEGRATION_DOCKER_IMAGE
+  artifacts:
+    expire_in: 2 weeks
+    paths:
+      - 'packages/*/build*'
+      - 'apps/*/build*'
+  before_script:
+    - source ci/env-setup.sh
+    - export REACT_APP_ALGOLIA_APP_ID=$(aws ssm get-parameter --name "algolia-app-id-dev" --query Parameter.Value --output text)
+    - export REACT_APP_ALGOLIA_INDEX=$ALGOLIA_INDEX
+    - export REACT_APP_API_BASE_URL=$ASAP_API_URL
+    - export REACT_APP_ENVIRONMENT="development"
+    - export REACT_APP_RELEASE=${CI_PIPELINE_ID}-dev
+    - export REACT_APP_SENTRY_DSN=$REACT_APP_SENTRY_DSN
+  script:
+    - yarn run build
+  needs: []
+  stage: build
+
+build:ts:branch:
+  extends: .build:ts
+  variables:
+    REACT_APP_SENTRY_DSN: ''
+  rules:
+    - if: $CI_EXTERNAL_PULL_REQUEST_IID
+
+build:ts:dev:
+  extends: .build:ts
+  variables:
+    REACT_APP_SENTRY_DSN: ${REACT_APP_SENTRY_DSN_DEV}
+  rules:
+    - if: $CI_COMMIT_BRANCH == 'master'
+
+build:ts:prod:
+  extends: .build:ts
+  rules:
+    - if: $CI_COMMIT_BRANCH == 'master'
+  before_script:
+    - export AUTH_FRONTEND_BASE_URL=$ASAP_APP_URL/.auth/
+    - export REACT_APP_ALGOLIA_APP_ID=$(aws ssm get-parameter --name "algolia-app-id-prod" --query Parameter.Value --output text)
+    - export REACT_APP_ALGOLIA_INDEX="asap-hub_research_outputs_prod"
+    - export REACT_APP_API_BASE_URL=$ASAP_API_URL
+    - export REACT_APP_ENVIRONMENT="production"
+    - export REACT_APP_RELEASE=${CI_PIPELINE_ID}-production
 
 prepare:squidex:branch:
   <<: *tmpl_branch
@@ -87,34 +129,7 @@ prepare:squidex:branch:
     - touch first_run/squidex_app_create
   needs: []
 
-build:ts:
-  image: $INTEGRATION_DOCKER_IMAGE
-  rules:
-    - if: $CI_COMMIT_BRANCH == 'master'
-      variables:
-        REACT_APP_SENTRY_DSN: ${REACT_APP_SENTRY_DSN_DEV}
-    - if: $CI_COMMIT_BRANCH != 'master'
-      variables:
-        REACT_APP_SENTRY_DSN: ''
-  artifacts:
-    expire_in: 2 weeks
-    paths:
-      - 'packages/*/build*'
-      - 'apps/*/build*'
-  script:
-    - source ci/env-setup.sh
-    - export REACT_APP_API_BASE_URL=$ASAP_API_URL
-    - export REACT_APP_ALGOLIA_INDEX=$ALGOLIA_INDEX
-    - export REACT_APP_ALGOLIA_APP_ID=$(aws ssm get-parameter --name "algolia-app-id-dev" --query Parameter.Value --output text)
-    - export REACT_APP_RELEASE=${CI_PIPELINE_ID}-dev
-    - export REACT_APP_SENTRY_DSN=$REACT_APP_SENTRY_DSN
-    - export REACT_APP_ENVIRONMENT="development"
-    - yarn run build
-  needs: []
-  stage: build
-
-build:sls:package:
-  <<: *tmpl_branch
+.build:sls:package:
   image: $INTEGRATION_DOCKER_IMAGE
   stage: build
   variables:
@@ -133,6 +148,21 @@ build:sls:package:
     - yarn build:typecheck # Duplicated for performance
     - yarn build:babel # Duplicated for performance
     - yarn sls package
+
+build:sls:package:branch:
+  extends: .build:sls:package
+  rules:
+    - if: $CI_EXTERNAL_PULL_REQUEST_IID
+
+build:sls:package:dev:
+  extends: .build:sls:package
+  rules:
+    - if: $CI_COMMIT_BRANCH == 'master'
+
+build:sls:package:prod:
+  extends: .build:sls:package
+  rules:
+    - if: $CI_COMMIT_BRANCH == 'master'
 
 build:native:
   artifacts:
@@ -172,11 +202,13 @@ test:browser:
   stage: test
 
 test:build-output:
+  rules:
+    - if: $CI_EXTERNAL_PULL_REQUEST_IID
   script:
     - yarn run test:build-output
-  needs:
-    - build:ts
   stage: test
+  needs:
+    - build:ts:branch
 
 ##############
 # stage check #
@@ -209,9 +241,9 @@ check:bundlewatch:
     - yarn bundlewatch
   stage: check
   needs:
-    - build:ts
+    - build:ts:branch
   dependencies:
-    - build:ts
+    - build:ts:branch
 
 ####################
 # stage deploy-dev #
@@ -231,9 +263,9 @@ deploy:sls:branch:
     - source ci/env-setup.sh
     - yarn sls deploy --package .serverless --verbose
   dependencies:
-    - build:sls:package
     - build:native
-    - build:ts
+    - build:sls:package
+    - build:ts:branch
 
 deploy:sls:development:
   <<: *tmpl_master
@@ -247,7 +279,7 @@ deploy:sls:development:
     SLS_STAGE: 'dev'
   stage: deploy-dev
   needs:
-    - build:ts
+    - build:ts:dev
     - build:native
 
 ####################
@@ -259,11 +291,6 @@ verify:branch:
   stage: verify-dev
   variables:
     API_URL: https://api-$CI_EXTERNAL_PULL_REQUEST_IID.$ASAP_HOSTNAME
-  needs:
-    - build:ts
-    - build:native
-    - prepare:squidex:branch
-    - deploy:sls:branch
   script:
     - ASAP_API_URL=$API_URL yarn test:e2e
 
@@ -273,11 +300,6 @@ e2e:branch:
   image: mcr.microsoft.com/playwright:focal
   variables:
     APP_URL: https://$CI_EXTERNAL_PULL_REQUEST_IID.$ASAP_HOSTNAME
-  needs:
-    - build:ts
-    - build:native
-    - prepare:squidex:branch
-    - deploy:sls:branch
   script:
     - yarn workspace @asap-hub/e2e-tests run playwright install
     - ASAP_APP_URL=$APP_URL yarn workspace @asap-hub/e2e-tests run playwright test
@@ -303,10 +325,6 @@ verify:schema:branch:
 report:frontend:release:dev:
   <<: *tmpl_master
   stage: verify-dev
-  needs:
-    - build:ts
-    - build:native
-    - deploy:sls:development
   script:
     - yarn install --immutable --immutable-cache
     - export FRONTEND_SENTRY_RELEASE_AUTH_TOKEN=$FRONTEND_SENTRY_RELEASE_AUTH_TOKEN
@@ -319,10 +337,6 @@ verify:development:
   environment:
     name: dev
     url: $ASAP_APP_URL
-  needs:
-    - build:ts
-    - build:native
-    - deploy:sls:development
   script:
     - yarn test:e2e
 
@@ -334,18 +348,6 @@ deploy:sls:production:
   <<: *tmpl_master
   <<: *tmpl_deploy
   image: $INTEGRATION_DOCKER_IMAGE
-  artifacts:
-    paths:
-      - 'apps/*/build*'
-      - 'packages/*/build*'
-  before_script:
-    - export AUTH_FRONTEND_BASE_URL=$ASAP_APP_URL/.auth/
-    - export REACT_APP_API_BASE_URL=$ASAP_API_URL
-    - export REACT_APP_RELEASE=${CI_PIPELINE_ID}-production
-    - export REACT_APP_ENVIRONMENT="production"
-    - export REACT_APP_ALGOLIA_INDEX="asap-hub_research_outputs_prod"
-    - export REACT_APP_ALGOLIA_APP_ID=$(aws ssm get-parameter --name "algolia-app-id-prod" --query Parameter.Value --output text)
-    - yarn run build # create production build
   environment:
     name: production
     url: $ASAP_APP_URL
@@ -353,14 +355,9 @@ deploy:sls:production:
     <<: *tmpl_master_variables
     <<: *tmpl_deploy_variables
   stage: deploy-prod
-  needs:
-    - build:ts
+  dependencies:
+    - build:ts:prod
     - build:native
-    - test:unit
-    - test:browser
-    - test:build-output
-    - sync:squidex:production
-    - verify:development
 
 #####################
 # stage verify-prod #
@@ -369,8 +366,6 @@ deploy:sls:production:
 report:frontend:release:production:
   <<: *tmpl_master
   stage: verify-prod
-  needs:
-    - deploy:sls:production
   script:
     - yarn install --immutable --immutable-cache
     - export FRONTEND_SENTRY_RELEASE_AUTH_TOKEN=$FRONTEND_SENTRY_RELEASE_AUTH_TOKEN
@@ -383,9 +378,5 @@ verify:production:
   environment:
     name: production
     url: $ASAP_APP_URL
-  needs:
-    - build:ts
-    - build:native
-    - deploy:sls:production
   script:
     - yarn test:e2e

--- a/ci/.gitlab-ci.integration.yml
+++ b/ci/.gitlab-ci.integration.yml
@@ -50,10 +50,10 @@ test:integration:
 
 sync:squidex:dev:
   <<: *tmpl_sync
-  stage: prepare-dev
+  stage: deploy-dev
 
 sync:squidex:production:
   <<: *tmpl_sync
-  stage: prepare-prod
+  stage: deploy-prod
   environment:
     name: production

--- a/ci/.gitlab-ci.ses.yml
+++ b/ci/.gitlab-ci.ses.yml
@@ -5,7 +5,7 @@ deploy:ses:prod:
     - yarn workspace @asap-hub/messages deploy $SES_REGION
   stage: deploy-prod
   needs:
-    - build:ts
+    - build:ts:prod
   variables:
     SLS_STAGE: production
     APP_ORIGIN: $ASAP_APP_URL
@@ -17,4 +17,4 @@ deploy:ses:dev:
     - yarn workspace @asap-hub/messages deploy $SES_SANDBOX_REGION
   stage: deploy-dev
   needs:
-    - build:ts
+    - build:ts:dev


### PR DESCRIPTION
In this PR we are speeding up the development and production pipeline. This has been done by having the schema sync occur at the same time as the sls deploy. 

We have also moved all build steps to the start of the build. We have done this by turning our PR deployment jobs into a template and extending these templates with the environment specific configuration.

We have removed the needs condition in favour of using the default gitlab behaviour of having all prior stages jobs successfully completed to try and simplify the configuration