### PR TITLE
When searches are equal relevance show newer outputs first

### DIFF
--- a/ci/algolia-schema.json
+++ b/ci/algolia-schema.json
@@ -39,7 +39,7 @@
     "exact",
     "custom"
   ],
-  "customRanking": null,
+  "customRanking": ["desc(addedDate)"],
   "separatorsToIndex": "",
   "removeWordsIfNoResults": "none",
   "queryType": "prefixLast",


### PR DESCRIPTION
https://trello.com/c/kALPxvWV/1850-sort-algolia-listings-when-no-search-has-been-performed