### PR TITLE
fix overriding of feature flags

### DIFF
--- a/packages/flags/src/index.ts
+++ b/packages/flags/src/index.ts
@@ -1,7 +1,8 @@
 export type Flag = 'PERSISTENT_EXAMPLE' | 'ROMS_FORM';
 
-export type Flags = Partial<Record<Flag, boolean>>;
+export type Flags = Partial<Record<Flag, boolean | undefined>>;
 let overrides: Flags = {
+  ROMS_FORM: undefined,
   // flags already live in prod:
   // can also be used to manually disable a flag in development:
 };
@@ -20,11 +21,9 @@ export const isEnabled = (flag: Flag): boolean =>
 export const getOverrides = (): Flags => overrides;
 
 export const setCurrentOverrides = (flags?: Record<string, boolean>): void => {
-  overrides = Object.entries(overrides).reduce<Record<string, boolean>>(
+  overrides = Object.entries(overrides).reduce<Record<string, boolean | undefined>>(
     (acc, [name, val]) => {
-      if (typeof val === 'boolean') {
-        acc[name] = flags && flags[name] !== undefined ? flags[name] : val;
-      }
+      acc[name] = flags && flags[name] !== undefined ? flags[name] : val;
       return acc;
     },
     {},

--- a/packages/flags/src/index.ts
+++ b/packages/flags/src/index.ts
@@ -21,13 +21,12 @@ export const isEnabled = (flag: Flag): boolean =>
 export const getOverrides = (): Flags => overrides;
 
 export const setCurrentOverrides = (flags?: Record<string, boolean>): void => {
-  overrides = Object.entries(overrides).reduce<Record<string, boolean | undefined>>(
-    (acc, [name, val]) => {
-      acc[name] = flags && flags[name] !== undefined ? flags[name] : val;
-      return acc;
-    },
-    {},
-  );
+  overrides = Object.entries(overrides).reduce<
+    Record<string, boolean | undefined>
+  >((acc, [name, val]) => {
+    acc[name] = flags && flags[name] !== undefined ? flags[name] : val;
+    return acc;
+  }, {});
 };
 const setOverride = (flag: Flag, value: boolean): void => {
   overrides = { ...overrides, [flag]: value };


### PR DESCRIPTION
Before this PR, flags needed overrides to be specified in order for us to change them using cookies (see changes in setCurrentOverrides).

This changes it so that overrides are initialized with 'undefined' if there are no overrides yet