### PR TITLE
Feat/1822 Create Squidex availability metric

### DIFF
--- a/apps/asap-server/src/app.ts
+++ b/apps/asap-server/src/app.ts
@@ -4,6 +4,7 @@ import express, { Express, RequestHandler } from 'express';
 import { Tracer } from 'opentracing';
 import { Logger } from 'pino';
 import pinoHttp from 'pino-http';
+import AWS from 'aws-sdk';
 import AWSXray from 'aws-xray-sdk';
 import * as Sentry from '@sentry/serverless';
 import { SquidexGraphql } from '@asap-hub/squidex';
@@ -105,9 +106,9 @@ export const appFactory = (libs: Libs = {}): Express => {
    */
 
   /* istanbul ignore next */
-  if (libs.xRay) {
-    app.use(libs.xRay.express.openSegment('default'));
-    libs.xRay.middleware.enableDynamicNaming('*.hub.asap.science');
+  if (libs.awsXRay) {
+    app.use(libs.awsXRay.express.openSegment('default'));
+    libs.awsXRay.middleware.enableDynamicNaming('*.hub.asap.science');
   }
 
   /* istanbul ignore next */
@@ -167,8 +168,8 @@ export const appFactory = (libs: Libs = {}): Express => {
   });
 
   /* istanbul ignore next */
-  if (libs.xRay) {
-    app.use(libs.xRay.express.closeSegment());
+  if (libs.awsXRay) {
+    app.use(libs.awsXRay.express.closeSegment());
   }
 
   /* istanbul ignore next */
@@ -198,7 +199,8 @@ export type Libs = {
   logger?: Logger;
   // extra handlers only for tests and local development
   mockRequestHandlers?: RequestHandler[];
-  xRay?: typeof AWSXray;
+  awsXRay?: typeof AWSXray;
+  awsSdk?: typeof AWS;
   sentryErrorHandler?: typeof Sentry.Handlers.errorHandler;
   sentryRequestHandler?: typeof Sentry.Handlers.requestHandler;
   sentryTransactionIdHandler?: RequestHandler;

--- a/apps/asap-server/src/server.ts
+++ b/apps/asap-server/src/server.ts
@@ -1,9 +1,18 @@
 /* istanbul ignore file */
-
+import AWSXRay from 'aws-xray-sdk';
+import AWS from 'aws-sdk';
+import http from 'http';
 import { appFactory } from './app';
 
+const awsXRay = AWSXRay;
+awsXRay.captureHTTPsGlobal(http);
+const awsSdk = awsXRay.captureAWS(AWS);
+
 const port = 3333;
-const app = appFactory();
+const app = appFactory({
+  awsXRay,
+  awsSdk,
+});
 
 app.listen(port, () => {
   // eslint-disable-next-line no-console


### PR DESCRIPTION
We want to create metric for when squidex responds with: 

- 5XX 
- 4XX
- GraphQL errors

## Requirements

- have a visual representation of squidex downtime (see list above) along with duration and frequency

## Note
Look into XRay to see if it can do this