### PR TITLE
Feat/1821 Add new options for Subtype (on Research Output Schema)

### DIFF
--- a/apps/asap-server/src/entities/research-output.ts
+++ b/apps/asap-server/src/entities/research-output.ts
@@ -1,10 +1,8 @@
 import {
+  isResearchOutputType,
   ResearchOutputResponse,
   ResearchOutputSharingStatus,
-  ResearchOutputSubtype,
-  researchOutputSubtypes,
-  ResearchOutputType,
-  researchOutputTypes,
+  researchOutputMapSubtype,
   sharingStatuses,
   TeamResponse,
 } from '@asap-hub/model';
@@ -78,6 +76,8 @@ export const parseGraphQLResearchOutput = (
   const uniqueContactEmails = [...new Set(filteredContactEmails)];
 
   const data = output.flatData;
+  const subType = researchOutputMapSubtype(data.subtype);
+  const subTypes = subType ? [subType] : [];
 
   return {
     id: output.id,
@@ -87,10 +87,7 @@ export const parseGraphQLResearchOutput = (
       data.type && isResearchOutputType(data.type)
         ? data.type
         : 'Grant Document',
-    subTypes:
-      data.subtype && isResearchOutputSubtype(data.subtype)
-        ? [data.subtype]
-        : [],
+    subTypes,
     title: data.title || '',
     description: data.description || '',
     tags: data.tags || [],
@@ -138,14 +135,6 @@ const isSharingStatus = (
   status: string,
 ): status is ResearchOutputSharingStatus =>
   (sharingStatuses as ReadonlyArray<string>).includes(status);
-
-const isResearchOutputType = (type: string): type is ResearchOutputType =>
-  (researchOutputTypes as ReadonlyArray<string>).includes(type);
-
-const isResearchOutputSubtype = (
-  subtype: string,
-): subtype is ResearchOutputSubtype =>
-  (researchOutputSubtypes as ReadonlyArray<string>).includes(subtype);
 
 type FetchResearchOutputTeamContents = NonNullable<
   NonNullable<

--- a/apps/asap-server/src/migrations/16425956711335-add-new-options-for-subtype-on-research-output-schema.ts
+++ b/apps/asap-server/src/migrations/16425956711335-add-new-options-for-subtype-on-research-output-schema.ts
@@ -1,0 +1,27 @@
+/* istanbul ignore file */
+import { researchOutputMapSubtype } from '@asap-hub/model';
+import { RestResearchOutput } from '@asap-hub/squidex';
+import { Migration } from '../handlers/webhooks/webhook-run-migrations';
+import { applyToAllItemsInCollection } from '../utils/migrations';
+
+export default class SetResearchOutputAddedDateDefault extends Migration {
+  up = async (): Promise<void> => {
+    await applyToAllItemsInCollection<RestResearchOutput>(
+      'research-outputs',
+      async (researchOutput, squidexClient) => {
+        const mappedSubtype = researchOutputMapSubtype(
+          researchOutput.data?.subtype?.iv,
+        );
+
+        if (mappedSubtype) {
+          await squidexClient.patch(researchOutput.id, {
+            subtype: { iv: mappedSubtype },
+          });
+        }
+      },
+    );
+  };
+
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  down = async (): Promise<void> => {};
+}

--- a/packages/model/src/research-output.ts
+++ b/packages/model/src/research-output.ts
@@ -16,43 +16,108 @@ export const researchOutputTypes = [
 export type ResearchOutputType = typeof researchOutputTypes[number];
 
 export const researchOutputSubtypes = [
+  '3D Printing',
   'ASAP annual meeting',
   'ASAP subgroup meeting',
+  'Analysis',
+  'Animal Model',
+  'Antibody',
+  'Assay',
+  'Behavioral',
+  'Biosample',
+  'Cell Culture & Differentiation',
+  'Cell line',
+  'Cloning',
+  'Code',
+  'Compound',
+  'Data portal',
+  'Electrophysiology',
   'External meeting',
-  'Preprint',
-  'Published',
   'Genetic Data - DNA',
   'Genetic Data - RNA',
-  'Protein Data',
+  'Genotyping',
   'Microscopy',
-  'Electrophysiology',
-  'Mass Spectrometry',
-  'Code',
-  'Data portal',
-  'Web Portal',
-  'Analysis',
-  'Assays',
-  'Cell Culture & Differentiation',
-  'Cloning',
-  'Imaging',
+  'Microscopy & Imaging',
   'Model System',
+  'Plasmid',
+  'Preprint',
+  'Proposal',
+  'Protein Data',
   'Protein expression',
-  'Sample Collection',
-  'Shipment Procedures',
-  '3D Printing',
+  'Published',
+  'Report',
+  'Sample Prep',
+  'Shipment Procedure',
+  'Software',
+  'Spectroscopy',
+  'Teem meeting',
+  'Viral Vector',
+] as const;
+
+export const researchOutputDeprecatedSubtypes = [
   'Animal Models',
   'Antibodies',
-  'Biosample',
-  'Cell line',
+  'Assays',
   'Compounds',
-  'Plasmid',
-  'Protein',
-  'Viral Vector',
-  'Proposal',
-  'Report',
+  'Imaging',
+  'Sample Collection',
+  'Web Portal',
+  'Mass Spectrometry',
 ] as const;
 
 export type ResearchOutputSubtype = typeof researchOutputSubtypes[number];
+export type ResearchOutputDeprecatedSubtype =
+  typeof researchOutputDeprecatedSubtypes[number];
+
+export const researchOutputDeprecatedSubtypeToResearchOutputSubtypeMap: Record<
+  ResearchOutputDeprecatedSubtype,
+  ResearchOutputSubtype
+> = {
+  'Animal Models': 'Animal Model',
+  Antibodies: 'Antibody',
+  Assays: 'Assay',
+  Compounds: 'Compound',
+  Imaging: 'Microscopy & Imaging',
+  'Sample Collection': 'Sample Prep',
+  'Web Portal': 'Software',
+  'Mass Spectrometry': 'Spectroscopy',
+};
+
+export const isResearchOutputType = (
+  type: string,
+): type is ResearchOutputType =>
+  (researchOutputTypes as ReadonlyArray<string>).includes(type);
+
+export const isResearchOutputSubtype = (
+  subtype: string,
+): subtype is ResearchOutputSubtype =>
+  (researchOutputSubtypes as ReadonlyArray<string>).includes(subtype);
+
+export const researchOutputMapSubtype = (
+  subtype?: string,
+): ResearchOutputSubtype | null => {
+  if (subtype) {
+    if (
+      Object.prototype.hasOwnProperty.call(
+        researchOutputDeprecatedSubtypeToResearchOutputSubtypeMap,
+        subtype,
+      )
+    ) {
+      const mappedSubtype: ResearchOutputSubtype =
+        researchOutputDeprecatedSubtypeToResearchOutputSubtypeMap[
+          subtype as ResearchOutputDeprecatedSubtype
+        ];
+
+      return isResearchOutputSubtype(mappedSubtype) ? mappedSubtype : null;
+    }
+
+    if (isResearchOutputSubtype(subtype)) {
+      return subtype;
+    }
+  }
+
+  return null;
+};
 
 export const sharingStatuses = ['Public', 'Network Only'] as const;
 


### PR DESCRIPTION
##Requirements:

- **create** the following subtypes
 - Animal Model
 - Antibody
 - Assay
 - Behavioral 
 - Compound
 - Genotyping 
 - Microscopy & Imaging
 - Sample Prep
 - Shipment Procedure
 - Software 
 - Spectroscopy
 - Team meeting 
- **migrate** the following **old subtypes** into the **new subtypes**
 - Animal Models -> Animal Model
 - Antibodies -> Antibody
 - Assays -> Assay 
 - Compounds -> Compound 
 - Imaging -> Microscopy & Imaging
 - Sample Collection -> Sample Prep
 - Web Portal -> Software 
 - Mass Spectroscopy -> Spectroscopy
- deprecate the following **subtypes**:
 - Animal Models 
 - Antibodies 
 - Assays 
 - Compounds 
 - Imaging 
 - Sample Collection 
 - Web Portal 
 - Mass Spectroscopy 
 - Protein
 - Shipment Procedures

- nice to have: on the CMS, the subtype list should be shown alphabetically