### PR TITLE
fix: CRN-768 Single team role filter

### DIFF
--- a/apps/crn-server/src/validation/index.ts
+++ b/apps/crn-server/src/validation/index.ts
@@ -8,7 +8,7 @@ import {
 } from '../utils/types';
 
 const ajv = new Ajv({ useDefaults: true });
-const ajvCoerced = new Ajv({ coerceTypes: true, useDefaults: true });
+const ajvCoerced = new Ajv({ coerceTypes: 'array', useDefaults: true });
 addFormats(ajv, ['date-time']);
 addFormats(ajvCoerced, ['date-time']);
 

--- a/apps/crn-server/test/routes/user.route.test.ts
+++ b/apps/crn-server/test/routes/user.route.test.ts
@@ -114,6 +114,26 @@ describe('/users/ route', () => {
 
         expect(response.status).toBe(400);
       });
+
+      test('Should return the results correctly when a filter is used', async () => {
+        userControllerMock.fetch.mockResolvedValueOnce(fetchExpectation);
+
+        const response = await supertest(appWithMockedAuth).get(
+          '/users?filter=Project+Manager',
+        );
+
+        expect(response.status).toBe(200);
+      });
+
+      test('Should return the results correctly when multiple filters are used', async () => {
+        userControllerMock.fetch.mockResolvedValueOnce(fetchExpectation);
+
+        const response = await supertest(appWithMockedAuth).get(
+          '/users?filter=Project+Manager&filter=Lead+PI',
+        );
+
+        expect(response.status).toBe(200);
+      });
     });
   });
 


### PR DESCRIPTION
Fixes the bug whereby a single query string parameter for the array type filter is rejected by enabling coercion to an array.