### PR TITLE
CRN-693 Add access instructions

### DIFF
--- a/apps/crn-server/src/validation/research-output.validation.ts
+++ b/apps/crn-server/src/validation/research-output.validation.ts
@@ -63,6 +63,7 @@ const researchOutputPostRequestValidationSchema: JSONSchemaType<ResearchOutputPo
         nullable: true,
       },
       teams: { type: 'array', items: { type: 'string' }, minItems: 1 },
+      accessInstructions: { type: 'string', nullable: true },
     },
     required: [
       'type',

--- a/packages/model/src/research-output.ts
+++ b/packages/model/src/research-output.ts
@@ -177,6 +177,7 @@ export type ResearchOutputPostRequest = {
   asapFunded?: boolean;
   sharingStatus: ResearchOutputSharingStatus;
   usedInPublication?: boolean;
+  accessInstructions?: string;
 };
 
 export const researchOutputLabels: Record<ResearchOutputType, string> = {

--- a/packages/react-components/src/organisms/TeamCreateOutputExtraInformationCard.tsx
+++ b/packages/react-components/src/organisms/TeamCreateOutputExtraInformationCard.tsx
@@ -3,22 +3,30 @@ import { ComponentProps } from 'react';
 import { Link } from '../atoms';
 
 import { mailToSupport } from '../mail';
-import { FormCard, LabeledMultiSelect } from '../molecules';
+import { FormCard, LabeledMultiSelect, LabeledTextArea } from '../molecules';
 import { noop } from '../utils';
 
 type TeamCreateOutputExtraInformationProps = Pick<
   ResearchOutputPostRequest,
-  'tags'
+  'tags' | 'accessInstructions'
 > & {
   tagSuggestions: NonNullable<
     ComponentProps<typeof LabeledMultiSelect>['suggestions']
   >;
-  onChange?: (values: string[]) => void;
+  onChangeTags?: (values: string[]) => void;
+  onChangeAccessInstructions?: (values: string) => void;
   isSaving: boolean;
 };
 
 const TeamCreateOutputExtraInformationCard: React.FC<TeamCreateOutputExtraInformationProps> =
-  ({ onChange = noop, tags, tagSuggestions, isSaving }) => (
+  ({
+    onChangeTags = noop,
+    tags,
+    tagSuggestions,
+    onChangeAccessInstructions = noop,
+    accessInstructions,
+    isSaving,
+  }) => (
     <FormCard title="What extra information can you provide?">
       <LabeledMultiSelect
         title="Additional Keywords"
@@ -28,12 +36,21 @@ const TeamCreateOutputExtraInformationCard: React.FC<TeamCreateOutputExtraInform
         enabled={!isSaving}
         suggestions={tagSuggestions}
         placeholder="Add a keyword (E.g. Cell Biology)"
-        onChange={(options) => onChange(options.map(({ value }) => value))}
+        onChange={(options) => onChangeTags(options.map(({ value }) => value))}
       />
 
       <Link href={mailToSupport({ subject: 'New keyword' }).toString()}>
         Ask ASAP to add a new keyword
       </Link>
+
+      <LabeledTextArea
+        title="Access instructions"
+        subtitle="(optional)"
+        onChange={onChangeAccessInstructions}
+        placeholder="E.g. To access the output, you will first need to create an account on..."
+        enabled={!isSaving}
+        value={accessInstructions || ''}
+      />
     </FormCard>
   );
 

--- a/packages/react-components/src/organisms/TeamCreateOutputForm.tsx
+++ b/packages/react-components/src/organisms/TeamCreateOutputForm.tsx
@@ -84,6 +84,8 @@ const TeamCreateOutputForm: React.FC<TeamCreateOutputFormProps> = ({
   const [description, setDescription] =
     useState<ResearchOutputPostRequest['description']>('');
   const [link, setLink] = useState<ResearchOutputPostRequest['link']>('');
+  const [accessInstructions, setAccessInstructions] =
+    useState<ResearchOutputPostRequest['accessInstructions']>('');
 
   return (
     <Form
@@ -107,6 +109,10 @@ const TeamCreateOutputForm: React.FC<TeamCreateOutputFormProps> = ({
           authors: authors.map(({ value }) => value),
           labs: labs.map(({ value }) => value),
           teams: teams.map(({ value }) => value),
+          accessInstructions:
+            String(accessInstructions).trim() !== ''
+              ? accessInstructions
+              : undefined,
         })
       }
     >
@@ -128,7 +134,9 @@ const TeamCreateOutputForm: React.FC<TeamCreateOutputFormProps> = ({
             isSaving={isSaving}
             tagSuggestions={tagSuggestions}
             tags={tags}
-            onChange={setTags}
+            onChangeTags={setTags}
+            accessInstructions={accessInstructions}
+            onChangeAccessInstructions={setAccessInstructions}
           />
 
           <TeamCreateOutputContributorsCard

--- a/packages/react-components/src/organisms/__tests__/TeamCreateOutputExtraInformationCard.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/TeamCreateOutputExtraInformationCard.test.tsx
@@ -1,5 +1,5 @@
 import { ComponentProps } from 'react';
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import TeamCreateOutputExtraInformationCard from '../TeamCreateOutputExtraInformationCard';
@@ -23,10 +23,27 @@ it('should trigger an onChange event when a tag is selected', () => {
     <TeamCreateOutputExtraInformationCard
       {...props}
       tagSuggestions={['Example']}
-      onChange={mockOnChange}
+      onChangeTags={mockOnChange}
     />,
   );
   userEvent.click(getByLabelText(/keyword/i));
   userEvent.click(getByText('Example'));
   expect(mockOnChange).toHaveBeenCalledWith(['Example']);
+});
+
+it('should trigger an onChange event when a text is being typed into access instructions', () => {
+  const mockOnChange = jest.fn();
+  const { getByText, getByLabelText } = render(
+    <TeamCreateOutputExtraInformationCard
+      {...props}
+      accessInstructions="access-instructions-value"
+      onChangeAccessInstructions={mockOnChange}
+    />,
+  );
+
+  expect(getByText('access-instructions-value')).toBeVisible();
+
+  const input = getByLabelText(/access instructions/i);
+  fireEvent.change(input, { target: { value: 'test' } });
+  expect(mockOnChange).toHaveBeenLastCalledWith('test');
 });


### PR DESCRIPTION
As a user sharing an output that is hard to access
I want to explain to others how to access that output 
so that I comply with ASAP guidelines

## Requirements
- add a new input field on the Share an Output form, on the second section, after additional keywords and after identifiers (if already done)
- Label: Access instructions
- This field is optional
- This is a text input field similar to “Description”
- Save changes to accessInstructions on the CMS
- Please include a place holder as per the designs

## Note:
- this is currently RTF on the CMS
- it would be nice to accept hyperlinks in the future

