### PR TITLE
Feat/CRN-635 cleanup alerts and notifications

### DIFF
--- a/.github/actions/slack/action.yml
+++ b/.github/actions/slack/action.yml
@@ -10,11 +10,31 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: Slack Notification
+    - name: Slack Notification on Success
+      if: success()
       uses: rtCamp/action-slack-notify@v2
       env:
-        SLACK_WEBHOOK: ${{ inputs.webhook }} - with status ${{ job.status }}
+        SLACK_WEBHOOK: ${{ inputs.webhook }}
         SLACK_MESSAGE: ${{ inputs.message }}
         SLACK_ICON: https://asap-misc.s3.eu-west-1.amazonaws.com/robot.png
         SLACK_USERNAME: ASAP robot
-        SLACK_COLOR: ${{ (success() && '#00FF00') || (failure() && '#FF0000') || '#E3256B' }}
+        SLACK_COLOR: '#00FF00'
+
+    - name: Slack Notification on Failure
+      if: failure()
+      uses: rtCamp/action-slack-notify@v2
+      env:
+        SLACK_WEBHOOK: ${{ inputs.webhook }}
+        SLACK_MESSAGE: ${{ inputs.message }}
+        SLACK_ICON: https://asap-misc.s3.eu-west-1.amazonaws.com/robot.png
+        SLACK_USERNAME: ASAP robot
+        SLACK_COLOR: '#FF0000'
+    - name: Slack Notification on Cancelation
+      if: cancelled()
+      uses: rtCamp/action-slack-notify@v2
+      env:
+        SLACK_WEBHOOK: ${{ inputs.webhook }}
+        SLACK_MESSAGE: ${{ inputs.message }}
+        SLACK_ICON: https://asap-misc.s3.eu-west-1.amazonaws.com/robot.png
+        SLACK_USERNAME: ASAP robot
+        SLACK_COLOR: '#E3256B'

--- a/.github/actions/slack/action.yml
+++ b/.github/actions/slack/action.yml
@@ -17,4 +17,4 @@ runs:
         SLACK_MESSAGE: ${{ inputs.message }}
         SLACK_ICON: https://asap-misc.s3.eu-west-1.amazonaws.com/robot.png
         SLACK_USERNAME: ASAP robot
-        SLACK_COLOR: ${{ (job.status == 'success' && '#00FF00') || '#FF0000' }}
+        SLACK_COLOR: ${{ (success() && '#00FF00') || (failure() && '#FF0000') || '#E3256B' }}

--- a/.github/actions/slack/action.yml
+++ b/.github/actions/slack/action.yml
@@ -7,6 +7,9 @@ inputs:
   webhook:
     description: 'Slack webhook'
     required: true
+  status:
+    description: 'Status'
+    required: true
 runs:
   using: 'composite'
   steps:

--- a/.github/actions/slack/action.yml
+++ b/.github/actions/slack/action.yml
@@ -10,31 +10,11 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: Slack Notification on Success
-      if: success()
+    - name: Slack Notification
       uses: rtCamp/action-slack-notify@v2
       env:
-        SLACK_WEBHOOK: ${{ inputs.webhook }}
+        SLACK_WEBHOOK: ${{ inputs.webhook }} - with status ${{ inputs.status }}
         SLACK_MESSAGE: ${{ inputs.message }}
         SLACK_ICON: https://asap-misc.s3.eu-west-1.amazonaws.com/robot.png
         SLACK_USERNAME: ASAP robot
-        SLACK_COLOR: '#00FF00'
-
-    - name: Slack Notification on Failure
-      if: failure()
-      uses: rtCamp/action-slack-notify@v2
-      env:
-        SLACK_WEBHOOK: ${{ inputs.webhook }}
-        SLACK_MESSAGE: ${{ inputs.message }}
-        SLACK_ICON: https://asap-misc.s3.eu-west-1.amazonaws.com/robot.png
-        SLACK_USERNAME: ASAP robot
-        SLACK_COLOR: '#FF0000'
-    - name: Slack Notification on Cancelation
-      if: cancelled()
-      uses: rtCamp/action-slack-notify@v2
-      env:
-        SLACK_WEBHOOK: ${{ inputs.webhook }}
-        SLACK_MESSAGE: ${{ inputs.message }}
-        SLACK_ICON: https://asap-misc.s3.eu-west-1.amazonaws.com/robot.png
-        SLACK_USERNAME: ASAP robot
-        SLACK_COLOR: '#E3256B'
+        SLACK_COLOR: ${{ (inputs.status == 'success' && '#35a64f') || (inputs.status == 'failure' && '#FF0000') || '#E3256B' }}

--- a/.github/actions/slack/action.yml
+++ b/.github/actions/slack/action.yml
@@ -13,8 +13,8 @@ runs:
     - name: Slack Notification
       uses: rtCamp/action-slack-notify@v2
       env:
-        SLACK_WEBHOOK: ${{ inputs.webhook }}
+        SLACK_WEBHOOK: ${{ inputs.webhook }} - with status ${{ job.status }}
         SLACK_MESSAGE: ${{ inputs.message }}
         SLACK_ICON: https://asap-misc.s3.eu-west-1.amazonaws.com/robot.png
         SLACK_USERNAME: ASAP robot
-        SLACK_COLOR: ${{ inputs.color || job.status }}
+        SLACK_COLOR: ${{ (job.status == 'success' && '#00FF00') || '#FF0000' }}

--- a/.github/actions/slack/action.yml
+++ b/.github/actions/slack/action.yml
@@ -16,7 +16,7 @@ runs:
     - name: Slack Notification
       uses: rtCamp/action-slack-notify@v2
       env:
-        SLACK_WEBHOOK: ${{ inputs.webhook }} - with status ${{ inputs.status }}
+        SLACK_WEBHOOK: ${{ inputs.webhook }}
         SLACK_MESSAGE: ${{ inputs.message }}
         SLACK_ICON: https://asap-misc.s3.eu-west-1.amazonaws.com/robot.png
         SLACK_USERNAME: ASAP robot

--- a/.github/actions/slack/action.yml
+++ b/.github/actions/slack/action.yml
@@ -17,4 +17,4 @@ runs:
         SLACK_MESSAGE: ${{ inputs.message }}
         SLACK_ICON: https://asap-misc.s3.eu-west-1.amazonaws.com/robot.png
         SLACK_USERNAME: ASAP robot
-        SLACK_COLOR: ${{ job.status }}
+        SLACK_COLOR: ${{ inputs.color || job.status }}

--- a/.github/workflows/env-teardown.yml
+++ b/.github/workflows/env-teardown.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Rebuild dependencies
-        run: exit 1 && yarn rebuild
+        run: yarn rebuild
       - name: Remove CF Stack
         if: ${{ env.SLS_STAGE != 'production' && env.SLS_STAGE != 'dev' }}
         run: yarn sls remove --verbose
@@ -73,7 +73,6 @@ jobs:
         uses: actions/checkout@v2
       - name: Fetch the Algolia keys
         run: |
-          exit 1
           echo "ALGOLIA_APP_ID=$(aws ssm get-parameter --name 'algolia-app-id-dev' --query Parameter.Value --output text)" >> $GITHUB_ENV
           echo "ALGOLIA_API_KEY=$(aws ssm get-parameter --name 'algolia-api-key-ci-dev' --query Parameter.Value --output text)" >> $GITHUB_ENV
       - name: Delete the index

--- a/.github/workflows/env-teardown.yml
+++ b/.github/workflows/env-teardown.yml
@@ -77,7 +77,6 @@ jobs:
           echo "ALGOLIA_API_KEY=$(aws ssm get-parameter --name 'algolia-api-key-ci-dev' --query Parameter.Value --output text)" >> $GITHUB_ENV
       - name: Delete the index
         run: |
-          exit 1
           cd apps/asap-server
           export ALGOLIA_INDEX=asap-hub_research_outputs_CI-${{ needs.setup.outputs.pr-number }}
           yarn workspace @asap-hub/asap-server run algolia deleteindicespattern -a $ALGOLIA_APP_ID -k $ALGOLIA_API_KEY -r "^$ALGOLIA_INDEX$" -x false

--- a/.github/workflows/env-teardown.yml
+++ b/.github/workflows/env-teardown.yml
@@ -91,4 +91,3 @@ jobs:
         with:
           message: Environment teardown has failed
           webhook: ${{ secrets.SLACK_WEBHOOK }}
-          color: '#ff0000'

--- a/.github/workflows/env-teardown.yml
+++ b/.github/workflows/env-teardown.yml
@@ -73,10 +73,12 @@ jobs:
         uses: actions/checkout@v2
       - name: Fetch the Algolia keys
         run: |
+          exit 1
           echo "ALGOLIA_APP_ID=$(aws ssm get-parameter --name 'algolia-app-id-dev' --query Parameter.Value --output text)" >> $GITHUB_ENV
           echo "ALGOLIA_API_KEY=$(aws ssm get-parameter --name 'algolia-api-key-ci-dev' --query Parameter.Value --output text)" >> $GITHUB_ENV
       - name: Delete the index
         run: |
+          exit 1
           cd apps/asap-server
           export ALGOLIA_INDEX=asap-hub_CI-${{ needs.setup.outputs.pr-number }}
           yarn workspace @asap-hub/asap-server run algolia deleteindicespattern -a $ALGOLIA_APP_ID -k $ALGOLIA_API_KEY -r "^$ALGOLIA_INDEX$" -x false

--- a/.github/workflows/env-teardown.yml
+++ b/.github/workflows/env-teardown.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Delete the index
         run: |
           cd apps/asap-server
-          export ALGOLIA_INDEX=asap-hub_research_outputs_CI-${{ needs.setup.outputs.pr-number }}
+          export ALGOLIA_INDEX=asap-hub_CI-${{ needs.setup.outputs.pr-number }}
           yarn workspace @asap-hub/asap-server run algolia deleteindicespattern -a $ALGOLIA_APP_ID -k $ALGOLIA_API_KEY -r "^$ALGOLIA_INDEX$" -x false
   notify_failure:
     runs-on: ubuntu-18.04

--- a/.github/workflows/env-teardown.yml
+++ b/.github/workflows/env-teardown.yml
@@ -73,7 +73,6 @@ jobs:
         uses: actions/checkout@v2
       - name: Fetch the Algolia keys
         run: |
-          exit 1
           echo "ALGOLIA_APP_ID=$(aws ssm get-parameter --name 'algolia-app-id-dev' --query Parameter.Value --output text)" >> $GITHUB_ENV
           echo "ALGOLIA_API_KEY=$(aws ssm get-parameter --name 'algolia-api-key-ci-dev' --query Parameter.Value --output text)" >> $GITHUB_ENV
       - name: Delete the index

--- a/.github/workflows/env-teardown.yml
+++ b/.github/workflows/env-teardown.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Rebuild dependencies
-        run: yarn rebuild
+        run: exit 1 && yarn rebuild
       - name: Remove CF Stack
         if: ${{ env.SLS_STAGE != 'production' && env.SLS_STAGE != 'dev' }}
         run: yarn sls remove --verbose
@@ -78,7 +78,6 @@ jobs:
           echo "ALGOLIA_API_KEY=$(aws ssm get-parameter --name 'algolia-api-key-ci-dev' --query Parameter.Value --output text)" >> $GITHUB_ENV
       - name: Delete the index
         run: |
-          exit 1
           cd apps/asap-server
           export ALGOLIA_INDEX=asap-hub_CI-${{ needs.setup.outputs.pr-number }}
           yarn workspace @asap-hub/asap-server run algolia deleteindicespattern -a $ALGOLIA_APP_ID -k $ALGOLIA_API_KEY -r "^$ALGOLIA_INDEX$" -x false
@@ -91,5 +90,5 @@ jobs:
         uses: actions/checkout@v2
       - uses: ./.github/actions/slack/
         with:
-          message: Environment teardown has failed
+          message: Environment teardown
           webhook: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/env-teardown.yml
+++ b/.github/workflows/env-teardown.yml
@@ -73,6 +73,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Fetch the Algolia keys
         run: |
+          exit 1
           echo "ALGOLIA_APP_ID=$(aws ssm get-parameter --name 'algolia-app-id-dev' --query Parameter.Value --output text)" >> $GITHUB_ENV
           echo "ALGOLIA_API_KEY=$(aws ssm get-parameter --name 'algolia-api-key-ci-dev' --query Parameter.Value --output text)" >> $GITHUB_ENV
       - name: Delete the index

--- a/.github/workflows/env-teardown.yml
+++ b/.github/workflows/env-teardown.yml
@@ -60,8 +60,6 @@ jobs:
         continue-on-error: true
       - name: Delete PR Squidex App
         run: python ci/integration/scripts/delete-app.py
-      - name: Fail
-        run: exit 1
 
   delete_algolia_indice:
     needs: setup
@@ -79,8 +77,9 @@ jobs:
           echo "ALGOLIA_API_KEY=$(aws ssm get-parameter --name 'algolia-api-key-ci-dev' --query Parameter.Value --output text)" >> $GITHUB_ENV
       - name: Delete the index
         run: |
+          exit 1
           cd apps/asap-server
-          export ALGOLIA_INDEX=asap-hub_CI-${{ needs.setup.outputs.pr-number }}
+          export ALGOLIA_INDEX=asap-hub_research_outputs_CI-${{ needs.setup.outputs.pr-number }}
           yarn workspace @asap-hub/asap-server run algolia deleteindicespattern -a $ALGOLIA_APP_ID -k $ALGOLIA_API_KEY -r "^$ALGOLIA_INDEX$" -x false
   notify_failure:
     runs-on: ubuntu-18.04
@@ -91,5 +90,6 @@ jobs:
         uses: actions/checkout@v2
       - uses: ./.github/actions/slack/
         with:
-          message: Environment teardown
+          message: Environment teardown has failed
           webhook: ${{ secrets.SLACK_WEBHOOK }}
+          color: '#ff0000'

--- a/.github/workflows/env-teardown.yml
+++ b/.github/workflows/env-teardown.yml
@@ -92,3 +92,4 @@ jobs:
         with:
           message: Environment teardown
           webhook: ${{ secrets.SLACK_WEBHOOK }}
+          status: failure

--- a/.github/workflows/env-teardown.yml
+++ b/.github/workflows/env-teardown.yml
@@ -60,6 +60,8 @@ jobs:
         continue-on-error: true
       - name: Delete PR Squidex App
         run: python ci/integration/scripts/delete-app.py
+      - name: Fail
+        run: exit 1
 
   delete_algolia_indice:
     needs: setup

--- a/.github/workflows/master-sync.yml
+++ b/.github/workflows/master-sync.yml
@@ -34,4 +34,3 @@ jobs:
         with:
           message: Algolia Development & Production Sync
           webhook: ${{ secrets.SLACK_WEBHOOK }}
-          color: '#ff0000'

--- a/.github/workflows/master-sync.yml
+++ b/.github/workflows/master-sync.yml
@@ -34,3 +34,4 @@ jobs:
         with:
           message: Algolia Development & Production Sync
           webhook: ${{ secrets.SLACK_WEBHOOK }}
+          status: failure

--- a/.github/workflows/master-sync.yml
+++ b/.github/workflows/master-sync.yml
@@ -34,3 +34,4 @@ jobs:
         with:
           message: Algolia Development & Production Sync
           webhook: ${{ secrets.SLACK_WEBHOOK }}
+          color: '#ff0000'

--- a/.github/workflows/prod-algolia-sync-v2.yml
+++ b/.github/workflows/prod-algolia-sync-v2.yml
@@ -78,3 +78,4 @@ jobs:
         with:
           message: Algolia Prod Sync
           webhook: ${{ secrets.SLACK_WEBHOOK }}
+          status: failure

--- a/.github/workflows/prod-algolia-sync-v2.yml
+++ b/.github/workflows/prod-algolia-sync-v2.yml
@@ -78,4 +78,3 @@ jobs:
         with:
           message: Algolia Prod Sync
           webhook: ${{ secrets.SLACK_WEBHOOK }}
-          color: '#ff0000'

--- a/.github/workflows/prod-algolia-sync-v2.yml
+++ b/.github/workflows/prod-algolia-sync-v2.yml
@@ -78,3 +78,4 @@ jobs:
         with:
           message: Algolia Prod Sync
           webhook: ${{ secrets.SLACK_WEBHOOK }}
+          color: '#ff0000'

--- a/.github/workflows/prod-backup.yml
+++ b/.github/workflows/prod-backup.yml
@@ -48,3 +48,4 @@ jobs:
         with:
           message: Squidex Prod Backup
           webhook: ${{ secrets.SLACK_WEBHOOK }}
+          color: '#ff0000'

--- a/.github/workflows/prod-backup.yml
+++ b/.github/workflows/prod-backup.yml
@@ -48,3 +48,4 @@ jobs:
         with:
           message: Squidex Prod Backup
           webhook: ${{ secrets.SLACK_WEBHOOK }}
+          status: failure

--- a/.github/workflows/prod-backup.yml
+++ b/.github/workflows/prod-backup.yml
@@ -48,4 +48,3 @@ jobs:
         with:
           message: Squidex Prod Backup
           webhook: ${{ secrets.SLACK_WEBHOOK }}
-          color: '#ff0000'


### PR DESCRIPTION
# Requirements
- Create a new channel client-asap-notifications (done)
- Move all the notifications from client-asap-engineers to the above channel.  (done)
- Move successful master build notifications from client-asap-alerts to client-asap-notifications (from Gitlab)
- Fix Github actions failure alerts