### PR TITLE
Feat/Algolia works when the user session has timed out

### DIFF
--- a/apps/asap-server/src/config.ts
+++ b/apps/asap-server/src/config.ts
@@ -55,7 +55,7 @@ export const algoliaIndexApiKey = ALGOLIA_INDEX_API_KEY || '';
 export const algoliaCiApiKey = ALGOLIA_API_KEY || '';
 export const algoliaResearchOutputIndex =
   ALGOLIA_RESEARCH_OUTPUT_INDEX || 'asap-hub_research_outputs_dev';
-export const algoliaApiKeyTtl = 36060; // in [seconds] = 10 hours + 1 min - 1 minute is to account for network delays, and off-sync clocks between servers
+export const algoliaApiKeyTtl = 36060; // in [seconds] = 10 hours + 1 min - 1 minute is to account for network delays and off-sync clocks between servers
 export const sesRegion = SES_REGION || 'eu-west-1';
 export const userInviteSender = EMAIL_SENDER || `"ASAP Hub" <hub@asap.science>`;
 export const userInviteBcc = EMAIL_BCC || 'hub.invites.dev@asap.science';

--- a/apps/asap-server/src/config.ts
+++ b/apps/asap-server/src/config.ts
@@ -55,7 +55,7 @@ export const algoliaIndexApiKey = ALGOLIA_INDEX_API_KEY || '';
 export const algoliaCiApiKey = ALGOLIA_API_KEY || '';
 export const algoliaResearchOutputIndex =
   ALGOLIA_RESEARCH_OUTPUT_INDEX || 'asap-hub_research_outputs_dev';
-export const algoliaApiKeyTtl = 36060;
+export const algoliaApiKeyTtl = 36060; // in [seconds] = 10 hours + 1 min - 1 minute is to account for network delays, and off-sync clocks between servers
 export const sesRegion = SES_REGION || 'eu-west-1';
 export const userInviteSender = EMAIL_SENDER || `"ASAP Hub" <hub@asap.science>`;
 export const userInviteBcc = EMAIL_BCC || 'hub.invites.dev@asap.science';

--- a/apps/asap-server/src/handlers/webhooks/fetch-by-code/fetch-by-code.ts
+++ b/apps/asap-server/src/handlers/webhooks/fetch-by-code/fetch-by-code.ts
@@ -11,6 +11,8 @@ import { algoliaApiKeyTtl, algoliaSearchApiKey } from '../../../config';
 export const fetchUserByCodeHandlerFactory = (
   userController: UserController,
   algoliaClient: SearchClient,
+  date = new Date(),
+  ttl = algoliaApiKeyTtl,
 ): Handler =>
   http(async (request: lambda.Request): Promise<
     lambda.Response<UserMetadataResponse>
@@ -32,8 +34,8 @@ export const fetchUserByCodeHandlerFactory = (
     const user = await userController.fetchByCode(code);
     const apiKey = algoliaClient.generateSecuredApiKey(algoliaSearchApiKey, {
       validUntil: getValidUntilTimestampInSeconds({
-        date: new Date(),
-        ttl: algoliaApiKeyTtl,
+        date,
+        ttl,
       }),
     });
 

--- a/apps/asap-server/src/handlers/webhooks/fetch-by-code/fetch-by-code.ts
+++ b/apps/asap-server/src/handlers/webhooks/fetch-by-code/fetch-by-code.ts
@@ -31,7 +31,7 @@ export const fetchUserByCodeHandlerFactory = (
 
     const user = await userController.fetchByCode(code);
     const apiKey = algoliaClient.generateSecuredApiKey(algoliaSearchApiKey, {
-      validUntil: Math.floor(Date.now() / 1000) + algoliaApiKeyTtl, // which is one minute over the TTL of the ID token
+      validUntil: getValidUntil(algoliaApiKeyTtl), // which is one minute over the TTL of the ID token
     });
 
     return {
@@ -41,3 +41,6 @@ export const fetchUserByCodeHandlerFactory = (
       },
     };
   });
+
+export const getValidUntil = (ttl: number): number =>
+  Math.floor(Date.now() / 1000) + Math.floor(ttl);

--- a/apps/asap-server/src/handlers/webhooks/fetch-by-code/fetch-by-code.ts
+++ b/apps/asap-server/src/handlers/webhooks/fetch-by-code/fetch-by-code.ts
@@ -31,7 +31,7 @@ export const fetchUserByCodeHandlerFactory = (
 
     const user = await userController.fetchByCode(code);
     const apiKey = algoliaClient.generateSecuredApiKey(algoliaSearchApiKey, {
-      validUntil: Math.floor(Date.now()/1000) + algoliaApiKeyTtl, // which is one minute over the TTL of the ID token
+      validUntil: Math.floor(Date.now() / 1000) + algoliaApiKeyTtl, // which is one minute over the TTL of the ID token
     });
 
     return {

--- a/apps/asap-server/src/handlers/webhooks/fetch-by-code/fetch-by-code.ts
+++ b/apps/asap-server/src/handlers/webhooks/fetch-by-code/fetch-by-code.ts
@@ -31,7 +31,7 @@ export const fetchUserByCodeHandlerFactory = (
 
     const user = await userController.fetchByCode(code);
     const apiKey = algoliaClient.generateSecuredApiKey(algoliaSearchApiKey, {
-      validUntil: getValidUntil(algoliaApiKeyTtl), // which is one minute over the TTL of the ID token
+      validUntil: getValidUntilTimestampInSeconds(algoliaApiKeyTtl),
     });
 
     return {
@@ -42,5 +42,5 @@ export const fetchUserByCodeHandlerFactory = (
     };
   });
 
-export const getValidUntil = (ttl: number): number =>
+export const getValidUntilTimestampInSeconds = (ttl: number): number =>
   Math.floor(Date.now() / 1000) + Math.floor(ttl);

--- a/apps/asap-server/src/handlers/webhooks/fetch-by-code/fetch-by-code.ts
+++ b/apps/asap-server/src/handlers/webhooks/fetch-by-code/fetch-by-code.ts
@@ -31,7 +31,7 @@ export const fetchUserByCodeHandlerFactory = (
 
     const user = await userController.fetchByCode(code);
     const apiKey = algoliaClient.generateSecuredApiKey(algoliaSearchApiKey, {
-      validUntil: Date.now() + algoliaApiKeyTtl, // which is one minute over the TTL of the ID token
+      validUntil: Math.floor(Date.now()/1000) + algoliaApiKeyTtl, // which is one minute over the TTL of the ID token
     });
 
     return {

--- a/apps/asap-server/src/handlers/webhooks/fetch-by-code/fetch-by-code.ts
+++ b/apps/asap-server/src/handlers/webhooks/fetch-by-code/fetch-by-code.ts
@@ -31,7 +31,10 @@ export const fetchUserByCodeHandlerFactory = (
 
     const user = await userController.fetchByCode(code);
     const apiKey = algoliaClient.generateSecuredApiKey(algoliaSearchApiKey, {
-      validUntil: getValidUntilTimestampInSeconds(algoliaApiKeyTtl),
+      validUntil: getValidUntilTimestampInSeconds({
+        date: new Date(),
+        ttl: algoliaApiKeyTtl,
+      }),
     });
 
     return {
@@ -42,5 +45,13 @@ export const fetchUserByCodeHandlerFactory = (
     };
   });
 
-export const getValidUntilTimestampInSeconds = (ttl: number): number =>
-  Math.floor(Date.now() / 1000) + Math.floor(ttl);
+export type GetValidUntilTimestampInSecondsArgs = {
+  date: Date;
+  ttl: number;
+};
+
+export const getValidUntilTimestampInSeconds = ({
+  date,
+  ttl,
+}: GetValidUntilTimestampInSecondsArgs): number =>
+  Math.floor(date.getTime() / 1000) + Math.floor(ttl);

--- a/apps/asap-server/test/handlers/webhooks/fetch-by-code/fetch-by-code.test.ts
+++ b/apps/asap-server/test/handlers/webhooks/fetch-by-code/fetch-by-code.test.ts
@@ -6,7 +6,10 @@ import {
   auth0SharedSecret as secret,
 } from '../../../../src/config';
 import { identity } from '../../../helpers/squidex';
-import { fetchUserByCodeHandlerFactory } from '../../../../src/handlers/webhooks/fetch-by-code/fetch-by-code';
+import {
+  fetchUserByCodeHandlerFactory,
+  getValidUntil,
+} from '../../../../src/handlers/webhooks/fetch-by-code/fetch-by-code';
 import { SearchClient } from 'algoliasearch';
 import { userControllerMock } from '../../../mocks/user-controller.mock';
 import { getUserResponse } from '../../../fixtures/users.fixtures';
@@ -19,6 +22,11 @@ describe('Fetch-user-by-code handler', () => {
     userControllerMock,
     algoliaClientMock,
   );
+
+  describe('Check if algolia validUntil is in correct format(seconds)', () => {
+    jest.spyOn(Date, 'now').mockReturnValueOnce(1000);
+    expect(getValidUntil(1)).toStrictEqual(2);
+  });
 
   describe('Validation', () => {
     test("return 400 when code isn't present", async () => {

--- a/apps/asap-server/test/handlers/webhooks/fetch-by-code/fetch-by-code.test.ts
+++ b/apps/asap-server/test/handlers/webhooks/fetch-by-code/fetch-by-code.test.ts
@@ -24,8 +24,9 @@ describe('Fetch-user-by-code handler', () => {
   );
 
   describe('Check if algolia validUntil is in correct format(seconds)', () => {
-    jest.spyOn(Date, 'now').mockReturnValueOnce(1000);
-    expect(getValidUntilTimestampInSeconds(1)).toStrictEqual(2);
+    expect(
+      getValidUntilTimestampInSeconds({ date: new Date(1000), ttl: 1 }),
+    ).toStrictEqual(2);
   });
 
   describe('Validation', () => {

--- a/apps/asap-server/test/handlers/webhooks/fetch-by-code/fetch-by-code.test.ts
+++ b/apps/asap-server/test/handlers/webhooks/fetch-by-code/fetch-by-code.test.ts
@@ -8,7 +8,7 @@ import {
 import { identity } from '../../../helpers/squidex';
 import {
   fetchUserByCodeHandlerFactory,
-  getValidUntil,
+  getValidUntilTimestampInSeconds,
 } from '../../../../src/handlers/webhooks/fetch-by-code/fetch-by-code';
 import { SearchClient } from 'algoliasearch';
 import { userControllerMock } from '../../../mocks/user-controller.mock';
@@ -25,7 +25,7 @@ describe('Fetch-user-by-code handler', () => {
 
   describe('Check if algolia validUntil is in correct format(seconds)', () => {
     jest.spyOn(Date, 'now').mockReturnValueOnce(1000);
-    expect(getValidUntil(1)).toStrictEqual(2);
+    expect(getValidUntilTimestampInSeconds(1)).toStrictEqual(2);
   });
 
   describe('Validation', () => {


### PR DESCRIPTION
## Reproduction steps:

- log in
- let your session time out (leave your tab open for 10 hours)
- navigate the hub

(this is only reproducible before https://trello.com/c/BZEGD3jD/1594-users-are-able-to-navigate-the-hub-even-if-they-are-logged-out  is merged)

## current behaviour:

- most pages of the hub are broken
- shared outputs work

## expected behaviour:

- shared outputs don't work (because algolia token should expire when Auth0 expires)

## notes

- a technical should be able to product accept this