### PR TITLE
feat: Mark group as inactive

### DIFF
--- a/apps/asap-server/src/gql/graphql.ts
+++ b/apps/asap-server/src/gql/graphql.ts
@@ -2361,6 +2361,18 @@ export type Groups = Content & {
   version: Scalars['Int'];
 };
 
+/** The structure of the This group is active field of the Groups content type. */
+export type GroupsDataActiveDto = {
+  /** Active groups have Subscribe buttons and Calendar and Upcoming Events tabs */
+  iv: Maybe<Scalars['Boolean']>;
+};
+
+/** The structure of the This group is active field of the Groups content input type. */
+export type GroupsDataActiveInputDto = {
+  /** Active groups have Subscribe buttons and Calendar and Upcoming Events tabs */
+  iv: Maybe<Scalars['Boolean']>;
+};
+
 /** The structure of the Calendars field of the Groups content type. */
 export type GroupsDataCalendarsDto = {
   iv: Maybe<Array<Calendars>>;
@@ -2383,6 +2395,7 @@ export type GroupsDataDescriptionInputDto = {
 
 /** The structure of the Groups data type. */
 export type GroupsDataDto = {
+  active: Maybe<GroupsDataActiveDto>;
   calendars: Maybe<GroupsDataCalendarsDto>;
   description: Maybe<GroupsDataDescriptionDto>;
   leaders: Maybe<GroupsDataLeadersDto>;
@@ -2395,6 +2408,7 @@ export type GroupsDataDto = {
 
 /** The structure of the Groups data input type. */
 export type GroupsDataInputDto = {
+  active: Maybe<GroupsDataActiveInputDto>;
   calendars: Maybe<GroupsDataCalendarsInputDto>;
   description: Maybe<GroupsDataDescriptionInputDto>;
   leaders: Maybe<GroupsDataLeadersInputDto>;
@@ -2491,6 +2505,8 @@ export type GroupsDataToolsInputDto = {
 
 /** The structure of the flat Groups data type. */
 export type GroupsFlatDataDto = {
+  /** Active groups have Subscribe buttons and Calendar and Upcoming Events tabs */
+  active: Maybe<Scalars['Boolean']>;
   calendars: Maybe<Array<Calendars>>;
   description: Maybe<Scalars['String']>;
   leaders: Maybe<Array<GroupsDataLeadersChildDto>>;

--- a/apps/asap-server/src/schema/schema.graphql
+++ b/apps/asap-server/src/schema/schema.graphql
@@ -2395,6 +2395,18 @@ type Groups implements Content {
   version: Int!
 }
 
+"""The structure of the This group is active field of the Groups content type."""
+type GroupsDataActiveDto {
+  """Active groups have Subscribe buttons and Calendar and Upcoming Events tabs"""
+  iv: Boolean
+}
+
+"""The structure of the This group is active field of the Groups content input type."""
+input GroupsDataActiveInputDto {
+  """Active groups have Subscribe buttons and Calendar and Upcoming Events tabs"""
+  iv: Boolean
+}
+
 """The structure of the Calendars field of the Groups content type."""
 type GroupsDataCalendarsDto {
   iv: [Calendars!]
@@ -2417,6 +2429,7 @@ input GroupsDataDescriptionInputDto {
 
 """The structure of the Groups data type."""
 type GroupsDataDto {
+  active: GroupsDataActiveDto
   calendars: GroupsDataCalendarsDto
   description: GroupsDataDescriptionDto
   leaders: GroupsDataLeadersDto
@@ -2429,6 +2442,7 @@ type GroupsDataDto {
 
 """The structure of the Groups data input type."""
 input GroupsDataInputDto {
+  active: GroupsDataActiveInputDto
   calendars: GroupsDataCalendarsInputDto
   description: GroupsDataDescriptionInputDto
   leaders: GroupsDataLeadersInputDto
@@ -2525,6 +2539,8 @@ input GroupsDataToolsInputDto {
 
 """The structure of the flat Groups data type."""
 type GroupsFlatDataDto {
+  """Active groups have Subscribe buttons and Calendar and Upcoming Events tabs"""
+  active: Boolean
   calendars: [Calendars!]
   description: String
   leaders: [GroupsDataLeadersChildDto!]

--- a/packages/squidex/schema/schemas/groups.json
+++ b/packages/squidex/schema/schemas/groups.json
@@ -64,6 +64,24 @@
         }
       },
       {
+        "name": "active",
+        "isHidden": false,
+        "isLocked": false,
+        "isDisabled": false,
+        "partitioning": "invariant",
+        "properties": {
+          "fieldType": "Boolean",
+          "defaultValue": true,
+          "inlineEditable": true,
+          "editor": "Toggle",
+          "label": "This group is active",
+          "hints": "Active groups have Subscribe buttons and Calendar and Upcoming Events tabs",
+          "isRequired": true,
+          "isRequiredOnPublish": true,
+          "isHalfWidth": true
+        }
+      },
+      {
         "name": "tags",
         "isHidden": false,
         "isLocked": false,


### PR DESCRIPTION
https://trello.com/c/HhKZss3v/1781-admins-can-mark-groups-as-inactive-and-omit-them-from-calendars-page

Once its merged all groups should be marked as active or inactive as a way to migrate the missing data which is now going to be required.