### PR TITLE
Fix: Move prod build jobs to new stage

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,6 +38,7 @@ stages:
   - check
   - deploy-dev
   - verify-dev
+  - build-prod
   - prepare-prod
   - deploy-prod
   - verify-prod
@@ -77,21 +78,6 @@ build:ts:dev:
     REACT_APP_SENTRY_DSN: ${REACT_APP_SENTRY_DSN_DEV}
   rules:
     - if: $CI_COMMIT_BRANCH == 'master'
-
-build:ts:prod:
-  extends: .build:ts
-  rules:
-    - if: $CI_COMMIT_BRANCH == 'master'
-  environment:
-    name: production
-    url: $ASAP_APP_URL
-  before_script:
-    - export AUTH_FRONTEND_BASE_URL=$ASAP_APP_URL/.auth/
-    - export REACT_APP_ALGOLIA_APP_ID=$(aws ssm get-parameter --name "algolia-app-id-prod" --query Parameter.Value --output text)
-    - export REACT_APP_ALGOLIA_INDEX="asap-hub_research_outputs_prod"
-    - export REACT_APP_API_BASE_URL=$ASAP_API_URL
-    - export REACT_APP_ENVIRONMENT="production"
-    - export REACT_APP_RELEASE=${CI_PIPELINE_ID}-production
 
 prepare:squidex:branch:
   <<: *tmpl_branch
@@ -165,17 +151,6 @@ build:sls:package:dev:
   variables:
     <<: *tmpl_deploy_variables
     SLS_STAGE: 'dev'
-
-build:sls:package:prod:
-  extends: .build:sls:package
-  rules:
-    - if: $CI_COMMIT_BRANCH == 'master'
-  environment:
-    name: production
-    url: $ASAP_APP_URL
-  variables:
-    <<: *tmpl_deploy_variables
-    SLS_STAGE: production
 
 build:native:
   artifacts:
@@ -358,6 +333,41 @@ verify:development:
     url: $ASAP_APP_URL
   script:
     - yarn test:e2e
+
+#####################
+# stage build-prod #
+#####################
+
+build:ts:prod:
+  extends: .build:ts
+  rules:
+    - if: $CI_COMMIT_BRANCH == 'master'
+  stage: build-prod
+  environment:
+    name: production
+    url: $ASAP_APP_URL
+  before_script:
+    - export AUTH_FRONTEND_BASE_URL=$ASAP_APP_URL/.auth/
+    - export REACT_APP_ALGOLIA_APP_ID=$(aws ssm get-parameter --name "algolia-app-id-prod" --query Parameter.Value --output text)
+    - export REACT_APP_ALGOLIA_INDEX="asap-hub_research_outputs_prod"
+    - export REACT_APP_API_BASE_URL=$ASAP_API_URL
+    - export REACT_APP_ENVIRONMENT="production"
+    - export REACT_APP_RELEASE=${CI_PIPELINE_ID}-production
+  needs: []
+
+build:sls:package:prod:
+  extends: .build:sls:package
+  rules:
+    - if: $CI_COMMIT_BRANCH == 'master'
+  stage: build-prod
+  environment:
+    name: production
+    url: $ASAP_APP_URL
+  variables:
+    <<: *tmpl_deploy_variables
+    SLS_STAGE: production
+  needs:
+    - build:ts:prod
 
 #####################
 # stage deploy-prod #


### PR DESCRIPTION
Move Prod builds to later stage to avoid concurrent same enviroment builds occuring and avoid blocking the dev pipeline