### PR TITLE
Feat/1824 always show calendars which have no group

### DIFF
--- a/apps/asap-server/src/controllers/calendars.ts
+++ b/apps/asap-server/src/controllers/calendars.ts
@@ -65,17 +65,17 @@ export default class Calendars implements CalendarController {
       };
     }
 
-    const activeCalendars = calendars.filter(
-      (calendar) => {
-        if (!calendar?.referencingGroupsContents) {
-          return true;
-        }
-
-        return calendar.referencingGroupsContents.findIndex(
-          (group) => group.flatData.active === true,
-        ) !== -1;
+    const activeCalendars = calendars.filter((calendar) => {
+      if (!calendar?.referencingGroupsContents || calendar.referencingGroupsContents.length === 0) {
+        return true;
       }
-    );
+
+      return (
+        calendar.referencingGroupsContents.findIndex(
+          (group) => group.flatData.active === true,
+        ) !== -1
+      );
+    });
 
     return {
       total: activeCalendars.length,

--- a/apps/asap-server/src/controllers/calendars.ts
+++ b/apps/asap-server/src/controllers/calendars.ts
@@ -66,11 +66,15 @@ export default class Calendars implements CalendarController {
     }
 
     const activeCalendars = calendars.filter(
-      (calendar) =>
-        calendar.referencingGroupsContents &&
-        calendar.referencingGroupsContents.findIndex(
+      (calendar) => {
+        if (!calendar?.referencingGroupsContents) {
+          return true;
+        }
+
+        return calendar.referencingGroupsContents.findIndex(
           (group) => group.flatData.active === true,
-        ) !== -1,
+        ) !== -1;
+      }
     );
 
     return {

--- a/apps/asap-server/src/controllers/calendars.ts
+++ b/apps/asap-server/src/controllers/calendars.ts
@@ -66,7 +66,10 @@ export default class Calendars implements CalendarController {
     }
 
     const activeCalendars = calendars.filter((calendar) => {
-      if (!calendar?.referencingGroupsContents || calendar.referencingGroupsContents.length === 0) {
+      if (
+        !calendar?.referencingGroupsContents ||
+        calendar.referencingGroupsContents.length === 0
+      ) {
         return true;
       }
 

--- a/apps/asap-server/test/controllers/calendars.test.ts
+++ b/apps/asap-server/test/controllers/calendars.test.ts
@@ -153,13 +153,21 @@ describe('Calendars controller', () => {
         });
       });
 
-      test('Should skip the calendars which do not belong to any group', async () => {
+      test('Should show the calendars which do not belong to any group', async () => {
         const squidexGraphqlResponse = getSquidexCalendarsGraphqlResponse();
 
         const calendar1 = getSquidexGraphqlCalendar();
+        calendar1.flatData.googleCalendarId = 'calendar1@google.com';
         calendar1.referencingGroupsContents = null;
         const calendar2 = getSquidexGraphqlCalendar();
+        calendar2.flatData.googleCalendarId = 'calendar1@google.com';
         calendar2.referencingGroupsContents = [];
+
+        const expectedCalendar1 = getCalendarResponse();
+        expectedCalendar1.id = calendar1.flatData.googleCalendarId;
+
+        const expectedCalendar2 = getCalendarResponse();
+        expectedCalendar2.id = calendar2.flatData.googleCalendarId;
 
         squidexGraphqlResponse.queryCalendarsContentsWithTotal!.items = [
           calendar1,
@@ -174,8 +182,8 @@ describe('Calendars controller', () => {
         const result = await calendarsMockGraphlClient.fetch();
 
         expect(result).toEqual({
-          total: 0,
-          items: [],
+          total: 2,
+          items: [expectedCalendar1, expectedCalendar2],
         });
       });
 


### PR DESCRIPTION
missed requirement from this ticket: https://trello.com/c/HhKZss3v/1781-admins-can-mark-groups-as-inactive-and-omit-them-from-calendars-page .

## requirement

- when a calendar is NOT associated to any group, then default to the behaviour of a calendar associated to an active group (therefore always show the calendar).

## Expected behaviour:
Calendars without a group are treated as a calendar with group=active (therefore are shown in Calendar Page)

## Current behaviour
Calendars without a group are treated as a calendar with group=inactive (therefore are hidden in Calendar Page)