### PR TITLE
removes TeamCreateOutputIdentifier default values

### DIFF
--- a/apps/crn-frontend/src/network/teams/__tests__/TeamOutput.test.tsx
+++ b/apps/crn-frontend/src/network/teams/__tests__/TeamOutput.test.tsx
@@ -161,6 +161,9 @@ it('can submit a form when form data is valid', async () => {
   );
   userEvent.click(screen.getByText('Person A 3'));
 
+  userEvent.type(screen.getByLabelText(/Identifier/i), 'DO');
+  userEvent.click(screen.getByText('DOI'));
+
   const button = screen.getByRole('button', { name: /Share/i });
 
   userEvent.click(button);
@@ -180,6 +183,7 @@ it('can submit a form when form data is valid', async () => {
         description: 'example description',
         type: 'Animal Model',
         labs: ['l0'],
+        doi: '',
         authors: [
           {
             userId: 'u2',
@@ -220,6 +224,9 @@ it('will show server side validation error for link', async () => {
   });
   userEvent.type(screen.getByLabelText(/type/i), 'Preprint');
 
+  fireEvent.change(screen.getByLabelText(/Identifier/i), {
+    target: { value: 'DOI' },
+  });
   const button = screen.getByRole('button', { name: /Share/i });
   userEvent.click(button);
 
@@ -263,6 +270,10 @@ it('will toast server side errors for unknown errors', async () => {
     target: { value: 'example description' },
   });
   userEvent.type(screen.getByLabelText(/type/i), 'Preprint');
+
+  fireEvent.change(screen.getByLabelText(/Identifier/i), {
+    target: { value: 'DOI' },
+  });
 
   const button = screen.getByRole('button', { name: /Share/i });
   userEvent.click(button);

--- a/apps/storybook/src/TeamCreateOutputExtraInformationCard.stories.tsx
+++ b/apps/storybook/src/TeamCreateOutputExtraInformationCard.stories.tsx
@@ -1,7 +1,7 @@
 import { TeamCreateOutputExtraInformationCard } from '@asap-hub/react-components';
 import { ComponentProps } from 'react';
 import { researchOutputDocumentTypes } from '@asap-hub/model';
-import { boolean, select } from '@storybook/addon-knobs';
+import { select } from '@storybook/addon-knobs';
 
 export default {
   title: 'Organisms / Team Profile / Team Create Output Extra Information Card',
@@ -19,7 +19,6 @@ const commonProps: ComponentProps<typeof TeamCreateOutputExtraInformationCard> =
       value: suggestion,
     })),
     documentType: select('type', researchOutputDocumentTypes, 'Article'),
-    identifierRequired: boolean('identifierRequired', false),
   };
 
 export const Normal = () => (

--- a/packages/model/src/research-output.ts
+++ b/packages/model/src/research-output.ts
@@ -129,7 +129,7 @@ export const researchOutputMapType = (
 };
 
 export enum ResearchOutputIdentifierType {
-  None = 'None',
+  None = '',
   DOI = 'DOI',
   AccessionNumber = 'Accession Number',
   RRID = 'RRID',

--- a/packages/react-components/src/organisms/TeamCreateOutputExtraInformationCard.tsx
+++ b/packages/react-components/src/organisms/TeamCreateOutputExtraInformationCard.tsx
@@ -25,7 +25,6 @@ type TeamCreateOutputExtraInformationProps = Pick<
   onChangeAccessInstructions?: (values: string) => void;
   isSaving: boolean;
   documentType: ResearchOutputDocumentType;
-  identifierRequired: boolean;
 } & Omit<TeamCreateOutputIdentifierProps, 'required'>;
 
 const TeamCreateOutputExtraInformationCard: React.FC<TeamCreateOutputExtraInformationProps> =
@@ -40,7 +39,6 @@ const TeamCreateOutputExtraInformationCard: React.FC<TeamCreateOutputExtraInform
     identifierType = ResearchOutputIdentifierType.None,
     setIdentifier = noop,
     setIdentifierType = noop,
-    identifierRequired,
     documentType,
   }) => (
     <FormCard title="What extra information can you provide?">
@@ -65,7 +63,6 @@ const TeamCreateOutputExtraInformationCard: React.FC<TeamCreateOutputExtraInform
         setIdentifier={setIdentifier}
         identifierType={identifierType}
         setIdentifierType={setIdentifierType}
-        required={identifierRequired}
       />
 
       <LabeledTextArea

--- a/packages/react-components/src/organisms/TeamCreateOutputForm.tsx
+++ b/packages/react-components/src/organisms/TeamCreateOutputForm.tsx
@@ -239,9 +239,6 @@ const TeamCreateOutputForm: React.FC<TeamCreateOutputFormProps> = ({
             setIdentifier={setIdentifier}
             identifierType={identifierType}
             setIdentifierType={setIdentifierType}
-            identifierRequired={
-              usedInPublication === 'Yes' && asapFunded === 'Yes'
-            }
           />
           <TeamCreateOutputContributorsCard
             isSaving={isSaving}

--- a/packages/react-components/src/organisms/TeamCreateOutputIdentifier.tsx
+++ b/packages/react-components/src/organisms/TeamCreateOutputIdentifier.tsx
@@ -9,7 +9,6 @@ import { noop } from '../utils';
 
 const getIdentifiers = (
   researchOutputDocumentType: ResearchOutputDocumentType,
-  required: boolean,
 ): Array<{
   value: ResearchOutputIdentifierType;
   label: ResearchOutputIdentifierType;
@@ -17,11 +16,9 @@ const getIdentifiers = (
   let identifiers =
     researchOutputToIdentifierType[researchOutputDocumentType] ?? [];
 
-  if (required) {
-    identifiers = identifiers.filter(
-      (identifier) => identifier !== ResearchOutputIdentifierType.None,
-    );
-  }
+  identifiers = identifiers.filter(
+    (identifier) => identifier !== ResearchOutputIdentifierType.None,
+  );
 
   return identifiers.map((identifier) => ({
     value: identifier,
@@ -69,7 +66,6 @@ export interface TeamCreateOutputIdentifierProps {
   identifierType?: ResearchOutputIdentifierType;
   setIdentifierType?: (value: ResearchOutputIdentifierType) => void;
   documentType: ResearchOutputDocumentType;
-  required: boolean;
 }
 
 export const TeamCreateOutputIdentifier: React.FC<TeamCreateOutputIdentifierProps> =
@@ -79,20 +75,12 @@ export const TeamCreateOutputIdentifier: React.FC<TeamCreateOutputIdentifierProp
     identifier = '',
     setIdentifier = noop,
     documentType,
-    required,
   }) => {
     const data = useMemo(() => identifierMap[identifierType], [identifierType]);
     const identifiers = useMemo(
-      () => getIdentifiers(documentType, required),
-      [documentType, required],
+      () => getIdentifiers(documentType),
+      [documentType],
     );
-
-    useEffect(() => {
-      if (required && identifierType === ResearchOutputIdentifierType.None) {
-        setIdentifierType(identifiers[0].value);
-      }
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [required, setIdentifierType]);
 
     useEffect(() => {
       setIdentifier('');
@@ -106,8 +94,6 @@ export const TeamCreateOutputIdentifier: React.FC<TeamCreateOutputIdentifierProp
           )
         ) {
           setIdentifierType(newType as ResearchOutputIdentifierType);
-        } else {
-          setIdentifierType(identifiers[0].value);
         }
       },
       [setIdentifierType, identifiers],
@@ -121,6 +107,9 @@ export const TeamCreateOutputIdentifier: React.FC<TeamCreateOutputIdentifierProp
           options={identifiers}
           value={identifierType}
           onChange={onChangeIdentifierType}
+          required
+          placeholder={'Choose an identifier'}
+          getValidationMessage={() => 'Please choose an identifier'}
         />
         {identifierType !== ResearchOutputIdentifierType.None && (
           <LabeledTextField

--- a/packages/react-components/src/organisms/__tests__/TeamCreateOutputExtraInformationCard.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/TeamCreateOutputExtraInformationCard.test.tsx
@@ -10,7 +10,6 @@ const props: ComponentProps<typeof TeamCreateOutputExtraInformationCard> = {
   tags: [],
 
   documentType: 'Article',
-  identifierRequired: false,
 };
 
 it('should render a tag', () => {

--- a/packages/react-components/src/organisms/__tests__/TeamCreateOutputForm.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/TeamCreateOutputForm.test.tsx
@@ -170,6 +170,8 @@ it('can submit a form when form data is valid', async () => {
   );
   userEvent.click(screen.getAllByText('Alex White')[1]);
 
+  userEvent.type(screen.getByLabelText(/Identifier/i), 'DO');
+  userEvent.click(screen.getByText('DOI'));
   fireEvent.change(screen.getByLabelText(/doi/i), {
     target: { value: 'doi:12.1234' },
   });

--- a/packages/react-components/src/organisms/__tests__/TeamCreateOutputIdentifier.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/TeamCreateOutputIdentifier.test.tsx
@@ -7,15 +7,17 @@ import { ENTER_KEYCODE } from '../../atoms/Dropdown';
 
 const props: ComponentProps<typeof TeamCreateOutputIdentifier> = {
   documentType: 'Article',
-  required: false,
 };
 
 it('should render Identifier', () => {
-  const { getByText } = render(<TeamCreateOutputIdentifier {...props} />);
-  expect(getByText(/Identifier/i)).toBeVisible();
+  const { getByLabelText, getByText } = render(
+    <TeamCreateOutputIdentifier {...props} />,
+  );
+  expect(getByLabelText(/Identifier/i)).toBeVisible();
+  expect(getByText('Choose an identifier')).toBeVisible();
 });
 
-it('should reset the identifier to a valid value on entering something unknown', () => {
+it('should clear the identifier field on entering something unknown', () => {
   const setIdentifierType = jest.fn();
   const { getByLabelText } = render(
     <TeamCreateOutputIdentifier
@@ -31,9 +33,17 @@ it('should reset the identifier to a valid value on entering something unknown',
 
   fireEvent.keyDown(getByLabelText(/identifier/i), { keyCode: ENTER_KEYCODE });
 
-  expect(setIdentifierType).toHaveBeenCalledWith(
+  expect(getByLabelText(/identifier/i)).toHaveValue(
     ResearchOutputIdentifierType.None,
   );
+});
+
+it('shows error message for missing value', () => {
+  const { getByLabelText, getByText } = render(
+    <TeamCreateOutputIdentifier {...props} />,
+  );
+  fireEvent.focusOut(getByLabelText(/identifier/i));
+  expect(getByText('Please choose an identifier')).toBeVisible();
 });
 
 it('should set the identifier to the selected value', () => {
@@ -52,7 +62,7 @@ it('should set the identifier to the selected value', () => {
 
   fireEvent.keyDown(getByLabelText(/identifier/i), { keyCode: ENTER_KEYCODE });
 
-  expect(setIdentifierType).toHaveBeenCalledWith(
+  expect(getByLabelText(/identifier/i)).toHaveValue(
     ResearchOutputIdentifierType.DOI,
   );
 });


### PR DESCRIPTION
https://asaphub.atlassian.net/jira/software/c/projects/CRN/boards/8?modal=detail&selectedIssue=CRN-802

1/When I land on the RO form, and navigate to the identifier field I do not want to see a default option of ‘None’ populated in the field. This should have a place holder ‘Choose an identifier’.

2/If I select ‘ASAP Fund' and ‘Used in a publication ' (radio buttons), then I want to remove ‘None’ from the drop down options AND I do not want to populate the field with a default of 'DOI’. DOI and Accession number should be available as options in the list (NO DEFAULTS) pre-populated