### PR TITLE
CRN-767 Show Avatars in the user selector

### DIFF
--- a/apps/crn-frontend/src/network/teams/TeamOutput.tsx
+++ b/apps/crn-frontend/src/network/teams/TeamOutput.tsx
@@ -80,10 +80,21 @@ const TeamOutput: React.FC<TeamOutputProps> = ({ teamId }) => {
       <Frame title="Share Research Output">
         <TeamCreateOutputPage
           team={team}
-          tagSuggestions={researchSuggestions}
+          tagSuggestions={researchSuggestions.map((suggestion) => ({
+            label: suggestion,
+            value: suggestion,
+          }))}
           type={type}
           getLabSuggestions={getLabSuggestions}
-          getAuthorSuggestions={getAuthorSuggestions}
+          getAuthorSuggestions={(input) =>
+            getAuthorSuggestions(input).then((users) =>
+              users.map((user) => ({
+                user,
+                label: user.displayName,
+                value: user.id,
+              })),
+            )
+          }
           getTeamSuggestions={getTeamSuggestions}
           onSave={(output) =>
             createResearchOutput({

--- a/apps/crn-frontend/src/network/teams/__tests__/TeamOutput.test.tsx
+++ b/apps/crn-frontend/src/network/teams/__tests__/TeamOutput.test.tsx
@@ -14,7 +14,7 @@ import { fireEvent } from '@testing-library/dom';
 import userEvent from '@testing-library/user-event';
 
 import { createTeamResearchOutput } from '../api';
-import { refreshTeamState, getAuthorLabel } from '../state';
+import { refreshTeamState } from '../state';
 import TeamOutput, { paramOutputTypeToResearchOutputType } from '../TeamOutput';
 
 jest.mock('../api');
@@ -187,20 +187,3 @@ const renderPage = async ({
   );
   return result;
 };
-
-describe('getAuthorLabel', () => {
-  it('should display (Non CRN) for external-author', () => {
-    expect(
-      getAuthorLabel({ id: '1234', displayName: 'external author' }),
-    ).toEqual('external author (Non CRN)');
-  });
-  it('should not add suffix for internal user', () => {
-    expect(
-      getAuthorLabel({
-        id: '1234',
-        displayName: 'internal user',
-        email: 'example@domain.com',
-      }),
-    ).toEqual('internal user');
-  });
-});

--- a/apps/crn-frontend/src/network/teams/state.ts
+++ b/apps/crn-frontend/src/network/teams/state.ts
@@ -1,12 +1,9 @@
 import {
-  ExternalAuthorResponse,
   ListTeamResponse,
   ResearchOutputPostRequest,
   TeamPatchRequest,
   TeamResponse,
-  UserResponse,
 } from '@asap-hub/model';
-import { isInternalUser } from '@asap-hub/validation';
 import {
   atomFamily,
   DefaultValue,
@@ -173,27 +170,11 @@ export const useTeamSuggestions = () => {
 export const useAuthorSuggestions = () => {
   const algoliaClient = useAlgolia();
 
-  return async (searchQuery: string) => {
-    const options: GetListOptions = {
+  return (searchQuery: string) =>
+    getUsersAndExternalAuthors(algoliaClient.client, {
       searchQuery,
       currentPage: null,
       pageSize: 100,
       filters: new Set(),
-    };
-
-    return getUsersAndExternalAuthors(algoliaClient.client, options).then(
-      ({ items }) =>
-        items.map((author) => ({
-          label: getAuthorLabel(author),
-          value: author.id,
-        })),
-    );
-  };
+    }).then(({ items }) => items);
 };
-
-export const getAuthorLabel = (
-  author: UserResponse | ExternalAuthorResponse,
-): string =>
-  isInternalUser(author)
-    ? author.displayName
-    : `${author.displayName} (Non CRN)`;

--- a/apps/storybook/src/LabeledMultiSelect.stories.tsx
+++ b/apps/storybook/src/LabeledMultiSelect.stories.tsx
@@ -25,7 +25,10 @@ export const Normal = () => (
       'Neuroprotection',
       'Movement Disorders',
       'ARJP (Autosomal recessive juvenile parkinsonism)',
-    ]}
+    ].map((suggestion) => ({
+      label: suggestion,
+      value: suggestion,
+    }))}
     values={['Neurological Diseases', 'Cell Biology', 'Clinical Neurology'].map(
       (value) => ({ label: value, value }),
     )}
@@ -38,7 +41,12 @@ export const Invalid = () => (
     title={text('Title', 'Airport')}
     subtitle={text('Subtitle', '(Required)')}
     description={text('Description', 'Pick some airports')}
-    suggestions={['LHR', 'LGW', 'STN', 'LTN', 'LCY', 'SEN']}
+    suggestions={['LHR', 'LGW', 'STN', 'LTN', 'LCY', 'SEN'].map(
+      (suggestion) => ({
+        label: suggestion,
+        value: suggestion,
+      }),
+    )}
     values={[]}
     placeholder={text('Placeholder', 'Please select some airports')}
     customValidationMessage={text(

--- a/apps/storybook/src/TeamCreateOutputExtraInformationCard.stories.tsx
+++ b/apps/storybook/src/TeamCreateOutputExtraInformationCard.stories.tsx
@@ -11,13 +11,19 @@ export const Normal = () => (
   <TeamCreateOutputExtraInformationCard
     isSaving={false}
     tags={[]}
-    tagSuggestions={tagSuggestions}
+    tagSuggestions={tagSuggestions.map((suggestion) => ({
+      label: suggestion,
+      value: suggestion,
+    }))}
   />
 );
 export const Filled = () => (
   <TeamCreateOutputExtraInformationCard
     isSaving={false}
     tags={tagSuggestions}
-    tagSuggestions={tagSuggestions}
+    tagSuggestions={tagSuggestions.map((suggestion) => ({
+      label: suggestion,
+      value: suggestion,
+    }))}
   />
 );

--- a/apps/storybook/src/TeamCreateOutputForm.stories.tsx
+++ b/apps/storybook/src/TeamCreateOutputForm.stories.tsx
@@ -1,4 +1,4 @@
-import { createTeamResponse } from '@asap-hub/fixtures';
+import { createTeamResponse, createUserResponse } from '@asap-hub/fixtures';
 import { researchOutputTypes } from '@asap-hub/model';
 import { TeamCreateOutputForm } from '@asap-hub/react-components';
 import { select } from '@storybook/addon-knobs';
@@ -12,7 +12,10 @@ export default {
 export const Normal = () => (
   <StaticRouter>
     <TeamCreateOutputForm
-      tagSuggestions={['A53T', 'Activity assay']}
+      tagSuggestions={['A53T', 'Activity assay'].map((suggestion) => ({
+        label: suggestion,
+        value: suggestion,
+      }))}
       type={select('type', researchOutputTypes, 'Article')}
       team={createTeamResponse()}
       getTeamSuggestions={() =>
@@ -32,7 +35,9 @@ export const Normal = () => (
       getAuthorSuggestions={() =>
         new Promise((resolve) => {
           setTimeout(() => {
-            resolve([{ label: 'author name', value: '1' }]);
+            resolve([
+              { label: 'author name', value: '1', user: createUserResponse() },
+            ]);
           }, 1000);
         })
       }

--- a/apps/storybook/src/TeamCreateOutputPage.stories.tsx
+++ b/apps/storybook/src/TeamCreateOutputPage.stories.tsx
@@ -1,4 +1,4 @@
-import { createTeamResponse } from '@asap-hub/fixtures';
+import { createTeamResponse, createUserResponse } from '@asap-hub/fixtures';
 import { TeamCreateOutputPage } from '@asap-hub/react-components';
 import { StaticRouter } from 'react-router-dom';
 
@@ -10,7 +10,10 @@ export default {
 export const Normal = () => (
   <StaticRouter>
     <TeamCreateOutputPage
-      tagSuggestions={['A53T', 'Activity assay']}
+      tagSuggestions={['A53T', 'Activity assay'].map((suggestion) => ({
+        label: suggestion,
+        value: suggestion,
+      }))}
       type="Article"
       getLabSuggestions={() =>
         new Promise((resolve) => {
@@ -22,7 +25,9 @@ export const Normal = () => (
       getAuthorSuggestions={() =>
         new Promise((resolve) => {
           setTimeout(() => {
-            resolve([{ label: 'user name', value: '1' }]);
+            resolve([
+              { label: 'user name', value: '1', user: createUserResponse() },
+            ]);
           }, 1000);
         })
       }

--- a/packages/react-components/src/atoms/__tests__/MultiSelect.test.tsx
+++ b/packages/react-components/src/atoms/__tests__/MultiSelect.test.tsx
@@ -90,7 +90,7 @@ describe('Sorting elements', () => {
 it('shows the selected value', () => {
   const { getByText } = render(
     <MultiSelect
-      suggestions={['LHR']}
+      suggestions={[{ label: 'LHR', value: 'LHR' }]}
       values={[{ label: 'LHR', value: 'LHR' }]}
     />,
   );
@@ -99,7 +99,10 @@ it('shows the selected value', () => {
 
 it('when empty shows a placeholder message', () => {
   const { container } = render(
-    <MultiSelect suggestions={['LHR']} placeholder="Start typing" />,
+    <MultiSelect
+      suggestions={[{ label: 'LHR', value: 'LHR' }]}
+      placeholder="Start typing"
+    />,
   );
   expect(container).toHaveTextContent(/start typing/i);
 });
@@ -115,7 +118,13 @@ it('shows the no option message when there are no options', () => {
 it('opens a menu to select from on click', () => {
   const handleChange = jest.fn();
   const { getByText, getByDisplayValue } = render(
-    <MultiSelect suggestions={['LHR', 'LGW']} onChange={handleChange} />,
+    <MultiSelect
+      suggestions={[
+        { label: 'LHR', value: 'LHR' },
+        { label: 'LGW', value: 'LGW' },
+      ]}
+      onChange={handleChange}
+    />,
   );
 
   userEvent.click(getByDisplayValue(''));
@@ -129,7 +138,10 @@ it('does not open a menu when clicking a value', () => {
   const handleChange = jest.fn();
   const { getByText } = render(
     <MultiSelect
-      suggestions={['LHR', 'LGW']}
+      suggestions={[
+        { label: 'LHR', value: 'LHR' },
+        { label: 'LGW', value: 'LGW' },
+      ]}
       values={[{ label: 'LGW', value: 'LGW' }]}
       onChange={handleChange}
     />,
@@ -142,7 +154,14 @@ it('does not open a menu when clicking a value', () => {
 it('opens a filtered menu to select from when typing', () => {
   const handleChange = jest.fn();
   const { getByText, queryByText, getByDisplayValue } = render(
-    <MultiSelect suggestions={['LHR', 'LGW', 'LTN']} onChange={handleChange} />,
+    <MultiSelect
+      suggestions={[
+        { label: 'LHR', value: 'LHR' },
+        { label: 'LGW', value: 'LGW' },
+        { label: 'LTN', value: 'LTN' },
+      ]}
+      onChange={handleChange}
+    />,
   );
 
   userEvent.type(getByDisplayValue(''), 'LT');
@@ -157,7 +176,13 @@ it('opens a filtered menu to select from when typing', () => {
 it('does not allow non-suggested input', () => {
   const handleChange = jest.fn();
   const { getByDisplayValue } = render(
-    <MultiSelect suggestions={['LHR', 'LGW']} onChange={handleChange} />,
+    <MultiSelect
+      suggestions={[
+        { label: 'LHR', value: 'LHR' },
+        { label: 'LGW', value: 'LGW' },
+      ]}
+      onChange={handleChange}
+    />,
   );
   userEvent.type(getByDisplayValue(''), 'LTN');
   userEvent.tab();
@@ -166,7 +191,12 @@ it('does not allow non-suggested input', () => {
 
 it('shows the focused suggestion in green', () => {
   const { getByText, getByDisplayValue } = render(
-    <MultiSelect suggestions={['LHR', 'LGW']} />,
+    <MultiSelect
+      suggestions={[
+        { label: 'LHR', value: 'LHR' },
+        { label: 'LGW', value: 'LGW' },
+      ]}
+    />,
   );
   userEvent.click(getByDisplayValue(''));
   expect(
@@ -183,7 +213,10 @@ describe('invalidity', () => {
   it('shows the error state when input is not focused', () => {
     const { getByRole, getByText } = render(
       <MultiSelect
-        suggestions={['LHR', 'LGW']}
+        suggestions={[
+          { label: 'LHR', value: 'LHR' },
+          { label: 'LGW', value: 'LGW' },
+        ]}
         customValidationMessage="Nope."
       />,
     );
@@ -201,7 +234,10 @@ describe('invalidity', () => {
   it('shows the default state when input is focused', () => {
     const { getByRole, queryByText } = render(
       <MultiSelect
-        suggestions={['LHR', 'LGW']}
+        suggestions={[
+          { label: 'LHR', value: 'LHR' },
+          { label: 'LGW', value: 'LGW' },
+        ]}
         customValidationMessage="Nope."
       />,
     );
@@ -218,7 +254,10 @@ describe('invalidity', () => {
     const blurSelect = jest.spyOn(Select.prototype, 'blur');
     const { getByRole, queryByText } = render(
       <MultiSelect
-        suggestions={['LHR', 'LGW']}
+        suggestions={[
+          { label: 'LHR', value: 'LHR' },
+          { label: 'LGW', value: 'LGW' },
+        ]}
         customValidationMessage="Nope."
       />,
     );

--- a/packages/react-components/src/atoms/index.ts
+++ b/packages/react-components/src/atoms/index.ts
@@ -17,6 +17,7 @@ export { default as Label } from './Label';
 export { default as Link } from './Link';
 export { default as LinkConditional } from './LinkConditional';
 export { default as MultiSelect } from './MultiSelect';
+export type { MultiSelectOptionsType, MultiSelectProps } from './MultiSelect';
 export { default as NavigationLink } from './NavigationLink';
 export { default as Overlay } from './Overlay';
 export { default as Paragraph } from './Paragraph';

--- a/packages/react-components/src/molecules/LabeledMultiSelect.tsx
+++ b/packages/react-components/src/molecules/LabeledMultiSelect.tsx
@@ -1,6 +1,12 @@
 import { css } from '@emotion/react';
-import { ComponentProps, ReactNode } from 'react';
-import { MultiSelect, Paragraph, Label } from '../atoms';
+import { ReactElement, ReactNode } from 'react';
+import {
+  MultiSelect,
+  MultiSelectProps,
+  MultiSelectOptionsType,
+  Paragraph,
+  Label,
+} from '../atoms';
 import { lead } from '../colors';
 import { perRem } from '../pixels';
 
@@ -12,18 +18,18 @@ const descriptionStyles = css({
   color: lead.rgb,
 });
 
-type LabeledMultiSelectProps = {
+export type LabeledMultiSelectProps<T extends MultiSelectOptionsType> = {
   readonly title: ReactNode;
   readonly subtitle?: React.ReactNode;
   readonly description?: ReactNode;
-} & Exclude<ComponentProps<typeof MultiSelect>, 'id'>;
+} & Exclude<MultiSelectProps<T>, 'id'>;
 
-const LabeledMultiSelect: React.FC<LabeledMultiSelectProps> = ({
+const LabeledMultiSelect = <T extends MultiSelectOptionsType>({
   title,
   subtitle,
   description,
   ...multiSelectProps
-}) => (
+}: LabeledMultiSelectProps<T>): ReactElement => (
   <div css={{ paddingBottom: `${18 / perRem}em` }}>
     <Label forContent={(id) => <MultiSelect {...multiSelectProps} id={id} />}>
       <Paragraph>

--- a/packages/react-components/src/molecules/__tests__/LabeledMultiSelect.test.tsx
+++ b/packages/react-components/src/molecules/__tests__/LabeledMultiSelect.test.tsx
@@ -8,7 +8,7 @@ it('renders a labeled multi select, passing through props', () => {
       title="Title"
       subtitle="Subtitle"
       description="Description"
-      suggestions={['Value']}
+      suggestions={[{ label: 'Value', value: 'Value' }]}
       values={[{ label: 'Value', value: 'Value' }]}
     />,
   );

--- a/packages/react-components/src/organisms/AuthorSelect.tsx
+++ b/packages/react-components/src/organisms/AuthorSelect.tsx
@@ -1,0 +1,79 @@
+import { ExternalAuthorResponse, UserResponse } from '@asap-hub/model';
+import { isInternalUser } from '@asap-hub/validation';
+import { css } from '@emotion/react';
+import { components } from 'react-select';
+import { Avatar } from '../atoms';
+import { MultiSelectOptionsType } from '../atoms/MultiSelect';
+import LabeledMultiSelect, {
+  LabeledMultiSelectProps,
+} from '../molecules/LabeledMultiSelect';
+import { perRem } from '../pixels';
+
+const optionStyles = css({
+  display: 'grid',
+
+  gridTemplateColumns: `${24 / perRem}em 1fr`,
+  gridColumnGap: `${8 / perRem}em`,
+});
+
+type AuthorOption = {
+  user: UserResponse | ExternalAuthorResponse;
+} & MultiSelectOptionsType;
+
+type AuthorSelectProps = LabeledMultiSelectProps<AuthorOption>;
+
+const getFirstAndLastName = (user: UserResponse | ExternalAuthorResponse) => {
+  if (isInternalUser(user)) {
+    return {
+      firstName: user.firstName,
+      lastName: user.lastName,
+    };
+  }
+
+  return {
+    firstName: user.displayName,
+    lastName: user.displayName.split(' ')[1],
+  };
+};
+
+const AuthorSelect: React.FC<AuthorSelectProps> = (props) => (
+  <LabeledMultiSelect<AuthorOption>
+    {...props}
+    components={{
+      MultiValueContainer: (multiValueContainerProps) => (
+        <div
+          css={{
+            ...multiValueContainerProps.selectProps.styles.multiValue(),
+            paddingLeft: `${8 / perRem}em`,
+          }}
+        >
+          {multiValueContainerProps.children}
+        </div>
+      ),
+      MultiValueLabel: (multiValueLabelProps) => (
+        <components.MultiValueLabel {...multiValueLabelProps}>
+          <div css={optionStyles}>
+            <Avatar
+              {...getFirstAndLastName(multiValueLabelProps.data.user)}
+              imageUrl={multiValueLabelProps.data.user?.avatarUrl}
+            />
+            <span>{multiValueLabelProps.children}</span>
+          </div>
+        </components.MultiValueLabel>
+      ),
+      Option: (optionProps) => (
+        <components.Option {...optionProps}>
+          <div css={optionStyles}>
+            <Avatar
+              {...getFirstAndLastName(optionProps.data.user)}
+              imageUrl={optionProps.data.user?.avatarUrl}
+            />
+            <span>{optionProps.children}</span>
+          </div>
+        </components.Option>
+      ),
+    }}
+  />
+);
+
+export default AuthorSelect;

--- a/packages/react-components/src/organisms/AuthorSelect.tsx
+++ b/packages/react-components/src/organisms/AuthorSelect.tsx
@@ -1,13 +1,44 @@
 import { ExternalAuthorResponse, UserResponse } from '@asap-hub/model';
 import { isInternalUser } from '@asap-hub/validation';
 import { css } from '@emotion/react';
+import { ReactElement, ReactNode } from 'react';
 import { components } from 'react-select';
 import { Avatar } from '../atoms';
+import { userPlaceholderIcon } from '../icons';
 import { MultiSelectOptionsType } from '../atoms/MultiSelect';
 import LabeledMultiSelect, {
   LabeledMultiSelectProps,
 } from '../molecules/LabeledMultiSelect';
 import { perRem } from '../pixels';
+
+const externalAuthorStyles = css({
+  borderRadius: '50%',
+  height: `${24 / perRem}em`,
+  overflow: 'hidden',
+});
+
+const LabelWithAvatar = ({
+  author,
+  children,
+}: {
+  author: UserResponse | ExternalAuthorResponse;
+  children: ReactElement | ReactNode;
+}) =>
+  isInternalUser(author) ? (
+    <>
+      <Avatar
+        firstName={author.firstName}
+        lastName={author.lastName}
+        imageUrl={author.avatarUrl}
+      />
+      <span>{children}</span>
+    </>
+  ) : (
+    <>
+      <div css={externalAuthorStyles}>{userPlaceholderIcon}</div>
+      <span>{children} (Non CRN)</span>
+    </>
+  );
 
 const optionStyles = css({
   display: 'grid',
@@ -21,20 +52,6 @@ type AuthorOption = {
 } & MultiSelectOptionsType;
 
 type AuthorSelectProps = LabeledMultiSelectProps<AuthorOption>;
-
-const getFirstAndLastName = (user: UserResponse | ExternalAuthorResponse) => {
-  if (isInternalUser(user)) {
-    return {
-      firstName: user.firstName,
-      lastName: user.lastName,
-    };
-  }
-
-  return {
-    firstName: user.displayName,
-    lastName: user.displayName.split(' ')[1],
-  };
-};
 
 const AuthorSelect: React.FC<AuthorSelectProps> = (props) => (
   <LabeledMultiSelect<AuthorOption>
@@ -53,22 +70,18 @@ const AuthorSelect: React.FC<AuthorSelectProps> = (props) => (
       MultiValueLabel: (multiValueLabelProps) => (
         <components.MultiValueLabel {...multiValueLabelProps}>
           <div css={optionStyles}>
-            <Avatar
-              {...getFirstAndLastName(multiValueLabelProps.data.user)}
-              imageUrl={multiValueLabelProps.data.user?.avatarUrl}
-            />
-            <span>{multiValueLabelProps.children}</span>
+            <LabelWithAvatar author={multiValueLabelProps.data.user}>
+              {multiValueLabelProps.children}
+            </LabelWithAvatar>
           </div>
         </components.MultiValueLabel>
       ),
       Option: (optionProps) => (
         <components.Option {...optionProps}>
           <div css={optionStyles}>
-            <Avatar
-              {...getFirstAndLastName(optionProps.data.user)}
-              imageUrl={optionProps.data.user?.avatarUrl}
-            />
-            <span>{optionProps.children}</span>
+            <LabelWithAvatar author={optionProps.data.user}>
+              {optionProps.children}
+            </LabelWithAvatar>
           </div>
         </components.Option>
       ),

--- a/packages/react-components/src/organisms/TeamCreateOutputContributorsCard.tsx
+++ b/packages/react-components/src/organisms/TeamCreateOutputContributorsCard.tsx
@@ -2,6 +2,7 @@ import { ComponentPropsWithRef } from 'react';
 
 import { FormCard, LabeledMultiSelect } from '../molecules';
 import { noop } from '../utils';
+import AuthorSelect from './AuthorSelect';
 
 type TeamCreateOutputContributorsProps = {
   readonly labs: ComponentPropsWithRef<typeof LabeledMultiSelect>['values'];
@@ -12,12 +13,12 @@ type TeamCreateOutputContributorsProps = {
     typeof LabeledMultiSelect
   >['onChange'];
 
-  readonly authors: ComponentPropsWithRef<typeof LabeledMultiSelect>['values'];
+  readonly authors: ComponentPropsWithRef<typeof AuthorSelect>['values'];
   readonly getAuthorSuggestions?: ComponentPropsWithRef<
-    typeof LabeledMultiSelect
+    typeof AuthorSelect
   >['loadOptions'];
   readonly onChangeAuthors?: ComponentPropsWithRef<
-    typeof LabeledMultiSelect
+    typeof AuthorSelect
   >['onChange'];
 
   readonly teams: ComponentPropsWithRef<typeof LabeledMultiSelect>['values'];
@@ -71,7 +72,7 @@ const TeamCreateOutputContributorsCard: React.FC<TeamCreateOutputContributorsPro
           `Sorry, no labs match ${inputValue}`
         }
       />
-      <LabeledMultiSelect
+      <AuthorSelect
         title="Authors"
         description=""
         subtitle="(optional)"

--- a/packages/react-components/src/organisms/__tests__/AuthorSelect.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/AuthorSelect.test.tsx
@@ -63,7 +63,7 @@ it('renders a author multi select, passing through props for user with avatar', 
 });
 
 it('renders a author multi select, passing through props for external author', () => {
-  const { getByText, getByLabelText } = render(
+  const { getByText, getByTitle, getByLabelText } = render(
     <AuthorSelect
       title="Title"
       subtitle="Subtitle"
@@ -86,6 +86,6 @@ it('renders a author multi select, passing through props for external author', (
   expect(getByLabelText(/Title/i)).toBeVisible();
   expect(getByLabelText(/Subtitle/i)).toBeVisible();
   expect(getByLabelText(/Description/i)).toBeVisible();
-  expect(getByText('Andy Smith')).toBeVisible();
-  expect(getByText('AS')).toBeVisible();
+  expect(getByText('Andy Smith (Non CRN)')).toBeVisible();
+  expect(getByTitle('User Placeholder')).toBeInTheDocument();
 });

--- a/packages/react-components/src/organisms/__tests__/AuthorSelect.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/AuthorSelect.test.tsx
@@ -1,0 +1,91 @@
+import { render } from '@testing-library/react';
+import { createUserResponse } from '@asap-hub/fixtures';
+import AuthorSelect from '../AuthorSelect';
+
+it('renders a author multi select, passing through props for user', () => {
+  const { getByText, getByLabelText } = render(
+    <AuthorSelect
+      title="Title"
+      subtitle="Subtitle"
+      description="Description"
+      suggestions={[
+        { label: 'Value', value: 'Value', user: createUserResponse() },
+      ]}
+      values={[
+        {
+          user: {
+            ...createUserResponse(),
+            firstName: 'Andy',
+            lastName: 'Smith',
+          },
+          label: 'Andy Smith',
+          value: 'user-id',
+        },
+      ]}
+    />,
+  );
+  expect(getByLabelText(/Title/i)).toBeVisible();
+  expect(getByLabelText(/Subtitle/i)).toBeVisible();
+  expect(getByLabelText(/Description/i)).toBeVisible();
+  expect(getByText('Andy Smith')).toBeVisible();
+  expect(getByText('AS')).toBeVisible();
+});
+
+it('renders a author multi select, passing through props for user with avatar', () => {
+  const { getByRole, getByText, getByLabelText } = render(
+    <AuthorSelect
+      title="Title"
+      subtitle="Subtitle"
+      description="Description"
+      suggestions={[
+        { label: 'Value', value: 'Value', user: createUserResponse() },
+      ]}
+      values={[
+        {
+          user: {
+            ...createUserResponse(),
+            firstName: 'Andy',
+            lastName: 'Smith',
+            avatarUrl: 'avatar.png',
+          },
+          label: 'Andy Smith',
+          value: 'user-id',
+        },
+      ]}
+    />,
+  );
+  expect(getByLabelText(/Title/i)).toBeVisible();
+  expect(getByLabelText(/Subtitle/i)).toBeVisible();
+  expect(getByLabelText(/Description/i)).toBeVisible();
+  expect(getByText('Andy Smith')).toBeVisible();
+  const { backgroundImage } = getComputedStyle(getByRole('img'));
+  expect(backgroundImage).toContain('url(avatar.png)');
+});
+
+it('renders a author multi select, passing through props for external author', () => {
+  const { getByText, getByLabelText } = render(
+    <AuthorSelect
+      title="Title"
+      subtitle="Subtitle"
+      description="Description"
+      suggestions={[
+        { label: 'Value', value: 'Value', user: createUserResponse() },
+      ]}
+      values={[
+        {
+          user: {
+            id: 'external-author-id',
+            displayName: 'Andy Smith',
+          },
+          label: 'Andy Smith',
+          value: 'external-author-id',
+        },
+      ]}
+    />,
+  );
+  expect(getByLabelText(/Title/i)).toBeVisible();
+  expect(getByLabelText(/Subtitle/i)).toBeVisible();
+  expect(getByLabelText(/Description/i)).toBeVisible();
+  expect(getByText('Andy Smith')).toBeVisible();
+  expect(getByText('AS')).toBeVisible();
+});

--- a/packages/react-components/src/organisms/__tests__/TeamCreateOutputContributorCard.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/TeamCreateOutputContributorCard.test.tsx
@@ -2,6 +2,7 @@ import { waitFor } from '@testing-library/dom';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ComponentProps } from 'react';
+import { createUserResponse } from '@asap-hub/fixtures';
 import TeamCreateOutputContributorsCard from '../TeamCreateOutputContributorsCard';
 
 const props: ComponentProps<typeof TeamCreateOutputContributorsCard> = {
@@ -63,8 +64,8 @@ describe('Labs', () => {
     const loadOptions = jest.fn();
     const mockOnChange = jest.fn();
     loadOptions.mockResolvedValue([
-      { label: 'Author One', value: '1' },
-      { label: 'Author Two', value: '2' },
+      { user: createUserResponse(), label: 'Author One', value: '1' },
+      { user: createUserResponse(), label: 'Author Two', value: '2' },
     ]);
 
     const { getByText, getByLabelText, queryByText } = render(
@@ -80,7 +81,7 @@ describe('Labs', () => {
     );
     userEvent.click(getByText('Author One'));
     expect(mockOnChange).toHaveBeenCalledWith([
-      { label: 'Author One', value: '1' },
+      { user: createUserResponse(), label: 'Author One', value: '1' },
     ]);
   });
   it('should render message when there is no match', async () => {

--- a/packages/react-components/src/organisms/__tests__/TeamCreateOutputContributorsCard.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/TeamCreateOutputContributorsCard.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { StaticRouter } from 'react-router-dom';
 import { ComponentProps } from 'react';
 import { waitFor } from '@testing-library/dom';
+import { createUserResponse } from '@asap-hub/fixtures';
 
 import TeamCreateOutputContributorsCard from '../TeamCreateOutputContributorsCard';
 
@@ -27,8 +28,8 @@ describe('Authors Multiselect', () => {
     const onChangeAuthors = jest.fn();
     const getAuthorSuggestions = jest.fn();
     getAuthorSuggestions.mockResolvedValue([
-      { label: 'Author Two', value: '2' },
-      { label: 'Author One', value: '1' },
+      { user: createUserResponse(), label: 'Author Two', value: '2' },
+      { user: createUserResponse(), label: 'Author One', value: '1' },
     ]);
 
     render(

--- a/packages/react-components/src/organisms/__tests__/TeamCreateOutputExtraInformationCard.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/TeamCreateOutputExtraInformationCard.test.tsx
@@ -22,7 +22,7 @@ it('should trigger an onChange event when a tag is selected', () => {
   const { getByText, getByLabelText } = render(
     <TeamCreateOutputExtraInformationCard
       {...props}
-      tagSuggestions={['Example']}
+      tagSuggestions={[{ label: 'Example', value: 'Example' }]}
       onChangeTags={mockOnChange}
     />,
   );

--- a/packages/react-components/src/organisms/__tests__/TeamCreateOutputForm.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/TeamCreateOutputForm.test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { StaticRouter } from 'react-router-dom';
 import { ComponentProps } from 'react';
 import { fireEvent, waitFor } from '@testing-library/dom';
-import { createTeamResponse } from '@asap-hub/fixtures';
+import { createTeamResponse, createUserResponse } from '@asap-hub/fixtures';
 
 import TeamCreateOutputForm from '../TeamCreateOutputForm';
 import { ENTER_KEYCODE } from '../../atoms/Dropdown';
@@ -60,8 +60,8 @@ it('can submit a form when form data is valid', async () => {
     { label: 'Two Lab', value: '2' },
   ]);
   getAuthorSuggestions.mockResolvedValue([
-    { label: 'Author Two', value: '2' },
-    { label: 'Author One', value: '1' },
+    { user: createUserResponse(), label: 'Author Two', value: '2' },
+    { user: createUserResponse(), label: 'Author One', value: '1' },
   ]);
   render(
     <StaticRouter>

--- a/packages/react-components/src/select.ts
+++ b/packages/react-components/src/select.ts
@@ -131,9 +131,9 @@ export const reactSelectStyles = (
   }),
 });
 
-export const reactMultiSelectStyles = (
+export const reactMultiSelectStyles = <T extends MultiSelectOptionsType>(
   isInvalid: boolean,
-): StylesConfig<MultiSelectOptionsType, true> => ({
+): StylesConfig<T, true> => ({
   ...baseSelectStyles,
   option: (provided, { isFocused }) => ({
     ...provided,

--- a/packages/react-components/src/templates/ExpertiseAndResourcesModal.tsx
+++ b/packages/react-components/src/templates/ExpertiseAndResourcesModal.tsx
@@ -94,7 +94,12 @@ const ExpertiseAndResourcesModal: React.FC<ExpertiseAndResourcesModalProps> = ({
                         `Please add a minimum of ${MINIMUM_EXPERTISE_AND_RESOURCES} tags`,
                       );
                 }}
-                suggestions={expertiseAndResourceSuggestions}
+                suggestions={expertiseAndResourceSuggestions.map(
+                  (suggestion) => ({
+                    label: suggestion,
+                    value: suggestion,
+                  }),
+                )}
                 noOptionsMessage={({ inputValue }) =>
                   `Sorry, No current tags match "${inputValue}"`
                 }


### PR DESCRIPTION
## Story Description
As a Product Owner
I want to see the appropriate avatar displayed on author selector function of the shared outputs form
So that I am able to visually identify tag labels

## Assumptions
- This behaviour should apply to the ‘Author’ selector on the Shared Outputs form; all other instances of this component should remain unchanged.
- The Avatar should be 24x24 px in a circle - it should be spaced 8px before the tag label 

## Requirement
- Update the component multi-select to display an avatar image with each option (including: those tags that are selected AND those tags that are to be selected)
- for each option on the results list of the user search (i.e. drop-down), show an avatar to the left:
- for each selected option (i.e. in the input text area), show the avatar inside the tag pill on the left
- The avatar should vary depending on the attribute of the option
- for users with an avatar, show their picture (when available)
- for users without an avatar picture, use the fallback avatar for users (Initials + color)  
- external authors should have a placeholder avatar -  
