### PR TITLE
CRN-682 Search across users and external authors

### DIFF
--- a/apps/crn-frontend/src/__fixtures__/algolia.ts
+++ b/apps/crn-frontend/src/__fixtures__/algolia.ts
@@ -8,11 +8,10 @@ import {
 } from '@asap-hub/algolia';
 
 export const createAlgoliaResponse = <EntityType extends keyof EntityResponses>(
-  type: EntityType,
-  data: EntityResponses[EntityType][],
+  hits: EntityHit<EntityType>[],
   overrides: Partial<SearchEntityResponse<EntityType>> = {},
 ): SearchEntityResponse<EntityType> => ({
-  nbHits: data.length,
+  nbHits: hits.length,
   page: 0,
   nbPages: 1,
   hitsPerPage: 10,
@@ -21,15 +20,8 @@ export const createAlgoliaResponse = <EntityType extends keyof EntityResponses>(
   params: 'page=0&hitsPerPage=10&validUntil=1629454922296',
   renderingContent: {},
   processingTimeMS: 1,
+  hits,
   ...overrides,
-  hits: data.map(
-    (item, i) =>
-      ({
-        ...item,
-        objectID: `${i}`,
-        __meta: { type },
-      } as EntityHit<EntityType>),
-  ),
 });
 
 export const createResearchOutputAlgoliaRecord = (
@@ -51,7 +43,6 @@ export const createResearchOutputListAlgoliaResponse = (
   >,
 ): SearchEntityResponse<typeof RESEARCH_OUTPUT_ENTITY_TYPE> =>
   createAlgoliaResponse<typeof RESEARCH_OUTPUT_ENTITY_TYPE>(
-    RESEARCH_OUTPUT_ENTITY_TYPE,
     Array.from({ length: items }, (_, itemIndex) =>
       createResearchOutputAlgoliaRecord(itemIndex),
     ),

--- a/apps/crn-frontend/src/__fixtures__/algolia.ts
+++ b/apps/crn-frontend/src/__fixtures__/algolia.ts
@@ -1,6 +1,7 @@
 import { createResearchOutputResponse } from '@asap-hub/fixtures';
 import {
   EntityRecord,
+  EntityHit,
   RESEARCH_OUTPUT_ENTITY_TYPE,
   EntityResponses,
   SearchEntityResponse,
@@ -21,11 +22,14 @@ export const createAlgoliaResponse = <EntityType extends keyof EntityResponses>(
   renderingContent: {},
   processingTimeMS: 1,
   ...overrides,
-  hits: data.map((item, i) => ({
-    ...item,
-    objectID: `${i}`,
-    __meta: { type },
-  })),
+  hits: data.map(
+    (item, i) =>
+      ({
+        ...item,
+        objectID: `${i}`,
+        __meta: { type },
+      } as EntityHit<EntityType>),
+  ),
 });
 
 export const createResearchOutputAlgoliaRecord = (

--- a/apps/crn-frontend/src/network/teams/__tests__/TeamOutput.test.tsx
+++ b/apps/crn-frontend/src/network/teams/__tests__/TeamOutput.test.tsx
@@ -14,7 +14,7 @@ import { fireEvent } from '@testing-library/dom';
 import userEvent from '@testing-library/user-event';
 
 import { createTeamResearchOutput } from '../api';
-import { refreshTeamState } from '../state';
+import { refreshTeamState, getAuthorLabel } from '../state';
 import TeamOutput, { paramOutputTypeToResearchOutputType } from '../TeamOutput';
 
 jest.mock('../api');
@@ -187,3 +187,20 @@ const renderPage = async ({
   );
   return result;
 };
+
+describe('getAuthorLabel', () => {
+  it('should display (Non CRN) for external-author', () => {
+    expect(
+      getAuthorLabel({ id: '1234', displayName: 'external author' }),
+    ).toEqual('external author (Non CRN)');
+  });
+  it('should not add suffix for internal user', () => {
+    expect(
+      getAuthorLabel({
+        id: '1234',
+        displayName: 'internal user',
+        email: 'example@domain.com',
+      }),
+    ).toEqual('internal user');
+  });
+});

--- a/apps/crn-frontend/src/network/teams/state.ts
+++ b/apps/crn-frontend/src/network/teams/state.ts
@@ -1,9 +1,12 @@
 import {
+  ExternalAuthorResponse,
   ListTeamResponse,
   ResearchOutputPostRequest,
   TeamPatchRequest,
   TeamResponse,
+  UserResponse,
 } from '@asap-hub/model';
+import { isInternalUser } from '@asap-hub/validation';
 import {
   atomFamily,
   DefaultValue,
@@ -23,7 +26,7 @@ import {
   getTeams,
   patchTeam,
 } from './api';
-import { getUsers } from '../users/api';
+import { getUsersAndExternalAuthors } from '../users/api';
 import { useAlgolia } from '../../hooks/algolia';
 
 const teamIndexState = atomFamily<
@@ -174,15 +177,23 @@ export const useAuthorSuggestions = () => {
     const options: GetListOptions = {
       searchQuery,
       currentPage: null,
-      pageSize: null,
+      pageSize: 100,
       filters: new Set(),
     };
 
-    return (await getUsers(algoliaClient.client, options)).items.map(
-      ({ id, displayName }) => ({
-        label: displayName,
-        value: id,
-      }),
+    return getUsersAndExternalAuthors(algoliaClient.client, options).then(
+      ({ items }) =>
+        items.map((author) => ({
+          label: getAuthorLabel(author),
+          value: author.id,
+        })),
     );
   };
 };
+
+export const getAuthorLabel = (
+  author: UserResponse | ExternalAuthorResponse,
+): string =>
+  isInternalUser(author)
+    ? author.displayName
+    : `${author.displayName} (Non CRN)`;

--- a/apps/crn-frontend/src/network/users/__mocks__/api.ts
+++ b/apps/crn-frontend/src/network/users/__mocks__/api.ts
@@ -44,6 +44,10 @@ export const getUsers = jest.fn(
   async (): Promise<ListUserResponse> => createListUserResponse(10),
 );
 
+export const getUsersAndExternalAuthors = jest.fn(
+  async (): Promise<ListUserResponse> => createListUserResponse(10),
+);
+
 export const getInstitutions = jest.fn(
   async (): Promise<InstitutionsResponse> => ({
     number_of_results: 20,

--- a/apps/crn-frontend/src/network/users/__tests__/api.test.ts
+++ b/apps/crn-frontend/src/network/users/__tests__/api.test.ts
@@ -84,7 +84,17 @@ describe('getUsers', () => {
 
   beforeEach(() => {
     search.mockReset();
-    search.mockResolvedValue(createAlgoliaResponse('user', []));
+
+    const userResponse = createUserResponse();
+    search.mockResolvedValue(
+      createAlgoliaResponse([
+        {
+          ...userResponse,
+          objectID: userResponse.id,
+          __meta: { type: 'user' },
+        },
+      ]),
+    );
   });
 
   it('will not filter users by default', async () => {
@@ -190,11 +200,27 @@ describe('getUsersAndExternalAuthors', () => {
   };
 
   beforeEach(() => {
-    const algoliaUsersResponse = createAlgoliaResponse('user', []);
-    const alogliaExternalAuthorsResponse = createAlgoliaResponse(
-      'external-author',
-      [],
-    );
+    const userResponse = createUserResponse();
+    const algoliaUsersResponse = createAlgoliaResponse([
+      {
+        ...userResponse,
+        objectID: userResponse.id,
+        __meta: { type: 'user' },
+      },
+    ]);
+
+    const externalAuthorResponse = {
+      id: '1234-external-author',
+      displayName: '1234 external author',
+    };
+
+    const alogliaExternalAuthorsResponse = createAlgoliaResponse([
+      {
+        ...externalAuthorResponse,
+        objectID: externalAuthorResponse.id,
+        __meta: { type: 'external-author' },
+      },
+    ]);
 
     search.mockReset();
     search.mockResolvedValue({

--- a/apps/crn-frontend/src/network/users/__tests__/api.test.ts
+++ b/apps/crn-frontend/src/network/users/__tests__/api.test.ts
@@ -13,6 +13,7 @@ import {
   getUser,
   getUsersLegacy,
   getUsers,
+  getUsersAndExternalAuthors,
   InstitutionsResponse,
   patchUser,
   postUserAvatar,
@@ -68,11 +69,10 @@ describe('getUsersLegacy', () => {
 });
 
 describe('getUsers', () => {
-  const searchEntity: jest.MockedFunction<AlgoliaSearchClient['searchEntity']> =
-    jest.fn();
+  const search: jest.MockedFunction<AlgoliaSearchClient['search']> = jest.fn();
 
   const algoliaSearchClient = {
-    searchEntity,
+    search,
   } as unknown as AlgoliaSearchClient;
 
   const defaultOptions: GetListOptions = {
@@ -83,16 +83,16 @@ describe('getUsers', () => {
   };
 
   beforeEach(() => {
-    searchEntity.mockReset();
-    searchEntity.mockResolvedValue(createAlgoliaResponse('user', []));
+    search.mockReset();
+    search.mockResolvedValue(createAlgoliaResponse('user', []));
   });
 
   it('will not filter users by default', async () => {
     await getUsers(algoliaSearchClient, {
       ...defaultOptions,
     });
-    expect(searchEntity).toHaveBeenCalledWith(
-      'user',
+    expect(search).toHaveBeenCalledWith(
+      ['user'],
       '',
       expect.objectContaining({
         filters: undefined,
@@ -104,8 +104,8 @@ describe('getUsers', () => {
     await getUsers(algoliaSearchClient, {
       ...defaultOptions,
     });
-    expect(searchEntity).toHaveBeenCalledWith(
-      'user',
+    expect(search).toHaveBeenCalledWith(
+      ['user'],
       '',
       expect.objectContaining({
         hitsPerPage: undefined,
@@ -119,8 +119,8 @@ describe('getUsers', () => {
       ...defaultOptions,
       searchQuery: 'Hello World!',
     });
-    expect(searchEntity).toHaveBeenCalledWith(
-      'user',
+    expect(search).toHaveBeenCalledWith(
+      ['user'],
       'Hello World!',
       expect.objectContaining({}),
     );
@@ -131,7 +131,7 @@ describe('getUsers', () => {
       ...defaultOptions,
       filters: new Set(['Collaborating PI']),
     });
-    expect(searchEntity).toHaveBeenCalledWith('user', '', {
+    expect(search).toHaveBeenCalledWith(['user'], '', {
       filters: 'teams.role:"Collaborating PI"',
     });
   });
@@ -141,7 +141,7 @@ describe('getUsers', () => {
       ...defaultOptions,
       filters: new Set(['Collaborating PI', 'Project Manager']),
     });
-    expect(searchEntity).toHaveBeenCalledWith('user', '', {
+    expect(search).toHaveBeenCalledWith(['user'], '', {
       filters: 'teams.role:"Collaborating PI" OR teams.role:"Project Manager"',
     });
   });
@@ -158,7 +158,7 @@ describe('getUsers', () => {
         },
       })),
     };
-    searchEntity.mockResolvedValueOnce({
+    search.mockResolvedValueOnce({
       hits: transformedUsers.items,
       nbHits: transformedUsers.total,
       page: 0,
@@ -171,6 +171,77 @@ describe('getUsers', () => {
     });
     expect(await getUsers(algoliaSearchClient, defaultOptions)).toEqual(
       transformedUsers,
+    );
+  });
+});
+
+describe('getUsersAndExternalAuthors', () => {
+  const search: jest.MockedFunction<AlgoliaSearchClient['search']> = jest.fn();
+
+  const algoliaSearchClient = {
+    search,
+  } as unknown as AlgoliaSearchClient;
+
+  const defaultOptions: GetListOptions = {
+    searchQuery: '',
+    pageSize: null,
+    currentPage: null,
+    filters: new Set(),
+  };
+
+  beforeEach(() => {
+    const algoliaUsersResponse = createAlgoliaResponse('user', []);
+    const alogliaExternalAuthorsResponse = createAlgoliaResponse(
+      'external-author',
+      [],
+    );
+
+    search.mockReset();
+    search.mockResolvedValue({
+      ...algoliaUsersResponse,
+      hits: [
+        ...algoliaUsersResponse.hits,
+        ...alogliaExternalAuthorsResponse.hits,
+      ],
+    });
+  });
+
+  it('will not filter users nor external-authors by default', async () => {
+    await getUsersAndExternalAuthors(algoliaSearchClient, {
+      ...defaultOptions,
+    });
+    expect(search).toHaveBeenCalledWith(
+      ['user', 'external-author'],
+      '',
+      expect.objectContaining({
+        filters: undefined,
+      }),
+    );
+  });
+
+  it('will not default to not specifying page and limits hits per page by default', async () => {
+    await getUsersAndExternalAuthors(algoliaSearchClient, {
+      ...defaultOptions,
+    });
+    expect(search).toHaveBeenCalledWith(
+      ['user', 'external-author'],
+      '',
+      expect.objectContaining({
+        hitsPerPage: undefined,
+        page: undefined,
+      }),
+    );
+  });
+
+  it('will pass the search query to algolia', async () => {
+    await getUsersAndExternalAuthors(algoliaSearchClient, {
+      ...defaultOptions,
+      searchQuery: 'Hello World!',
+    });
+    expect(search).toHaveBeenCalledWith(
+      ['user', 'external-author'],
+      'Hello World!',
+      expect.objectContaining({}),
     );
   });
 });

--- a/apps/crn-frontend/src/network/users/api.ts
+++ b/apps/crn-frontend/src/network/users/api.ts
@@ -1,8 +1,10 @@
 import {
+  ExternalAuthorResponse,
+  ListResponse,
+  ListUserResponse,
   UserResponse,
   UserPatchRequest,
   UserAvatarPostRequest,
-  ListUserResponse,
 } from '@asap-hub/model';
 
 import type { AlgoliaSearchClient } from '@asap-hub/algolia';
@@ -39,11 +41,29 @@ export const getUsers = async (
     .map((filter) => `teams.role:"${filter}"`)
     .join(' OR ');
 
-  const result = await algoliaClient.searchEntity('user', searchQuery, {
+  const result = await algoliaClient.search(['user'], searchQuery, {
     filters: algoliaFilters.length > 0 ? algoliaFilters : undefined,
     page: currentPage ?? undefined,
     hitsPerPage: pageSize ?? undefined,
   });
+
+  return { items: result.hits, total: result.nbHits };
+};
+
+export const getUsersAndExternalAuthors = async (
+  algoliaClient: AlgoliaSearchClient,
+  { searchQuery, currentPage, pageSize }: GetListOptions,
+): Promise<ListResponse<UserResponse | ExternalAuthorResponse>> => {
+  const result = await algoliaClient.search(
+    ['user', 'external-author'],
+    searchQuery,
+    {
+      filters: undefined,
+      page: currentPage ?? undefined,
+      hitsPerPage: pageSize ?? undefined,
+      restrictSearchableAttributes: ['displayName'],
+    },
+  );
 
   return { items: result.hits, total: result.nbHits };
 };

--- a/apps/crn-frontend/src/shared-research/__tests__/api.test.ts
+++ b/apps/crn-frontend/src/shared-research/__tests__/api.test.ts
@@ -25,7 +25,7 @@ const options: GetListOptions = {
 
 describe('getResearchOutputs', () => {
   const mockAlgoliaSearchClient = {
-    searchEntity: jest
+    search: jest
       .fn()
       .mockResolvedValue(createResearchOutputListAlgoliaResponse(10)),
   } as unknown as jest.Mocked<AlgoliaSearchClient>;
@@ -41,8 +41,8 @@ describe('getResearchOutputs', () => {
       pageSize: null,
     });
 
-    expect(mockAlgoliaSearchClient.searchEntity).toHaveBeenLastCalledWith(
-      'research-output',
+    expect(mockAlgoliaSearchClient.search).toHaveBeenLastCalledWith(
+      ['research-output'],
       'test',
       expect.objectContaining({ hitsPerPage: 10, page: 0 }),
     );
@@ -54,8 +54,8 @@ describe('getResearchOutputs', () => {
       pageSize: 20,
     });
 
-    expect(mockAlgoliaSearchClient.searchEntity).toHaveBeenLastCalledWith(
-      'research-output',
+    expect(mockAlgoliaSearchClient.search).toHaveBeenLastCalledWith(
+      ['research-output'],
       '',
       expect.objectContaining({ hitsPerPage: 20, page: 1 }),
     );
@@ -66,8 +66,8 @@ describe('getResearchOutputs', () => {
       filters: new Set<ResearchOutputType>(['Article']),
     });
 
-    expect(mockAlgoliaSearchClient.searchEntity).toHaveBeenLastCalledWith(
-      'research-output',
+    expect(mockAlgoliaSearchClient.search).toHaveBeenLastCalledWith(
+      ['research-output'],
       '',
       expect.objectContaining({
         filters: '(type:Article)',
@@ -81,8 +81,8 @@ describe('getResearchOutputs', () => {
       filters: new Set<ResearchOutputType>(['Article', 'Grant Document']),
     });
 
-    expect(mockAlgoliaSearchClient.searchEntity).toHaveBeenLastCalledWith(
-      'research-output',
+    expect(mockAlgoliaSearchClient.search).toHaveBeenLastCalledWith(
+      ['research-output'],
       '',
       expect.objectContaining({
         filters: '(type:Article OR type:"Grant Document")',
@@ -96,8 +96,8 @@ describe('getResearchOutputs', () => {
       filters: new Set<ResearchOutputType | 'invalid'>(['Article', 'invalid']),
     });
 
-    expect(mockAlgoliaSearchClient.searchEntity).toHaveBeenLastCalledWith(
-      'research-output',
+    expect(mockAlgoliaSearchClient.search).toHaveBeenLastCalledWith(
+      ['research-output'],
       '',
       expect.objectContaining({
         filters: '(type:Article)',
@@ -111,8 +111,8 @@ describe('getResearchOutputs', () => {
       teamId: '12345',
     });
 
-    expect(mockAlgoliaSearchClient.searchEntity).toHaveBeenLastCalledWith(
-      'research-output',
+    expect(mockAlgoliaSearchClient.search).toHaveBeenLastCalledWith(
+      ['research-output'],
       '',
       expect.objectContaining({
         filters: 'teams.id:"12345"',
@@ -127,8 +127,8 @@ describe('getResearchOutputs', () => {
       teamId: '12345',
     });
 
-    expect(mockAlgoliaSearchClient.searchEntity).toHaveBeenLastCalledWith(
-      'research-output',
+    expect(mockAlgoliaSearchClient.search).toHaveBeenLastCalledWith(
+      ['research-output'],
       '',
       expect.objectContaining({
         filters: '(type:Article) AND teams.id:"12345"',
@@ -143,8 +143,8 @@ describe('getResearchOutputs', () => {
       teamId: '12345',
     });
 
-    expect(mockAlgoliaSearchClient.searchEntity).toHaveBeenLastCalledWith(
-      'research-output',
+    expect(mockAlgoliaSearchClient.search).toHaveBeenLastCalledWith(
+      ['research-output'],
       '',
       expect.objectContaining({
         filters: '(type:Article OR type:"Grant Document") AND teams.id:"12345"',
@@ -157,8 +157,8 @@ describe('getResearchOutputs', () => {
       userId: '12345',
     });
 
-    expect(mockAlgoliaSearchClient.searchEntity).toHaveBeenLastCalledWith(
-      'research-output',
+    expect(mockAlgoliaSearchClient.search).toHaveBeenLastCalledWith(
+      ['research-output'],
       '',
       expect.objectContaining({
         filters: 'authors.id:"12345"',
@@ -173,8 +173,8 @@ describe('getResearchOutputs', () => {
       userId: '12345',
     });
 
-    expect(mockAlgoliaSearchClient.searchEntity).toHaveBeenLastCalledWith(
-      'research-output',
+    expect(mockAlgoliaSearchClient.search).toHaveBeenLastCalledWith(
+      ['research-output'],
       '',
       expect.objectContaining({
         filters: '(type:Article) AND authors.id:"12345"',
@@ -189,8 +189,8 @@ describe('getResearchOutputs', () => {
       userId: '12345',
     });
 
-    expect(mockAlgoliaSearchClient.searchEntity).toHaveBeenLastCalledWith(
-      'research-output',
+    expect(mockAlgoliaSearchClient.search).toHaveBeenLastCalledWith(
+      ['research-output'],
       '',
       expect.objectContaining({
         filters:
@@ -200,7 +200,7 @@ describe('getResearchOutputs', () => {
   });
 
   it('throws an error of type error', async () => {
-    mockAlgoliaSearchClient.searchEntity.mockRejectedValue({
+    mockAlgoliaSearchClient.search.mockRejectedValue({
       message: 'Some Error',
     });
     await expect(

--- a/apps/crn-frontend/src/shared-research/__tests__/export.test.ts
+++ b/apps/crn-frontend/src/shared-research/__tests__/export.test.ts
@@ -222,8 +222,13 @@ describe('algoliaResultsToStream', () => {
       () =>
         Promise.resolve(
           createAlgoliaResponse(
-            'research-output',
-            [createResearchOutputResponse()],
+            [
+              {
+                ...createResearchOutputResponse(),
+                objectID: 'ro-1',
+                __meta: { type: 'research-output' },
+              },
+            ],
             {
               nbPages: 1,
             },
@@ -244,11 +249,12 @@ describe('algoliaResultsToStream', () => {
       (parameters) =>
         Promise.resolve(
           createAlgoliaResponse(
-            'research-output',
             [
               {
                 ...createResearchOutputResponse(),
                 title: `${parameters.currentPage}`,
+                objectID: 'ro-1',
+                __meta: { type: 'research-output' },
               },
             ],
             {
@@ -286,8 +292,14 @@ describe('algoliaResultsToStream', () => {
       () =>
         Promise.resolve(
           createAlgoliaResponse(
-            'research-output',
-            [{ ...createResearchOutputResponse(), title: 'a' }],
+            [
+              {
+                ...createResearchOutputResponse(),
+                title: 'a',
+                objectID: 'ro-1',
+                __meta: { type: 'research-output' },
+              },
+            ],
             {
               nbPages: 2,
             },

--- a/apps/crn-frontend/src/shared-research/api.ts
+++ b/apps/crn-frontend/src/shared-research/api.ts
@@ -70,7 +70,7 @@ export const getResearchOutputs = (
   options: ResearchOutputListOptions,
 ) =>
   client
-    .searchEntity('research-output', options.searchQuery, {
+    .search(['research-output'], options.searchQuery, {
       page: options.currentPage ?? 0,
       hitsPerPage: options.pageSize ?? 10,
       filters: getAllFilters(options.filters, options.teamId, options.userId),

--- a/apps/crn-server/test/mocks/algolia-client.mock.ts
+++ b/apps/crn-server/test/mocks/algolia-client.mock.ts
@@ -4,5 +4,5 @@ export const algoliaSearchClientMock = {
   save: jest.fn(),
   saveMany: jest.fn(),
   remove: jest.fn(),
-  searchEntity: jest.fn(),
+  search: jest.fn(),
 } as unknown as jest.Mocked<AlgoliaSearchClient>;

--- a/packages/algolia/test/client.test.ts
+++ b/packages/algolia/test/client.test.ts
@@ -124,8 +124,8 @@ describe('Algolia Search Client', () => {
       searchResearchOutputResponse,
     );
 
-    const response = await algoliaSearchClient.searchEntity(
-      'research-output',
+    const response = await algoliaSearchClient.search(
+      ['research-output'],
       'query',
       {
         hitsPerPage: 10,
@@ -138,18 +138,36 @@ describe('Algolia Search Client', () => {
     expect(algoliaSearchIndex.search).toBeCalledWith('query', {
       hitsPerPage: 10,
       page: 0,
-      filters: 'some-filters AND __meta.type:"research-output"',
+      filters: '(some-filters) AND (__meta.type:"research-output")',
     });
   });
 
   test('Should search user entity', async () => {
     algoliaSearchIndex.search.mockResolvedValueOnce(searchUserResponse);
 
-    const response = await algoliaSearchClient.searchEntity('user', 'query');
+    const response = await algoliaSearchClient.search(['user'], 'query');
 
     expect(response).toEqual(searchUserResponse);
     expect(algoliaSearchIndex.search).toBeCalledWith('query', {
       filters: '__meta.type:"user"',
+    });
+  });
+
+  test('Should search multiple entities', async () => {
+    algoliaSearchIndex.search.mockResolvedValueOnce(searchUserResponse);
+
+    const response = await algoliaSearchClient.search(
+      ['user', 'external-author', 'lab'],
+      'query',
+      {
+        filters: 'some-filters',
+      },
+    );
+
+    expect(response).toEqual(searchUserResponse);
+    expect(algoliaSearchIndex.search).toBeCalledWith('query', {
+      filters:
+        '(some-filters) AND (__meta.type:"user" OR __meta.type:"external-author" OR __meta.type:"lab")',
     });
   });
 });

--- a/packages/react-components/src/organisms/TeamCreateOutputContributorsCard.tsx
+++ b/packages/react-components/src/organisms/TeamCreateOutputContributorsCard.tsx
@@ -46,19 +46,6 @@ const TeamCreateOutputContributorsCard: React.FC<TeamCreateOutputContributorsPro
   }) => (
     <FormCard title="Who were the contributors?">
       <LabeledMultiSelect
-        title="Authors"
-        description="Add author that contributed to this output. Only authors whose PI is part of the CRN will appear."
-        subtitle="(optional)"
-        enabled={!isSaving}
-        placeholder="Start typing..."
-        loadOptions={getAuthorSuggestions}
-        onChange={onChangeAuthors}
-        values={authors}
-        noOptionsMessage={({ inputValue }) =>
-          `Sorry, no authors match ${inputValue}`
-        }
-      />
-      <LabeledMultiSelect
         title="Teams"
         description="Add other teams that contributed to this output. Those teams will also then be able to edit."
         subtitle="(required)"
@@ -82,6 +69,19 @@ const TeamCreateOutputContributorsCard: React.FC<TeamCreateOutputContributorsPro
         values={labs}
         noOptionsMessage={({ inputValue }) =>
           `Sorry, no labs match ${inputValue}`
+        }
+      />
+      <LabeledMultiSelect
+        title="Authors"
+        description=""
+        subtitle="(optional)"
+        enabled={!isSaving}
+        placeholder="Start typing..."
+        loadOptions={getAuthorSuggestions}
+        onChange={onChangeAuthors}
+        values={authors}
+        noOptionsMessage={({ inputValue }) =>
+          `Sorry, no authors match ${inputValue}`
         }
       />
     </FormCard>


### PR DESCRIPTION
## Requirements:
- on the Share an Output form, in the author selector, show items which can be either users or external authors 
- display  external authors differently from users:
- external authors 's names should be followed by “(Non CRN)”
- be able to select from at least 3 existing external authors 
- search what is typed on the author selector against these fields only:
  - display name of  external authors 
  - first name of  users 
  - last name of users 
- when user clicks "Share", all users and external authors   selected must be added to the "Authors" field on the CMS
- the order of users and external authors must be remembered
- when user clicks "Share", this field must become disabled (as the page is saving)
- testing strategy: on the FE, it will be possible to find and select those  external authors 

## OOS:
- keep external authors in sync (manually or automatically)


Previous PR: https://github.com/yldio/asap-hub/pull/1423