### PR TITLE
feature/use mock server for controllers ac after

### DIFF
--- a/.github/workflows/dev-backup.yml
+++ b/.github/workflows/dev-backup.yml
@@ -1,7 +1,7 @@
 name: DEV - Create database backups
 on:
   schedule:
-    - cron: '0 7 * * FRI' # Every Friday at 7am UTC
+    - cron: '0 7 * * MON-FRI' # At 07:00 UTC on every day-of-week from Monday through Friday.
   workflow_dispatch:
 jobs:
   make_squidex_backup:

--- a/apps/asap-server/src/app.ts
+++ b/apps/asap-server/src/app.ts
@@ -69,7 +69,8 @@ export const appFactory = (libs: Libs = {}): Express => {
   const newsController = libs.newsController || new News();
   const discoverController =
     libs.discoverController || new Discover(squidexGraphlClient);
-  const eventController = libs.eventController || new Events();
+  const eventController =
+    libs.eventController || new Events(squidexGraphlClient);
   const groupController =
     libs.groupController || new Groups(squidexGraphlClient);
   const pageController = libs.pageController || new Pages();

--- a/apps/asap-server/src/app.ts
+++ b/apps/asap-server/src/app.ts
@@ -63,7 +63,8 @@ export const appFactory = (libs: Libs = {}): Express => {
 
   // Controllers
   const calendarController = libs.calendarController || new Calendars();
-  const dashboardController = libs.dashboardController || new Dashboard();
+  const dashboardController =
+    libs.dashboardController || new Dashboard(squidexGraphlClient);
   const newsController = libs.newsController || new News();
   const discoverController =
     libs.discoverController || new Discover(squidexGraphlClient);

--- a/apps/asap-server/src/app.ts
+++ b/apps/asap-server/src/app.ts
@@ -59,25 +59,25 @@ export const appFactory = (libs: Libs = {}): Express => {
   const errorHandler = errorHandlerFactory();
 
   // Clients
-  const squidexGraphlClient = new InstrumentedSquidexGraphql();
+  const squidexGraphqlClient = new InstrumentedSquidexGraphql();
 
   // Controllers
   const calendarController =
-    libs.calendarController || new Calendars(squidexGraphlClient);
+    libs.calendarController || new Calendars(squidexGraphqlClient);
   const dashboardController =
-    libs.dashboardController || new Dashboard(squidexGraphlClient);
+    libs.dashboardController || new Dashboard(squidexGraphqlClient);
   const newsController = libs.newsController || new News();
   const discoverController =
-    libs.discoverController || new Discover(squidexGraphlClient);
+    libs.discoverController || new Discover(squidexGraphqlClient);
   const eventController =
-    libs.eventController || new Events(squidexGraphlClient);
+    libs.eventController || new Events(squidexGraphqlClient);
   const groupController =
-    libs.groupController || new Groups(squidexGraphlClient);
+    libs.groupController || new Groups(squidexGraphqlClient);
   const pageController = libs.pageController || new Pages();
   const researchOutputController =
-    libs.researchOutputController || new ResearchOutputs(squidexGraphlClient);
-  const teamController = libs.teamController || new Teams(squidexGraphlClient);
-  const userController = libs.userController || new Users(squidexGraphlClient);
+    libs.researchOutputController || new ResearchOutputs(squidexGraphqlClient);
+  const teamController = libs.teamController || new Teams(squidexGraphqlClient);
+  const userController = libs.userController || new Users(squidexGraphqlClient);
 
   // Handlers
   const authHandler = libs.authHandler || authHandlerFactory(decodeToken);

--- a/apps/asap-server/src/app.ts
+++ b/apps/asap-server/src/app.ts
@@ -65,7 +65,8 @@ export const appFactory = (libs: Libs = {}): Express => {
   const calendarController = libs.calendarController || new Calendars();
   const dashboardController = libs.dashboardController || new Dashboard();
   const newsController = libs.newsController || new News();
-  const discoverController = libs.discoverController || new Discover();
+  const discoverController =
+    libs.discoverController || new Discover(squidexGraphlClient);
   const eventController = libs.eventController || new Events();
   const groupController =
     libs.groupController || new Groups(squidexGraphlClient);

--- a/apps/asap-server/src/app.ts
+++ b/apps/asap-server/src/app.ts
@@ -62,7 +62,8 @@ export const appFactory = (libs: Libs = {}): Express => {
   const squidexGraphlClient = new InstrumentedSquidexGraphql();
 
   // Controllers
-  const calendarController = libs.calendarController || new Calendars();
+  const calendarController =
+    libs.calendarController || new Calendars(squidexGraphlClient);
   const dashboardController =
     libs.dashboardController || new Dashboard(squidexGraphlClient);
   const newsController = libs.newsController || new News();

--- a/apps/asap-server/src/app.ts
+++ b/apps/asap-server/src/app.ts
@@ -67,12 +67,13 @@ export const appFactory = (libs: Libs = {}): Express => {
   const newsController = libs.newsController || new News();
   const discoverController = libs.discoverController || new Discover();
   const eventController = libs.eventController || new Events();
-  const groupController = libs.groupController || new Groups();
+  const groupController =
+    libs.groupController || new Groups(squidexGraphlClient);
   const pageController = libs.pageController || new Pages();
   const researchOutputController =
     libs.researchOutputController || new ResearchOutputs(squidexGraphlClient);
-  const teamController = libs.teamController || new Teams();
-  const userController = libs.userController || new Users();
+  const teamController = libs.teamController || new Teams(squidexGraphlClient);
+  const userController = libs.userController || new Users(squidexGraphlClient);
 
   // Handlers
   const authHandler = libs.authHandler || authHandlerFactory(decodeToken);

--- a/apps/asap-server/src/controllers/calendars.ts
+++ b/apps/asap-server/src/controllers/calendars.ts
@@ -25,9 +25,9 @@ export default class Calendars implements CalendarController {
   calendars: InstrumentedSquidex<RestCalendar>;
   client: SquidexGraphqlClient;
 
-  constructor(squidexGraphlClient: SquidexGraphqlClient) {
+  constructor(squidexGraphqlClient: SquidexGraphqlClient) {
     this.calendars = new InstrumentedSquidex('calendars');
-    this.client = squidexGraphlClient;
+    this.client = squidexGraphqlClient;
   }
 
   async fetch(options: {

--- a/apps/asap-server/src/controllers/calendars.ts
+++ b/apps/asap-server/src/controllers/calendars.ts
@@ -1,6 +1,6 @@
 import Boom from '@hapi/boom';
 import Intercept from 'apr-intercept';
-import type {
+import {
   RestCalendar,
   Calendar,
   Query,
@@ -16,7 +16,7 @@ import { InstrumentedSquidex } from '../utils/instrumented-client';
 import { parseCalendar } from '../entities';
 import logger from '../utils/logger';
 import { FETCH_CALENDAR } from '../queries/calendars.queries';
-import type {
+import {
   FetchCalendarQuery,
   FetchCalendarQueryVariables,
 } from '../gql/graphql';

--- a/apps/asap-server/src/controllers/calendars.ts
+++ b/apps/asap-server/src/controllers/calendars.ts
@@ -1,31 +1,33 @@
 import Boom from '@hapi/boom';
 import Intercept from 'apr-intercept';
-import { RestCalendar, Calendar, Query } from '@asap-hub/squidex';
+import type {
+  RestCalendar,
+  Calendar,
+  Query,
+  SquidexGraphqlClient,
+} from '@asap-hub/squidex';
 import {
   ListCalendarResponse,
   CalendarResponse,
   isGoogleLegacyCalendarColor,
 } from '@asap-hub/model';
 
-import {
-  InstrumentedSquidex,
-  InstrumentedSquidexGraphql,
-} from '../utils/instrumented-client';
+import { InstrumentedSquidex } from '../utils/instrumented-client';
 import { parseCalendar } from '../entities';
 import logger from '../utils/logger';
 import { FETCH_CALENDAR } from '../queries/calendars.queries';
-import {
+import type {
   FetchCalendarQuery,
   FetchCalendarQueryVariables,
 } from '../gql/graphql';
 
 export default class Calendars implements CalendarController {
   calendars: InstrumentedSquidex<RestCalendar>;
-  graphqlClient: InstrumentedSquidexGraphql;
+  client: SquidexGraphqlClient;
 
-  constructor() {
+  constructor(squidexGraphlClient: SquidexGraphqlClient) {
     this.calendars = new InstrumentedSquidex('calendars');
-    this.graphqlClient = new InstrumentedSquidexGraphql();
+    this.client = squidexGraphlClient;
   }
 
   async fetch(options: {
@@ -112,7 +114,7 @@ export default class Calendars implements CalendarController {
     calendarId: string,
     options?: { raw: boolean },
   ): Promise<CalendarRaw | CalendarResponse> {
-    const calendarResponse = await this.graphqlClient.request<
+    const calendarResponse = await this.client.request<
       FetchCalendarQuery,
       FetchCalendarQueryVariables
     >(FETCH_CALENDAR, { id: calendarId });

--- a/apps/asap-server/src/controllers/dashboard.ts
+++ b/apps/asap-server/src/controllers/dashboard.ts
@@ -12,8 +12,8 @@ export interface DashboardController {
 export default class Dashboard {
   client: SquidexGraphqlClient;
 
-  constructor(squidexGraphlClient: SquidexGraphqlClient) {
-    this.client = squidexGraphlClient;
+  constructor(squidexGraphqlClient: SquidexGraphqlClient) {
+    this.client = squidexGraphqlClient;
   }
 
   async fetch(): Promise<DashboardResponse> {

--- a/apps/asap-server/src/controllers/dashboard.ts
+++ b/apps/asap-server/src/controllers/dashboard.ts
@@ -1,19 +1,19 @@
-import { DashboardResponse } from '@asap-hub/model';
+import type { DashboardResponse } from '@asap-hub/model';
+import type { SquidexGraphqlClient } from '@asap-hub/squidex';
 
-import { InstrumentedSquidexGraphql } from '../utils/instrumented-client';
 import { parseGraphQLPage, parseGraphQLNews } from '../entities';
 import { FETCH_DASHBOARD } from '../queries/dashboard.queries';
-import { FetchDashboardQuery } from '../gql/graphql';
+import type { FetchDashboardQuery } from '../gql/graphql';
 
 export interface DashboardController {
   fetch: () => Promise<DashboardResponse>;
 }
 
 export default class Dashboard {
-  client: InstrumentedSquidexGraphql;
+  client: SquidexGraphqlClient;
 
-  constructor(ctxHeaders?: Record<string, string>) {
-    this.client = new InstrumentedSquidexGraphql(ctxHeaders);
+  constructor(squidexGraphlClient: SquidexGraphqlClient) {
+    this.client = squidexGraphlClient;
   }
 
   async fetch(): Promise<DashboardResponse> {

--- a/apps/asap-server/src/controllers/dashboard.ts
+++ b/apps/asap-server/src/controllers/dashboard.ts
@@ -1,9 +1,9 @@
-import type { DashboardResponse } from '@asap-hub/model';
-import type { SquidexGraphqlClient } from '@asap-hub/squidex';
+import { DashboardResponse } from '@asap-hub/model';
+import { SquidexGraphqlClient } from '@asap-hub/squidex';
 
 import { parseGraphQLPage, parseGraphQLNews } from '../entities';
 import { FETCH_DASHBOARD } from '../queries/dashboard.queries';
-import type { FetchDashboardQuery } from '../gql/graphql';
+import { FetchDashboardQuery } from '../gql/graphql';
 
 export interface DashboardController {
   fetch: () => Promise<DashboardResponse>;

--- a/apps/asap-server/src/controllers/discover.ts
+++ b/apps/asap-server/src/controllers/discover.ts
@@ -1,7 +1,11 @@
-import { GraphqlPage, GraphqlNews, GraphqlUser } from '@asap-hub/squidex';
+import {
+  GraphqlPage,
+  GraphqlNews,
+  GraphqlUser,
+  SquidexGraphqlClient,
+} from '@asap-hub/squidex';
 import { DiscoverResponse } from '@asap-hub/model';
 
-import { InstrumentedSquidexGraphql } from '../utils/instrumented-client';
 import {
   parseGraphQLUser,
   parseGraphQLPage,
@@ -23,17 +27,18 @@ export interface SquidexDiscoverResponse {
 }
 
 export default class Discover implements DiscoverController {
-  client: InstrumentedSquidexGraphql;
+  client: SquidexGraphqlClient;
 
-  constructor(ctxHeaders?: Record<string, string>) {
-    this.client = new InstrumentedSquidexGraphql(ctxHeaders);
+  constructor(squidexGraphlClient: SquidexGraphqlClient) {
+    this.client = squidexGraphlClient;
   }
 
   async fetch(): Promise<DiscoverResponse> {
-    const { queryDiscoverContents } = await this.client.request<
-      FetchDiscoverQuery,
-      unknown
-    >(FETCH_DISCOVER);
+    const data = await this.client.request<FetchDiscoverQuery, unknown>(
+      FETCH_DISCOVER,
+    );
+
+    const { queryDiscoverContents } = data;
     if (
       !queryDiscoverContents ||
       queryDiscoverContents.length === 0 ||

--- a/apps/asap-server/src/controllers/discover.ts
+++ b/apps/asap-server/src/controllers/discover.ts
@@ -1,17 +1,17 @@
-import type {
+import {
   GraphqlPage,
   GraphqlNews,
   GraphqlUser,
   SquidexGraphqlClient,
 } from '@asap-hub/squidex';
-import type { DiscoverResponse } from '@asap-hub/model';
+import { DiscoverResponse } from '@asap-hub/model';
 
 import {
   parseGraphQLUser,
   parseGraphQLPage,
   parseGraphQLNews,
 } from '../entities';
-import type { FetchDiscoverQuery } from '../gql/graphql';
+import { FetchDiscoverQuery } from '../gql/graphql';
 
 import { FETCH_DISCOVER } from '../queries/discover.queries';
 

--- a/apps/asap-server/src/controllers/discover.ts
+++ b/apps/asap-server/src/controllers/discover.ts
@@ -1,17 +1,17 @@
-import {
+import type {
   GraphqlPage,
   GraphqlNews,
   GraphqlUser,
   SquidexGraphqlClient,
 } from '@asap-hub/squidex';
-import { DiscoverResponse } from '@asap-hub/model';
+import type { DiscoverResponse } from '@asap-hub/model';
 
 import {
   parseGraphQLUser,
   parseGraphQLPage,
   parseGraphQLNews,
 } from '../entities';
-import { FetchDiscoverQuery } from '../gql/graphql';
+import type { FetchDiscoverQuery } from '../gql/graphql';
 
 import { FETCH_DISCOVER } from '../queries/discover.queries';
 

--- a/apps/asap-server/src/controllers/discover.ts
+++ b/apps/asap-server/src/controllers/discover.ts
@@ -29,8 +29,8 @@ export interface SquidexDiscoverResponse {
 export default class Discover implements DiscoverController {
   client: SquidexGraphqlClient;
 
-  constructor(squidexGraphlClient: SquidexGraphqlClient) {
-    this.client = squidexGraphlClient;
+  constructor(squidexGraphqlClient: SquidexGraphqlClient) {
+    this.client = squidexGraphqlClient;
   }
 
   async fetch(): Promise<DiscoverResponse> {

--- a/apps/asap-server/src/controllers/events.ts
+++ b/apps/asap-server/src/controllers/events.ts
@@ -1,11 +1,8 @@
 import Boom from '@hapi/boom';
 import Intercept from 'apr-intercept';
 import { EventResponse, ListEventResponse } from '@asap-hub/model';
-import { RestEvent, Event } from '@asap-hub/squidex';
-import {
-  InstrumentedSquidexGraphql,
-  InstrumentedSquidex,
-} from '../utils/instrumented-client';
+import { RestEvent, Event, SquidexGraphqlClient } from '@asap-hub/squidex';
+import { InstrumentedSquidex } from '../utils/instrumented-client';
 import { parseGraphQLEvent } from '../entities/event';
 import { AllOrNone, FetchOptions } from '../utils/types';
 
@@ -34,12 +31,12 @@ export interface EventController {
 }
 
 export default class Events implements EventController {
-  client: InstrumentedSquidexGraphql;
+  client: SquidexGraphqlClient;
 
   events: InstrumentedSquidex<RestEvent>;
 
-  constructor() {
-    this.client = new InstrumentedSquidexGraphql();
+  constructor(squidexGraphqlClient: SquidexGraphqlClient) {
+    this.client = squidexGraphqlClient;
     this.events = new InstrumentedSquidex('events');
   }
 

--- a/apps/asap-server/src/controllers/groups.ts
+++ b/apps/asap-server/src/controllers/groups.ts
@@ -39,10 +39,10 @@ export interface GroupController {
 }
 
 export default class Groups implements GroupController {
-  graphqlClient: SquidexGraphqlClient;
+  client: SquidexGraphqlClient;
 
-  constructor(squidexGraphlClient: SquidexGraphqlClient) {
-    this.graphqlClient = squidexGraphlClient;
+  constructor(squidexGraphqlClient: SquidexGraphqlClient) {
+    this.client = squidexGraphqlClient;
   }
 
   async fetchGroups(
@@ -50,7 +50,7 @@ export default class Groups implements GroupController {
     options: FetchOptions,
   ): Promise<ListGroupResponse> {
     const { take = 50, skip = 0 } = options;
-    const { queryGroupsContentsWithTotal } = await this.graphqlClient.request<
+    const { queryGroupsContentsWithTotal } = await this.client.request<
       FetchGroupsQuery,
       FetchGroupsQueryVariables
     >(FETCH_GROUPS, { filter, top: take, skip });
@@ -100,7 +100,7 @@ export default class Groups implements GroupController {
   }
 
   async fetchById(groupId: string): Promise<GroupResponse> {
-    const { findGroupsContent: group } = await this.graphqlClient.request<
+    const { findGroupsContent: group } = await this.client.request<
       FetchGroupQuery,
       FetchGroupQueryVariables
     >(FETCH_GROUP, { id: groupId });

--- a/apps/asap-server/src/controllers/groups.ts
+++ b/apps/asap-server/src/controllers/groups.ts
@@ -1,9 +1,7 @@
 import Boom from '@hapi/boom';
-import { GraphqlGroup } from '@asap-hub/squidex';
+import { GraphqlGroup, SquidexGraphqlClient } from '@asap-hub/squidex';
 import { ListGroupResponse, GroupResponse } from '@asap-hub/model';
 import uniqBy from 'lodash.uniqby';
-
-import { InstrumentedSquidexGraphql } from '../utils/instrumented-client';
 import { FetchOptions } from '../utils/types';
 import { parseGraphQLGroup } from '../entities';
 import { sanitiseForSquidex } from '../utils/squidex';
@@ -41,10 +39,10 @@ export interface GroupController {
 }
 
 export default class Groups implements GroupController {
-  client: InstrumentedSquidexGraphql;
+  graphqlClient: SquidexGraphqlClient;
 
-  constructor(ctxHeaders?: Record<string, string>) {
-    this.client = new InstrumentedSquidexGraphql(ctxHeaders);
+  constructor(squidexGraphlClient: SquidexGraphqlClient) {
+    this.graphqlClient = squidexGraphlClient;
   }
 
   async fetchGroups(
@@ -52,7 +50,7 @@ export default class Groups implements GroupController {
     options: FetchOptions,
   ): Promise<ListGroupResponse> {
     const { take = 50, skip = 0 } = options;
-    const { queryGroupsContentsWithTotal } = await this.client.request<
+    const { queryGroupsContentsWithTotal } = await this.graphqlClient.request<
       FetchGroupsQuery,
       FetchGroupsQueryVariables
     >(FETCH_GROUPS, { filter, top: take, skip });
@@ -102,7 +100,7 @@ export default class Groups implements GroupController {
   }
 
   async fetchById(groupId: string): Promise<GroupResponse> {
-    const { findGroupsContent: group } = await this.client.request<
+    const { findGroupsContent: group } = await this.graphqlClient.request<
       FetchGroupQuery,
       FetchGroupQueryVariables
     >(FETCH_GROUP, { id: groupId });

--- a/apps/asap-server/src/controllers/research-outputs.ts
+++ b/apps/asap-server/src/controllers/research-outputs.ts
@@ -20,18 +20,17 @@ import {
 } from '../gql/graphql';
 
 export default class ResearchOutputs implements ResearchOutputController {
-  squidexGraphlClient: SquidexGraphqlClient;
+  client: SquidexGraphqlClient;
 
-  constructor(squidexGraphlClient: SquidexGraphqlClient) {
-    this.squidexGraphlClient = squidexGraphlClient;
+  constructor(squidexGraphqlClient: SquidexGraphqlClient) {
+    this.client = squidexGraphqlClient;
   }
 
   async fetchById(id: string): Promise<ResearchOutputResponse> {
-    const researchOutputGraphqlResponse =
-      await this.squidexGraphlClient.request<
-        FetchResearchOutputQuery,
-        FetchResearchOutputQueryVariables
-      >(FETCH_RESEARCH_OUTPUT, { id, withTeams: true });
+    const researchOutputGraphqlResponse = await this.client.request<
+      FetchResearchOutputQuery,
+      FetchResearchOutputQueryVariables
+    >(FETCH_RESEARCH_OUTPUT, { id, withTeams: true });
 
     const { findResearchOutputsContent: researchOutputContent } =
       researchOutputGraphqlResponse;
@@ -90,16 +89,15 @@ export default class ResearchOutputs implements ResearchOutputController {
       .filter(Boolean)
       .join(' and ');
 
-    const { queryResearchOutputsContentsWithTotal } =
-      await this.squidexGraphlClient.request<
-        FetchResearchOutputsQuery,
-        FetchResearchOutputsQueryVariables
-      >(FETCH_RESEARCH_OUTPUTS, {
-        top: take,
-        skip,
-        filter: filterGraphql,
-        withTeams: true,
-      });
+    const { queryResearchOutputsContentsWithTotal } = await this.client.request<
+      FetchResearchOutputsQuery,
+      FetchResearchOutputsQueryVariables
+    >(FETCH_RESEARCH_OUTPUTS, {
+      top: take,
+      skip,
+      filter: filterGraphql,
+      withTeams: true,
+    });
 
     if (queryResearchOutputsContentsWithTotal === null) {
       logger.warn('queryResearchOutputsContentsWithTotal returned null');

--- a/apps/asap-server/src/controllers/teams.ts
+++ b/apps/asap-server/src/controllers/teams.ts
@@ -48,12 +48,12 @@ export type FetchTeamsOptions = {
 };
 
 export default class Teams implements TeamController {
-  teamRestClient: InstrumentedSquidex<RestTeam>;
-  graphqlClient: SquidexGraphqlClient;
+  teams: InstrumentedSquidex<RestTeam>;
+  client: SquidexGraphqlClient;
 
-  constructor(squidexGraphlClient: SquidexGraphqlClient) {
-    this.graphqlClient = squidexGraphlClient;
-    this.teamRestClient = new InstrumentedSquidex('teams');
+  constructor(squidexGraphqlClient: SquidexGraphqlClient) {
+    this.client = squidexGraphqlClient;
+    this.teams = new InstrumentedSquidex('teams');
   }
 
   async update(id: string, tools: TeamTool[]): Promise<TeamResponse> {
@@ -67,7 +67,7 @@ export default class Teams implements TeamController {
       ),
     );
 
-    await this.teamRestClient.patch(id, { tools: { iv: cleanUpdate } });
+    await this.teams.patch(id, { tools: { iv: cleanUpdate } });
     return this.fetchById(id);
   }
 
@@ -91,7 +91,7 @@ export default class Teams implements TeamController {
       )
       .join(' and ');
 
-    const { queryTeamsContentsWithTotal } = await this.graphqlClient.request<
+    const { queryTeamsContentsWithTotal } = await this.client.request<
       FetchTeamsQuery,
       FetchTeamsQueryVariables
     >(FETCH_TEAMS, {
@@ -142,7 +142,7 @@ export default class Teams implements TeamController {
     teamId: string,
     options?: FetchTeamOptions,
   ): Promise<TeamResponse> {
-    const teamResponse = await this.graphqlClient.request<
+    const teamResponse = await this.client.request<
       FetchTeamQuery,
       FetchTeamQueryVariables
     >(FETCH_TEAM, { id: teamId });

--- a/apps/asap-server/src/controllers/teams.ts
+++ b/apps/asap-server/src/controllers/teams.ts
@@ -1,10 +1,5 @@
 import Boom from '@hapi/boom';
-import {
-  RestTeam,
-  RestUser,
-  GraphqlTeam,
-  SquidexGraphqlClient,
-} from '@asap-hub/squidex';
+import { RestTeam, GraphqlTeam, SquidexGraphqlClient } from '@asap-hub/squidex';
 import { ListTeamResponse, TeamResponse, TeamTool } from '@asap-hub/model';
 
 import { InstrumentedSquidex } from '../utils/instrumented-client';
@@ -54,12 +49,10 @@ export type FetchTeamsOptions = {
 
 export default class Teams implements TeamController {
   teamRestClient: InstrumentedSquidex<RestTeam>;
-  userRestClient: InstrumentedSquidex<RestUser>;
   graphqlClient: SquidexGraphqlClient;
 
   constructor(squidexGraphlClient: SquidexGraphqlClient) {
     this.graphqlClient = squidexGraphlClient;
-    this.userRestClient = new InstrumentedSquidex('users');
     this.teamRestClient = new InstrumentedSquidex('teams');
   }
 

--- a/apps/asap-server/src/controllers/users.ts
+++ b/apps/asap-server/src/controllers/users.ts
@@ -3,7 +3,12 @@ import {
   UserPatchRequest,
   UserResponse,
 } from '@asap-hub/model';
-import { config, GraphqlUser, RestUser } from '@asap-hub/squidex';
+import {
+  config,
+  GraphqlUser,
+  RestUser,
+  SquidexGraphqlClient,
+} from '@asap-hub/squidex';
 import Boom from '@hapi/boom';
 import Intercept from 'apr-intercept';
 import FormData from 'form-data';
@@ -18,10 +23,7 @@ import {
 } from '../gql/graphql';
 import { FETCH_USER, FETCH_USERS } from '../queries/users.queries';
 import { fetchOrcidProfile, transformOrcidWorks } from '../utils/fetch-orcid';
-import {
-  InstrumentedSquidex,
-  InstrumentedSquidexGraphql,
-} from '../utils/instrumented-client';
+import { InstrumentedSquidex } from '../utils/instrumented-client';
 import { sanitiseForSquidex } from '../utils/squidex';
 import { FetchOptions } from '../utils/types';
 
@@ -78,12 +80,11 @@ const fetchByCode = async (code: string, client: Got): Promise<RestUser> => {
 
 export default class Users implements UserController {
   users: InstrumentedSquidex<RestUser>;
+  client: SquidexGraphqlClient;
 
-  client: InstrumentedSquidexGraphql;
-
-  constructor(ctxHeaders?: Record<string, string>) {
-    this.client = new InstrumentedSquidexGraphql(ctxHeaders);
-    this.users = new InstrumentedSquidex('users', ctxHeaders);
+  constructor(squidexGraphlClient: SquidexGraphqlClient) {
+    this.client = squidexGraphlClient;
+    this.users = new InstrumentedSquidex('users');
   }
 
   async update(id: string, update: UserPatchRequest): Promise<UserResponse> {

--- a/apps/asap-server/src/controllers/users.ts
+++ b/apps/asap-server/src/controllers/users.ts
@@ -82,8 +82,8 @@ export default class Users implements UserController {
   users: InstrumentedSquidex<RestUser>;
   client: SquidexGraphqlClient;
 
-  constructor(squidexGraphlClient: SquidexGraphqlClient) {
-    this.client = squidexGraphlClient;
+  constructor(squidexGraphqlClient: SquidexGraphqlClient) {
+    this.client = squidexGraphqlClient;
     this.users = new InstrumentedSquidex('users');
   }
 

--- a/apps/asap-server/src/handlers/calendar/resubscribe-handler.ts
+++ b/apps/asap-server/src/handlers/calendar/resubscribe-handler.ts
@@ -1,4 +1,5 @@
 import { DateTime } from 'luxon';
+import { SquidexGraphql } from '@asap-hub/squidex';
 import Calendars, { CalendarController } from '../../controllers/calendars';
 import {
   UnsubscribeFromEventChanges,
@@ -60,9 +61,10 @@ export const resubscribeCalendarsHandlerFactory =
       }),
     );
   };
+const squidexGraphqlClient = new SquidexGraphql();
 
 export const handler = resubscribeCalendarsHandlerFactory(
-  new Calendars(),
+  new Calendars(squidexGraphqlClient),
   unsubscribeFromEventChangesFactory(getJWTCredentials),
   subscribeToEventChangesFactory(getJWTCredentials),
 );

--- a/apps/asap-server/src/handlers/calendar/subscribe-handler.ts
+++ b/apps/asap-server/src/handlers/calendar/subscribe-handler.ts
@@ -4,7 +4,7 @@ import Joi from '@hapi/joi';
 import { Auth } from 'googleapis';
 import * as Sentry from '@sentry/serverless';
 import { framework as lambda } from '@asap-hub/services-common';
-import { WebhookPayload, Calendar } from '@asap-hub/squidex';
+import { WebhookPayload, Calendar, SquidexGraphql } from '@asap-hub/squidex';
 
 import {
   googleApiUrl,
@@ -197,11 +197,11 @@ Sentry.AWSLambda.init({
   environment,
   release: currentRevision,
 });
-
+const squidexGraphqlClient = new SquidexGraphql();
 const webhookHandler = calendarCreatedHandlerFactory(
   subscribeToEventChangesFactory(getJWTCredentialsAWS),
   unsubscribeFromEventChangesFactory(getJWTCredentialsAWS),
-  new Calendars(),
+  new Calendars(squidexGraphqlClient),
   new AlertsSentry(Sentry.captureException.bind(Sentry)),
 );
 

--- a/apps/asap-server/src/handlers/webhooks/cronjob-sync-orcid.ts
+++ b/apps/asap-server/src/handlers/webhooks/cronjob-sync-orcid.ts
@@ -1,6 +1,6 @@
 import pLimit from 'p-limit';
 import { framework as lambda } from '@asap-hub/services-common';
-import { Squidex, RestUser } from '@asap-hub/squidex';
+import { Squidex, RestUser, SquidexGraphql } from '@asap-hub/squidex';
 
 import Users from '../../controllers/users';
 
@@ -8,7 +8,8 @@ export const handler = async (): Promise<lambda.Response> => {
   const ONE_MONTH = 1000 * 60 * 60 * 24 * 31;
 
   const limit = pLimit(5);
-  const users = new Users();
+  const squidexGraphqlClient = new SquidexGraphql();
+  const users = new Users(squidexGraphqlClient);
   const squidexUsers: Squidex<RestUser> = new Squidex('users');
 
   const { items: outdatedUsers } = await squidexUsers.fetch({

--- a/apps/asap-server/src/handlers/webhooks/fetch-by-code/handler.ts
+++ b/apps/asap-server/src/handlers/webhooks/fetch-by-code/handler.ts
@@ -1,4 +1,5 @@
 /* istanbul ignore file */
+import { SquidexGraphql } from '@asap-hub/squidex';
 import algoliasearch from 'algoliasearch';
 import { algoliaAppId, algoliaSearchApiKey } from '../../../config';
 import Users from '../../../controllers/users';
@@ -6,6 +7,6 @@ import { Handler } from '../../../utils/types';
 import { fetchUserByCodeHandlerFactory } from './fetch-by-code';
 
 export const handler: Handler = fetchUserByCodeHandlerFactory(
-  new Users(),
+  new Users(new SquidexGraphql()),
   algoliasearch(algoliaAppId, algoliaSearchApiKey),
 );

--- a/apps/asap-server/src/handlers/webhooks/webhook-connect-by-code.ts
+++ b/apps/asap-server/src/handlers/webhooks/webhook-connect-by-code.ts
@@ -1,9 +1,10 @@
 import Joi from '@hapi/joi';
 import { framework as lambda } from '@asap-hub/services-common';
-import { http } from '../../utils/instrumented-framework';
+import { SquidexGraphql } from '@asap-hub/squidex';
 
 import Users from '../../controllers/users';
 import { Handler } from '../../utils/types';
+import { http } from '../../utils/instrumented-framework';
 import validateRequest from '../../utils/validate-auth0-request';
 
 export const handler: Handler = http(
@@ -24,7 +25,8 @@ export const handler: Handler = http(
       userId: string;
     };
 
-    const users = new Users(request.headers);
+    const squidexGraphqlClient = new SquidexGraphql();
+    const users = new Users(squidexGraphqlClient);
     await users.connectByCode(code, userId);
 
     return {

--- a/apps/asap-server/src/handlers/webhooks/webhook-events-updated.ts
+++ b/apps/asap-server/src/handlers/webhooks/webhook-events-updated.ts
@@ -68,11 +68,11 @@ export const webhookEventUpdatedHandlerFactory = (
     };
   }, logger);
 
+const squidexGraphqlClient = new SquidexGraphql();
 const syncCalendar = syncCalendarFactory(
-  syncEventFactory(new Events()),
+  syncEventFactory(new Events(squidexGraphqlClient)),
   getJWTCredentials,
 );
-const squidexGraphqlClient = new SquidexGraphql();
 
 export const handler: Handler = webhookEventUpdatedHandlerFactory(
   new Calendars(squidexGraphqlClient),

--- a/apps/asap-server/src/handlers/webhooks/webhook-events-updated.ts
+++ b/apps/asap-server/src/handlers/webhooks/webhook-events-updated.ts
@@ -1,5 +1,5 @@
 import Boom from '@hapi/boom';
-import { RestCalendar } from '@asap-hub/squidex';
+import { RestCalendar, SquidexGraphql } from '@asap-hub/squidex';
 import { framework as lambda } from '@asap-hub/services-common';
 
 import { Handler } from '../../utils/types';
@@ -72,8 +72,9 @@ const syncCalendar = syncCalendarFactory(
   syncEventFactory(new Events()),
   getJWTCredentials,
 );
+const squidexGraphqlClient = new SquidexGraphql();
 
 export const handler: Handler = webhookEventUpdatedHandlerFactory(
-  new Calendars(),
+  new Calendars(squidexGraphqlClient),
   syncCalendar,
 );

--- a/apps/asap-server/src/handlers/webhooks/webhook-sync-orcid.ts
+++ b/apps/asap-server/src/handlers/webhooks/webhook-sync-orcid.ts
@@ -1,6 +1,6 @@
 import Joi from '@hapi/joi';
 import { framework as lambda } from '@asap-hub/services-common';
-import { WebhookPayload, User } from '@asap-hub/squidex';
+import { WebhookPayload, User, SquidexGraphql } from '@asap-hub/squidex';
 import { http } from '../../utils/instrumented-framework';
 
 import { Handler } from '../../utils/types';
@@ -30,7 +30,8 @@ export const handler: Handler = http(
       bodySchema,
     ) as WebhookPayload<User>;
 
-    const users = new Users(request.headers);
+    const squidexGraphqlClient = new SquidexGraphql();
+    const users = new Users(squidexGraphqlClient);
     const { id } = payload;
     const newOrcid = payload.data.orcid?.iv;
 

--- a/apps/asap-server/test/controllers/calendars.test.ts
+++ b/apps/asap-server/test/controllers/calendars.test.ts
@@ -11,7 +11,6 @@ import {
   getCalendarsGraphqlResponse,
   getCalendarsRestResponse,
   getRestCalendar,
-  squidexGraphqlCalendarsResponse,
 } from '../fixtures/calendars.fixtures';
 import { FETCH_CALENDAR } from '../../src/queries/calendars.queries';
 import { getSquidexGraphqlClientMockServer } from '../mocks/squidex-graphql-client-with-server.mock';
@@ -164,7 +163,7 @@ describe('Calendars controller', () => {
       test('Should fetch the users from squidex graphql', async () => {
         const result = await calendarsMockGraphql.fetchById('calendar-id-1');
 
-        const expected = squidexGraphqlCalendarsResponse();
+        const expected = getCalendarResponse();
         expect(result).toMatchObject(expected);
       });
     });

--- a/apps/asap-server/test/controllers/calendars.test.ts
+++ b/apps/asap-server/test/controllers/calendars.test.ts
@@ -1,5 +1,5 @@
 import nock from 'nock';
-import { config } from '@asap-hub/squidex';
+import { config, SquidexGraphql } from '@asap-hub/squidex';
 import { badGateway, notFound } from '@hapi/boom';
 import { print } from 'graphql';
 
@@ -11,25 +11,30 @@ import {
   getCalendarsGraphqlResponse,
   getCalendarsRestResponse,
   getRestCalendar,
+  squidexGraphqlCalendarsResponse,
 } from '../fixtures/calendars.fixtures';
 import { FETCH_CALENDAR } from '../../src/queries/calendars.queries';
+import { getSquidexGraphqlClientMockServer } from '../mocks/squidex-graphql-client-with-server.mock';
 
 describe('Calendars controller', () => {
-  const calendars = new Calendars();
+  const squidexGraphqlClientMock = new SquidexGraphql();
+  const calendars = new Calendars(squidexGraphqlClientMock);
+
+  const squidexGraphqlClientMockServer = getSquidexGraphqlClientMockServer();
+  const calendarsMockGraphql = new Calendars(squidexGraphqlClientMockServer);
 
   beforeAll(() => {
     identity();
   });
 
-  afterEach(() => {
-    expect(nock.isDone()).toBe(true);
-  });
-
-  afterEach(() => {
-    nock.cleanAll();
-  });
-
   describe('Fetch method', () => {
+    afterEach(() => {
+      expect(nock.isDone()).toBe(true);
+    });
+
+    afterEach(() => {
+      nock.cleanAll();
+    });
     test('Should return an empty result when the no calendars are found', async () => {
       nock(config.baseUrl)
         .get(`/api/content/${config.appName}/calendars`)
@@ -80,6 +85,13 @@ describe('Calendars controller', () => {
   });
 
   describe('FetchRaw method', () => {
+    afterEach(() => {
+      expect(nock.isDone()).toBe(true);
+    });
+
+    afterEach(() => {
+      nock.cleanAll();
+    });
     test('Should return an empty result when the no calendars are found', async () => {
       nock(config.baseUrl)
         .get(`/api/content/${config.appName}/calendars`)
@@ -148,97 +160,124 @@ describe('Calendars controller', () => {
   });
 
   describe('FetchById method', () => {
-    test('Should throw an error when the calendar is not found', async () => {
-      const calendarId = 'not-found';
+    describe('with mock-server', () => {
+      test('Should fetch the users from squidex graphql', async () => {
+        const result = await calendarsMockGraphql.fetchById('calendar-id-1');
 
-      nock(config.baseUrl)
-        .post(`/api/content/${config.appName}/graphql`, {
-          query: print(FETCH_CALENDAR),
-          variables: {
-            id: calendarId,
-          },
-        })
-        .reply(200, {
-          data: {
-            findCalendarsContent: null,
-          },
-        });
-
-      await expect(calendars.fetchById(calendarId)).rejects.toThrow(notFound());
+        const expected = squidexGraphqlCalendarsResponse();
+        expect(result).toMatchObject(expected);
+      });
     });
 
-    test('Should return the calendar response', async () => {
-      const calendarId = 'calendar-id-1';
+    describe('with intercepted http layer', () => {
+      afterEach(() => {
+        expect(nock.isDone()).toBe(true);
+      });
 
-      nock(config.baseUrl)
-        .post(`/api/content/${config.appName}/graphql`, {
-          query: print(FETCH_CALENDAR),
-          variables: {
-            id: calendarId,
-          },
-        })
-        .reply(200, getCalendarsGraphqlResponse());
+      afterEach(() => {
+        nock.cleanAll();
+      });
+      test('Should throw an error when the calendar is not found', async () => {
+        const calendarId = 'not-found';
 
-      const result = await calendars.fetchById(calendarId);
+        nock(config.baseUrl)
+          .post(`/api/content/${config.appName}/graphql`, {
+            query: print(FETCH_CALENDAR),
+            variables: {
+              id: calendarId,
+            },
+          })
+          .reply(200, {
+            data: {
+              findCalendarsContent: null,
+            },
+          });
 
-      expect(result).toEqual(getCalendarResponse());
-    });
+        await expect(calendars.fetchById(calendarId)).rejects.toThrow(
+          notFound(),
+        );
+      });
 
-    test('Should throw if squidex response has invalid colour', async () => {
-      const id = 'calendar-id-1';
-      const response = getCalendarsGraphqlResponse();
-      response.data.findCalendarsContent!.flatData.color = 'invalid';
+      test('Should return the calendar response', async () => {
+        const calendarId = 'calendar-id-1';
 
-      nock(config.baseUrl)
-        .post(`/api/content/${config.appName}/graphql`, {
-          query: print(FETCH_CALENDAR),
-          variables: {
-            id,
-          },
-        })
-        .reply(200, response);
-      await expect(calendars.fetchById(id)).rejects.toThrow(
-        badGateway('Invalid colour'),
-      );
-    });
+        nock(config.baseUrl)
+          .post(`/api/content/${config.appName}/graphql`, {
+            query: print(FETCH_CALENDAR),
+            variables: {
+              id: calendarId,
+            },
+          })
+          .reply(200, getCalendarsGraphqlResponse());
 
-    test('Should throw if missing required data', async () => {
-      const id = 'calendar-id-1';
-      const response = getCalendarsGraphqlResponse();
-      response.data.findCalendarsContent!.flatData.color = null;
+        const result = await calendars.fetchById(calendarId);
 
-      nock(config.baseUrl)
-        .post(`/api/content/${config.appName}/graphql`, {
-          query: print(FETCH_CALENDAR),
-          variables: {
-            id,
-          },
-        })
-        .reply(200, response);
-      await expect(calendars.fetchById(id)).rejects.toThrow(
-        badGateway('Missing required data'),
-      );
-    });
+        expect(result).toEqual(getCalendarResponse());
+      });
 
-    test('Should return the calendar raw response', async () => {
-      const calendarId = 'calendar-id-1';
+      test('Should throw if squidex response has invalid colour', async () => {
+        const id = 'calendar-id-1';
+        const response = getCalendarsGraphqlResponse();
+        response.data.findCalendarsContent!.flatData.color = 'invalid';
 
-      nock(config.baseUrl)
-        .post(`/api/content/${config.appName}/graphql`, {
-          query: print(FETCH_CALENDAR),
-          variables: {
-            id: calendarId,
-          },
-        })
-        .reply(200, getCalendarsGraphqlResponse());
+        nock(config.baseUrl)
+          .post(`/api/content/${config.appName}/graphql`, {
+            query: print(FETCH_CALENDAR),
+            variables: {
+              id,
+            },
+          })
+          .reply(200, response);
+        await expect(calendars.fetchById(id)).rejects.toThrow(
+          badGateway('Invalid colour'),
+        );
+      });
 
-      const result = await calendars.fetchById(calendarId, { raw: true });
+      test('Should throw if missing required data', async () => {
+        const id = 'calendar-id-1';
+        const response = getCalendarsGraphqlResponse();
+        response.data.findCalendarsContent!.flatData.color = null;
 
-      expect(result).toEqual(getCalendarRaw());
+        nock(config.baseUrl)
+          .post(`/api/content/${config.appName}/graphql`, {
+            query: print(FETCH_CALENDAR),
+            variables: {
+              id,
+            },
+          })
+          .reply(200, response);
+        await expect(calendars.fetchById(id)).rejects.toThrow(
+          badGateway('Missing required data'),
+        );
+      });
+
+      test('Should return the calendar raw response', async () => {
+        const calendarId = 'calendar-id-1';
+
+        nock(config.baseUrl)
+          .post(`/api/content/${config.appName}/graphql`, {
+            query: print(FETCH_CALENDAR),
+            variables: {
+              id: calendarId,
+            },
+          })
+          .reply(200, getCalendarsGraphqlResponse());
+
+        const result = await calendars.fetchById(calendarId, { raw: true });
+
+        expect(result).toEqual(getCalendarRaw());
+      });
     });
   });
 
   describe('FetchByResourceId method', () => {
+    afterEach(() => {
+      expect(nock.isDone()).toBe(true);
+    });
+
+    afterEach(() => {
+      nock.cleanAll();
+    });
     const resourceId = 'resource-id';
     test('Should throw Bad Gateway when squidex throws an error', async () => {
       nock(config.baseUrl)
@@ -298,6 +337,13 @@ describe('Calendars controller', () => {
   });
 
   describe('Update method', () => {
+    afterEach(() => {
+      expect(nock.isDone()).toBe(true);
+    });
+
+    afterEach(() => {
+      nock.cleanAll();
+    });
     test('Should throw when calendar does not exist', async () => {
       nock(config.baseUrl)
         .patch(`/api/content/${config.appName}/calendars/calendar-not-found`)
@@ -330,6 +376,13 @@ describe('Calendars controller', () => {
   });
 
   describe('getSyncToken method', () => {
+    afterEach(() => {
+      expect(nock.isDone()).toBe(true);
+    });
+
+    afterEach(() => {
+      nock.cleanAll();
+    });
     test('Should throw when calendar does not exist', async () => {
       nock(config.baseUrl)
         .get(`/api/content/${config.appName}/calendars/calendar-not-found`)

--- a/apps/asap-server/test/controllers/dashboard.test.ts
+++ b/apps/asap-server/test/controllers/dashboard.test.ts
@@ -26,7 +26,8 @@ describe('Dashboard controller', () => {
       test('Should fetch the discover from squidex graphql', async () => {
         const result = await dashboardMockGraphql.fetch();
 
-        expect(result).toMatchObject(squidexGraphqlDashboardResponse);
+        const expected = squidexGraphqlDashboardResponse();
+        expect(result).toMatchObject(expected);
       });
     });
     describe('with intercepted http layer', () => {

--- a/apps/asap-server/test/controllers/dashboard.test.ts
+++ b/apps/asap-server/test/controllers/dashboard.test.ts
@@ -3,7 +3,7 @@ import Dashboard from '../../src/controllers/dashboard';
 import { config, SquidexGraphql } from '@asap-hub/squidex';
 import { identity } from '../helpers/squidex';
 import {
-  dashboardResponse,
+  squidexGraphqlDashboardFlatData,
   squidexGraphqlDashboardResponse,
 } from '../fixtures/dashboard.fixtures';
 import { FETCH_DASHBOARD } from '../../src/queries/dashboard.queries';
@@ -105,33 +105,7 @@ describe('Dashboard controller', () => {
             data: {
               queryDashboardContents: [
                 {
-                  flatData: {
-                    news: [
-                      {
-                        id: 'news-1',
-                        flatData: {
-                          title: 'News 1',
-                          type: 'News',
-                          shortText: 'Short text of news 1',
-                          text: '<p>text</p>',
-                          thumbnail: [{ id: 'thumbnail-uuid1' }],
-                        },
-                        created: '2020-09-08T16:35:28Z',
-                      },
-                      {
-                        id: 'news-2',
-                        flatData: {
-                          title: 'Event 2',
-                          type: 'Event',
-                          shortText: 'Short text of event 2',
-                          text: '<p>text</p>',
-                          thumbnail: [{ id: 'thumbnail-uuid2' }],
-                        },
-                        created: '2020-09-16T14:31:19Z',
-                      },
-                    ],
-                    pages: null,
-                  },
+                  flatData: squidexGraphqlDashboardFlatData(),
                 },
               ],
             },
@@ -139,7 +113,7 @@ describe('Dashboard controller', () => {
 
         const result = await dashboard.fetch();
 
-        expect(result).toEqual(dashboardResponse);
+        expect(result).toEqual(squidexGraphqlDashboardResponse());
       });
     });
   });

--- a/apps/asap-server/test/controllers/dashboard.test.ts
+++ b/apps/asap-server/test/controllers/dashboard.test.ts
@@ -1,124 +1,145 @@
 import nock from 'nock';
 import Dashboard from '../../src/controllers/dashboard';
-import { config } from '@asap-hub/squidex';
+import { config, SquidexGraphql } from '@asap-hub/squidex';
 import { identity } from '../helpers/squidex';
-import { dashboardResponse } from '../fixtures/dashboard.fixtures';
+import {
+  dashboardResponse,
+  squidexGraphqlDashboardResponse,
+} from '../fixtures/dashboard.fixtures';
 import { FETCH_DASHBOARD } from '../../src/queries/dashboard.queries';
 import { print } from 'graphql';
+import { getSquidexGraphqlClientMockServer } from '../mocks/squidex-graphql-client-with-server.mock';
 
 describe('Dashboard controller', () => {
-  const dashboard = new Dashboard();
+  const squidexGraphqlClientMock = new SquidexGraphql();
+  const dashboard = new Dashboard(squidexGraphqlClientMock);
+
+  const squidexGraphqlClientMockServer = getSquidexGraphqlClientMockServer();
+  const dashboardMockGraphql = new Dashboard(squidexGraphqlClientMockServer);
 
   beforeAll(() => {
     identity();
   });
 
-  afterEach(() => {
-    expect(nock.isDone()).toBe(true);
-  });
-
   describe('Fetch method', () => {
-    test('Should return an empty result when the client returns an empty array of data', async () => {
-      nock(config.baseUrl)
-        .post(`/api/content/${config.appName}/graphql`, {
-          query: print(FETCH_DASHBOARD),
-        })
-        .reply(200, {
-          data: {
-            queryDashboardContents: [{ flatData: { news: [], pages: [] } }],
-          },
-        });
+    describe('with mock-server', () => {
+      test('Should fetch the discover from squidex graphql', async () => {
+        const result = await dashboardMockGraphql.fetch();
 
-      const result = await dashboard.fetch();
-
-      expect(result).toEqual({
-        news: [],
-        pages: [],
+        expect(result).toMatchObject(squidexGraphqlDashboardResponse);
       });
     });
-
-    test('Should return an empty result when the client returns an empty array of data', async () => {
-      nock(config.baseUrl)
-        .post(`/api/content/${config.appName}/graphql`, {
-          query: print(FETCH_DASHBOARD),
-        })
-        .reply(200, {
-          data: {
-            queryDashboardContents: [],
-          },
-        });
-
-      const result = await dashboard.fetch();
-
-      expect(result).toEqual({
-        news: [],
-        pages: [],
+    describe('with intercepted http layer', () => {
+      afterEach(() => {
+        expect(nock.isDone()).toBe(true);
       });
-    });
-
-    test('Should return an empty result when the client returns nulls', async () => {
-      nock(config.baseUrl)
-        .post(`/api/content/${config.appName}/graphql`, {
-          query: print(FETCH_DASHBOARD),
-        })
-        .reply(200, {
-          data: {
-            queryDashboardContents: [{ flatData: { news: null, pages: null } }],
-          },
-        });
-
-      const result = await dashboard.fetch();
-
-      expect(result).toEqual({
-        news: [],
-        pages: [],
+      afterEach(() => {
+        nock.cleanAll();
       });
-    });
+      test('Should return an empty result when the client returns an empty array of data', async () => {
+        nock(config.baseUrl)
+          .post(`/api/content/${config.appName}/graphql`, {
+            query: print(FETCH_DASHBOARD),
+          })
+          .reply(200, {
+            data: {
+              queryDashboardContents: [{ flatData: { news: [], pages: [] } }],
+            },
+          });
 
-    test('Should return the dashboard news', async () => {
-      nock(config.baseUrl)
-        .post(`/api/content/${config.appName}/graphql`, {
-          query: print(FETCH_DASHBOARD),
-        })
-        .reply(200, {
-          data: {
-            queryDashboardContents: [
-              {
-                flatData: {
-                  news: [
-                    {
-                      id: 'news-1',
-                      flatData: {
-                        title: 'News 1',
-                        type: 'News',
-                        shortText: 'Short text of news 1',
-                        text: '<p>text</p>',
-                        thumbnail: [{ id: 'thumbnail-uuid1' }],
+        const result = await dashboard.fetch();
+
+        expect(result).toEqual({
+          news: [],
+          pages: [],
+        });
+      });
+
+      test('Should return an empty result when the client returns an empty array of data', async () => {
+        nock(config.baseUrl)
+          .post(`/api/content/${config.appName}/graphql`, {
+            query: print(FETCH_DASHBOARD),
+          })
+          .reply(200, {
+            data: {
+              queryDashboardContents: [],
+            },
+          });
+
+        const result = await dashboard.fetch();
+
+        expect(result).toEqual({
+          news: [],
+          pages: [],
+        });
+      });
+
+      test('Should return an empty result when the client returns nulls', async () => {
+        nock(config.baseUrl)
+          .post(`/api/content/${config.appName}/graphql`, {
+            query: print(FETCH_DASHBOARD),
+          })
+          .reply(200, {
+            data: {
+              queryDashboardContents: [
+                { flatData: { news: null, pages: null } },
+              ],
+            },
+          });
+
+        const result = await dashboard.fetch();
+
+        expect(result).toEqual({
+          news: [],
+          pages: [],
+        });
+      });
+
+      test('Should return the dashboard news', async () => {
+        nock(config.baseUrl)
+          .post(`/api/content/${config.appName}/graphql`, {
+            query: print(FETCH_DASHBOARD),
+          })
+          .reply(200, {
+            data: {
+              queryDashboardContents: [
+                {
+                  flatData: {
+                    news: [
+                      {
+                        id: 'news-1',
+                        flatData: {
+                          title: 'News 1',
+                          type: 'News',
+                          shortText: 'Short text of news 1',
+                          text: '<p>text</p>',
+                          thumbnail: [{ id: 'thumbnail-uuid1' }],
+                        },
+                        created: '2020-09-08T16:35:28Z',
                       },
-                      created: '2020-09-08T16:35:28Z',
-                    },
-                    {
-                      id: 'news-2',
-                      flatData: {
-                        title: 'Event 2',
-                        type: 'Event',
-                        shortText: 'Short text of event 2',
-                        text: '<p>text</p>',
-                        thumbnail: [{ id: 'thumbnail-uuid2' }],
+                      {
+                        id: 'news-2',
+                        flatData: {
+                          title: 'Event 2',
+                          type: 'Event',
+                          shortText: 'Short text of event 2',
+                          text: '<p>text</p>',
+                          thumbnail: [{ id: 'thumbnail-uuid2' }],
+                        },
+                        created: '2020-09-16T14:31:19Z',
                       },
-                      created: '2020-09-16T14:31:19Z',
-                    },
-                  ],
-                  pages: null,
+                    ],
+                    pages: null,
+                  },
                 },
-              },
-            ],
-          },
-        });
+              ],
+            },
+          });
 
-      const result = await dashboard.fetch();
+        const result = await dashboard.fetch();
 
-      expect(result).toEqual(dashboardResponse);
+        expect(result).toEqual(dashboardResponse);
+      });
     });
   });
 });

--- a/apps/asap-server/test/controllers/discover.test.ts
+++ b/apps/asap-server/test/controllers/discover.test.ts
@@ -28,7 +28,8 @@ describe('Discover controller', () => {
       test('Should fetch the discover from squidex graphql', async () => {
         const result = await discoverMockGraphql.fetch();
 
-        expect(result).toMatchObject(squidexGraphqlDiscoverResponse);
+        const expected = squidexGraphqlDiscoverResponse();
+        expect(result).toMatchObject(expected);
       });
     });
     describe('with intercepted http layer', () => {

--- a/apps/asap-server/test/controllers/discover.test.ts
+++ b/apps/asap-server/test/controllers/discover.test.ts
@@ -1,85 +1,101 @@
-import nock from 'nock';
 import Discover from '../../src/controllers/discover';
-import { config } from '@asap-hub/squidex';
+import { config, SquidexGraphql } from '@asap-hub/squidex';
 import { identity } from '../helpers/squidex';
 import { DiscoverResponse } from '@asap-hub/model';
+import nock from 'nock';
 import {
   squidexDiscoverResponse,
   discoverResponse,
+  squidexGraphqlDiscoverResponse,
 } from '../fixtures/discover.fixtures';
 import { FETCH_DISCOVER } from '../../src/queries/discover.queries';
 import { print } from 'graphql';
+import { getSquidexGraphqlClientMockServer } from '../mocks/squidex-graphql-client-with-server.mock';
 
 describe('Discover controller', () => {
-  const discover = new Discover();
+  const squidexGraphqlClientMock = new SquidexGraphql();
+  const discover = new Discover(squidexGraphqlClientMock);
+
+  const squidexGraphqlClientMockServer = getSquidexGraphqlClientMockServer();
+  const discoverMockGraphql = new Discover(squidexGraphqlClientMockServer);
 
   beforeAll(() => {
     identity();
   });
 
-  afterEach(() => {
-    expect(nock.isDone()).toBe(true);
-  });
-
   describe('Fetch method', () => {
-    test('Should return an empty result', async () => {
-      nock(config.baseUrl)
-        .post(`/api/content/${config.appName}/graphql`, {
-          query: print(FETCH_DISCOVER),
-        })
-        .reply(200, {
-          data: {
-            queryDiscoverContents: [
-              { flatData: { aboutUs: null, pages: null, members: null } },
-            ],
-          },
-        });
+    describe('with mock-server', () => {
+      test('Should fetch the discover from squidex graphql', async () => {
+        const result = await discoverMockGraphql.fetch();
 
-      const result = await discover.fetch();
-
-      const expectedResponse: DiscoverResponse = {
-        aboutUs: '',
-        training: [],
-        members: [],
-        pages: [],
-      };
-      expect(result).toEqual(expectedResponse);
+        expect(result).toMatchObject(squidexGraphqlDiscoverResponse);
+      });
     });
+    describe('with intercepted http layer', () => {
+      afterEach(() => {
+        expect(nock.isDone()).toBe(true);
+      });
+      afterEach(() => {
+        nock.cleanAll();
+      });
 
-    test('Should return an empty result when no resource doesnt exist', async () => {
-      nock(config.baseUrl)
-        .post(`/api/content/${config.appName}/graphql`, {
-          query: print(FETCH_DISCOVER),
-        })
-        .reply(200, {
-          data: {
-            queryDiscoverContents: [],
-          },
-        });
+      test('Should return an empty result', async () => {
+        nock(config.baseUrl)
+          .post(`/api/content/${config.appName}/graphql`, {
+            query: print(FETCH_DISCOVER),
+          })
+          .reply(200, {
+            data: {
+              queryDiscoverContents: [
+                { flatData: { aboutUs: null, pages: null, members: null } },
+              ],
+            },
+          });
 
-      const result = await discover.fetch();
+        const result = await discover.fetch();
 
-      const expectedResponse: DiscoverResponse = {
-        aboutUs: '',
-        training: [],
-        members: [],
-        pages: [],
-      };
-      expect(result).toEqual(expectedResponse);
-    });
+        const expectedResponse: DiscoverResponse = {
+          aboutUs: '',
+          training: [],
+          members: [],
+          pages: [],
+        };
+        expect(result).toEqual(expectedResponse);
+      });
+      test('Should return an empty result when no resource doesnt exist', async () => {
+        nock(config.baseUrl)
+          .post(`/api/content/${config.appName}/graphql`, {
+            query: print(FETCH_DISCOVER),
+          })
+          .reply(200, {
+            data: {
+              queryDiscoverContents: [],
+            },
+          });
 
-    test('Should return the discover information', async () => {
-      nock(config.baseUrl)
-        .post(`/api/content/${config.appName}/graphql`, {
-          query: print(FETCH_DISCOVER),
-        })
-        .reply(200, {
-          data: squidexDiscoverResponse,
-        });
+        const result = await discover.fetch();
 
-      const result = await discover.fetch();
+        const expectedResponse: DiscoverResponse = {
+          aboutUs: '',
+          training: [],
+          members: [],
+          pages: [],
+        };
+        expect(result).toEqual(expectedResponse);
+      });
+      test('Should return the discover information', async () => {
+        nock(config.baseUrl)
+          .post(`/api/content/${config.appName}/graphql`, {
+            query: print(FETCH_DISCOVER),
+          })
+          .reply(200, {
+            data: squidexDiscoverResponse,
+          });
 
-      expect(result).toEqual(discoverResponse);
+        const result = await discover.fetch();
+
+        expect(result).toEqual(discoverResponse);
+      });
     });
   });
 });

--- a/apps/asap-server/test/controllers/discover.test.ts
+++ b/apps/asap-server/test/controllers/discover.test.ts
@@ -5,7 +5,6 @@ import { DiscoverResponse } from '@asap-hub/model';
 import nock from 'nock';
 import {
   squidexDiscoverResponse,
-  discoverResponse,
   squidexGraphqlDiscoverResponse,
 } from '../fixtures/discover.fixtures';
 import { FETCH_DISCOVER } from '../../src/queries/discover.queries';
@@ -95,7 +94,8 @@ describe('Discover controller', () => {
 
         const result = await discover.fetch();
 
-        expect(result).toEqual(discoverResponse);
+        const discoverResponse = squidexGraphqlDiscoverResponse();
+        expect(result).toMatchObject(discoverResponse);
       });
     });
   });

--- a/apps/asap-server/test/controllers/events.test.ts
+++ b/apps/asap-server/test/controllers/events.test.ts
@@ -7,12 +7,12 @@ import { ListEventResponse, EventStatus } from '@asap-hub/model';
 import {
   fetchEventsResponse,
   listEventResponse,
-  graphqlEvent,
   findEventResponse,
   eventResponse,
   getRestEvent,
   squidexGraphqlEventsResponse,
   squidexGraphqlEventResponse,
+  getSquidexGraphqlEvents,
 } from '../fixtures/events.fixtures';
 import { queryGroupsResponse } from '../fixtures/groups.fixtures';
 import { print } from 'graphql';
@@ -21,10 +21,10 @@ import {
   FETCH_EVENTS,
   FETCH_GROUP_CALENDAR,
 } from '../../src/queries/events.queries';
-import { FetchEventQuery, FetchEventsQuery } from '../../src/gql/graphql';
 import { getSquidexGraphqlClientMockServer } from '../mocks/squidex-graphql-client-with-server.mock';
 
 describe('Event controller', () => {
+  const graphqlEvent = getSquidexGraphqlEvents();
   const squidexGraphqlClientMock = new SquidexGraphql();
   const events = new Events(squidexGraphqlClientMock);
 
@@ -439,7 +439,7 @@ describe('Event controller', () => {
         // change event start date to 06/06/2020, one hour from the above
         event.flatData!.startDate = '2020-06-06T14:00:00Z';
 
-        const fetchEventsResponse: { data: FetchEventsQuery } = {
+        const fetchEventsResponse = {
           data: {
             queryEventsContentsWithTotal: {
               total: 2,
@@ -470,7 +470,7 @@ describe('Event controller', () => {
         // change event start date to 2020
         event.flatData!.startDate = '2020-06-06T14:00:00Z';
 
-        const fetchEventsResponse: { data: FetchEventsQuery } = {
+        const fetchEventsResponse = {
           data: {
             queryEventsContentsWithTotal: {
               total: 2,
@@ -501,7 +501,7 @@ describe('Event controller', () => {
         // change event start date to year 2021
         event.flatData!.startDate = '2021-06-06T13:00:00Z';
 
-        const fetchEventsResponse: { data: FetchEventsQuery } = {
+        const fetchEventsResponse = {
           data: {
             queryEventsContentsWithTotal: {
               total: 2,
@@ -755,7 +755,7 @@ describe('Event controller', () => {
           // change event start date to 06/06/2020, one hour from the above
           event.flatData!.startDate = '2020-06-06T14:00:00Z';
 
-          const fetchEventResponse: { data: FetchEventQuery } = {
+          const fetchEventResponse = {
             data: {
               findEventsContent: event,
             },
@@ -784,7 +784,7 @@ describe('Event controller', () => {
           // change event start date to 2020
           event.flatData!.startDate = '2020-06-06T14:00:00Z';
 
-          const fetchEventResponse: { data: FetchEventQuery } = {
+          const fetchEventResponse = {
             data: {
               findEventsContent: event,
             },
@@ -813,7 +813,7 @@ describe('Event controller', () => {
           // change event start date to year 2021
           event.flatData!.startDate = '2021-06-06T13:00:00Z';
 
-          const fetchEventResponse: { data: FetchEventQuery } = {
+          const fetchEventResponse = {
             data: {
               findEventsContent: event,
             },

--- a/apps/asap-server/test/controllers/groups.test.ts
+++ b/apps/asap-server/test/controllers/groups.test.ts
@@ -1,5 +1,5 @@
 import nock from 'nock';
-import { config } from '@asap-hub/squidex';
+import { config, SquidexGraphql } from '@asap-hub/squidex';
 import { print } from 'graphql';
 import Groups from '../../src/controllers/groups';
 import { identity } from '../helpers/squidex';
@@ -7,235 +7,271 @@ import * as fixtures from '../fixtures/groups.fixtures';
 import { FetchOptions } from '../../src/utils/types';
 import {
   getGroupResponse,
+  getListGroupResponse,
   getResponseFetchGroup,
 } from '../fixtures/groups.fixtures';
 import { FETCH_GROUP, FETCH_GROUPS } from '../../src/queries/groups.queries';
-
-const groups = new Groups();
+import { getSquidexGraphqlClientMockServer } from '../mocks/squidex-graphql-client-with-server.mock';
 
 describe('Group controller', () => {
+  const squidexGraphqlClient = new SquidexGraphql();
+  const groupController = new Groups(squidexGraphqlClient);
+
+  const squidexGraphqlClientMockServer = getSquidexGraphqlClientMockServer();
+  const groupControllerMockGraphql = new Groups(squidexGraphqlClientMockServer);
+
   beforeAll(() => {
     identity();
   });
 
-  afterEach(() => {
-    expect(nock.isDone()).toBe(true);
-  });
-
-  afterEach(() => {
-    nock.cleanAll();
-  });
-
   describe('Fetch method', () => {
-    test('Should return an empty result', async () => {
-      nock(config.baseUrl)
-        .post(`/api/content/${config.appName}/graphql`, {
-          query: print(FETCH_GROUPS),
-          variables: {
-            filter: '',
-            top: 50,
-            skip: 0,
-          },
-        })
-        .reply(200, {
-          data: {
-            queryGroupsContentsWithTotal: {
-              total: 0,
-              items: [],
+    describe('with mock-server', () => {
+      test('Should fetch the groups from squidex graphql', async () => {
+        const result = await groupControllerMockGraphql.fetch({});
+
+        expect(result).toMatchObject(getListGroupResponse());
+      });
+    });
+
+    describe('with intercepted http layer', () => {
+      afterEach(() => {
+        expect(nock.isDone()).toBe(true);
+      });
+
+      afterEach(() => {
+        nock.cleanAll();
+      });
+
+      test('Should return an empty result', async () => {
+        nock(config.baseUrl)
+          .post(`/api/content/${config.appName}/graphql`, {
+            query: print(FETCH_GROUPS),
+            variables: {
+              filter: '',
+              top: 50,
+              skip: 0,
             },
-          },
-        });
-
-      const result = await groups.fetch({});
-      expect(result).toEqual({ items: [], total: 0 });
-    });
-    test('Should return an empty result when the client returns a response with queryGroupsContentsWithTotal property set to null', async () => {
-      nock(config.baseUrl)
-        .post(`/api/content/${config.appName}/graphql`, {
-          query: print(FETCH_GROUPS),
-          variables: {
-            filter: '',
-            top: 50,
-            skip: 0,
-          },
-        })
-        .reply(200, {
-          data: {
-            queryGroupsContentsWithTotal: {
-              total: 0,
-              items: null,
+          })
+          .reply(200, {
+            data: {
+              queryGroupsContentsWithTotal: {
+                total: 0,
+                items: [],
+              },
             },
-          },
-        });
+          });
 
-      const result = await groups.fetch({});
-      expect(result).toEqual({ items: [], total: 0 });
-    });
-    test('Should return an empty result when the client returns a response with item property set to null', async () => {
-      nock(config.baseUrl)
-        .post(`/api/content/${config.appName}/graphql`, {
-          query: print(FETCH_GROUPS),
-          variables: {
-            filter: '',
-            top: 50,
-            skip: 0,
-          },
-        })
-        .reply(200, {
-          data: {
-            queryGroupsContentsWithTotal: null,
-          },
-        });
+        const result = await groupController.fetch({});
+        expect(result).toEqual({ items: [], total: 0 });
+      });
+      test('Should return an empty result when the client returns a response with queryGroupsContentsWithTotal property set to null', async () => {
+        nock(config.baseUrl)
+          .post(`/api/content/${config.appName}/graphql`, {
+            query: print(FETCH_GROUPS),
+            variables: {
+              filter: '',
+              top: 50,
+              skip: 0,
+            },
+          })
+          .reply(200, {
+            data: {
+              queryGroupsContentsWithTotal: {
+                total: 0,
+                items: null,
+              },
+            },
+          });
 
-      const result = await groups.fetch({});
-      expect(result).toEqual({ items: [], total: 0 });
-    });
+        const result = await groupController.fetch({});
+        expect(result).toEqual({ items: [], total: 0 });
+      });
+      test('Should return an empty result when the client returns a response with item property set to null', async () => {
+        nock(config.baseUrl)
+          .post(`/api/content/${config.appName}/graphql`, {
+            query: print(FETCH_GROUPS),
+            variables: {
+              filter: '',
+              top: 50,
+              skip: 0,
+            },
+          })
+          .reply(200, {
+            data: {
+              queryGroupsContentsWithTotal: null,
+            },
+          });
 
-    test('Should query with filters and return the groups', async () => {
-      const fetchOptions: FetchOptions = {
-        take: 12,
-        skip: 2,
-        search: 'first last',
-      };
+        const result = await groupController.fetch({});
+        expect(result).toEqual({ items: [], total: 0 });
+      });
 
-      const expetedFilter =
-        "(contains(data/name/iv, 'first')" +
-        " or contains(data/description/iv, 'first')" +
-        " or contains(data/tags/iv, 'first'))" +
-        ' and' +
-        " (contains(data/name/iv, 'last')" +
-        " or contains(data/description/iv, 'last')" +
-        " or contains(data/tags/iv, 'last'))";
+      test('Should query with filters and return the groups', async () => {
+        const fetchOptions: FetchOptions = {
+          take: 12,
+          skip: 2,
+          search: 'first last',
+        };
 
-      nock(config.baseUrl)
-        .post(`/api/content/${config.appName}/graphql`, {
-          query: print(FETCH_GROUPS),
-          variables: {
-            filter: expetedFilter,
-            top: 12,
-            skip: 2,
-          },
-        })
-        .reply(200, fixtures.queryGroupsResponse);
+        const expetedFilter =
+          "(contains(data/name/iv, 'first')" +
+          " or contains(data/description/iv, 'first')" +
+          " or contains(data/tags/iv, 'first'))" +
+          ' and' +
+          " (contains(data/name/iv, 'last')" +
+          " or contains(data/description/iv, 'last')" +
+          " or contains(data/tags/iv, 'last'))";
 
-      const result = await groups.fetch(fetchOptions);
-      expect(result).toEqual(fixtures.listGroupsResponse);
-    });
+        nock(config.baseUrl)
+          .post(`/api/content/${config.appName}/graphql`, {
+            query: print(FETCH_GROUPS),
+            variables: {
+              filter: expetedFilter,
+              top: 12,
+              skip: 2,
+            },
+          })
+          .reply(200, fixtures.queryGroupsResponse);
 
-    test('Should sanitise single quotes by doubling them and encoding to hex', async () => {
-      const fetchOptions: FetchOptions = {
-        take: 12,
-        skip: 2,
-        search: "'",
-      };
+        const result = await groupController.fetch(fetchOptions);
+        expect(result).toEqual(fixtures.listGroupsResponse);
+      });
 
-      const expectedFilter =
-        "(contains(data/name/iv, '%27%27')" +
-        " or contains(data/description/iv, '%27%27')" +
-        " or contains(data/tags/iv, '%27%27'))";
+      test('Should sanitise single quotes by doubling them and encoding to hex', async () => {
+        const fetchOptions: FetchOptions = {
+          take: 12,
+          skip: 2,
+          search: "'",
+        };
 
-      nock(config.baseUrl)
-        .post(`/api/content/${config.appName}/graphql`, {
-          query: print(FETCH_GROUPS),
-          variables: {
-            filter: expectedFilter,
-            top: 12,
-            skip: 2,
-          },
-        })
-        .reply(200, fixtures.queryGroupsResponse);
+        const expectedFilter =
+          "(contains(data/name/iv, '%27%27')" +
+          " or contains(data/description/iv, '%27%27')" +
+          " or contains(data/tags/iv, '%27%27'))";
 
-      const result = await groups.fetch(fetchOptions);
+        nock(config.baseUrl)
+          .post(`/api/content/${config.appName}/graphql`, {
+            query: print(FETCH_GROUPS),
+            variables: {
+              filter: expectedFilter,
+              top: 12,
+              skip: 2,
+            },
+          })
+          .reply(200, fixtures.queryGroupsResponse);
 
-      expect(result).toEqual(fixtures.listGroupsResponse);
-    });
+        const result = await groupController.fetch(fetchOptions);
 
-    test('Should sanitise double quotation mark by encoding to hex', async () => {
-      const fetchOptions: FetchOptions = {
-        take: 12,
-        skip: 2,
-        search: '"',
-      };
+        expect(result).toEqual(fixtures.listGroupsResponse);
+      });
 
-      const expectedFilter =
-        "(contains(data/name/iv, '%22')" +
-        " or contains(data/description/iv, '%22')" +
-        " or contains(data/tags/iv, '%22'))";
+      test('Should sanitise double quotation mark by encoding to hex', async () => {
+        const fetchOptions: FetchOptions = {
+          take: 12,
+          skip: 2,
+          search: '"',
+        };
 
-      nock(config.baseUrl)
-        .post(`/api/content/${config.appName}/graphql`, {
-          query: print(FETCH_GROUPS),
-          variables: {
-            filter: expectedFilter,
-            top: 12,
-            skip: 2,
-          },
-        })
-        .reply(200, fixtures.queryGroupsResponse);
+        const expectedFilter =
+          "(contains(data/name/iv, '%22')" +
+          " or contains(data/description/iv, '%22')" +
+          " or contains(data/tags/iv, '%22'))";
 
-      const result = await groups.fetch(fetchOptions);
+        nock(config.baseUrl)
+          .post(`/api/content/${config.appName}/graphql`, {
+            query: print(FETCH_GROUPS),
+            variables: {
+              filter: expectedFilter,
+              top: 12,
+              skip: 2,
+            },
+          })
+          .reply(200, fixtures.queryGroupsResponse);
 
-      expect(result).toEqual(fixtures.listGroupsResponse);
+        const result = await groupController.fetch(fetchOptions);
+
+        expect(result).toEqual(fixtures.listGroupsResponse);
+      });
     });
   });
 
   describe('Fetch by id method', () => {
-    test("Should return 404 when the group doesn't exist", async () => {
-      const groupId = 'not-found';
-      nock(config.baseUrl)
-        .post(`/api/content/${config.appName}/graphql`, {
-          query: print(FETCH_GROUP),
-          variables: {
-            id: groupId,
-          },
-        })
-        .reply(200, {
-          data: {
-            findGroupsContent: null,
-          },
-        });
+    describe('with mock-server', () => {
+      test('Should fetch the groups from squidex graphql', async () => {
+        const result = await groupControllerMockGraphql.fetchById('group-id-1');
 
-      await expect(groups.fetchById(groupId)).rejects.toThrow('Not Found');
+        expect(result).toMatchObject(getGroupResponse());
+      });
     });
 
-    test('Should return the group', async () => {
-      const groupId = 'group-id-1';
-      nock(config.baseUrl)
-        .post(`/api/content/${config.appName}/graphql`, {
-          query: print(FETCH_GROUP),
-          variables: {
-            id: groupId,
-          },
-        })
-        .reply(200, getResponseFetchGroup());
+    describe('with intercepted http layer', () => {
+      afterEach(() => {
+        expect(nock.isDone()).toBe(true);
+      });
 
-      const result = await groups.fetchById(groupId);
-      expect(result).toEqual(getGroupResponse());
-    });
+      afterEach(() => {
+        nock.cleanAll();
+      });
 
-    test('Should return the group when the leader user is undefined (ie entity marked as a draft) and skip the leader', async () => {
-      const groupId = 'group-id-1';
-      const responseFetchGroup = getResponseFetchGroup();
-      responseFetchGroup.data.findGroupsContent.flatData!.leaders![0]!.user =
-        [];
+      test("Should return 404 when the group doesn't exist", async () => {
+        const groupId = 'not-found';
+        nock(config.baseUrl)
+          .post(`/api/content/${config.appName}/graphql`, {
+            query: print(FETCH_GROUP),
+            variables: {
+              id: groupId,
+            },
+          })
+          .reply(200, {
+            data: {
+              findGroupsContent: null,
+            },
+          });
 
-      nock(config.baseUrl)
-        .post(`/api/content/${config.appName}/graphql`, {
-          query: print(FETCH_GROUP),
-          variables: {
-            id: groupId,
-          },
-        })
-        .reply(200, responseFetchGroup);
+        await expect(groupController.fetchById(groupId)).rejects.toThrow(
+          'Not Found',
+        );
+      });
 
-      const result = await groups.fetchById(groupId);
+      test('Should return the group', async () => {
+        const groupId = 'group-id-1';
+        nock(config.baseUrl)
+          .post(`/api/content/${config.appName}/graphql`, {
+            query: print(FETCH_GROUP),
+            variables: {
+              id: groupId,
+            },
+          })
+          .reply(200, getResponseFetchGroup());
 
-      const expectedGroupResponse = getGroupResponse();
-      expect(result).toEqual(
-        expect.objectContaining({
-          leaders: [expectedGroupResponse.leaders[1]],
-        }),
-      );
+        const result = await groupController.fetchById(groupId);
+        expect(result).toEqual(getGroupResponse());
+      });
+
+      test('Should return the group when the leader user is undefined (ie entity marked as a draft) and skip the leader', async () => {
+        const groupId = 'group-id-1';
+        const responseFetchGroup = getResponseFetchGroup();
+        responseFetchGroup.data.findGroupsContent!.flatData!.leaders![0]!.user =
+          [];
+
+        nock(config.baseUrl)
+          .post(`/api/content/${config.appName}/graphql`, {
+            query: print(FETCH_GROUP),
+            variables: {
+              id: groupId,
+            },
+          })
+          .reply(200, responseFetchGroup);
+
+        const result = await groupController.fetchById(groupId);
+
+        const expectedGroupResponse = getGroupResponse();
+        expect(result).toEqual(
+          expect.objectContaining({
+            leaders: [expectedGroupResponse.leaders[1]],
+          }),
+        );
+      });
     });
   });
 
@@ -262,7 +298,7 @@ describe('Group controller', () => {
           },
         });
 
-      const result = await groups.fetchByTeamId(teamUUID, {});
+      const result = await groupController.fetchByTeamId(teamUUID, {});
       expect(result).toEqual({ items: [], total: 0 });
     });
 
@@ -287,7 +323,10 @@ describe('Group controller', () => {
         })
         .reply(200, fixtures.queryGroupsResponse);
 
-      const result = await groups.fetchByTeamId(teamUUID, fetchOptions);
+      const result = await groupController.fetchByTeamId(
+        teamUUID,
+        fetchOptions,
+      );
       expect(result).toEqual(fixtures.listGroupsResponse);
     });
   });
@@ -333,7 +372,7 @@ describe('Group controller', () => {
           },
         });
 
-      const result = await groups.fetchByUserId(
+      const result = await groupController.fetchByUserId(
         userUUID,
         ['team-id-1', 'team-id-3'],
         {},
@@ -368,7 +407,7 @@ describe('Group controller', () => {
         })
         .reply(200, fixtures.queryGroupsResponse);
 
-      const result = await groups.fetchByUserId(
+      const result = await groupController.fetchByUserId(
         userUUID,
         ['team-id-1', 'team-id-3'],
         {},

--- a/apps/asap-server/test/controllers/teams.test.ts
+++ b/apps/asap-server/test/controllers/teams.test.ts
@@ -1,10 +1,9 @@
 import nock from 'nock';
-import { config } from '@asap-hub/squidex';
+import { config, SquidexGraphql } from '@asap-hub/squidex';
 import { print } from 'graphql';
 import {
-  graphQlTeamsResponseSingle,
-  getListTeamResponse,
   getGraphQlTeamsResponse,
+  getListTeamResponse,
   fetchTeamByIdExpectation,
   graphQlTeamResponse,
   getUpdateTeamResponse,
@@ -12,418 +11,374 @@ import {
   updateExpectation,
   referencingUsersContentsResponse,
   GraphTeamTool,
+  getGraphqlTeam,
+  getTeamResponse,
 } from '../fixtures/teams.fixtures';
 import Teams from '../../src/controllers/teams';
 import { identity } from '../helpers/squidex';
 import { getGraphQLUser } from '../fixtures/users.fixtures';
 import { FETCH_TEAM, FETCH_TEAMS } from '../../src/queries/teams.queries';
-import { FetchTeamsQuery } from '../../src/gql/graphql';
+import { getSquidexGraphqlClientMockServer } from '../mocks/squidex-graphql-client-with-server.mock';
 
 describe('Team controller', () => {
-  const teams = new Teams();
+  const squidexGraphqlClient = new SquidexGraphql();
+  const teamController = new Teams(squidexGraphqlClient);
+
+  const squidexGraphqlClientMockServer = getSquidexGraphqlClientMockServer();
+  const teamControllerMockGraphql = new Teams(squidexGraphqlClientMockServer);
 
   beforeAll(() => {
     identity();
   });
 
-  afterEach(() => {
-    expect(nock.isDone()).toBe(true);
-  });
-
-  afterEach(() => {
-    nock.cleanAll();
-  });
-
   describe('Fetch method', () => {
-    test('Should return an empty result', async () => {
-      nock(config.baseUrl)
-        .post(`/api/content/${config.appName}/graphql`, {
-          query: print(FETCH_TEAMS),
-          variables: {
-            filter: '',
-            top: 10,
-            skip: 8,
-          },
-        })
-        .reply(200, {
-          data: {
-            queryTeamsContentsWithTotal: {
-              total: 0,
-              items: [],
-            },
-          },
+    describe('with mock-server', () => {
+      test('Should fetch the teams from squidex graphql', async () => {
+        const result = await teamControllerMockGraphql.fetch({
+          take: 10,
+          skip: 8,
         });
 
-      const result = await teams.fetch({ take: 10, skip: 8 });
-
-      expect(result).toEqual({ items: [], total: 0 });
-    });
-    test('Should return an empty result when the client returns a response with queryTeamsContentsWithTotal property set to null', async () => {
-      nock(config.baseUrl)
-        .post(`/api/content/${config.appName}/graphql`, {
-          query: print(FETCH_TEAMS),
-          variables: {
-            filter: '',
-            top: 10,
-            skip: 8,
-          },
-        })
-        .reply(200, {
-          data: {
-            queryTeamsContentsWithTotal: null,
-          },
-        });
-
-      const result = await teams.fetch({ take: 10, skip: 8 });
-
-      expect(result).toEqual({ items: [], total: 0 });
-    });
-    test('Should return an empty result when the client returns a response with items property set to null', async () => {
-      nock(config.baseUrl)
-        .post(`/api/content/${config.appName}/graphql`, {
-          query: print(FETCH_TEAMS),
-          variables: {
-            filter: '',
-            top: 10,
-            skip: 8,
-          },
-        })
-        .reply(200, {
-          data: {
-            queryTeamsContentsWithTotal: {
-              total: 0,
-              items: null,
-            },
-          },
-        });
-
-      const result = await teams.fetch({ take: 10, skip: 8 });
-
-      expect(result).toEqual({ items: [], total: 0 });
-    });
-
-    describe('Text search', () => {
-      test('Should search by name and return the teams', async () => {
-        const searchQ =
-          "(contains(data/displayName/iv, 'Cristiano')" +
-          " or contains(data/projectTitle/iv, 'Cristiano')" +
-          " or contains(data/expertiseAndResourceTags/iv, 'Cristiano'))" +
-          ' and' +
-          " (contains(data/displayName/iv, 'Ronaldo')" +
-          " or contains(data/projectTitle/iv, 'Ronaldo')" +
-          " or contains(data/expertiseAndResourceTags/iv, 'Ronaldo'))";
-
-        nock(config.baseUrl)
-          .post(`/api/content/${config.appName}/graphql`, {
-            query: print(FETCH_TEAMS),
-            variables: {
-              filter: searchQ,
-              top: 8,
-              skip: 0,
-            },
-          })
-          .reply(200, graphQlTeamsResponseSingle);
-
-        const result = await teams.fetch({
-          take: 8,
-          skip: 0,
-          search: 'Cristiano Ronaldo',
-        });
-
-        expect(result).toEqual({
-          total: 1,
-          items: getListTeamResponse().items.slice(0, 1),
-        });
-      });
-
-      test('Should sanitise single quotes by doubling them and encoding to hex', async () => {
-        const expectedSearchFilter =
-          `(contains(data/displayName/iv, '%27%27')` +
-          ` or contains(data/projectTitle/iv, '%27%27')` +
-          ` or contains(data/expertiseAndResourceTags/iv, '%27%27'))`;
-
-        nock(config.baseUrl)
-          .post(`/api/content/${config.appName}/graphql`, {
-            query: print(FETCH_TEAMS),
-            variables: {
-              filter: expectedSearchFilter,
-              top: 8,
-              skip: 0,
-            },
-          })
-          .reply(200, graphQlTeamsResponseSingle);
-
-        const result = await teams.fetch({ take: 8, skip: 0, search: "'" });
-
-        expect(result).toEqual({
-          total: 1,
-          items: getListTeamResponse().items.slice(0, 1),
-        });
-      });
-
-      test('Should sanitise double quotation mark by encoding to hex', async () => {
-        const expectedSearchFilter =
-          `(contains(data/displayName/iv, '%22')` +
-          ` or contains(data/projectTitle/iv, '%22')` +
-          ` or contains(data/expertiseAndResourceTags/iv, '%22'))`;
-
-        nock(config.baseUrl)
-          .post(`/api/content/${config.appName}/graphql`, {
-            query: print(FETCH_TEAMS),
-            variables: {
-              filter: expectedSearchFilter,
-              top: 8,
-              skip: 0,
-            },
-          })
-          .reply(200, graphQlTeamsResponseSingle);
-
-        const result = await teams.fetch({ take: 8, skip: 0, search: '"' });
-
-        expect(result).toEqual({
-          total: 1,
-          items: getListTeamResponse().items.slice(0, 1),
-        });
+        expect(result).toMatchObject(getListTeamResponse());
       });
     });
 
-    describe('Tools', () => {
-      const tools = [
-        {
-          url: 'testUrl',
-          name: 'slack',
-          description: 'this is a test',
-        },
-      ];
+    describe('with intercepted http layer', () => {
+      afterEach(() => {
+        expect(nock.isDone()).toBe(true);
+      });
 
-      test('Should return all the team tools by default', async () => {
-        const squidexTeamResponse = getGraphQlTeamsResponse();
-        squidexTeamResponse.data.queryTeamsContentsWithTotal.items[0]!.flatData!.tools =
-          [];
-        squidexTeamResponse.data.queryTeamsContentsWithTotal.items[1]!.flatData!.tools =
-          tools;
-        squidexTeamResponse.data.queryTeamsContentsWithTotal.items[2]!.flatData!.tools =
-          tools;
+      afterEach(() => {
+        nock.cleanAll();
+      });
 
+      test('Should return an empty result', async () => {
         nock(config.baseUrl)
           .post(`/api/content/${config.appName}/graphql`, {
             query: print(FETCH_TEAMS),
             variables: {
               filter: '',
-              top: 8,
-              skip: 0,
+              top: 10,
+              skip: 8,
             },
           })
-          .reply(200, squidexTeamResponse);
+          .reply(200, {
+            data: {
+              queryTeamsContentsWithTotal: {
+                total: 0,
+                items: [],
+              },
+            },
+          });
 
-        const result = await teams.fetch({
-          take: 8,
-          skip: 0,
-        });
+        const result = await teamController.fetch({ take: 10, skip: 8 });
 
-        // should return empty arrays too
-        expect(result.items[0]!.tools).toEqual([]);
-        expect(result.items[1]!.tools).toEqual(tools);
-        expect(result.items[2]!.tools).toEqual(tools);
+        expect(result).toEqual({ items: [], total: 0 });
+      });
+      test('Should return an empty result when the client returns a response with queryTeamsContentsWithTotal property set to null', async () => {
+        nock(config.baseUrl)
+          .post(`/api/content/${config.appName}/graphql`, {
+            query: print(FETCH_TEAMS),
+            variables: {
+              filter: '',
+              top: 10,
+              skip: 8,
+            },
+          })
+          .reply(200, {
+            data: {
+              queryTeamsContentsWithTotal: null,
+            },
+          });
+
+        const result = await teamController.fetch({ take: 10, skip: 8 });
+
+        expect(result).toEqual({ items: [], total: 0 });
+      });
+      test('Should return an empty result when the client returns a response with items property set to null', async () => {
+        nock(config.baseUrl)
+          .post(`/api/content/${config.appName}/graphql`, {
+            query: print(FETCH_TEAMS),
+            variables: {
+              filter: '',
+              top: 10,
+              skip: 8,
+            },
+          })
+          .reply(200, {
+            data: {
+              queryTeamsContentsWithTotal: {
+                total: 0,
+                items: null,
+              },
+            },
+          });
+
+        const result = await teamController.fetch({ take: 10, skip: 8 });
+
+        expect(result).toEqual({ items: [], total: 0 });
       });
 
-      test('should only return team tools with name and url defined', async () => {
-        const brokenUrlTools = [
-          ...tools,
-          {
-            url: null,
-            name: 'testTool',
-            description: 'tool description',
-          },
-        ];
-        const brokenNameTools = [
-          ...tools,
+      describe('Text search', () => {
+        test('Should search by name and return the teams', async () => {
+          const searchQ =
+            "(contains(data/displayName/iv, 'Cristiano')" +
+            " or contains(data/projectTitle/iv, 'Cristiano')" +
+            " or contains(data/expertiseAndResourceTags/iv, 'Cristiano'))" +
+            ' and' +
+            " (contains(data/displayName/iv, 'Ronaldo')" +
+            " or contains(data/projectTitle/iv, 'Ronaldo')" +
+            " or contains(data/expertiseAndResourceTags/iv, 'Ronaldo'))";
+
+          nock(config.baseUrl)
+            .post(`/api/content/${config.appName}/graphql`, {
+              query: print(FETCH_TEAMS),
+              variables: {
+                filter: searchQ,
+                top: 8,
+                skip: 0,
+              },
+            })
+            .reply(200, getGraphQlTeamsResponse);
+
+          const result = await teamController.fetch({
+            take: 8,
+            skip: 0,
+            search: 'Cristiano Ronaldo',
+          });
+
+          expect(result).toEqual({
+            total: 1,
+            items: getListTeamResponse().items.slice(0, 1),
+          });
+        });
+
+        test('Should sanitise single quotes by doubling them and encoding to hex', async () => {
+          const expectedSearchFilter =
+            `(contains(data/displayName/iv, '%27%27')` +
+            ` or contains(data/projectTitle/iv, '%27%27')` +
+            ` or contains(data/expertiseAndResourceTags/iv, '%27%27'))`;
+
+          nock(config.baseUrl)
+            .post(`/api/content/${config.appName}/graphql`, {
+              query: print(FETCH_TEAMS),
+              variables: {
+                filter: expectedSearchFilter,
+                top: 8,
+                skip: 0,
+              },
+            })
+            .reply(200, getGraphQlTeamsResponse);
+
+          const result = await teamController.fetch({
+            take: 8,
+            skip: 0,
+            search: "'",
+          });
+
+          expect(result).toEqual({
+            total: 1,
+            items: getListTeamResponse().items.slice(0, 1),
+          });
+        });
+
+        test('Should sanitise double quotation mark by encoding to hex', async () => {
+          const expectedSearchFilter =
+            `(contains(data/displayName/iv, '%22')` +
+            ` or contains(data/projectTitle/iv, '%22')` +
+            ` or contains(data/expertiseAndResourceTags/iv, '%22'))`;
+
+          nock(config.baseUrl)
+            .post(`/api/content/${config.appName}/graphql`, {
+              query: print(FETCH_TEAMS),
+              variables: {
+                filter: expectedSearchFilter,
+                top: 8,
+                skip: 0,
+              },
+            })
+            .reply(200, getGraphQlTeamsResponse);
+
+          const result = await teamController.fetch({
+            take: 8,
+            skip: 0,
+            search: '"',
+          });
+
+          expect(result).toEqual({
+            total: 1,
+            items: getListTeamResponse().items.slice(0, 1),
+          });
+        });
+      });
+
+      describe('Tools', () => {
+        const tools = [
           {
             url: 'testUrl',
-            name: null,
-            description: 'tool description',
-          },
-        ];
-        const fullTools = [
-          ...tools,
-          {
-            url: 'testUrl',
-            name: 'testTool',
-            description: 'tool description',
+            name: 'slack',
+            description: 'this is a test',
           },
         ];
 
-        const squidexTeamResponse = {
-          data: getGraphQlTeamsResponse().data as FetchTeamsQuery,
-        };
+        test('Should return all the team tools by default', async () => {
+          const squidexTeamResponse = getGraphQlTeamsResponse();
+          const team1 = getGraphqlTeam();
+          const team2 = getGraphqlTeam();
+          const team3 = getGraphqlTeam();
+          team1.flatData!.tools = [];
+          team2.flatData!.tools = tools;
+          team3.flatData!.tools = tools;
+          squidexTeamResponse.data.queryTeamsContentsWithTotal!.items = [
+            team1,
+            team2,
+            team3,
+          ];
 
-        squidexTeamResponse.data.queryTeamsContentsWithTotal!.items![0]!.flatData!.tools =
-          brokenUrlTools;
-        squidexTeamResponse.data.queryTeamsContentsWithTotal!.items![1]!.flatData!.tools =
-          brokenNameTools;
-        squidexTeamResponse.data.queryTeamsContentsWithTotal!.items![2]!.flatData!.tools =
-          fullTools;
+          nock(config.baseUrl)
+            .post(`/api/content/${config.appName}/graphql`, {
+              query: print(FETCH_TEAMS),
+              variables: {
+                filter: '',
+                top: 8,
+                skip: 0,
+              },
+            })
+            .reply(200, squidexTeamResponse);
 
-        nock(config.baseUrl)
-          .post(`/api/content/${config.appName}/graphql`, {
-            query: print(FETCH_TEAMS),
-            variables: {
-              filter: '',
-              top: 8,
-              skip: 0,
-            },
-          })
-          .reply(200, squidexTeamResponse);
+          const result = await teamController.fetch({
+            take: 8,
+            skip: 0,
+          });
 
-        const result = await teams.fetch({
-          take: 8,
-          skip: 0,
+          // should return empty arrays too
+          expect(result.items[0]!.tools).toEqual([]);
+          expect(result.items[1]!.tools).toEqual(tools);
+          expect(result.items[2]!.tools).toEqual(tools);
         });
 
-        // should return empty arrays too
-        expect(result.items[0]!.tools).toEqual(tools);
-        expect(result.items[1]!.tools).toEqual(tools);
-        expect(result.items[2]!.tools).toEqual(fullTools);
-      });
-
-      test('Should select the teams for which the tools should be returned and mark the rest of them as undefined', async () => {
-        const squidexTeamResponse = getGraphQlTeamsResponse();
-        squidexTeamResponse.data.queryTeamsContentsWithTotal.items[0]!.flatData!.tools =
-          tools;
-        squidexTeamResponse.data.queryTeamsContentsWithTotal.items[1]!.flatData!.tools =
-          tools;
-        squidexTeamResponse.data.queryTeamsContentsWithTotal.items[2]!.flatData!.tools =
-          [];
-
-        nock(config.baseUrl)
-          .post(`/api/content/${config.appName}/graphql`, {
-            query: print(FETCH_TEAMS),
-            variables: {
-              filter: '',
-              top: 8,
-              skip: 0,
+        test('should only return team tools with name and url defined', async () => {
+          const brokenUrlTools = [
+            ...tools,
+            {
+              url: null,
+              name: 'testTool',
+              description: 'tool description',
             },
-          })
-          .reply(200, squidexTeamResponse);
+          ];
+          const brokenNameTools = [
+            ...tools,
+            {
+              url: 'testUrl',
+              name: null,
+              description: 'tool description',
+            },
+          ];
+          const fullTools = [
+            ...tools,
+            {
+              url: 'testUrl',
+              name: 'testTool',
+              description: 'tool description',
+            },
+          ];
 
-        const result = await teams.fetch({
-          take: 8,
-          skip: 0,
-          showTeamTools: [
-            squidexTeamResponse.data.queryTeamsContentsWithTotal.items[0]!.id,
-            squidexTeamResponse.data.queryTeamsContentsWithTotal.items[2]!.id,
-          ],
+          const squidexTeamResponse = getGraphQlTeamsResponse();
+          const team1 = getGraphqlTeam();
+          const team2 = getGraphqlTeam();
+          const team3 = getGraphqlTeam();
+          team1.flatData!.tools = brokenUrlTools;
+          team2.flatData!.tools = brokenNameTools;
+          team3.flatData!.tools = fullTools;
+          squidexTeamResponse.data.queryTeamsContentsWithTotal!.items = [
+            team1,
+            team2,
+            team3,
+          ];
+
+          nock(config.baseUrl)
+            .post(`/api/content/${config.appName}/graphql`, {
+              query: print(FETCH_TEAMS),
+              variables: {
+                filter: '',
+                top: 8,
+                skip: 0,
+              },
+            })
+            .reply(200, squidexTeamResponse);
+
+          const result = await teamController.fetch({
+            take: 8,
+            skip: 0,
+          });
+
+          // should return empty arrays too
+          expect(result.items[0]!.tools).toEqual(tools);
+          expect(result.items[1]!.tools).toEqual(tools);
+          expect(result.items[2]!.tools).toEqual(fullTools);
         });
 
-        expect(result.items[0]!.tools).toEqual(tools);
-        expect(result.items[1]!.tools).toBeUndefined();
-        // should return empty array as empty array, not undefined
-        expect(result.items[2]!.tools).toEqual([]);
+        test('Should select the teams for which the tools should be returned and mark the rest of them as undefined', async () => {
+          const squidexTeamResponse = getGraphQlTeamsResponse();
+          const team1 = getGraphqlTeam(undefined, 'team-id-1');
+          const team2 = getGraphqlTeam(undefined, 'team-id-2');
+          const team3 = getGraphqlTeam(undefined, 'team-id-3');
+          team1.flatData!.tools = tools;
+          team2.flatData!.tools = tools;
+          team3.flatData!.tools = [];
+          squidexTeamResponse.data.queryTeamsContentsWithTotal!.items = [
+            team1,
+            team2,
+            team3,
+          ];
+
+          nock(config.baseUrl)
+            .post(`/api/content/${config.appName}/graphql`, {
+              query: print(FETCH_TEAMS),
+              variables: {
+                filter: '',
+                top: 8,
+                skip: 0,
+              },
+            })
+            .reply(200, squidexTeamResponse);
+
+          const result = await teamController.fetch({
+            take: 8,
+            skip: 0,
+            showTeamTools: [team1.id, team3.id],
+          });
+
+          expect(result.items[0]!.tools).toEqual(tools);
+          expect(result.items[1]!.tools).toBeUndefined();
+          // should return empty array as empty array, not undefined
+          expect(result.items[2]!.tools).toEqual([]);
+        });
       });
     });
   });
 
   describe('Fetch-by-id method', () => {
-    test('Should throw a Not Found error when the team is not found', async () => {
-      const teamId = 'not-found';
+    describe('with mock-server', () => {
+      test('Should fetch the teams from squidex graphql', async () => {
+        const teamId = 'team-id-1';
+        const result = await teamControllerMockGraphql.fetchById(teamId);
 
-      nock(config.baseUrl)
-        .post(`/api/content/${config.appName}/graphql`, {
-          query: print(FETCH_TEAM),
-          variables: {
-            id: teamId,
-          },
-        })
-        .reply(200, {
-          data: {
-            findTeamsContent: null,
-          },
-        });
-
-      await expect(teams.fetchById(teamId)).rejects.toThrow('Not Found');
-    });
-
-    test('Should return the team even when team members are not found', async () => {
-      const teamId = 'team-id-1';
-
-      nock(config.baseUrl)
-        .post(`/api/content/${config.appName}/graphql`, {
-          query: print(FETCH_TEAM),
-          variables: {
-            id: teamId,
-          },
-        })
-        .reply(200, {
-          ...graphQlTeamResponse,
-          data: {
-            ...graphQlTeamResponse.data,
-            findTeamsContent: {
-              ...graphQlTeamResponse.data.findTeamsContent,
-              referencingUsersContents: [],
-            },
-          },
-        });
-
-      const result = await teams.fetchById(teamId);
-      expect(result).toEqual({
-        ...fetchTeamByIdExpectation,
-        members: [],
-        labCount: 0,
+        expect(result).toMatchObject(getTeamResponse());
       });
     });
 
-    test('Should return the team even when team members do not exist', async () => {
-      const teamId = 'team-id-1';
-
-      nock(config.baseUrl)
-        .post(`/api/content/${config.appName}/graphql`, {
-          query: print(FETCH_TEAM),
-          variables: {
-            id: teamId,
-          },
-        })
-        .reply(200, {
-          ...graphQlTeamResponse,
-          data: {
-            ...graphQlTeamResponse.data,
-            findTeamsContent: {
-              ...graphQlTeamResponse.data.findTeamsContent,
-              referencingUsersContents: [],
-            },
-          },
-        });
-
-      const result = await teams.fetchById(teamId);
-
-      expect(result).toEqual({
-        ...fetchTeamByIdExpectation,
-        members: [],
-        labCount: 0,
+    describe('with intercepted http layer', () => {
+      afterEach(() => {
+        expect(nock.isDone()).toBe(true);
       });
-    });
 
-    test('Should return the result when the team exists', async () => {
-      const teamId = 'team-id-1';
+      afterEach(() => {
+        nock.cleanAll();
+      });
 
-      nock(config.baseUrl)
-        .post(`/api/content/${config.appName}/graphql`, {
-          query: print(FETCH_TEAM),
-          variables: {
-            id: teamId,
-          },
-        })
-        .reply(200, graphQlTeamResponse);
-
-      const result = await teams.fetchById(teamId);
-
-      expect(result).toEqual(fetchTeamByIdExpectation);
-    });
-
-    describe('Tools', () => {
-      test('Should return the tools as an empty array when they are defined as null in squidex', async () => {
-        const teamId = 'team-id-1';
-
-        const tools = null;
+      test('Should throw a Not Found error when the team is not found', async () => {
+        const teamId = 'not-found';
 
         nock(config.baseUrl)
           .post(`/api/content/${config.appName}/graphql`, {
@@ -432,267 +387,18 @@ describe('Team controller', () => {
               id: teamId,
             },
           })
-          .reply(200, getGraphQlTeamResponse(tools));
+          .reply(200, {
+            data: {
+              findTeamsContent: null,
+            },
+          });
 
-        const result = await teams.fetchById(teamId);
-
-        expect(result.tools).toEqual([]);
+        await expect(teamController.fetchById(teamId)).rejects.toThrow(
+          'Not Found',
+        );
       });
 
-      test('Should return the tools when the showTools parameter is missing', async () => {
-        const teamId = 'team-id-1';
-
-        const tools = [
-          {
-            url: 'https://example.com',
-            name: 'good link',
-            // squidex graphql api typings aren't perfect
-            description: null,
-          },
-        ];
-
-        nock(config.baseUrl)
-          .post(`/api/content/${config.appName}/graphql`, {
-            query: print(FETCH_TEAM),
-            variables: {
-              id: teamId,
-            },
-          })
-          .reply(200, getGraphQlTeamResponse(tools));
-
-        const result = await teams.fetchById(teamId);
-
-        expect(result.tools).toEqual([
-          {
-            url: 'https://example.com',
-            name: 'good link',
-          },
-        ]);
-      });
-
-      test('Should return the tools when the showTools parameter is set to true', async () => {
-        const teamId = 'team-id-1';
-
-        const tools = [
-          {
-            url: 'https://example.com',
-            name: 'good link',
-            description: null,
-          },
-        ];
-
-        nock(config.baseUrl)
-          .post(`/api/content/${config.appName}/graphql`, {
-            query: print(FETCH_TEAM),
-            variables: {
-              id: teamId,
-            },
-          })
-          .reply(200, getGraphQlTeamResponse(tools));
-
-        const result = await teams.fetchById(teamId, { showTools: true });
-
-        expect(result.tools).toEqual([
-          {
-            url: 'https://example.com',
-            name: 'good link',
-          },
-        ]);
-      });
-
-      test('Should return the an empty array when the showTools parameter is missing but no tools are present', async () => {
-        const teamId = 'team-id-1';
-        const tools: GraphTeamTool[] = [];
-
-        nock(config.baseUrl)
-          .post(`/api/content/${config.appName}/graphql`, {
-            query: print(FETCH_TEAM),
-            variables: {
-              id: teamId,
-            },
-          })
-          .reply(200, getGraphQlTeamResponse(tools));
-
-        const result = await teams.fetchById(teamId);
-
-        expect(result.tools).toEqual([]);
-      });
-
-      test('Should return the tools as undefined you when the "showTools" parameter is set to false', async () => {
-        const teamId = 'team-id-1';
-
-        const tools = [
-          {
-            url: 'https://example.com',
-            name: 'good link',
-            description: null,
-          },
-        ];
-
-        nock(config.baseUrl)
-          .post(`/api/content/${config.appName}/graphql`, {
-            query: print(FETCH_TEAM),
-            variables: {
-              id: teamId,
-            },
-          })
-          .reply(200, getGraphQlTeamResponse(tools));
-
-        const result = await teams.fetchById(teamId, { showTools: false });
-
-        expect(result.tools).toBeUndefined();
-      });
-    });
-
-    describe('Labs', () => {
-      test('Should return the lab count', async () => {
-        const teamId = 'team-id-1';
-        const teamResponse = getGraphQlTeamResponse();
-        // create a user with labs
-        const graphqlUser1 = getGraphQLUser();
-        graphqlUser1.flatData!.labs = [
-          {
-            id: 'lab-id-1',
-            flatData: {
-              name: 'lab name',
-            },
-          },
-          {
-            id: 'lab-id-2',
-            flatData: {
-              name: 'lab name',
-            },
-          },
-        ];
-        // create another user with labs one of which is a duplicate of the first user's lab
-        const graphqlUser2 = getGraphQLUser();
-        graphqlUser2.flatData!.labs = [
-          {
-            id: 'lab-id-2',
-            flatData: {
-              name: 'lab name',
-            },
-          },
-          {
-            id: 'lab-id-3',
-            flatData: {
-              name: 'lab name',
-            },
-          },
-        ];
-
-        teamResponse.data.findTeamsContent!.referencingUsersContents = [
-          graphqlUser1,
-          graphqlUser2,
-        ];
-
-        nock(config.baseUrl)
-          .post(`/api/content/${config.appName}/graphql`, {
-            query: print(FETCH_TEAM),
-            variables: {
-              id: teamId,
-            },
-          })
-          .reply(200, teamResponse);
-
-        const result = await teams.fetchById(teamId);
-
-        expect(result.labCount).toEqual(3);
-      });
-
-      test('Should return the team member lab list', async () => {
-        const teamId = 'team-id-1';
-        const teamResponse = getGraphQlTeamResponse();
-        // create a user with labs
-        const graphqlUser1 = getGraphQLUser();
-        graphqlUser1.flatData!.labs = [
-          {
-            id: 'lab-id-1',
-            flatData: {
-              name: 'lab name',
-            },
-          },
-          {
-            id: 'lab-id-2',
-            flatData: {
-              name: 'lab name',
-            },
-          },
-        ];
-
-        teamResponse.data.findTeamsContent!.referencingUsersContents = [
-          graphqlUser1,
-        ];
-
-        nock(config.baseUrl)
-          .post(`/api/content/${config.appName}/graphql`, {
-            query: print(FETCH_TEAM),
-            variables: {
-              id: teamId,
-            },
-          })
-          .reply(200, teamResponse);
-
-        const result = await teams.fetchById(teamId);
-
-        expect(result.members[0]!.labs).toEqual([
-          {
-            id: 'lab-id-1',
-            name: 'lab name',
-          },
-          {
-            id: 'lab-id-2',
-            name: 'lab name',
-          },
-        ]);
-      });
-
-      test('Should skip the team member lab if the name is empty', async () => {
-        const teamId = 'team-id-1';
-        const teamResponse = getGraphQlTeamResponse();
-        // create a user with labs
-        const graphqlUser1 = getGraphQLUser();
-        graphqlUser1.flatData!.labs = [
-          {
-            id: 'lab-id-1',
-            flatData: {
-              name: null,
-            },
-          },
-          {
-            id: 'lab-id-2',
-            flatData: {
-              name: 'lab name',
-            },
-          },
-        ];
-
-        teamResponse.data.findTeamsContent!.referencingUsersContents = [
-          graphqlUser1,
-        ];
-
-        nock(config.baseUrl)
-          .post(`/api/content/${config.appName}/graphql`, {
-            query: print(FETCH_TEAM),
-            variables: {
-              id: teamId,
-            },
-          })
-          .reply(200, teamResponse);
-
-        const result = await teams.fetchById(teamId);
-
-        expect(result.members[0]!.labs).toEqual([
-          {
-            id: 'lab-id-2',
-            name: 'lab name',
-          },
-        ]);
-      });
-    });
-
-    describe('Avatar', () => {
-      test('Should parse the team user correctly when the avatar is null', async () => {
+      test('Should return the team even when team members are not found', async () => {
         const teamId = 'team-id-1';
 
         nock(config.baseUrl)
@@ -708,29 +414,20 @@ describe('Team controller', () => {
               ...graphQlTeamResponse.data,
               findTeamsContent: {
                 ...graphQlTeamResponse.data.findTeamsContent,
-                referencingUsersContents: referencingUsersContentsResponse({
-                  avatar: null,
-                }),
+                referencingUsersContents: [],
               },
             },
           });
 
-        const result = await teams.fetchById(teamId);
-
-        const expectedResponse = {
+        const result = await teamController.fetchById(teamId);
+        expect(result).toEqual({
           ...fetchTeamByIdExpectation,
-          members: [
-            {
-              ...fetchTeamByIdExpectation.members[0],
-              avatarUrl: undefined,
-            },
-          ],
-        };
-
-        expect(result).toEqual(expectedResponse);
+          members: [],
+          labCount: 0,
+        });
       });
 
-      test('Should parse the team user correctly when the avatar is undefined', async () => {
+      test('Should return the team even when team members do not exist', async () => {
         const teamId = 'team-id-1';
 
         nock(config.baseUrl)
@@ -746,26 +443,389 @@ describe('Team controller', () => {
               ...graphQlTeamResponse.data,
               findTeamsContent: {
                 ...graphQlTeamResponse.data.findTeamsContent,
-                referencingUsersContents: referencingUsersContentsResponse({
-                  avatar: undefined,
-                }),
+                referencingUsersContents: [],
               },
             },
           });
 
-        const result = await teams.fetchById(teamId);
+        const result = await teamController.fetchById(teamId);
 
-        const expectedResponse = {
+        expect(result).toEqual({
           ...fetchTeamByIdExpectation,
-          members: [
-            {
-              ...fetchTeamByIdExpectation.members[0],
-              avatarUrl: undefined,
-            },
-          ],
-        };
+          members: [],
+          labCount: 0,
+        });
+      });
 
-        expect(result).toEqual(expectedResponse);
+      test('Should return the result when the team exists', async () => {
+        const teamId = 'team-id-1';
+
+        nock(config.baseUrl)
+          .post(`/api/content/${config.appName}/graphql`, {
+            query: print(FETCH_TEAM),
+            variables: {
+              id: teamId,
+            },
+          })
+          .reply(200, graphQlTeamResponse);
+
+        const result = await teamController.fetchById(teamId);
+
+        expect(result).toEqual(fetchTeamByIdExpectation);
+      });
+
+      describe('Tools', () => {
+        test('Should return the tools as an empty array when they are defined as null in squidex', async () => {
+          const teamId = 'team-id-1';
+
+          const tools = null;
+
+          nock(config.baseUrl)
+            .post(`/api/content/${config.appName}/graphql`, {
+              query: print(FETCH_TEAM),
+              variables: {
+                id: teamId,
+              },
+            })
+            .reply(200, getGraphQlTeamResponse(tools as any));
+
+          const result = await teamController.fetchById(teamId);
+
+          expect(result.tools).toEqual([]);
+        });
+
+        test('Should return the tools when the showTools parameter is missing', async () => {
+          const teamId = 'team-id-1';
+
+          const tools = [
+            {
+              url: 'https://example.com',
+              name: 'good link',
+              // squidex graphql api typings aren't perfect
+              description: null,
+            },
+          ];
+
+          nock(config.baseUrl)
+            .post(`/api/content/${config.appName}/graphql`, {
+              query: print(FETCH_TEAM),
+              variables: {
+                id: teamId,
+              },
+            })
+            .reply(200, getGraphQlTeamResponse(tools));
+
+          const result = await teamController.fetchById(teamId);
+
+          expect(result.tools).toEqual([
+            {
+              url: 'https://example.com',
+              name: 'good link',
+            },
+          ]);
+        });
+
+        test('Should return the tools when the showTools parameter is set to true', async () => {
+          const teamId = 'team-id-1';
+
+          const tools = [
+            {
+              url: 'https://example.com',
+              name: 'good link',
+              description: null,
+            },
+          ];
+
+          nock(config.baseUrl)
+            .post(`/api/content/${config.appName}/graphql`, {
+              query: print(FETCH_TEAM),
+              variables: {
+                id: teamId,
+              },
+            })
+            .reply(200, getGraphQlTeamResponse(tools));
+
+          const result = await teamController.fetchById(teamId, {
+            showTools: true,
+          });
+
+          expect(result.tools).toEqual([
+            {
+              url: 'https://example.com',
+              name: 'good link',
+            },
+          ]);
+        });
+
+        test('Should return the an empty array when the showTools parameter is missing but no tools are present', async () => {
+          const teamId = 'team-id-1';
+          const tools: GraphTeamTool[] = [];
+
+          nock(config.baseUrl)
+            .post(`/api/content/${config.appName}/graphql`, {
+              query: print(FETCH_TEAM),
+              variables: {
+                id: teamId,
+              },
+            })
+            .reply(200, getGraphQlTeamResponse(tools));
+
+          const result = await teamController.fetchById(teamId);
+
+          expect(result.tools).toEqual([]);
+        });
+
+        test('Should return the tools as undefined you when the "showTools" parameter is set to false', async () => {
+          const teamId = 'team-id-1';
+
+          const tools = [
+            {
+              url: 'https://example.com',
+              name: 'good link',
+              description: null,
+            },
+          ];
+
+          nock(config.baseUrl)
+            .post(`/api/content/${config.appName}/graphql`, {
+              query: print(FETCH_TEAM),
+              variables: {
+                id: teamId,
+              },
+            })
+            .reply(200, getGraphQlTeamResponse(tools));
+
+          const result = await teamController.fetchById(teamId, {
+            showTools: false,
+          });
+
+          expect(result.tools).toBeUndefined();
+        });
+      });
+
+      describe('Labs', () => {
+        test('Should return the lab count', async () => {
+          const teamId = 'team-id-1';
+          const teamResponse = getGraphQlTeamResponse();
+          // create a user with labs
+          const graphqlUser1 = getGraphQLUser();
+          graphqlUser1.flatData!.labs = [
+            {
+              id: 'lab-id-1',
+              flatData: {
+                name: 'lab name',
+              },
+            },
+            {
+              id: 'lab-id-2',
+              flatData: {
+                name: 'lab name',
+              },
+            },
+          ];
+          // create another user with labs one of which is a duplicate of the first user's lab
+          const graphqlUser2 = getGraphQLUser();
+          graphqlUser2.flatData!.labs = [
+            {
+              id: 'lab-id-2',
+              flatData: {
+                name: 'lab name',
+              },
+            },
+            {
+              id: 'lab-id-3',
+              flatData: {
+                name: 'lab name',
+              },
+            },
+          ];
+
+          teamResponse.data.findTeamsContent!.referencingUsersContents = [
+            graphqlUser1,
+            graphqlUser2,
+          ];
+
+          nock(config.baseUrl)
+            .post(`/api/content/${config.appName}/graphql`, {
+              query: print(FETCH_TEAM),
+              variables: {
+                id: teamId,
+              },
+            })
+            .reply(200, teamResponse);
+
+          const result = await teamController.fetchById(teamId);
+
+          expect(result.labCount).toEqual(3);
+        });
+
+        test('Should return the team member lab list', async () => {
+          const teamId = 'team-id-1';
+          const teamResponse = getGraphQlTeamResponse();
+          // create a user with labs
+          const graphqlUser1 = getGraphQLUser();
+          graphqlUser1.flatData!.labs = [
+            {
+              id: 'lab-id-1',
+              flatData: {
+                name: 'lab name',
+              },
+            },
+            {
+              id: 'lab-id-2',
+              flatData: {
+                name: 'lab name',
+              },
+            },
+          ];
+
+          teamResponse.data.findTeamsContent!.referencingUsersContents = [
+            graphqlUser1,
+          ];
+
+          nock(config.baseUrl)
+            .post(`/api/content/${config.appName}/graphql`, {
+              query: print(FETCH_TEAM),
+              variables: {
+                id: teamId,
+              },
+            })
+            .reply(200, teamResponse);
+
+          const result = await teamController.fetchById(teamId);
+
+          expect(result.members[0]!.labs).toEqual([
+            {
+              id: 'lab-id-1',
+              name: 'lab name',
+            },
+            {
+              id: 'lab-id-2',
+              name: 'lab name',
+            },
+          ]);
+        });
+
+        test('Should skip the team member lab if the name is empty', async () => {
+          const teamId = 'team-id-1';
+          const teamResponse = getGraphQlTeamResponse();
+          // create a user with labs
+          const graphqlUser1 = getGraphQLUser();
+          graphqlUser1.flatData!.labs = [
+            {
+              id: 'lab-id-1',
+              flatData: {
+                name: null,
+              },
+            },
+            {
+              id: 'lab-id-2',
+              flatData: {
+                name: 'lab name',
+              },
+            },
+          ];
+
+          teamResponse.data.findTeamsContent!.referencingUsersContents = [
+            graphqlUser1,
+          ];
+
+          nock(config.baseUrl)
+            .post(`/api/content/${config.appName}/graphql`, {
+              query: print(FETCH_TEAM),
+              variables: {
+                id: teamId,
+              },
+            })
+            .reply(200, teamResponse);
+
+          const result = await teamController.fetchById(teamId);
+
+          expect(result.members[0]!.labs).toEqual([
+            {
+              id: 'lab-id-2',
+              name: 'lab name',
+            },
+          ]);
+        });
+      });
+
+      describe('Avatar', () => {
+        test('Should parse the team user correctly when the avatar is null', async () => {
+          const teamId = 'team-id-1';
+
+          nock(config.baseUrl)
+            .post(`/api/content/${config.appName}/graphql`, {
+              query: print(FETCH_TEAM),
+              variables: {
+                id: teamId,
+              },
+            })
+            .reply(200, {
+              ...graphQlTeamResponse,
+              data: {
+                ...graphQlTeamResponse.data,
+                findTeamsContent: {
+                  ...graphQlTeamResponse.data.findTeamsContent,
+                  referencingUsersContents: referencingUsersContentsResponse({
+                    avatar: null,
+                  }),
+                },
+              },
+            });
+
+          const result = await teamController.fetchById(teamId);
+
+          const expectedResponse = {
+            ...fetchTeamByIdExpectation,
+            members: [
+              {
+                ...fetchTeamByIdExpectation.members[0],
+                avatarUrl: undefined,
+              },
+            ],
+          };
+
+          expect(result).toEqual(expectedResponse);
+        });
+
+        test('Should parse the team user correctly when the avatar is undefined', async () => {
+          const teamId = 'team-id-1';
+
+          nock(config.baseUrl)
+            .post(`/api/content/${config.appName}/graphql`, {
+              query: print(FETCH_TEAM),
+              variables: {
+                id: teamId,
+              },
+            })
+            .reply(200, {
+              ...graphQlTeamResponse,
+              data: {
+                ...graphQlTeamResponse.data,
+                findTeamsContent: {
+                  ...graphQlTeamResponse.data.findTeamsContent,
+                  referencingUsersContents: referencingUsersContentsResponse({
+                    avatar: undefined,
+                  }),
+                },
+              },
+            });
+
+          const result = await teamController.fetchById(teamId);
+
+          const expectedResponse = {
+            ...fetchTeamByIdExpectation,
+            members: [
+              {
+                ...fetchTeamByIdExpectation.members[0],
+                avatarUrl: undefined,
+              },
+            ],
+          };
+
+          expect(result).toEqual(expectedResponse);
+        });
       });
     });
   });
@@ -777,7 +837,9 @@ describe('Team controller', () => {
         .patch(`/api/content/${config.appName}/teams/${teamId}`)
         .reply(404);
 
-      await expect(teams.update(teamId, [])).rejects.toThrow('Not Found');
+      await expect(teamController.update(teamId, [])).rejects.toThrow(
+        'Not Found',
+      );
     });
 
     test('Should remove the tools are return the team', async () => {
@@ -796,7 +858,7 @@ describe('Team controller', () => {
         })
         .reply(200, graphQlTeamResponse);
 
-      const result = await teams.update(teamId, []);
+      const result = await teamController.update(teamId, []);
 
       expect(result).toEqual(updateExpectation);
     });
@@ -830,7 +892,7 @@ describe('Team controller', () => {
         })
         .reply(200, getGraphQlTeamResponse(toolsResponse));
 
-      const result = await teams.update(teamId, [
+      const result = await teamController.update(teamId, [
         {
           url: 'https://example.com',
           name: 'good link',

--- a/apps/asap-server/test/entities/events.test.ts
+++ b/apps/asap-server/test/entities/events.test.ts
@@ -2,9 +2,10 @@ import {
   getMeetingMaterial,
   parseGraphQLEvent,
 } from '../../src/entities/event';
-import { graphqlEvent } from '../fixtures/events.fixtures';
+import { getSquidexGraphqlEvents } from '../fixtures/events.fixtures';
 
 describe('events entity', () => {
+  const graphqlEvent = getSquidexGraphqlEvents();
   describe('parseGraphQLEvent', () => {
     it(`throws when provided event doesn't have a calendar`, () => {
       const event = {

--- a/apps/asap-server/test/entities/team.test.ts
+++ b/apps/asap-server/test/entities/team.test.ts
@@ -4,7 +4,7 @@ import {
 } from '../../src/entities/team';
 import { FetchTeamQuery } from '../../src/gql/graphql';
 import {
-  graphQlTeamsResponseSingle,
+  getGraphQlTeamsResponse,
   referencingUsersContentsResponse,
 } from '../fixtures/teams.fixtures';
 
@@ -59,7 +59,7 @@ describe('parseGraphQLTeamMember', () => {
 });
 describe('parseGraphQLTeam', () => {
   const team = {
-    ...graphQlTeamsResponseSingle.data.queryTeamsContentsWithTotal.items[0],
+    ...getGraphQlTeamsResponse().data.queryTeamsContentsWithTotal!.items![0],
   };
   it('should throw when projectTitle is null', () => {
     const teamWithInvalidProjectTitle = {

--- a/apps/asap-server/test/fixtures/calendars.fixtures.ts
+++ b/apps/asap-server/test/fixtures/calendars.fixtures.ts
@@ -139,3 +139,26 @@ export const getCalendarsGraphqlResponse = (): {
     },
   },
 });
+
+export const getSquidexGraphqlCalendars = () => ({
+  id: 'ec3086d4-aa64-4f30-a0f7-5c5b95ffbcca',
+  created: '2020-09-23T16:34:26.842Z',
+  lastModified: '2021-05-14T14:48:46Z',
+  version: 42,
+  flatData: squidexGraphqlCalendarsFlatData(),
+});
+
+const squidexGraphqlCalendarsFlatData = () => ({
+  googleCalendarId: '3@group.calendar.google.com',
+  color: '#2952A3',
+  name: 'Tech 4a - iPSCs - 3D & Co-cultures',
+  resourceId: 'resource-id',
+  syncToken: 'sync-token',
+  expirationDate: 1617196357000,
+});
+
+export const squidexGraphqlCalendarsResponse = () => ({
+  color: '#2952A3',
+  id: '3@group.calendar.google.com',
+  name: 'Tech 4a - iPSCs - 3D & Co-cultures',
+});

--- a/apps/asap-server/test/fixtures/calendars.fixtures.ts
+++ b/apps/asap-server/test/fixtures/calendars.fixtures.ts
@@ -9,7 +9,7 @@ import {
 import { FetchCalendarQuery } from '../../src/gql/graphql';
 
 export const getCalendarRaw = (): CalendarRaw => ({
-  id: 'cc5f74e0-c611-4043-abde-cd3c0d5a3414',
+  id: 'ec3086d4-aa64-4f30-a0f7-5c5b95ffbcca',
   color: '#2952A3',
   name: 'Tech 4a - iPSCs - 3D & Co-cultures',
   syncToken: 'sync-token',
@@ -123,20 +123,7 @@ export const getCalendarsGraphqlResponse = (): {
   data: NonNullable<FetchCalendarQuery>;
 } => ({
   data: {
-    findCalendarsContent: {
-      id: 'cc5f74e0-c611-4043-abde-cd3c0d5a3414',
-      created: '2021-01-07T16:44:09Z',
-      lastModified: '2021-01-07T16:44:09Z',
-      version: 42,
-      flatData: {
-        googleCalendarId: '3@group.calendar.google.com',
-        color: '#2952A3',
-        name: 'Tech 4a - iPSCs - 3D & Co-cultures',
-        resourceId: 'resource-id',
-        syncToken: 'sync-token',
-        expirationDate: 1617196357000,
-      },
-    },
+    findCalendarsContent: getSquidexGraphqlCalendars(),
   },
 });
 

--- a/apps/asap-server/test/fixtures/calendars.fixtures.ts
+++ b/apps/asap-server/test/fixtures/calendars.fixtures.ts
@@ -143,9 +143,3 @@ const squidexGraphqlCalendarsFlatData = () => ({
   syncToken: 'sync-token',
   expirationDate: 1617196357000,
 });
-
-export const squidexGraphqlCalendarsResponse = () => ({
-  color: '#2952A3',
-  id: '3@group.calendar.google.com',
-  name: 'Tech 4a - iPSCs - 3D & Co-cultures',
-});

--- a/apps/asap-server/test/fixtures/dashboard.fixtures.ts
+++ b/apps/asap-server/test/fixtures/dashboard.fixtures.ts
@@ -24,3 +24,75 @@ export const dashboardResponse: DashboardResponse = {
   ],
   pages: [],
 };
+export const squidexGraphqlDashboardFlatData = {
+  news: [
+    {
+      id: 'guid-news-1',
+      created: '2020-09-24T11:06:27.164Z',
+      lastModified: '2020-10-15T17:55:21Z',
+      version: 42,
+      flatData: {
+        title: 'News 1',
+        type: 'News',
+        shortText: 'Short text of news 1',
+        text: '<p>text</p>',
+        thumbnail: [
+          {
+            id: 'news-url-1',
+            thumbnailUrl: `${config.baseUrl}/api/assets/${config.appName}/thumbnail-uuid4`,
+          },
+        ],
+      },
+    },
+    {
+      id: 'guid-news-2',
+      created: '2020-09-24T11:06:27.164Z',
+      lastModified: '2020-10-15T17:55:21Z',
+      version: 42,
+      flatData: {
+        title: 'Event 2',
+        type: 'Event',
+        shortText: 'Short text of event 2',
+        text: '<p>text</p>',
+        thumbnail: [
+          {
+            id: 'news-url-2',
+            thumbnailUrl: `${config.baseUrl}/api/assets/${config.appName}/thumbnail-uuid2`,
+          },
+        ],
+      },
+    },
+  ],
+  pages: [],
+};
+
+export const getSquidexGraphqlDashboard = () => ({
+  id: 'ec3086d4-aa64-4f30-a0f7-5c5b95ffbcca',
+  created: '2020-09-23T16:34:26.842Z',
+  lastModified: '2021-05-14T14:48:46Z',
+  version: 42,
+  flatData: squidexGraphqlDashboardFlatData,
+});
+export const squidexGraphqlDashboardResponse = {
+  news: [
+    {
+      created: '2020-09-24T11:06:27.164Z',
+      id: 'guid-news-1',
+      shortText: 'Short text of news 1',
+      text: '<p>text</p>',
+      thumbnail: 'https://cloud.squidex.io/api/assets/1153/news-url-1',
+      title: 'News 1',
+      type: 'News',
+    },
+    {
+      created: '2020-09-24T11:06:27.164Z',
+      id: 'guid-news-2',
+      shortText: 'Short text of event 2',
+      text: '<p>text</p>',
+      thumbnail: 'https://cloud.squidex.io/api/assets/1153/news-url-2',
+      title: 'Event 2',
+      type: 'Event',
+    },
+  ],
+  pages: [],
+};

--- a/apps/asap-server/test/fixtures/dashboard.fixtures.ts
+++ b/apps/asap-server/test/fixtures/dashboard.fixtures.ts
@@ -24,7 +24,7 @@ export const dashboardResponse: DashboardResponse = {
   ],
   pages: [],
 };
-export const squidexGraphqlDashboardFlatData = {
+const squidexGraphqlDashboardFlatData = () => ({
   news: [
     {
       id: 'guid-news-1',
@@ -64,16 +64,16 @@ export const squidexGraphqlDashboardFlatData = {
     },
   ],
   pages: [],
-};
+});
 
 export const getSquidexGraphqlDashboard = () => ({
   id: 'ec3086d4-aa64-4f30-a0f7-5c5b95ffbcca',
   created: '2020-09-23T16:34:26.842Z',
   lastModified: '2021-05-14T14:48:46Z',
   version: 42,
-  flatData: squidexGraphqlDashboardFlatData,
+  flatData: squidexGraphqlDashboardFlatData(),
 });
-export const squidexGraphqlDashboardResponse = {
+export const squidexGraphqlDashboardResponse = () => ({
   news: [
     {
       created: '2020-09-24T11:06:27.164Z',
@@ -95,4 +95,4 @@ export const squidexGraphqlDashboardResponse = {
     },
   ],
   pages: [],
-};
+});

--- a/apps/asap-server/test/fixtures/dashboard.fixtures.ts
+++ b/apps/asap-server/test/fixtures/dashboard.fixtures.ts
@@ -1,30 +1,7 @@
 import { DashboardResponse } from '@asap-hub/model';
 import { config } from '@asap-hub/squidex';
 
-export const dashboardResponse: DashboardResponse = {
-  news: [
-    {
-      id: 'news-1',
-      title: 'News 1',
-      type: 'News',
-      shortText: 'Short text of news 1',
-      text: '<p>text</p>',
-      thumbnail: `${config.baseUrl}/api/assets/${config.appName}/thumbnail-uuid1`,
-      created: '2020-09-08T16:35:28.000Z',
-    },
-    {
-      id: 'news-2',
-      title: 'Event 2',
-      type: 'Event',
-      shortText: 'Short text of event 2',
-      text: '<p>text</p>',
-      thumbnail: `${config.baseUrl}/api/assets/${config.appName}/thumbnail-uuid2`,
-      created: '2020-09-16T14:31:19.000Z',
-    },
-  ],
-  pages: [],
-};
-const squidexGraphqlDashboardFlatData = () => ({
+export const squidexGraphqlDashboardFlatData = () => ({
   news: [
     {
       id: 'guid-news-1',
@@ -38,8 +15,8 @@ const squidexGraphqlDashboardFlatData = () => ({
         text: '<p>text</p>',
         thumbnail: [
           {
-            id: 'news-url-1',
-            thumbnailUrl: `${config.baseUrl}/api/assets/${config.appName}/thumbnail-uuid4`,
+            id: 'thumbnail-uuid1',
+            thumbnailUrl: `${config.baseUrl}/api/assets/${config.appName}/thumbnail-uuid1`,
           },
         ],
       },
@@ -56,7 +33,7 @@ const squidexGraphqlDashboardFlatData = () => ({
         text: '<p>text</p>',
         thumbnail: [
           {
-            id: 'news-url-2',
+            id: 'thumbnail-uuid2',
             thumbnailUrl: `${config.baseUrl}/api/assets/${config.appName}/thumbnail-uuid2`,
           },
         ],
@@ -73,16 +50,14 @@ export const getSquidexGraphqlDashboard = () => ({
   version: 42,
   flatData: squidexGraphqlDashboardFlatData(),
 });
-export const squidexGraphqlDashboardResponse = () => ({
+export const squidexGraphqlDashboardResponse = (): DashboardResponse => ({
   news: [
     {
       created: '2020-09-24T11:06:27.164Z',
       id: 'guid-news-1',
       shortText: 'Short text of news 1',
       text: '<p>text</p>',
-      thumbnail: expect.stringMatching(
-        /https:\/\/cloud.squidex.io\/api\/assets\/(.+)\/news-url-1/,
-      ),
+      thumbnail: `${config.baseUrl}/api/assets/${config.appName}/thumbnail-uuid1`,
       title: 'News 1',
       type: 'News',
     },
@@ -91,9 +66,7 @@ export const squidexGraphqlDashboardResponse = () => ({
       id: 'guid-news-2',
       shortText: 'Short text of event 2',
       text: '<p>text</p>',
-      thumbnail: expect.stringMatching(
-        /https:\/\/cloud.squidex.io\/api\/assets\/(.+)\/news-url-2/,
-      ),
+      thumbnail: `${config.baseUrl}/api/assets/${config.appName}/thumbnail-uuid2`,
       title: 'Event 2',
       type: 'Event',
     },

--- a/apps/asap-server/test/fixtures/dashboard.fixtures.ts
+++ b/apps/asap-server/test/fixtures/dashboard.fixtures.ts
@@ -80,7 +80,9 @@ export const squidexGraphqlDashboardResponse = () => ({
       id: 'guid-news-1',
       shortText: 'Short text of news 1',
       text: '<p>text</p>',
-      thumbnail: 'https://cloud.squidex.io/api/assets/1153/news-url-1',
+      thumbnail: expect.stringMatching(
+        /https:\/\/cloud.squidex.io\/api\/assets\/(.+)\/news-url-1/,
+      ),
       title: 'News 1',
       type: 'News',
     },
@@ -89,7 +91,9 @@ export const squidexGraphqlDashboardResponse = () => ({
       id: 'guid-news-2',
       shortText: 'Short text of event 2',
       text: '<p>text</p>',
-      thumbnail: 'https://cloud.squidex.io/api/assets/1153/news-url-2',
+      thumbnail: expect.stringMatching(
+        /https:\/\/cloud.squidex.io\/api\/assets\/(.+)\/news-url-2/,
+      ),
       title: 'Event 2',
       type: 'Event',
     },

--- a/apps/asap-server/test/fixtures/discover.fixtures.ts
+++ b/apps/asap-server/test/fixtures/discover.fixtures.ts
@@ -161,7 +161,7 @@ export const discoverResponse: DiscoverResponse = {
   aboutUs: '<p>content<p>',
 };
 
-export const squidexGraphqlDiscoverFlatData = {
+const squidexGraphqlDiscoverFlatData = () => ({
   training: [
     {
       id: 'uuid-training-1',
@@ -236,17 +236,17 @@ export const squidexGraphqlDiscoverFlatData = {
     },
   ],
   aboutUs: '<p>content<p>',
-};
+});
 
 export const getSquidexGraphqlDiscover = () => ({
   id: 'ec3086d4-aa64-4f30-a0f7-5c5b95ffbcca',
   created: '2020-09-23T16:34:26.842Z',
   lastModified: '2021-05-14T14:48:46Z',
   version: 42,
-  flatData: squidexGraphqlDiscoverFlatData,
+  flatData: squidexGraphqlDiscoverFlatData(),
 });
 
-export const squidexGraphqlDiscoverResponse = {
+export const squidexGraphqlDiscoverResponse = () => ({
   aboutUs: '<p>content<p>',
   training: [
     {
@@ -327,4 +327,4 @@ export const squidexGraphqlDiscoverResponse = {
       title: 'Title',
     },
   ],
-};
+});

--- a/apps/asap-server/test/fixtures/discover.fixtures.ts
+++ b/apps/asap-server/test/fixtures/discover.fixtures.ts
@@ -281,7 +281,9 @@ export const squidexGraphqlDiscoverResponse = () => ({
       lastModifiedDate: '2020-10-15T17:55:21Z',
       teams: [],
       social: {},
-      avatarUrl: 'https://cloud.squidex.io/api/assets/1153/uuid-1',
+      avatarUrl: expect.stringMatching(
+        /https:\/\/cloud.squidex.io\/api\/assets\/(.+)\/uuid-1/,
+      ),
       role: 'Guest',
       responsibilities: undefined,
       reachOut: undefined,

--- a/apps/asap-server/test/fixtures/discover.fixtures.ts
+++ b/apps/asap-server/test/fixtures/discover.fixtures.ts
@@ -1,165 +1,6 @@
+import { DiscoverResponse } from '@asap-hub/model';
 import { config } from '@asap-hub/squidex';
-import type { DiscoverResponse } from '@asap-hub/model';
-import type { SquidexDiscoverResponse } from '../../src/controllers/discover';
-
-export const squidexDiscoverResponse: SquidexDiscoverResponse = {
-  queryDiscoverContents: [
-    {
-      flatData: {
-        training: [
-          {
-            id: 'uuid',
-            created: '2020-09-24T11:06:27.164Z',
-            lastModified: '2020-10-15T17:55:21Z',
-            version: 42,
-            flatData: {
-              title: 'Title',
-              text: 'Content',
-              link: 'https://hub.asap.science',
-              linkText: 'ASAP Training',
-              type: 'Training',
-            },
-          },
-        ],
-        pages: [
-          {
-            id: 'uuid',
-            created: '2020-09-24T11:06:27.164Z',
-            lastModified: '2020-10-15T17:55:21Z',
-            version: 42,
-            flatData: {
-              path: '/',
-              title: 'Title',
-              text: 'Content',
-              link: 'https://hub.asap.science',
-              linkText: 'ASAP Hub',
-            },
-          },
-          {
-            id: 'uuid',
-            created: '2020-09-24T11:06:27.164Z',
-            lastModified: '2020-10-15T17:55:21Z',
-            version: 42,
-            flatData: {
-              path: '/',
-              title: 'Title',
-            },
-          },
-        ],
-        members: [
-          {
-            id: 'uuid-1',
-            created: '2020-10-15T17:55:21Z',
-            lastModified: '2020-10-15T17:55:21Z',
-            version: 42,
-            flatData: {
-              avatar: [
-                {
-                  id: 'uuid-1',
-                },
-              ],
-              email: 'john@example.com',
-              firstName: 'John',
-              lastModifiedDate: '2020-10-15T17:55:21Z',
-              lastName: 'Doe',
-            },
-          },
-          {
-            id: 'uuid-2',
-            created: '2020-10-14T17:55:21Z',
-            lastModified: '2020-10-15T17:55:21Z',
-            version: 42,
-            flatData: {
-              email: null,
-              firstName: 'Jon',
-              lastModifiedDate: '2020-10-15T17:55:21Z',
-              lastName: 'Do',
-              role: 'Staff',
-              responsibilities: 'responsibilities',
-              reachOut: 'reach out',
-            },
-          },
-        ],
-        aboutUs: '<p>content<p>',
-      },
-    },
-  ],
-};
-
-export const discoverResponse: DiscoverResponse = {
-  training: [
-    {
-      created: '2020-09-24T11:06:27.164Z',
-      id: 'uuid',
-      link: 'https://hub.asap.science',
-      linkText: 'ASAP Training',
-      shortText: '',
-      text: 'Content',
-      title: 'Title',
-      type: 'Training',
-    },
-  ],
-  pages: [
-    {
-      id: 'uuid',
-      link: 'https://hub.asap.science',
-      linkText: 'ASAP Hub',
-      path: '/',
-      shortText: '',
-      title: 'Title',
-      text: 'Content',
-    },
-    {
-      id: 'uuid',
-      link: '',
-      linkText: '',
-      path: '/',
-      shortText: '',
-      title: 'Title',
-      text: '',
-    },
-  ],
-  members: [
-    {
-      id: 'uuid-1',
-      onboarded: true,
-      createdDate: '2020-10-15T17:55:21.000Z',
-      displayName: 'John Doe',
-      email: 'john@example.com',
-      firstName: 'John',
-      lastModifiedDate: '2020-10-15T17:55:21Z',
-      lastName: 'Doe',
-      orcidWorks: [],
-      questions: [],
-      expertiseAndResourceTags: [],
-      social: {},
-      teams: [],
-      avatarUrl: `${config.baseUrl}/api/assets/${config.appName}/uuid-1`,
-      role: 'Guest',
-      labs: [],
-    },
-    {
-      id: 'uuid-2',
-      onboarded: true,
-      createdDate: '2020-10-14T17:55:21.000Z',
-      displayName: 'Jon Do',
-      email: '',
-      firstName: 'Jon',
-      lastModifiedDate: '2020-10-15T17:55:21Z',
-      lastName: 'Do',
-      orcidWorks: [],
-      questions: [],
-      expertiseAndResourceTags: [],
-      teams: [],
-      social: {},
-      reachOut: 'reach out',
-      responsibilities: 'responsibilities',
-      role: 'Staff',
-      labs: [],
-    },
-  ],
-  aboutUs: '<p>content<p>',
-};
+import { FetchDiscoverQuery } from '../../src/gql/graphql';
 
 const squidexGraphqlDiscoverFlatData = () => ({
   training: [
@@ -174,6 +15,13 @@ const squidexGraphqlDiscoverFlatData = () => ({
         link: 'https://hub.asap.science',
         linkText: 'ASAP Training',
         type: 'Training',
+        shortText: 'Short text',
+        thumbnail: [
+          {
+            id: 'thumbnail-uuid1',
+            thumbnailUrl: `${config.baseUrl}/api/assets/${config.appName}/thumbnail-uuid1`,
+          },
+        ],
       },
     },
   ],
@@ -184,11 +32,11 @@ const squidexGraphqlDiscoverFlatData = () => ({
       lastModified: '2020-10-15T17:55:21Z',
       version: 42,
       flatData: {
-        path: '/',
         title: 'Title',
         text: 'Content',
         link: 'https://hub.asap.science',
         linkText: 'ASAP Hub',
+        shortText: 'Short text',
       },
     },
     {
@@ -197,8 +45,11 @@ const squidexGraphqlDiscoverFlatData = () => ({
       lastModified: '2020-10-15T17:55:21Z',
       version: 42,
       flatData: {
-        path: '/s',
         title: 'Title',
+        text: 'Content',
+        link: 'https://hub.asap.science',
+        linkText: 'ASAP Hub',
+        shortText: 'Short text',
       },
     },
   ],
@@ -218,6 +69,8 @@ const squidexGraphqlDiscoverFlatData = () => ({
         firstName: 'John',
         lastModifiedDate: '2020-10-15T17:55:21Z',
         lastName: 'Doe',
+        institution: 'ASAP',
+        jobTitle: 'Job title',
       },
     },
     {
@@ -229,9 +82,14 @@ const squidexGraphqlDiscoverFlatData = () => ({
         email: null,
         lastModifiedDate: '2020-10-15T17:55:21Z',
         lastName: 'Do',
-        role: 'Staff',
-        responsibilities: 'responsibilities',
-        reachOut: 'reach out',
+        firstName: 'John',
+        institution: 'ASAP',
+        jobTitle: 'Job title',
+        avatar: [
+          {
+            id: 'uuid-2',
+          },
+        ],
       },
     },
   ],
@@ -246,7 +104,7 @@ export const getSquidexGraphqlDiscover = () => ({
   flatData: squidexGraphqlDiscoverFlatData(),
 });
 
-export const squidexGraphqlDiscoverResponse = () => ({
+export const squidexGraphqlDiscoverResponse = (): DiscoverResponse => ({
   aboutUs: '<p>content<p>',
   training: [
     {
@@ -281,9 +139,7 @@ export const squidexGraphqlDiscoverResponse = () => ({
       lastModifiedDate: '2020-10-15T17:55:21Z',
       teams: [],
       social: {},
-      avatarUrl: expect.stringMatching(
-        /https:\/\/cloud.squidex.io\/api\/assets\/(.+)\/uuid-1/,
-      ),
+      avatarUrl: `${config.baseUrl}/api/assets/${config.appName}/uuid-1`,
       role: 'Guest',
       responsibilities: undefined,
       reachOut: undefined,
@@ -294,6 +150,8 @@ export const squidexGraphqlDiscoverResponse = () => ({
       onboarded: true,
       createdDate: '2020-10-14T17:55:21.000Z',
       orcid: undefined,
+      displayName: 'John Do',
+      firstName: 'John',
       lastName: 'Do',
       biography: undefined,
       degree: undefined,
@@ -322,11 +180,22 @@ export const squidexGraphqlDiscoverResponse = () => ({
       text: 'Content',
       link: 'https://hub.asap.science',
       linkText: 'ASAP Hub',
+      shortText: 'Short text',
     },
     {
       id: 'uuid-pages-2',
       path: '',
       title: 'Title',
+      shortText: 'Short text',
+      text: 'Content',
     },
   ],
 });
+
+export const squidexDiscoverResponse: NonNullable<FetchDiscoverQuery> = {
+  queryDiscoverContents: [
+    {
+      flatData: squidexGraphqlDiscoverFlatData(),
+    },
+  ],
+};

--- a/apps/asap-server/test/fixtures/discover.fixtures.ts
+++ b/apps/asap-server/test/fixtures/discover.fixtures.ts
@@ -1,6 +1,6 @@
 import { config } from '@asap-hub/squidex';
-import { DiscoverResponse } from '@asap-hub/model';
-import { SquidexDiscoverResponse } from '../../src/controllers/discover';
+import type { DiscoverResponse } from '@asap-hub/model';
+import type { SquidexDiscoverResponse } from '../../src/controllers/discover';
 
 export const squidexDiscoverResponse: SquidexDiscoverResponse = {
   queryDiscoverContents: [
@@ -159,4 +159,172 @@ export const discoverResponse: DiscoverResponse = {
     },
   ],
   aboutUs: '<p>content<p>',
+};
+
+export const squidexGraphqlDiscoverFlatData = {
+  training: [
+    {
+      id: 'uuid-training-1',
+      created: '2020-09-24T11:06:27.164Z',
+      lastModified: '2020-10-15T17:55:21Z',
+      version: 42,
+      flatData: {
+        title: 'Title',
+        text: 'Content',
+        link: 'https://hub.asap.science',
+        linkText: 'ASAP Training',
+        type: 'Training',
+      },
+    },
+  ],
+  pages: [
+    {
+      id: 'uuid-pages-1',
+      created: '2020-09-24T11:06:27.164Z',
+      lastModified: '2020-10-15T17:55:21Z',
+      version: 42,
+      flatData: {
+        path: '/',
+        title: 'Title',
+        text: 'Content',
+        link: 'https://hub.asap.science',
+        linkText: 'ASAP Hub',
+      },
+    },
+    {
+      id: 'uuid-pages-2',
+      created: '2020-09-24T11:06:27.164Z',
+      lastModified: '2020-10-15T17:55:21Z',
+      version: 42,
+      flatData: {
+        path: '/s',
+        title: 'Title',
+      },
+    },
+  ],
+  members: [
+    {
+      id: 'uuid-members-1',
+      created: '2020-10-15T17:55:21Z',
+      lastModified: '2020-10-15T17:55:21Z',
+      version: 42,
+      flatData: {
+        avatar: [
+          {
+            id: 'uuid-1',
+          },
+        ],
+        email: 'john@example.com',
+        firstName: 'John',
+        lastModifiedDate: '2020-10-15T17:55:21Z',
+        lastName: 'Doe',
+      },
+    },
+    {
+      id: 'uuid-members-2',
+      created: '2020-10-14T17:55:21Z',
+      lastModified: '2020-10-15T17:55:21Z',
+      version: 42,
+      flatData: {
+        email: null,
+        lastModifiedDate: '2020-10-15T17:55:21Z',
+        lastName: 'Do',
+        role: 'Staff',
+        responsibilities: 'responsibilities',
+        reachOut: 'reach out',
+      },
+    },
+  ],
+  aboutUs: '<p>content<p>',
+};
+
+export const getSquidexGraphqlDiscover = () => ({
+  id: 'ec3086d4-aa64-4f30-a0f7-5c5b95ffbcca',
+  created: '2020-09-23T16:34:26.842Z',
+  lastModified: '2021-05-14T14:48:46Z',
+  version: 42,
+  flatData: squidexGraphqlDiscoverFlatData,
+});
+
+export const squidexGraphqlDiscoverResponse = {
+  aboutUs: '<p>content<p>',
+  training: [
+    {
+      id: 'uuid-training-1',
+      created: '2020-09-24T11:06:27.164Z',
+      title: 'Title',
+      text: 'Content',
+      link: 'https://hub.asap.science',
+      linkText: 'ASAP Training',
+      type: 'Training',
+    },
+  ],
+  members: [
+    {
+      id: 'uuid-members-1',
+      onboarded: true,
+      createdDate: '2020-10-15T17:55:21.000Z',
+      displayName: 'John Doe',
+      orcid: undefined,
+      firstName: 'John',
+      lastName: 'Doe',
+      biography: undefined,
+      degree: undefined,
+      email: 'john@example.com',
+      contactEmail: undefined,
+      country: undefined,
+      city: undefined,
+      orcidWorks: [],
+      questions: [],
+      expertiseAndResourceTags: [],
+      expertiseAndResourceDescription: undefined,
+      lastModifiedDate: '2020-10-15T17:55:21Z',
+      teams: [],
+      social: {},
+      avatarUrl: 'https://cloud.squidex.io/api/assets/1153/uuid-1',
+      role: 'Guest',
+      responsibilities: undefined,
+      reachOut: undefined,
+      labs: [],
+    },
+    {
+      id: 'uuid-members-2',
+      onboarded: true,
+      createdDate: '2020-10-14T17:55:21.000Z',
+      orcid: undefined,
+      lastName: 'Do',
+      biography: undefined,
+      degree: undefined,
+      email: '',
+      contactEmail: undefined,
+      country: undefined,
+      city: undefined,
+      orcidWorks: [],
+      questions: [],
+      expertiseAndResourceTags: [],
+      expertiseAndResourceDescription: undefined,
+      lastModifiedDate: '2020-10-15T17:55:21Z',
+      teams: [],
+      social: {},
+      role: 'Guest',
+      responsibilities: undefined,
+      reachOut: undefined,
+      labs: [],
+    },
+  ],
+  pages: [
+    {
+      id: 'uuid-pages-1',
+      path: '',
+      title: 'Title',
+      text: 'Content',
+      link: 'https://hub.asap.science',
+      linkText: 'ASAP Hub',
+    },
+    {
+      id: 'uuid-pages-2',
+      path: '',
+      title: 'Title',
+    },
+  ],
 };

--- a/apps/asap-server/test/fixtures/events.fixtures.ts
+++ b/apps/asap-server/test/fixtures/events.fixtures.ts
@@ -242,3 +242,51 @@ export const getRestEvent = (): RestEvent => ({
     hidden: { iv: false },
   },
 });
+export const getSquidexGraphqlEvents = () => ({
+  id: 'ec3086d4-aa64-4f30-a0f7-5c5b95ffbcca',
+  created: '2020-09-23T16:34:26.842Z',
+  lastModified: '2021-05-14T14:48:46Z',
+  version: 42,
+  flatData: squidexGraphqlEventsFlatData(),
+});
+
+const squidexGraphqlEventsFlatData = () => ({
+  description: 'This event is awesome',
+  endDate: '2009-12-24T16:20:14Z',
+  startDate: '2009-12-02T16:19:31Z',
+  meetingLink: 'https://zoom.com/room/123',
+  status: 'Confirmed',
+  tags: [],
+  title: 'Example Event',
+  calendar: [
+    {
+      flatData: {
+        googleCalendarId:
+          'c_t92qa82jd702q1fkreoi0hf4hk@group.calendar.google.com',
+        color: '#125A12' as const,
+        name: 'Tech 1 - Sequencing/omics',
+      },
+      referencingGroupsContents: [],
+    },
+  ],
+});
+
+export const squidexGraphqlEventsResponse = () => ({
+  items: [squidexGraphqlEventResponse()],
+  total: 1,
+});
+
+export const squidexGraphqlEventResponse = () => ({
+  description: 'This event is awesome',
+  meetingLink: 'https://zoom.com/room/123',
+  endDate: '2009-12-24T16:20:14.000Z',
+  startDate: '2009-12-02T16:19:31.000Z',
+  status: 'Confirmed',
+  tags: [],
+  title: 'Example Event',
+  calendar: {
+    color: '#125A12',
+    name: 'Tech 1 - Sequencing/omics',
+    id: 'c_t92qa82jd702q1fkreoi0hf4hk@group.calendar.google.com',
+  },
+});

--- a/apps/asap-server/test/fixtures/events.fixtures.ts
+++ b/apps/asap-server/test/fixtures/events.fixtures.ts
@@ -1,13 +1,8 @@
 import { RestEvent, config } from '@asap-hub/squidex';
 import { listGroupsResponse, queryGroupsResponse } from './groups.fixtures';
 import { ListEventResponse, EventResponse } from '@asap-hub/model';
-import {
-  EventContentFragment,
-  FetchEventQuery,
-  FetchEventsQuery,
-} from '../../src/gql/graphql';
 
-export const fetchEventsResponse: { data: FetchEventsQuery } = {
+export const fetchEventsResponse = {
   data: {
     queryEventsContentsWithTotal: {
       total: 2,
@@ -96,8 +91,7 @@ export const fetchEventsResponse: { data: FetchEventsQuery } = {
         },
       ],
     },
-    // eslint-disable-next-line
-  } as any as FetchEventsQuery, // @todo Remove with fixtures work
+  },
 };
 
 export const listEventResponse: ListEventResponse = {
@@ -188,34 +182,7 @@ export const eventResponse: EventResponse = {
   group: listGroupsResponse.items[0],
 };
 
-export const graphqlEvent = {
-  id: 'afcee0ec-fcd5-479c-9809-e397636f815a',
-  created: '2021-02-08T16:04:56Z',
-  lastModified: '2021-02-08T16:22:12Z',
-  flatData: {
-    description: 'This event is awesome',
-    endDate: '2009-12-24T16:20:14Z',
-    startDate: '2009-12-02T16:19:31Z',
-    meetingLink: 'https://zoom.com/room/123',
-    status: 'Confirmed',
-    tags: [],
-    title: 'Example Event',
-    calendar: [
-      {
-        flatData: {
-          googleCalendarId:
-            'c_t92qa82jd702q1fkreoi0hf4hk@group.calendar.google.com',
-          color: '#125A12' as const,
-          name: 'Tech 1 - Sequencing/omics',
-        },
-        referencingGroupsContents: [],
-      },
-    ],
-  },
-  // eslint-disable-next-line
-} as any as EventContentFragment; // @todo Remove with fixtures work
-
-export const findEventResponse: { data: FetchEventQuery } = {
+export const findEventResponse = {
   data: {
     findEventsContent:
       fetchEventsResponse.data.queryEventsContentsWithTotal!.items![0]!,
@@ -258,6 +225,27 @@ const squidexGraphqlEventsFlatData = () => ({
   status: 'Confirmed',
   tags: [],
   title: 'Example Event',
+  startDateTimeZone: 'UTC',
+  endDateTimeZone: 'UTC',
+  notesPermanentlyUnavailable: false,
+  notes: 'These are the notes from the meeting',
+  videoRecordingPermanentlyUnavailable: false,
+  videoRecording: '<embeded>video</embeded>',
+  presentationPermanentlyUnavailable: true,
+  presentation: '<embeded>presentation</embeded>',
+  meetingMaterialsPermanentlyUnavailable: true,
+  meetingMaterials: [
+    {
+      title: 'My additional link',
+      url: 'https://link.pt/additional-material',
+    },
+  ],
+  thumbnail: [
+    {
+      id: 'uuid-thumbnail-2',
+    },
+  ],
+  eventLink: 'https://zoom.com/room/123',
   calendar: [
     {
       flatData: {

--- a/apps/asap-server/test/fixtures/groups.fixtures.ts
+++ b/apps/asap-server/test/fixtures/groups.fixtures.ts
@@ -1,9 +1,12 @@
 import { ListGroupResponse, GroupResponse } from '@asap-hub/model';
-import { config, GraphqlGroup } from '@asap-hub/squidex';
+import { config } from '@asap-hub/squidex';
 import {
   ResponseFetchGroups,
   ResponseFetchGroup,
 } from '../../src/controllers/groups';
+import { FetchGroupQuery } from '../../src/gql/graphql';
+import { getGraphqlTeam } from './teams.fixtures';
+import { getGraphQLUser, getUserResponse } from './users.fixtures';
 
 export const queryGroupsResponse: { data: ResponseFetchGroups } = {
   data: {
@@ -358,7 +361,9 @@ export const listGroupsResponse: ListGroupResponse = {
   ],
 };
 
-export const getGraphqlGroup = (): GraphqlGroup => ({
+export const getGraphqlGroup = (): NonNullable<
+  FetchGroupQuery['findGroupsContent']
+> => ({
   id: 'group-id-1',
   created: '2020-12-11T14:33:50Z',
   lastModified: '2020-12-11T15:06:26Z',
@@ -370,22 +375,17 @@ export const getGraphqlGroup = (): GraphqlGroup => ({
     thumbnail: [
       {
         id: 'uuid-thumbnail-1',
-        created: '2020-12-11T14:33:50Z',
-        lastModified: '2020-12-11T15:06:26Z',
-        version: 42,
       },
     ],
     tools: [
       {
         slack: 'https://example.com/secure-comms',
+        googleDrive: null,
       },
     ],
     calendars: [
       {
         id: 'calendar-id-1',
-        created: '2020-12-11T14:33:50Z',
-        lastModified: '2020-12-11T15:06:26Z',
-        version: 42,
         flatData: {
           color: '#B1365F',
           googleCalendarId: 'hub@asap.science',
@@ -393,160 +393,21 @@ export const getGraphqlGroup = (): GraphqlGroup => ({
         },
       },
     ],
-    teams: [
-      {
-        __typename: 'Teams',
-        id: 'team-id-1',
-        created: '2020-12-11T14:33:50Z',
-        lastModified: '2020-12-11T15:06:26Z',
-        version: 42,
-        flatData: {
-          applicationNumber: 'ASAP-000592',
-          displayName: 'Lee, M',
-          projectSummary: null,
-          projectTitle:
-            'Senescence in Parkinson’s disease and related disorders',
-          expertiseAndResourceTags: [],
-          proposal: [
-            {
-              id: 'output-id-1',
-            },
-          ],
-          tools: [
-            {
-              name: 'dropbox',
-              url: '  https://example.com/secure-comms',
-            },
-          ],
-        },
-      },
-    ],
+    teams: [getGraphqlTeam()],
     leaders: [
       {
         role: 'Chair',
-        user: [
-          {
-            id: 'user-id-1',
-            created: '2020-12-11T14:33:50Z',
-            lastModified: '2020-12-11T15:06:26Z',
-            version: 42,
-            flatData: {
-              avatar: [
-                {
-                  id: 'asset-id-1',
-                },
-              ],
-              social: [
-                {
-                  github: 'fampinheiro',
-                  googleScholar: null,
-                  linkedIn: 'fampinheiro',
-                  researcherId: null,
-                  researchGate: null,
-                  twitter: 'fampinheiro',
-                },
-              ],
-              biography:
-                'Filipe is an Engineering Manager who works closely with our clients to ensure process and technical standards improvements. He previously worked at startups and multinational companies, leading tech projects in mobile and web apps, before bringing this gathered experience to YLD.',
-              degree: null,
-              email: 'filipe@yld.io',
-              firstName: 'Filipe',
-              institution: 'YLD',
-              jobTitle: 'Software Engineer',
-              lastModifiedDate: null,
-              lastName: 'Pinheiro',
-              orcid: null,
-              orcidLastModifiedDate: null,
-              orcidLastSyncDate: null,
-              orcidWorks: [],
-              labs: [
-                { id: 'cd7be4904', flatData: { name: 'Manchester' } },
-                { id: 'cd7be4905', flatData: { name: 'Glasgow' } },
-              ],
-              questions: [
-                {
-                  question: 'What is the meaning of life?',
-                },
-                {
-                  question: 'Question 2',
-                },
-              ],
-              expertiseAndResourceTags: ['React'],
-              expertiseAndResourceDescription:
-                "In addition to his expertise in not for profit management, Todd has scientific experience in animal models and the cell biology of Parkinson's disease.",
-              teams: [
-                {
-                  role: 'Co-PI (Core Leadership)',
-                  responsibilities: null,
-                  mainResearchInterests: null,
-                  id: [
-                    {
-                      __typename: 'Teams',
-                      id: 'team-id-2',
-                      created: '2020-12-11T14:33:50Z',
-                      lastModified: '2020-12-11T15:06:26Z',
-                      version: 42,
-                      flatData: {
-                        displayName: 'Rio, D',
-                        proposal: [],
-                      },
-                    },
-                  ],
-                },
-              ],
-            },
-          },
-        ],
+        user: [getGraphQLUser()],
       },
       {
         role: 'Project Manager',
-        user: [
-          {
-            id: 'user-id-2',
-            created: '2020-12-11T14:33:50Z',
-            lastModified: '2020-12-11T15:06:26Z',
-            version: 42,
-            flatData: {
-              avatar: [],
-              social: [
-                {
-                  github: 'johnytiago',
-                  googleScholar: null,
-                  linkedIn: null,
-                  researcherId: null,
-                  researchGate: null,
-                  twitter: null,
-                },
-              ],
-              biography: null,
-              degree: null,
-              email: 'joao.tiago@yld.io',
-              firstName: 'João',
-              institution: 'YLD',
-              jobTitle: null,
-              lastModifiedDate: null,
-              lastName: 'Tiago',
-              orcid: null,
-              orcidLastModifiedDate: null,
-              orcidLastSyncDate: null,
-              orcidWorks: [],
-              questions: [],
-              expertiseAndResourceTags: [],
-              expertiseAndResourceDescription: null,
-              labs: [
-                { id: 'cd7be4902', flatData: { name: 'Barcelona' } },
-                { id: 'cd7be4905', flatData: { name: 'Glasgow' } },
-              ],
-              teams: [],
-            },
-          },
-        ],
+        user: [getGraphQLUser()],
       },
     ],
   },
 });
 
-export const getResponseFetchGroup = (): { data: ResponseFetchGroup } => ({
+export const getResponseFetchGroup = (): { data: FetchGroupQuery } => ({
   data: {
     findGroupsContent: getGraphqlGroup(),
   },
@@ -574,86 +435,32 @@ export const getGroupResponse = (): GroupResponse => ({
   teams: [
     {
       id: 'team-id-1',
-      displayName: 'Lee, M',
-      lastModifiedDate: '2020-12-11T15:06:26.000Z',
-      expertiseAndResourceTags: [],
-      projectTitle: 'Senescence in Parkinson’s disease and related disorders',
-      proposalURL: 'output-id-1',
-      tools: [
-        {
-          name: 'dropbox',
-          url: '  https://example.com/secure-comms',
-        },
-      ],
+      displayName: 'Team A',
+      lastModifiedDate: '2020-11-26T11:56:04.000Z',
+      expertiseAndResourceTags: ['Animal resources'],
+
+      projectTitle:
+        'The genome-microbiome axis in the cause of Parkinson disease: Mechanistic insights and therapeutic implications from experimental models and a genetically stratified patient population.',
+      proposalURL: '4cfb1b7b-bafe-4fca-b2ab-197e84d98996',
+      tools: [],
     },
   ],
   leaders: [
     {
-      user: {
-        id: 'user-id-1',
-        onboarded: true,
-        createdDate: '2020-12-11T14:33:50.000Z',
-        displayName: 'Filipe Pinheiro',
-        firstName: 'Filipe',
-        lastName: 'Pinheiro',
-        biography:
-          'Filipe is an Engineering Manager who works closely with our clients to ensure process and technical standards improvements. He previously worked at startups and multinational companies, leading tech projects in mobile and web apps, before bringing this gathered experience to YLD.',
-        email: 'filipe@yld.io',
-        institution: 'YLD',
-        jobTitle: 'Software Engineer',
-        orcidWorks: [],
-        questions: ['What is the meaning of life?', 'Question 2'],
-        expertiseAndResourceTags: ['React'],
-        expertiseAndResourceDescription:
-          "In addition to his expertise in not for profit management, Todd has scientific experience in animal models and the cell biology of Parkinson's disease.",
-        lastModifiedDate: '2020-12-11T14:33:50.000Z',
-        teams: [
-          {
-            id: 'team-id-2',
-            role: 'Co-PI (Core Leadership)',
-            displayName: 'Rio, D',
-          },
-        ],
-        social: {
-          github: 'fampinheiro',
-          linkedIn: 'fampinheiro',
-          twitter: 'fampinheiro',
-        },
-        avatarUrl: `${config.baseUrl}/api/assets/${config.appName}/asset-id-1`,
-        role: 'Guest',
-        labs: [
-          { id: 'cd7be4904', name: 'Manchester' },
-          { id: 'cd7be4905', name: 'Glasgow' },
-        ],
-      },
+      user: getUserResponse(),
       role: 'Chair',
     },
     {
-      user: {
-        id: 'user-id-2',
-        onboarded: true,
-        createdDate: '2020-12-11T14:33:50.000Z',
-        displayName: 'João Tiago',
-        firstName: 'João',
-        lastName: 'Tiago',
-        email: 'joao.tiago@yld.io',
-        institution: 'YLD',
-        orcidWorks: [],
-        questions: [],
-        expertiseAndResourceTags: [],
-        lastModifiedDate: '2020-12-11T14:33:50.000Z',
-        teams: [],
-        social: { github: 'johnytiago' },
-        role: 'Guest',
-        labs: [
-          { id: 'cd7be4902', name: 'Barcelona' },
-          { id: 'cd7be4905', name: 'Glasgow' },
-        ],
-      },
+      user: getUserResponse(),
       role: 'Project Manager',
     },
   ],
   calendars: [{ id: 'hub@asap.science', color: '#B1365F', name: 'ASAP Hub' }],
+});
+
+export const getListGroupResponse = (): ListGroupResponse => ({
+  total: 1,
+  items: [getGroupResponse()],
 });
 
 export const groupResponse: GroupResponse = listGroupsResponse.items[0]!;

--- a/apps/asap-server/test/fixtures/news.fixtures.ts
+++ b/apps/asap-server/test/fixtures/news.fixtures.ts
@@ -1,5 +1,5 @@
 import { config, RestNews } from '@asap-hub/squidex';
-import { ListNewsResponse } from '@asap-hub/model';
+import type { ListNewsResponse } from '@asap-hub/model';
 
 export const newsSquidexApiResponse: {
   total: number;

--- a/apps/asap-server/test/fixtures/research-output.fixtures.ts
+++ b/apps/asap-server/test/fixtures/research-output.fixtures.ts
@@ -16,6 +16,7 @@ import {
 } from './users.fixtures';
 import { createEventBridgeEventMock } from '../../test/helpers/events';
 import { ResearchOutputEventType } from '../../src/handlers/webhooks/webhook-research-output';
+import { getGraphqlTeam } from './teams.fixtures';
 
 export const getSquidexResearchOutputsGraphqlResponse =
   (): FetchResearchOutputsQuery => ({
@@ -87,175 +88,7 @@ export const getSquidexGraphqlResearchOutput = (): NonNullable<
       },
     ],
   },
-  referencingTeamsContents: [
-    {
-      id: 'team-id-1',
-      created: '2020-09-23T20:33:36Z',
-      lastModified: '2020-11-26T11:56:04Z',
-      version: 42,
-      flatData: {
-        displayName: 'Team A',
-      },
-      referencingUsersContents: [
-        {
-          flatData: {
-            email: 'pm1@example.com',
-            teams: [
-              {
-                id: [
-                  {
-                    id: 'team-id-1',
-                    created: '2020-09-23T20:33:36Z',
-                    lastModified: '2020-11-26T11:56:04Z',
-                    flatData: {},
-                  },
-                ],
-                role: 'Project Manager',
-              },
-            ],
-          },
-        },
-        {
-          flatData: {
-            email: 'pm1@example.com',
-            teams: [
-              {
-                id: [
-                  {
-                    id: 'team-id-1',
-                    created: '2020-09-23T20:33:36Z',
-                    lastModified: '2020-11-26T11:56:04Z',
-                    flatData: {},
-                  },
-                ],
-                role: 'Project Manager',
-              },
-            ],
-          },
-        },
-        {
-          flatData: {
-            email: 'notapm1@example.com',
-            teams: null,
-          },
-        },
-        {
-          flatData: {
-            email: 'notapm2@example.com',
-            teams: [
-              {
-                id: [
-                  {
-                    id: 'wrong-team-id',
-                    created: '2020-09-23T20:33:36Z',
-                    lastModified: '2020-11-26T11:56:04Z',
-                    flatData: {},
-                  },
-                ],
-                role: 'Project Manager',
-              },
-            ],
-          },
-        },
-        {
-          flatData: {
-            email: 'notapm3@example.com',
-            teams: [
-              {
-                id: [
-                  {
-                    id: 'team-id-1',
-                    created: '2020-09-23T20:33:36Z',
-                    lastModified: '2020-11-26T11:56:04Z',
-                    flatData: {},
-                  },
-                ],
-                role: 'Key Personnel',
-              },
-            ],
-          },
-        },
-      ],
-    },
-    {
-      id: 'team-id-2',
-      created: '2020-09-23T20:33:36Z',
-      lastModified: '2020-11-26T11:56:04Z',
-      version: 42,
-      flatData: {
-        displayName: 'Team B',
-      },
-      referencingUsersContents: [
-        {
-          flatData: {
-            email: 'pm2@example.com',
-            teams: [
-              {
-                id: [
-                  {
-                    id: 'team-id-2',
-                    created: '2020-09-23T20:33:36Z',
-                    lastModified: '2020-11-26T11:56:04Z',
-                    version: 42,
-                    flatData: {},
-                  },
-                ],
-                role: 'Project Manager',
-              },
-            ],
-          },
-        },
-        {
-          flatData: {
-            email: 'pm2@example.com',
-            teams: [
-              {
-                id: [
-                  {
-                    id: 'team-id-2',
-                    created: '2020-09-23T20:33:36Z',
-                    lastModified: '2020-11-26T11:56:04Z',
-                    version: 42,
-                    flatData: {},
-                  },
-                ],
-                role: 'Project Manager',
-              },
-            ],
-          },
-        },
-        {
-          flatData: {
-            email: 'multiple-pms-on-same-team@example.com',
-            teams: [
-              {
-                id: [
-                  {
-                    id: 'team-id-2',
-                    created: '2020-09-23T20:33:36Z',
-                    lastModified: '2020-11-26T11:56:04Z',
-                    version: 42,
-                    flatData: {},
-                  },
-                ],
-                role: 'Project Manager',
-              },
-            ],
-          },
-        },
-        {
-          id: '94adc252-cf5e-4950-bbcf-339e46d326a0',
-          created: '2020-09-23T20:33:36Z',
-          lastModified: '2020-11-26T11:56:04Z',
-          version: 42,
-          flatData: {
-            email: 'notapm4@example.com',
-            teams: null,
-          },
-        },
-      ],
-    },
-  ],
+  referencingTeamsContents: [getGraphqlTeam()],
 });
 
 export const getResearchOutputResponse =
@@ -268,10 +101,7 @@ export const getResearchOutputResponse =
     description: 'Text',
     tags: ['tag', 'test'],
     authors: (fetchExpectation as DeepWriteable<ListUserResponse>).items,
-    teams: [
-      { id: 'team-id-1', displayName: 'Team A' },
-      { id: 'team-id-2', displayName: 'Team B' },
-    ],
+    teams: [{ id: 'team-id-1', displayName: 'Team A' }],
     publishDate: '2021-05-21T13:18:31Z',
     labCatalogNumber: 'http://example.com',
     doi: '10.5555/YFRU1371',
@@ -282,7 +112,7 @@ export const getResearchOutputResponse =
     sharingStatus: 'Network Only',
     asapFunded: true,
     usedInPublication: false,
-    contactEmails: ['multiple-pms-on-same-team@example.com'],
+    contactEmails: [],
     labs: [
       { id: '99c78dd7-627e-4fbd-aaec-d1977895189e', name: 'Test' },
       { id: 'cd7be402-84d7-4d21-a360-82e2695f2dd9', name: 'mike' },

--- a/apps/asap-server/test/fixtures/teams.fixtures.ts
+++ b/apps/asap-server/test/fixtures/teams.fixtures.ts
@@ -1,12 +1,10 @@
 import { ListTeamResponse, TeamResponse, TeamTool } from '@asap-hub/model';
 import { config, RestTeam, Team, WebhookPayload } from '@asap-hub/squidex';
 import { RestUser } from '@asap-hub/squidex';
-import {
-  ResponseFetchTeams,
-  ResponseFetchTeam,
-} from '../../src/controllers/teams';
+import { ResponseFetchTeam } from '../../src/controllers/teams';
 import {
   FetchTeamQuery,
+  FetchTeamsQuery,
   Labs,
   UsersDataQuestionsChildDto,
   UsersDataTeamsChildDto,
@@ -75,360 +73,36 @@ export const referencingUsersContentsResponse = ({
   },
 ];
 
-export const getGraphQlTeamsResponse = (): { data: ResponseFetchTeams } => ({
-  data: {
-    queryTeamsContentsWithTotal: {
-      total: 3,
-      items: [
-        {
-          __typename: 'Teams',
-          id: 'team-id-1',
-          created: '2020-09-23T20:33:36Z',
-          lastModified: '2020-11-26T11:56:04Z',
-          version: 42,
-          flatData: {
-            applicationNumber: 'ASAP-000420',
-            displayName: 'Schipa, A',
-            projectSummary: null,
-            projectTitle:
-              'The genome-microbiome axis in the cause of Parkinson disease: Mechanistic insights and therapeutic implications from experimental models and a genetically stratified patient population.',
-            expertiseAndResourceTags: ['Animal resources'],
-            proposal: [
-              {
-                id: '4cfb1b7b-bafe-4fca-b2ab-197e84d98996',
-              },
-            ],
-            tools: [
-              {
-                url: 'testUrl',
-                name: 'slack',
-                description: 'this is a test',
-              },
-            ],
-          },
-          referencingUsersContents: [
-            {
-              id: 'user-id-1',
-              created: '2020-09-25T09:42:51.132Z',
-              lastModified: '2020-09-25T09:42:51.132Z',
-              version: 42,
-              flatData: {
-                avatar: [
-                  {
-                    id: 'uuid-user-id-1',
-                  },
-                ],
-                email: 'cristiano@ronaldo.com',
-                firstName: 'Cristiano',
-                lastName: 'Ronaldo',
-                jobTitle: 'Junior',
-                institution: 'Dollar General Corporation',
-                connections: [],
-                biography: '',
-                teams: [
-                  {
-                    id: [
-                      {
-                        __typename: 'Teams',
-                        id: 'team-id-1',
-                        created: '2020-09-23T20:33:36Z',
-                        lastModified: '2020-11-26T11:56:04Z',
-                        version: 42,
-                        flatData: {
-                          displayName: 'Schipa, A',
-                        },
-                      },
-                    ],
-                    role: 'Lead PI (Core Leadership)',
-                  },
-                ],
-                questions: [],
-                expertiseAndResourceTags: [],
-                role: 'Grantee',
-                onboarded: true,
-                labs: [
-                  { id: 'cd7be4902', flatData: { name: 'Barcelona' } },
-                  { id: 'cd7be4905', flatData: { name: 'Glasgow' } },
-                ],
-              },
-            },
-          ],
-        },
-        {
-          __typename: 'Teams',
-          id: 'team-id-2',
-          created: '2020-09-23T20:29:45Z',
-          lastModified: '2020-10-26T20:54:00Z',
-          version: 42,
-          flatData: {
-            applicationNumber: 'ASAP-000463',
-            displayName: 'John T.',
-            projectSummary: null,
-            projectTitle:
-              'Mapping the LRRK2 signalling pathway and its interplay with other Parkinson’s disease components',
-            expertiseAndResourceTags: [],
-            proposal: null,
-            tools: null,
-          },
-          referencingUsersContents: [
-            {
-              id: 'user-id-2',
-              created: '2020-09-25T09:42:51.132Z',
-              lastModified: '2020-09-25T09:42:51.132Z',
-              version: 42,
-              flatData: {
-                avatar: [
-                  {
-                    id: 'uuid-user-id-2',
-                  },
-                ],
-                email: 'john@ed.ma',
-                firstName: 'John',
-                lastName: 'Travista',
-                jobTitle: 'Junior',
-                institution: 'Dollar General Corporation',
-                connections: [],
-                biography: '',
-                teams: [
-                  {
-                    id: [
-                      {
-                        __typename: 'Teams',
-                        id: 'team-id-2',
-                        created: '2020-09-23T20:33:36Z',
-                        lastModified: '2020-11-26T11:56:04Z',
-                        version: 42,
-                        flatData: {
-                          displayName: 'Schipa, A',
-                        },
-                      },
-                    ],
-                    role: 'Lead PI (Core Leadership)',
-                  },
-                ],
-                questions: [],
-                expertiseAndResourceTags: [],
-                role: 'Grantee',
-                onboarded: true,
-                labs: [],
-              },
-            },
-            {
-              id: 'user-id-3',
-              created: '2020-09-25T09:42:51.132Z',
-              lastModified: '2020-09-25T09:42:51.132Z',
-              version: 42,
-              flatData: {
-                avatar: [
-                  {
-                    id: 'uuid-user-id-3',
-                  },
-                ],
-                email: 'bill@ed.ma',
-                firstName: 'Bill',
-                lastName: 'Travista',
-                jobTitle: 'Junior',
-                institution: 'Dollar General Corporation',
-                connections: [],
-                biography: '',
-                teams: [
-                  {
-                    id: [
-                      {
-                        __typename: 'Teams',
-                        id: 'team-id-2',
-                        created: '2020-09-23T20:33:36Z',
-                        lastModified: '2020-11-26T11:56:04Z',
-                        version: 42,
-                        flatData: {
-                          displayName: 'Schipa, A',
-                        },
-                      },
-                    ],
-                    role: 'Key Personnel',
-                  },
-                ],
-                questions: [],
-                expertiseAndResourceTags: [],
-                role: 'Grantee',
-                onboarded: true,
-                labs: [],
-              },
-            },
-          ],
-        },
-        {
-          __typename: 'Teams',
-          id: 'team-id-3',
-          created: '2020-09-23T20:29:52Z',
-          lastModified: '2020-09-23T20:29:52Z',
-          version: 42,
-          flatData: {
-            applicationNumber: 'ASAP-000312',
-            displayName: 'Zac T.',
-            projectSummary: 'Its good',
-            projectTitle: 'This is good',
-            expertiseAndResourceTags: [],
-            proposal: null,
-            tools: null,
-          },
-          referencingUsersContents: [
-            {
-              id: 'user-id-4',
-              created: '2020-09-25T09:42:51.132Z',
-              lastModified: '2020-09-25T09:42:51.132Z',
-              version: 42,
-              flatData: {
-                avatar: [
-                  {
-                    id: 'uuid-user-id-4',
-                  },
-                ],
-                email: 'seb@.da',
-                firstName: 'Seb',
-                lastName: 'Oliver',
-                jobTitle: 'Junior',
-                institution: 'Dollar General Corporation',
-                connections: [],
-                biography: '',
-                teams: [
-                  {
-                    id: [
-                      {
-                        __typename: 'Teams',
-                        id: 'team-id-3',
-                        created: '2020-09-23T20:33:36Z',
-                        lastModified: '2020-11-26T11:56:04Z',
-                        version: 42,
-                        flatData: {
-                          displayName: 'Schipa, A',
-                        },
-                      },
-                    ],
-                    role: 'Lead PI (Core Leadership)',
-                  },
-                ],
-                questions: [],
-                expertiseAndResourceTags: [],
-                role: 'Grantee',
-                onboarded: true,
-                labs: [
-                  { id: 'cd7be4904', flatData: { name: 'Manchester' } },
-                  { id: 'cd7be4905', flatData: { name: 'Glasgow' } },
-                ],
-              },
-            },
-          ],
-        },
-      ],
-    },
-  },
+export const getListTeamResponse = (): ListTeamResponse => ({
+  total: 1,
+  items: [getTeamResponse()],
 });
 
-export const graphQlTeamsResponseSingle: { data: ResponseFetchTeams } = {
-  data: {
-    queryTeamsContentsWithTotal: {
-      total: 1,
-      items: [
-        getGraphQlTeamsResponse().data.queryTeamsContentsWithTotal.items[0]!,
-      ],
-    },
-  },
-};
-
-export const getListTeamResponse = (): ListTeamResponse => ({
-  total: 3,
-  items: [
+export const getTeamResponse = (): TeamResponse => ({
+  id: 'team-id-1',
+  displayName: 'Team A',
+  lastModifiedDate: '2020-11-26T11:56:04.000Z',
+  labCount: 2,
+  expertiseAndResourceTags: ['Animal resources'],
+  members: [
     {
-      id: 'team-id-1',
-      displayName: 'Schipa, A',
-      lastModifiedDate: '2020-11-26T11:56:04.000Z',
-      labCount: 2,
-      expertiseAndResourceTags: ['Animal resources'],
-      members: [
-        {
-          id: 'user-id-1',
-          displayName: 'Cristiano Ronaldo',
-          firstName: 'Cristiano',
-          lastName: 'Ronaldo',
-          email: 'cristiano@ronaldo.com',
-          role: 'Lead PI (Core Leadership)',
-          avatarUrl: `${config.baseUrl}/api/assets/${config.appName}/uuid-user-id-1`,
-          labs: [
-            { id: 'cd7be4902', name: 'Barcelona' },
-            { id: 'cd7be4905', name: 'Glasgow' },
-          ],
-        },
+      id: 'user-id-1',
+      email: 'H@rdy.io',
+      firstName: 'Tom',
+      lastName: 'Hardy',
+      displayName: 'Tom Hardy',
+      role: 'Lead PI (Core Leadership)',
+      avatarUrl: undefined,
+      labs: [
+        { id: 'cd7be4902', name: 'Brighton' },
+        { id: 'cd7be4903', name: 'Liverpool' },
       ],
-      projectTitle:
-        'The genome-microbiome axis in the cause of Parkinson disease: Mechanistic insights and therapeutic implications from experimental models and a genetically stratified patient population.',
-      proposalURL: '4cfb1b7b-bafe-4fca-b2ab-197e84d98996',
-      tools: [
-        {
-          url: 'testUrl',
-          name: 'slack',
-          description: 'this is a test',
-        },
-      ],
-    },
-    {
-      id: 'team-id-2',
-      displayName: 'John T.',
-      labCount: 0,
-      projectTitle:
-        'Mapping the LRRK2 signalling pathway and its interplay with other Parkinson’s disease components',
-      expertiseAndResourceTags: [],
-      members: [
-        {
-          id: 'user-id-2',
-          firstName: 'John',
-          lastName: 'Travista',
-          avatarUrl: `${config.baseUrl}/api/assets/${config.appName}/uuid-user-id-2`,
-          email: 'john@ed.ma',
-          displayName: 'John Travista',
-          role: 'Lead PI (Core Leadership)',
-          labs: [],
-        },
-        {
-          id: 'user-id-3',
-          firstName: 'Bill',
-          lastName: 'Travista',
-          avatarUrl: `${config.baseUrl}/api/assets/${config.appName}/uuid-user-id-3`,
-          email: 'bill@ed.ma',
-          displayName: 'Bill Travista',
-          role: 'Key Personnel',
-          labs: [],
-        },
-      ],
-      lastModifiedDate: '2020-10-26T20:54:00.000Z',
-      tools: [],
-    },
-    {
-      id: 'team-id-3',
-      displayName: 'Zac T.',
-      labCount: 2,
-      expertiseAndResourceTags: [],
-      members: [
-        {
-          avatarUrl: `${config.baseUrl}/api/assets/${config.appName}/uuid-user-id-4`,
-          displayName: 'Seb Oliver',
-          email: 'seb@.da',
-          firstName: 'Seb',
-          id: 'user-id-4',
-          lastName: 'Oliver',
-          role: 'Lead PI (Core Leadership)',
-          labs: [
-            { id: 'cd7be4904', name: 'Manchester' },
-            { id: 'cd7be4905', name: 'Glasgow' },
-          ],
-        },
-      ],
-      tools: [],
-      projectTitle: 'This is good',
-      projectSummary: 'Its good',
-      lastModifiedDate: '2020-09-23T20:29:52.000Z',
     },
   ],
+  projectTitle:
+    'The genome-microbiome axis in the cause of Parkinson disease: Mechanistic insights and therapeutic implications from experimental models and a genetically stratified patient population.',
+  proposalURL: '4cfb1b7b-bafe-4fca-b2ab-197e84d98996',
+  tools: [],
 });
 
 export const graphQlTeamResponse: { data: ResponseFetchTeam } = {
@@ -555,30 +229,44 @@ export type GraphTeamTool = NonNullable<
   NonNullable<FetchTeamQuery['findTeamsContent']>['flatData']['tools']
 >[number];
 
+export const getGraphqlTeam = (
+  tools: GraphTeamTool[] = [],
+  id: string = 'team-id-1',
+): NonNullable<FetchTeamQuery['findTeamsContent']> => ({
+  id,
+  created: '2020-09-23T20:33:36Z',
+  lastModified: '2020-11-26T11:56:04Z',
+  version: 42,
+  flatData: {
+    applicationNumber: 'ASAP-000420',
+    displayName: 'Team A',
+    projectSummary: null,
+    projectTitle:
+      'The genome-microbiome axis in the cause of Parkinson disease: Mechanistic insights and therapeutic implications from experimental models and a genetically stratified patient population.',
+    expertiseAndResourceTags: ['Animal resources'],
+    proposal: [
+      {
+        id: '4cfb1b7b-bafe-4fca-b2ab-197e84d98996',
+      },
+    ],
+    tools,
+  },
+  referencingUsersContents: [getGraphQLUser(undefined, id)],
+});
+
 export const getGraphQlTeamResponse = (
-  tools: GraphTeamTool[] | null = [],
+  tools: GraphTeamTool[] = [],
 ): { data: FetchTeamQuery } => ({
   data: {
-    findTeamsContent: {
-      id: 'team-id-1',
-      created: '2020-09-23T20:33:36Z',
-      lastModified: '2020-11-26T11:56:04Z',
-      version: 42,
-      flatData: {
-        applicationNumber: 'ASAP-000420',
-        displayName: 'Schipa, A',
-        projectSummary: null,
-        projectTitle:
-          'The genome-microbiome axis in the cause of Parkinson disease: Mechanistic insights and therapeutic implications from experimental models and a genetically stratified patient population.',
-        expertiseAndResourceTags: ['Animal resources'],
-        proposal: [
-          {
-            id: '4cfb1b7b-bafe-4fca-b2ab-197e84d98996',
-          },
-        ],
-        tools,
-      },
-      referencingUsersContents: [getGraphQLUser()],
+    findTeamsContent: getGraphqlTeam(tools),
+  },
+});
+
+export const getGraphQlTeamsResponse = (): { data: FetchTeamsQuery } => ({
+  data: {
+    queryTeamsContentsWithTotal: {
+      total: 1,
+      items: [getGraphqlTeam()],
     },
   },
 });

--- a/apps/asap-server/test/fixtures/users.fixtures.ts
+++ b/apps/asap-server/test/fixtures/users.fixtures.ts
@@ -85,10 +85,11 @@ export const getGraphqlResponseFetchUsers = (): {
   },
 });
 
-export const getGraphQLUser = (): NonNullable<
-  FetchUserQuery['findUsersContent']
-> => ({
-  id: 'user-id-1',
+export const getGraphQLUser = (
+  id: string = 'user-id-1',
+  teamId: string = 'team-id-1',
+): NonNullable<FetchUserQuery['findUsersContent']> => ({
+  id,
   lastModified: '2020-10-26T15:33:18Z',
   version: 42,
   created: '2020-09-23T20:45:22Z',
@@ -138,7 +139,7 @@ export const getGraphQLUser = (): NonNullable<
         responsibilities: 'some team responsibilities',
         id: [
           {
-            id: 'team-id-1',
+            id: teamId,
             flatData: {
               displayName: 'Team A',
               proposal: [{ id: 'proposalId1' }],
@@ -321,6 +322,11 @@ export const fetchExpectation: ListUserResponse = {
     },
   ],
 };
+
+export const getListUserResponse = (): ListUserResponse => ({
+  total: 1,
+  items: [getUserResponse()],
+});
 
 export const restUserMock = patchResponse;
 

--- a/apps/asap-server/test/integration/fetch-users.integration-test.ts
+++ b/apps/asap-server/test/integration/fetch-users.integration-test.ts
@@ -1,11 +1,12 @@
 import Chance from 'chance';
-import { User } from '@asap-hub/squidex';
+import { SquidexGraphql, User } from '@asap-hub/squidex';
 
 import Users from '../../src/controllers/users';
 import { createUser, createRandomOrcid } from '../helpers/users';
 
 const chance = new Chance();
-const users = new Users();
+const squidexGraphqlClient = new SquidexGraphql();
+const users = new Users(squidexGraphqlClient);
 
 describe('Users', () => {
   it('Should create and fetch a user', async () => {

--- a/apps/asap-server/test/mocks/squidex-graphql-client-with-server.mock.ts
+++ b/apps/asap-server/test/mocks/squidex-graphql-client-with-server.mock.ts
@@ -14,6 +14,7 @@ import { getGraphQLUser } from '../fixtures/users.fixtures';
 import { getGraphqlTeam } from '../fixtures/teams.fixtures';
 import { getGraphqlGroup } from '../fixtures/groups.fixtures';
 import { getSquidexGraphqlDiscover } from '../fixtures/discover.fixtures';
+import { getSquidexGraphqlDashboard } from '../fixtures/dashboard.fixtures';
 
 export const getSquidexGraphqlClientMockServer = (): SquidexGraphqlClient => {
   const schema = loadSchemaSync('../../src/schema/schema.graphql', {
@@ -46,6 +47,11 @@ export const getSquidexGraphqlClientMockServer = (): SquidexGraphqlClient => {
     }),
     Discover: () => getSquidexGraphqlDiscover(),
     DiscoveryResultDto: () => ({
+      items: [...new Array(1)],
+      total: 1,
+    }),
+    Dashboard: () => getSquidexGraphqlDashboard(),
+    DashboardResultDto: () => ({
       items: [...new Array(1)],
       total: 1,
     }),

--- a/apps/asap-server/test/mocks/squidex-graphql-client-with-server.mock.ts
+++ b/apps/asap-server/test/mocks/squidex-graphql-client-with-server.mock.ts
@@ -13,6 +13,7 @@ import { getSquidexGraphqlResearchOutput } from '../fixtures/research-output.fix
 import { getGraphQLUser } from '../fixtures/users.fixtures';
 import { getGraphqlTeam } from '../fixtures/teams.fixtures';
 import { getGraphqlGroup } from '../fixtures/groups.fixtures';
+import { getSquidexGraphqlDiscover } from '../fixtures/discover.fixtures';
 
 export const getSquidexGraphqlClientMockServer = (): SquidexGraphqlClient => {
   const schema = loadSchemaSync('../../src/schema/schema.graphql', {
@@ -40,6 +41,11 @@ export const getSquidexGraphqlClientMockServer = (): SquidexGraphqlClient => {
     }),
     Teams: () => getGraphqlTeam(),
     TeamsResultDto: () => ({
+      items: [...new Array(1)],
+      total: 1,
+    }),
+    Discover: () => getSquidexGraphqlDiscover(),
+    DiscoveryResultDto: () => ({
       items: [...new Array(1)],
       total: 1,
     }),

--- a/apps/asap-server/test/mocks/squidex-graphql-client-with-server.mock.ts
+++ b/apps/asap-server/test/mocks/squidex-graphql-client-with-server.mock.ts
@@ -21,40 +21,26 @@ export const getSquidexGraphqlClientMockServer = (): SquidexGraphqlClient => {
     cwd: __dirname,
     loaders: [new GraphQLFileLoader()],
   });
+  const resultDto = () => ({
+    items: [...new Array(1)],
+    total: 1,
+  });
   const mocks = {
     Int: () => 8,
     Instant: () => '2021-10-12T15:42:05Z',
     JsonScalar: () => {},
     Groups: () => getGraphqlGroup(),
-    GroupsResultDto: () => ({
-      items: [...new Array(1)],
-      total: 1,
-    }),
+    GroupsResultDto: resultDto,
     ResearchOutputs: () => getSquidexGraphqlResearchOutput(),
-    ResearchOutputsResultDto: () => ({
-      items: [...new Array(1)],
-      total: 1,
-    }),
+    ResearchOutputsResultDto: resultDto,
     Users: () => getGraphQLUser(),
-    UsersResultDto: () => ({
-      items: [...new Array(1)],
-      total: 1,
-    }),
+    UsersResultDto: resultDto,
     Teams: () => getGraphqlTeam(),
-    TeamsResultDto: () => ({
-      items: [...new Array(1)],
-      total: 1,
-    }),
+    TeamsResultDto: resultDto,
     Discover: () => getSquidexGraphqlDiscover(),
-    DiscoveryResultDto: () => ({
-      items: [...new Array(1)],
-      total: 1,
-    }),
+    DiscoveryResultDto: resultDto,
     Dashboard: () => getSquidexGraphqlDashboard(),
-    DashboardResultDto: () => ({
-      items: [...new Array(1)],
-      total: 1,
-    }),
+    DashboardResultDto: resultDto,
   };
   const store = createMockStore({
     schema,

--- a/apps/asap-server/test/mocks/squidex-graphql-client-with-server.mock.ts
+++ b/apps/asap-server/test/mocks/squidex-graphql-client-with-server.mock.ts
@@ -15,6 +15,7 @@ import { getGraphqlTeam } from '../fixtures/teams.fixtures';
 import { getGraphqlGroup } from '../fixtures/groups.fixtures';
 import { getSquidexGraphqlDiscover } from '../fixtures/discover.fixtures';
 import { getSquidexGraphqlDashboard } from '../fixtures/dashboard.fixtures';
+import { getSquidexGraphqlCalendars } from '../fixtures/calendars.fixtures';
 
 export const getSquidexGraphqlClientMockServer = (): SquidexGraphqlClient => {
   const schema = loadSchemaSync('../../src/schema/schema.graphql', {
@@ -41,6 +42,8 @@ export const getSquidexGraphqlClientMockServer = (): SquidexGraphqlClient => {
     DiscoveryResultDto: resultDto,
     Dashboard: () => getSquidexGraphqlDashboard(),
     DashboardResultDto: resultDto,
+    Calendars: () => getSquidexGraphqlCalendars(),
+    CalendarsResultDto: resultDto,
   };
   const store = createMockStore({
     schema,

--- a/apps/asap-server/test/mocks/squidex-graphql-client-with-server.mock.ts
+++ b/apps/asap-server/test/mocks/squidex-graphql-client-with-server.mock.ts
@@ -16,6 +16,7 @@ import { getGraphqlGroup } from '../fixtures/groups.fixtures';
 import { getSquidexGraphqlDiscover } from '../fixtures/discover.fixtures';
 import { getSquidexGraphqlDashboard } from '../fixtures/dashboard.fixtures';
 import { getSquidexGraphqlCalendars } from '../fixtures/calendars.fixtures';
+import { getSquidexGraphqlEvents } from '../fixtures/events.fixtures';
 
 export const getSquidexGraphqlClientMockServer = (): SquidexGraphqlClient => {
   const schema = loadSchemaSync('../../src/schema/schema.graphql', {
@@ -44,6 +45,8 @@ export const getSquidexGraphqlClientMockServer = (): SquidexGraphqlClient => {
     DashboardResultDto: resultDto,
     Calendars: () => getSquidexGraphqlCalendars(),
     CalendarsResultDto: resultDto,
+    Events: () => getSquidexGraphqlEvents(),
+    EventsResultDto: resultDto,
   };
   const store = createMockStore({
     schema,
@@ -56,6 +59,9 @@ export const getSquidexGraphqlClientMockServer = (): SquidexGraphqlClient => {
         keyFieldName: false,
       },
       Groups: {
+        keyFieldName: false,
+      },
+      Events: {
         keyFieldName: false,
       },
     },

--- a/apps/asap-server/test/mocks/squidex-graphql-client-with-server.mock.ts
+++ b/apps/asap-server/test/mocks/squidex-graphql-client-with-server.mock.ts
@@ -10,6 +10,9 @@ import { loadSchemaSync } from '@graphql-tools/load';
 import { GraphQLFileLoader } from '@graphql-tools/graphql-file-loader';
 import { SquidexGraphqlClient } from '@asap-hub/squidex';
 import { getSquidexGraphqlResearchOutput } from '../fixtures/research-output.fixtures';
+import { getGraphQLUser } from '../fixtures/users.fixtures';
+import { getGraphqlTeam } from '../fixtures/teams.fixtures';
+import { getGraphqlGroup } from '../fixtures/groups.fixtures';
 
 export const getSquidexGraphqlClientMockServer = (): SquidexGraphqlClient => {
   const schema = loadSchemaSync('../../src/schema/schema.graphql', {
@@ -20,8 +23,23 @@ export const getSquidexGraphqlClientMockServer = (): SquidexGraphqlClient => {
     Int: () => 8,
     Instant: () => '2021-10-12T15:42:05Z',
     JsonScalar: () => {},
+    Groups: () => getGraphqlGroup(),
+    GroupsResultDto: () => ({
+      items: [...new Array(1)],
+      total: 1,
+    }),
     ResearchOutputs: () => getSquidexGraphqlResearchOutput(),
     ResearchOutputsResultDto: () => ({
+      items: [...new Array(1)],
+      total: 1,
+    }),
+    Users: () => getGraphQLUser(),
+    UsersResultDto: () => ({
+      items: [...new Array(1)],
+      total: 1,
+    }),
+    Teams: () => getGraphqlTeam(),
+    TeamsResultDto: () => ({
       items: [...new Array(1)],
       total: 1,
     }),
@@ -31,6 +49,12 @@ export const getSquidexGraphqlClientMockServer = (): SquidexGraphqlClient => {
     mocks,
     typePolicies: {
       UsersDataTeamsChildDto: {
+        keyFieldName: false,
+      },
+      Teams: {
+        keyFieldName: false,
+      },
+      Groups: {
         keyFieldName: false,
       },
     },

--- a/apps/asap-server/test/routes/dashboard.route.test.ts
+++ b/apps/asap-server/test/routes/dashboard.route.test.ts
@@ -2,7 +2,7 @@ import { appFactory } from '../../src/app';
 import { authHandlerMock } from '../mocks/auth-handler.mock';
 import { dashboardControllerMock } from '../mocks/dashboard-controller.mock';
 import supertest from 'supertest';
-import { dashboardResponse } from '../fixtures/dashboard.fixtures';
+import { squidexGraphqlDashboardResponse } from '../fixtures/dashboard.fixtures';
 
 describe('/dashboard/ route', () => {
   const app = appFactory({
@@ -27,6 +27,7 @@ describe('/dashboard/ route', () => {
     });
 
     test('Should return the results correctly', async () => {
+      const dashboardResponse = squidexGraphqlDashboardResponse();
       dashboardControllerMock.fetch.mockResolvedValueOnce(dashboardResponse);
 
       const response = await supertest(app).get('/dashboard');

--- a/apps/asap-server/test/routes/discover.route.test.ts
+++ b/apps/asap-server/test/routes/discover.route.test.ts
@@ -2,7 +2,7 @@ import { appFactory } from '../../src/app';
 import { authHandlerMock } from '../mocks/auth-handler.mock';
 import supertest from 'supertest';
 import { discoverControllerMock } from '../mocks/discover-controller.mock';
-import { discoverResponse } from '../fixtures/discover.fixtures';
+import { squidexGraphqlDiscoverResponse } from '../fixtures/discover.fixtures';
 
 describe('/discover/ route', () => {
   const app = appFactory({
@@ -31,6 +31,7 @@ describe('/discover/ route', () => {
     });
 
     test('Should return the results correctly', async () => {
+      const discoverResponse = squidexGraphqlDiscoverResponse();
       discoverControllerMock.fetch.mockResolvedValueOnce(discoverResponse);
 
       const response = await supertest(app).get('/discover');

--- a/packages/model/src/news.ts
+++ b/packages/model/src/news.ts
@@ -15,5 +15,4 @@ export interface NewsResponse {
   linkText?: string;
   created: string;
 }
-
 export type ListNewsResponse = ListResponse<NewsResponse>;


### PR DESCRIPTION
- test file
- chore: add mock server tests to controllers (#1198)
- discover tests with mock-server
- dashboard tests with mock-server
- refactorings
- fixes test expectation
- mock graphql tests for calendars
- mock graphql tests for events
- removes castings
- renames squidexGraphqlClient
- merge fixtures
