### PR TITLE
CRN-682 search across users and external authors

### DIFF
--- a/apps/asap-server/test/mocks/algolia-client.mock.ts
+++ b/apps/asap-server/test/mocks/algolia-client.mock.ts
@@ -4,5 +4,5 @@ export const algoliaSearchClientMock = {
   save: jest.fn(),
   saveMany: jest.fn(),
   remove: jest.fn(),
-  searchEntity: jest.fn(),
+  search: jest.fn(),
 } as unknown as jest.Mocked<AlgoliaSearchClient>;

--- a/apps/frontend/src/__fixtures__/algolia.ts
+++ b/apps/frontend/src/__fixtures__/algolia.ts
@@ -1,16 +1,17 @@
 import { createResearchOutputResponse } from '@asap-hub/fixtures';
 import {
   EntityRecord,
-  RESEARCH_OUTPUT_ENTITY_TYPE,
+  EntityHit,
   EntityResponses,
-  SearchEntityResponse,
+  RESEARCH_OUTPUT_ENTITY_TYPE,
+  SearchByEntityResponse,
 } from '@asap-hub/algolia';
 
 export const createAlgoliaResponse = <EntityType extends keyof EntityResponses>(
   type: EntityType,
   data: EntityResponses[EntityType][],
-  overrides: Partial<SearchEntityResponse<EntityType>> = {},
-): SearchEntityResponse<EntityType> => ({
+  overrides: Partial<SearchByEntityResponse<EntityType>> = {},
+): SearchByEntityResponse<EntityType> => ({
   nbHits: data.length,
   page: 0,
   nbPages: 1,
@@ -21,11 +22,14 @@ export const createAlgoliaResponse = <EntityType extends keyof EntityResponses>(
   renderingContent: {},
   processingTimeMS: 1,
   ...overrides,
-  hits: data.map((item, i) => ({
-    ...item,
-    objectID: `${i}`,
-    __meta: { type },
-  })),
+  hits: data.map(
+    (item, i) =>
+      ({
+        ...item,
+        objectID: `${i}`,
+        __meta: { type },
+      } as EntityHit<EntityType>),
+  ),
 });
 
 export const createResearchOutputAlgoliaRecord = (
@@ -43,9 +47,9 @@ export const createResearchOutputAlgoliaRecord = (
 export const createResearchOutputListAlgoliaResponse = (
   items: number,
   responseOverride?: Partial<
-    SearchEntityResponse<typeof RESEARCH_OUTPUT_ENTITY_TYPE>
+    SearchByEntityResponse<typeof RESEARCH_OUTPUT_ENTITY_TYPE>
   >,
-): SearchEntityResponse<typeof RESEARCH_OUTPUT_ENTITY_TYPE> =>
+): SearchByEntityResponse<typeof RESEARCH_OUTPUT_ENTITY_TYPE> =>
   createAlgoliaResponse<typeof RESEARCH_OUTPUT_ENTITY_TYPE>(
     RESEARCH_OUTPUT_ENTITY_TYPE,
     Array.from({ length: items }, (_, itemIndex) =>

--- a/apps/frontend/src/network/teams/__tests__/TeamOutput.test.tsx
+++ b/apps/frontend/src/network/teams/__tests__/TeamOutput.test.tsx
@@ -14,7 +14,7 @@ import { fireEvent } from '@testing-library/dom';
 import userEvent from '@testing-library/user-event';
 
 import { createTeamResearchOutput } from '../api';
-import { refreshTeamState } from '../state';
+import { refreshTeamState, getAuthorLabel } from '../state';
 import TeamOutput, { paramOutputTypeToResearchOutputType } from '../TeamOutput';
 
 jest.mock('../api');
@@ -187,3 +187,20 @@ const renderPage = async ({
   );
   return result;
 };
+
+describe('getAuthorLabel', () => {
+  it('should display (Non CRN) for external-author', () => {
+    expect(
+      getAuthorLabel({ id: '1234', displayName: 'external author' }),
+    ).toEqual('external author (Non CRN)');
+  });
+  it('should not add suffix for internal user', () => {
+    expect(
+      getAuthorLabel({
+        id: '1234',
+        displayName: 'internal user',
+        email: 'example@domain.com',
+      }),
+    ).toEqual('internal user');
+  });
+});

--- a/apps/frontend/src/network/users/__mocks__/api.ts
+++ b/apps/frontend/src/network/users/__mocks__/api.ts
@@ -42,6 +42,9 @@ export const getUsersLegacy = jest.fn(
 export const getUsers = jest.fn(
   async (): Promise<ListUserResponse> => createListUserResponse(10),
 );
+export const getUsersOrExternalAuthors = jest.fn(
+  async (): Promise<ListUserResponse> => createListUserResponse(10),
+);
 
 export const getInstitutions = jest.fn(
   async (): Promise<InstitutionsResponse> => ({

--- a/apps/frontend/src/network/users/__tests__/api.test.ts
+++ b/apps/frontend/src/network/users/__tests__/api.test.ts
@@ -69,11 +69,10 @@ describe('getUsersLegacy', () => {
 });
 
 describe('getUsers', () => {
-  const searchEntity: jest.MockedFunction<AlgoliaSearchClient['searchEntity']> =
-    jest.fn();
+  const search: jest.MockedFunction<AlgoliaSearchClient['search']> = jest.fn();
 
   const algoliaSearchClient = {
-    searchEntity,
+    search,
   } as unknown as AlgoliaSearchClient;
 
   const defaultOptions: GetListOptions = {
@@ -84,15 +83,15 @@ describe('getUsers', () => {
   };
 
   beforeEach(() => {
-    searchEntity.mockReset();
-    searchEntity.mockResolvedValue(createAlgoliaResponse('user', []));
+    search.mockReset();
+    search.mockResolvedValue(createAlgoliaResponse('user', []));
   });
 
   it('will not filter users by default', async () => {
     await getUsers(algoliaSearchClient, {
       ...defaultOptions,
     });
-    expect(searchEntity).toHaveBeenCalledWith(
+    expect(search).toHaveBeenCalledWith(
       ['user'],
       '',
       expect.objectContaining({
@@ -105,7 +104,7 @@ describe('getUsers', () => {
     await getUsers(algoliaSearchClient, {
       ...defaultOptions,
     });
-    expect(searchEntity).toHaveBeenCalledWith(
+    expect(search).toHaveBeenCalledWith(
       ['user'],
       '',
       expect.objectContaining({
@@ -120,7 +119,7 @@ describe('getUsers', () => {
       ...defaultOptions,
       searchQuery: 'Hello World!',
     });
-    expect(searchEntity).toHaveBeenCalledWith(
+    expect(search).toHaveBeenCalledWith(
       ['user'],
       'Hello World!',
       expect.objectContaining({}),
@@ -132,7 +131,7 @@ describe('getUsers', () => {
       ...defaultOptions,
       filters: new Set(['Collaborating PI']),
     });
-    expect(searchEntity).toHaveBeenCalledWith(['user'], '', {
+    expect(search).toHaveBeenCalledWith(['user'], '', {
       filters: 'teams.role:"Collaborating PI"',
     });
   });
@@ -142,7 +141,7 @@ describe('getUsers', () => {
       ...defaultOptions,
       filters: new Set(['Collaborating PI', 'Project Manager']),
     });
-    expect(searchEntity).toHaveBeenCalledWith(['user'], '', {
+    expect(search).toHaveBeenCalledWith(['user'], '', {
       filters: 'teams.role:"Collaborating PI" OR teams.role:"Project Manager"',
     });
   });
@@ -159,7 +158,7 @@ describe('getUsers', () => {
         },
       })),
     };
-    searchEntity.mockResolvedValueOnce({
+    search.mockResolvedValueOnce({
       hits: transformedUsers.items,
       nbHits: transformedUsers.total,
       page: 0,
@@ -177,11 +176,10 @@ describe('getUsers', () => {
 });
 
 describe('getUsersOrExternalAuthors', () => {
-  const searchEntity: jest.MockedFunction<AlgoliaSearchClient['searchEntity']> =
-    jest.fn();
+  const search: jest.MockedFunction<AlgoliaSearchClient['search']> = jest.fn();
 
   const algoliaSearchClient = {
-    searchEntity,
+    search,
   } as unknown as AlgoliaSearchClient;
 
   const defaultOptions: GetListOptions = {
@@ -198,8 +196,8 @@ describe('getUsersOrExternalAuthors', () => {
       [],
     );
 
-    searchEntity.mockReset();
-    searchEntity.mockResolvedValue({
+    search.mockReset();
+    search.mockResolvedValue({
       ...algoliaUsersResponse,
       hits: [
         ...algoliaUsersResponse.hits,
@@ -212,7 +210,7 @@ describe('getUsersOrExternalAuthors', () => {
     await getUsersOrExternalAuthors(algoliaSearchClient, {
       ...defaultOptions,
     });
-    expect(searchEntity).toHaveBeenCalledWith(
+    expect(search).toHaveBeenCalledWith(
       ['user', 'external-author'],
       '',
       expect.objectContaining({
@@ -225,7 +223,7 @@ describe('getUsersOrExternalAuthors', () => {
     await getUsersOrExternalAuthors(algoliaSearchClient, {
       ...defaultOptions,
     });
-    expect(searchEntity).toHaveBeenCalledWith(
+    expect(search).toHaveBeenCalledWith(
       ['user', 'external-author'],
       '',
       expect.objectContaining({
@@ -240,7 +238,7 @@ describe('getUsersOrExternalAuthors', () => {
       ...defaultOptions,
       searchQuery: 'Hello World!',
     });
-    expect(searchEntity).toHaveBeenCalledWith(
+    expect(search).toHaveBeenCalledWith(
       ['user', 'external-author'],
       'Hello World!',
       expect.objectContaining({}),

--- a/apps/frontend/src/network/users/api.ts
+++ b/apps/frontend/src/network/users/api.ts
@@ -41,7 +41,7 @@ export const getUsers = async (
     .map((filter) => `teams.role:"${filter}"`)
     .join(' OR ');
 
-  const result = await algoliaClient.searchEntity(['user'], searchQuery, {
+  const result = await algoliaClient.search(['user'], searchQuery, {
     filters: algoliaFilters.length > 0 ? algoliaFilters : undefined,
     page: currentPage ?? undefined,
     hitsPerPage: pageSize ?? undefined,
@@ -54,13 +54,14 @@ export const getUsersOrExternalAuthors = async (
   algoliaClient: AlgoliaSearchClient,
   { searchQuery, currentPage, pageSize }: GetListOptions,
 ): Promise<ListResponse<UserResponse | ExternalAuthorResponse>> => {
-  const result = await algoliaClient.searchEntity(
+  const result = await algoliaClient.search(
     ['user', 'external-author'],
     searchQuery,
     {
       filters: undefined,
       page: currentPage ?? undefined,
       hitsPerPage: pageSize ?? undefined,
+      restrictSearchableAttributes: ['displayName'],
     },
   );
 

--- a/apps/frontend/src/network/users/api.ts
+++ b/apps/frontend/src/network/users/api.ts
@@ -1,8 +1,10 @@
 import {
+  ExternalAuthorResponse,
+  ListResponse,
+  ListUserResponse,
   UserResponse,
   UserPatchRequest,
   UserAvatarPostRequest,
-  ListUserResponse,
 } from '@asap-hub/model';
 
 import type { AlgoliaSearchClient } from '@asap-hub/algolia';
@@ -39,11 +41,28 @@ export const getUsers = async (
     .map((filter) => `teams.role:"${filter}"`)
     .join(' OR ');
 
-  const result = await algoliaClient.searchEntity('user', searchQuery, {
+  const result = await algoliaClient.searchEntity(['user'], searchQuery, {
     filters: algoliaFilters.length > 0 ? algoliaFilters : undefined,
     page: currentPage ?? undefined,
     hitsPerPage: pageSize ?? undefined,
   });
+
+  return { items: result.hits, total: result.nbHits };
+};
+
+export const getUsersOrExternalAuthors = async (
+  algoliaClient: AlgoliaSearchClient,
+  { searchQuery, currentPage, pageSize }: GetListOptions,
+): Promise<ListResponse<UserResponse | ExternalAuthorResponse>> => {
+  const result = await algoliaClient.searchEntity(
+    ['user', 'external-author'],
+    searchQuery,
+    {
+      filters: undefined,
+      page: currentPage ?? undefined,
+      hitsPerPage: pageSize ?? undefined,
+    },
+  );
 
   return { items: result.hits, total: result.nbHits };
 };

--- a/apps/frontend/src/shared-research/__mocks__/api.ts
+++ b/apps/frontend/src/shared-research/__mocks__/api.ts
@@ -1,6 +1,6 @@
 import {
   RESEARCH_OUTPUT_ENTITY_TYPE,
-  SearchEntityResponse,
+  SearchByEntityResponse,
 } from '@asap-hub/algolia';
 import { ResearchOutputResponse } from '@asap-hub/model';
 import { createResearchOutputResponse } from '@asap-hub/fixtures';
@@ -16,6 +16,6 @@ export const getResearchOutput = jest.fn(
 
 export const getResearchOutputs = jest.fn(
   async (): Promise<
-    Partial<SearchEntityResponse<typeof RESEARCH_OUTPUT_ENTITY_TYPE>>
+    Partial<SearchByEntityResponse<typeof RESEARCH_OUTPUT_ENTITY_TYPE>>
   > => createResearchOutputListAlgoliaResponse(2),
 );

--- a/apps/frontend/src/shared-research/__tests__/api.test.ts
+++ b/apps/frontend/src/shared-research/__tests__/api.test.ts
@@ -25,7 +25,7 @@ const options: GetListOptions = {
 
 describe('getResearchOutputs', () => {
   const mockAlgoliaSearchClient = {
-    searchEntity: jest
+    search: jest
       .fn()
       .mockResolvedValue(createResearchOutputListAlgoliaResponse(10)),
   } as unknown as jest.Mocked<AlgoliaSearchClient>;
@@ -41,7 +41,7 @@ describe('getResearchOutputs', () => {
       pageSize: null,
     });
 
-    expect(mockAlgoliaSearchClient.searchEntity).toHaveBeenLastCalledWith(
+    expect(mockAlgoliaSearchClient.search).toHaveBeenLastCalledWith(
       ['research-output'],
       'test',
       expect.objectContaining({ hitsPerPage: 10, page: 0 }),
@@ -54,7 +54,7 @@ describe('getResearchOutputs', () => {
       pageSize: 20,
     });
 
-    expect(mockAlgoliaSearchClient.searchEntity).toHaveBeenLastCalledWith(
+    expect(mockAlgoliaSearchClient.search).toHaveBeenLastCalledWith(
       ['research-output'],
       '',
       expect.objectContaining({ hitsPerPage: 20, page: 1 }),
@@ -66,7 +66,7 @@ describe('getResearchOutputs', () => {
       filters: new Set<ResearchOutputType>(['Article']),
     });
 
-    expect(mockAlgoliaSearchClient.searchEntity).toHaveBeenLastCalledWith(
+    expect(mockAlgoliaSearchClient.search).toHaveBeenLastCalledWith(
       ['research-output'],
       '',
       expect.objectContaining({
@@ -81,7 +81,7 @@ describe('getResearchOutputs', () => {
       filters: new Set<ResearchOutputType>(['Article', 'Grant Document']),
     });
 
-    expect(mockAlgoliaSearchClient.searchEntity).toHaveBeenLastCalledWith(
+    expect(mockAlgoliaSearchClient.search).toHaveBeenLastCalledWith(
       ['research-output'],
       '',
       expect.objectContaining({
@@ -96,7 +96,7 @@ describe('getResearchOutputs', () => {
       filters: new Set<ResearchOutputType | 'invalid'>(['Article', 'invalid']),
     });
 
-    expect(mockAlgoliaSearchClient.searchEntity).toHaveBeenLastCalledWith(
+    expect(mockAlgoliaSearchClient.search).toHaveBeenLastCalledWith(
       ['research-output'],
       '',
       expect.objectContaining({
@@ -111,7 +111,7 @@ describe('getResearchOutputs', () => {
       teamId: '12345',
     });
 
-    expect(mockAlgoliaSearchClient.searchEntity).toHaveBeenLastCalledWith(
+    expect(mockAlgoliaSearchClient.search).toHaveBeenLastCalledWith(
       ['research-output'],
       '',
       expect.objectContaining({
@@ -127,7 +127,7 @@ describe('getResearchOutputs', () => {
       teamId: '12345',
     });
 
-    expect(mockAlgoliaSearchClient.searchEntity).toHaveBeenLastCalledWith(
+    expect(mockAlgoliaSearchClient.search).toHaveBeenLastCalledWith(
       ['research-output'],
       '',
       expect.objectContaining({
@@ -143,7 +143,7 @@ describe('getResearchOutputs', () => {
       teamId: '12345',
     });
 
-    expect(mockAlgoliaSearchClient.searchEntity).toHaveBeenLastCalledWith(
+    expect(mockAlgoliaSearchClient.search).toHaveBeenLastCalledWith(
       ['research-output'],
       '',
       expect.objectContaining({
@@ -157,7 +157,7 @@ describe('getResearchOutputs', () => {
       userId: '12345',
     });
 
-    expect(mockAlgoliaSearchClient.searchEntity).toHaveBeenLastCalledWith(
+    expect(mockAlgoliaSearchClient.search).toHaveBeenLastCalledWith(
       ['research-output'],
       '',
       expect.objectContaining({
@@ -173,7 +173,7 @@ describe('getResearchOutputs', () => {
       userId: '12345',
     });
 
-    expect(mockAlgoliaSearchClient.searchEntity).toHaveBeenLastCalledWith(
+    expect(mockAlgoliaSearchClient.search).toHaveBeenLastCalledWith(
       ['research-output'],
       '',
       expect.objectContaining({
@@ -189,7 +189,7 @@ describe('getResearchOutputs', () => {
       userId: '12345',
     });
 
-    expect(mockAlgoliaSearchClient.searchEntity).toHaveBeenLastCalledWith(
+    expect(mockAlgoliaSearchClient.search).toHaveBeenLastCalledWith(
       ['research-output'],
       '',
       expect.objectContaining({
@@ -200,7 +200,7 @@ describe('getResearchOutputs', () => {
   });
 
   it('throws an error of type error', async () => {
-    mockAlgoliaSearchClient.searchEntity.mockRejectedValue({
+    mockAlgoliaSearchClient.search.mockRejectedValue({
       message: 'Some Error',
     });
     await expect(

--- a/apps/frontend/src/shared-research/__tests__/api.test.ts
+++ b/apps/frontend/src/shared-research/__tests__/api.test.ts
@@ -42,7 +42,7 @@ describe('getResearchOutputs', () => {
     });
 
     expect(mockAlgoliaSearchClient.searchEntity).toHaveBeenLastCalledWith(
-      'research-output',
+      ['research-output'],
       'test',
       expect.objectContaining({ hitsPerPage: 10, page: 0 }),
     );
@@ -55,7 +55,7 @@ describe('getResearchOutputs', () => {
     });
 
     expect(mockAlgoliaSearchClient.searchEntity).toHaveBeenLastCalledWith(
-      'research-output',
+      ['research-output'],
       '',
       expect.objectContaining({ hitsPerPage: 20, page: 1 }),
     );
@@ -67,7 +67,7 @@ describe('getResearchOutputs', () => {
     });
 
     expect(mockAlgoliaSearchClient.searchEntity).toHaveBeenLastCalledWith(
-      'research-output',
+      ['research-output'],
       '',
       expect.objectContaining({
         filters: '(type:Article)',
@@ -82,7 +82,7 @@ describe('getResearchOutputs', () => {
     });
 
     expect(mockAlgoliaSearchClient.searchEntity).toHaveBeenLastCalledWith(
-      'research-output',
+      ['research-output'],
       '',
       expect.objectContaining({
         filters: '(type:Article OR type:"Grant Document")',
@@ -97,7 +97,7 @@ describe('getResearchOutputs', () => {
     });
 
     expect(mockAlgoliaSearchClient.searchEntity).toHaveBeenLastCalledWith(
-      'research-output',
+      ['research-output'],
       '',
       expect.objectContaining({
         filters: '(type:Article)',
@@ -112,7 +112,7 @@ describe('getResearchOutputs', () => {
     });
 
     expect(mockAlgoliaSearchClient.searchEntity).toHaveBeenLastCalledWith(
-      'research-output',
+      ['research-output'],
       '',
       expect.objectContaining({
         filters: 'teams.id:"12345"',
@@ -128,7 +128,7 @@ describe('getResearchOutputs', () => {
     });
 
     expect(mockAlgoliaSearchClient.searchEntity).toHaveBeenLastCalledWith(
-      'research-output',
+      ['research-output'],
       '',
       expect.objectContaining({
         filters: '(type:Article) AND teams.id:"12345"',
@@ -144,7 +144,7 @@ describe('getResearchOutputs', () => {
     });
 
     expect(mockAlgoliaSearchClient.searchEntity).toHaveBeenLastCalledWith(
-      'research-output',
+      ['research-output'],
       '',
       expect.objectContaining({
         filters: '(type:Article OR type:"Grant Document") AND teams.id:"12345"',
@@ -158,7 +158,7 @@ describe('getResearchOutputs', () => {
     });
 
     expect(mockAlgoliaSearchClient.searchEntity).toHaveBeenLastCalledWith(
-      'research-output',
+      ['research-output'],
       '',
       expect.objectContaining({
         filters: 'authors.id:"12345"',
@@ -174,7 +174,7 @@ describe('getResearchOutputs', () => {
     });
 
     expect(mockAlgoliaSearchClient.searchEntity).toHaveBeenLastCalledWith(
-      'research-output',
+      ['research-output'],
       '',
       expect.objectContaining({
         filters: '(type:Article) AND authors.id:"12345"',
@@ -190,7 +190,7 @@ describe('getResearchOutputs', () => {
     });
 
     expect(mockAlgoliaSearchClient.searchEntity).toHaveBeenLastCalledWith(
-      'research-output',
+      ['research-output'],
       '',
       expect.objectContaining({
         filters:

--- a/apps/frontend/src/shared-research/api.ts
+++ b/apps/frontend/src/shared-research/api.ts
@@ -70,7 +70,7 @@ export const getResearchOutputs = (
   options: ResearchOutputListOptions,
 ) =>
   client
-    .searchEntity('research-output', options.searchQuery, {
+    .searchEntity(['research-output'], options.searchQuery, {
       page: options.currentPage ?? 0,
       hitsPerPage: options.pageSize ?? 10,
       filters: getAllFilters(options.filters, options.teamId, options.userId),

--- a/apps/frontend/src/shared-research/api.ts
+++ b/apps/frontend/src/shared-research/api.ts
@@ -70,7 +70,7 @@ export const getResearchOutputs = (
   options: ResearchOutputListOptions,
 ) =>
   client
-    .searchEntity(['research-output'], options.searchQuery, {
+    .search(['research-output'], options.searchQuery, {
       page: options.currentPage ?? 0,
       hitsPerPage: options.pageSize ?? 10,
       filters: getAllFilters(options.filters, options.teamId, options.userId),

--- a/apps/frontend/src/shared-research/export.ts
+++ b/apps/frontend/src/shared-research/export.ts
@@ -1,4 +1,4 @@
-import { EntityResponses, SearchEntityResponse } from '@asap-hub/algolia';
+import { EntityResponses, SearchByEntityResponse } from '@asap-hub/algolia';
 import { ResearchOutputResponse } from '@asap-hub/model';
 import { isInternalUser } from '@asap-hub/validation';
 import { CsvFormatterStream, Row, format } from '@fast-csv/format';
@@ -100,7 +100,7 @@ export const algoliaResultsToStream = async <T extends keyof EntityResponses>(
     currentPage,
     pageSize,
   }: Pick<GetListOptions, 'currentPage' | 'pageSize'>) => Readonly<
-    Promise<SearchEntityResponse<T>>
+    Promise<SearchByEntityResponse<T>>
   >,
   transform: (result: EntityResponses[T]) => Row,
 ) => {

--- a/packages/algolia/src/client.ts
+++ b/packages/algolia/src/client.ts
@@ -72,15 +72,19 @@ export class AlgoliaSearchClient {
   }
 
   async searchEntity<T extends keyof EntityResponses>(
-    entityType: T,
+    entityTypes: T[],
     query: string,
     requestOptions?: SearchOptions,
   ): Promise<SearchEntityResponse<T>> {
+    const entityTypesFilter = entityTypes
+      .map((entityType) => `__meta.type:"${entityType}"`)
+      .join(' OR ');
+
     const options: SearchOptions = {
       ...requestOptions,
       filters: requestOptions?.filters
-        ? `${requestOptions.filters} AND __meta.type:"${entityType}"`
-        : `__meta.type:"${entityType}"`,
+        ? `${requestOptions.filters} AND (${entityTypesFilter})`
+        : entityTypesFilter,
     };
 
     return this.index.search<EntityRecord<T>>(query, options);

--- a/packages/algolia/test/client.test.ts
+++ b/packages/algolia/test/client.test.ts
@@ -125,7 +125,7 @@ describe('Algolia Search Client', () => {
     );
 
     const response = await algoliaSearchClient.searchEntity(
-      'research-output',
+      ['research-output'],
       'query',
       {
         hitsPerPage: 10,
@@ -138,18 +138,36 @@ describe('Algolia Search Client', () => {
     expect(algoliaSearchIndex.search).toBeCalledWith('query', {
       hitsPerPage: 10,
       page: 0,
-      filters: 'some-filters AND __meta.type:"research-output"',
+      filters: 'some-filters AND (__meta.type:"research-output")',
     });
   });
 
   test('Should search user entity', async () => {
     algoliaSearchIndex.search.mockResolvedValueOnce(searchUserResponse);
 
-    const response = await algoliaSearchClient.searchEntity('user', 'query');
+    const response = await algoliaSearchClient.searchEntity(['user'], 'query');
 
     expect(response).toEqual(searchUserResponse);
     expect(algoliaSearchIndex.search).toBeCalledWith('query', {
       filters: '__meta.type:"user"',
+    });
+  });
+
+  test('Should search multiple entities', async () => {
+    algoliaSearchIndex.search.mockResolvedValueOnce(searchUserResponse);
+
+    const response = await algoliaSearchClient.searchEntity(
+      ['user', 'external-author', 'lab'],
+      'query',
+      {
+        filters: 'some-filters',
+      },
+    );
+
+    expect(response).toEqual(searchUserResponse);
+    expect(algoliaSearchIndex.search).toBeCalledWith('query', {
+      filters:
+        'some-filters AND (__meta.type:"user" OR __meta.type:"external-author" OR __meta.type:"lab")',
     });
   });
 });

--- a/packages/algolia/test/client.test.ts
+++ b/packages/algolia/test/client.test.ts
@@ -124,7 +124,7 @@ describe('Algolia Search Client', () => {
       searchResearchOutputResponse,
     );
 
-    const response = await algoliaSearchClient.searchEntity(
+    const response = await algoliaSearchClient.search(
       ['research-output'],
       'query',
       {
@@ -138,14 +138,14 @@ describe('Algolia Search Client', () => {
     expect(algoliaSearchIndex.search).toBeCalledWith('query', {
       hitsPerPage: 10,
       page: 0,
-      filters: 'some-filters AND (__meta.type:"research-output")',
+      filters: '(some-filters) AND (__meta.type:"research-output")',
     });
   });
 
   test('Should search user entity', async () => {
     algoliaSearchIndex.search.mockResolvedValueOnce(searchUserResponse);
 
-    const response = await algoliaSearchClient.searchEntity(['user'], 'query');
+    const response = await algoliaSearchClient.search(['user'], 'query');
 
     expect(response).toEqual(searchUserResponse);
     expect(algoliaSearchIndex.search).toBeCalledWith('query', {
@@ -156,7 +156,7 @@ describe('Algolia Search Client', () => {
   test('Should search multiple entities', async () => {
     algoliaSearchIndex.search.mockResolvedValueOnce(searchUserResponse);
 
-    const response = await algoliaSearchClient.searchEntity(
+    const response = await algoliaSearchClient.search(
       ['user', 'external-author', 'lab'],
       'query',
       {
@@ -167,7 +167,7 @@ describe('Algolia Search Client', () => {
     expect(response).toEqual(searchUserResponse);
     expect(algoliaSearchIndex.search).toBeCalledWith('query', {
       filters:
-        'some-filters AND (__meta.type:"user" OR __meta.type:"external-author" OR __meta.type:"lab")',
+        '(some-filters) AND (__meta.type:"user" OR __meta.type:"external-author" OR __meta.type:"lab")',
     });
   });
 });


### PR DESCRIPTION
## Requirements:
- on the Share an Output form, in the author selector, show items which can be either users or external authors 
- display  external authors differently from users:
- external authors 's names should be followed by “(Non CRN)”
- be able to select from at least 3 existing external authors 
- search what is typed on the author selector against these fields only:
  - display name of  external authors 
  - first name of  users 
  - last name of users 
- when user clicks "Share", all users and external authors   selected must be added to the "Authors" field on the CMS
- the order of users and external authors must be remembered
- when user clicks "Share", this field must become disabled (as the page is saving)
- testing strategy: on the FE, it will be possible to find and select those  external authors 

## OOS:
- keep external authors in sync (manually or automatically)

