### PR TITLE
CRN-648 Feature flags not working as expected in production

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -53,6 +53,8 @@ stages:
     paths:
       - 'packages/*/build*'
       - 'apps/*/build*'
+  variables:
+    NODE_ENV: 'production'
   before_script:
     - source ci/env-setup.sh
     - export REACT_APP_ALGOLIA_APP_ID=$(aws ssm get-parameter --name "algolia-app-id-dev" --query Parameter.Value --output text)

--- a/packages/flags/src/__tests__/index.test.ts
+++ b/packages/flags/src/__tests__/index.test.ts
@@ -7,30 +7,30 @@ import {
   enable,
 } from '..';
 
-const originalNodeEnv = process.env.NODE_ENV;
+const originalNodeEnv = process.env.REACT_APP_ENVIRONMENT;
 beforeEach(() => {
-  process.env.NODE_ENV = 'unknown';
+  process.env.REACT_APP_ENVIRONMENT = 'unknown';
 });
 afterEach(() => {
-  process.env.NODE_ENV = originalNodeEnv;
+  process.env.REACT_APP_ENVIRONMENT = originalNodeEnv;
 });
 
 it('disables flags in unknown environments', () => {
-  process.env.NODE_ENV = 'unknown';
+  process.env.REACT_APP_ENVIRONMENT = 'unknown';
   expect(isEnabled('PERSISTENT_EXAMPLE')).toBe(false);
 });
 it.each(['test', 'development'])('enables flags in %s', (nodeEnv) => {
-  process.env.NODE_ENV = nodeEnv;
+  process.env.REACT_APP_ENVIRONMENT = nodeEnv;
   expect(isEnabled('PERSISTENT_EXAMPLE')).toBe(true);
 });
 it.each(['production'])('disables flags in %s', (nodeEnv) => {
-  process.env.NODE_ENV = nodeEnv;
+  process.env.REACT_APP_ENVIRONMENT = nodeEnv;
   expect(isEnabled('PERSISTENT_EXAMPLE')).toBe(false);
 });
 
 describe('in test', () => {
   beforeEach(() => {
-    process.env.NODE_ENV = 'test';
+    process.env.REACT_APP_ENVIRONMENT = 'test';
   });
 
   describe('setCurrentOverrides,', () => {

--- a/packages/flags/src/index.ts
+++ b/packages/flags/src/index.ts
@@ -2,7 +2,6 @@ export type Flag = 'PERSISTENT_EXAMPLE' | 'ROMS_FORM';
 
 export type Flags = Partial<Record<Flag, boolean>>;
 let overrides: Flags = {
-  ROMS_FORM: false,
   // flags already live in prod:
   // can also be used to manually disable a flag in development:
 };

--- a/packages/flags/src/index.ts
+++ b/packages/flags/src/index.ts
@@ -14,7 +14,7 @@ const envDefaults: Record<string, boolean> = {
 
 export const isEnabled = (flag: Flag): boolean =>
   overrides[flag] ??
-  envDefaults[process.env.NODE_ENV ?? 'development'] ??
+  envDefaults[process.env.REACT_APP_ENVIRONMENT ?? 'development'] ??
   false;
 
 export const getOverrides = (): Flags => overrides;


### PR DESCRIPTION
In 87312e7eeb54abe64e8c36d82fbdfc85c47d033a `yarn run build` was removed from the `deploy:sls:production` job. Running `yarn run build` would override the build artifact created in the `build:ts:prod` step.

This change adds NODE_ENV production to the `build:ts` step.

Note that the frontend would build in production by default because of react-scripts. It is important to run `yarn run build:babel` using `NODE_ENV=production`