### PR TITLE
CRN-834 Create a new user role

### DIFF
--- a/apps/crn-server/src/entities/team.ts
+++ b/apps/crn-server/src/entities/team.ts
@@ -16,6 +16,7 @@ const priorities: Record<TeamRole, number> = {
   'Collaborating PI': 4,
   'Key Personnel': 5,
   'ASAP Staff': 6,
+  'Scientific Advisory Board': 7,
 };
 
 export const parseGraphQLTeamMember = (

--- a/apps/crn-server/test/helpers/users.ts
+++ b/apps/crn-server/test/helpers/users.ts
@@ -1,7 +1,7 @@
 import Chance from 'chance';
 import { SquidexRest, User } from '@asap-hub/squidex';
-import { TeamRole, UserResponse, Invitee } from '@asap-hub/model';
-import { RestTeam, RestUser } from '@asap-hub/squidex';
+import { UserResponse, Invitee } from '@asap-hub/model';
+import { RestUser } from '@asap-hub/squidex';
 import { parseUser } from '../../src/entities';
 
 const users = new SquidexRest<RestUser>('users');
@@ -62,35 +62,4 @@ export const createRandomOrcid = () => {
       chance.string({ length: 3, numeric: true }),
     ].join('-') + chance.string({ length: 1, pool: '0123456789X' })
   );
-};
-
-export const createUserOnTeam = async (
-  team: RestTeam,
-  role: TeamRole | null = null,
-): Promise<TestUserResponse> => {
-  const createdUser = await createUser();
-  const teams = [
-    {
-      role:
-        role ||
-        (chance.pickone([
-          'Lead PI (Core Leadership)',
-          'Co-PI (Core Leadership)',
-          'Collaborating PI',
-          'Project Manager',
-          'Key Personnel',
-          'Guest',
-          'Staff',
-          'Advisor',
-        ]) as TeamRole),
-      id: [team.id],
-    },
-  ];
-
-  const user = await users.patch(createdUser.id, {
-    email: { iv: createdUser.data.email.iv },
-    teams: { iv: teams },
-  });
-
-  return transform(user);
 };

--- a/packages/model/src/team.ts
+++ b/packages/model/src/team.ts
@@ -7,6 +7,7 @@ export const teamRole = [
   'Collaborating PI',
   'Project Manager',
   'Key Personnel',
+  'Scientific Advisory Board',
   'ASAP Staff',
 ] as const;
 

--- a/packages/react-components/src/templates/NetworkPageHeader.tsx
+++ b/packages/react-components/src/templates/NetworkPageHeader.tsx
@@ -56,6 +56,7 @@ const userFilters: Option<TeamRole | Role>[] = [
   { label: 'Collaborating PI', value: 'Collaborating PI' },
   { label: 'Key Personnel', value: 'Key Personnel' },
   { label: 'ASAP Staff', value: 'ASAP Staff' },
+  { label: 'SAB', value: 'Scientific Advisory Board' },
 ];
 
 const NetworkPageHeader: React.FC<NetworkPageHeaderProps> = ({

--- a/packages/squidex/schema/schemas/users.json
+++ b/packages/squidex/schema/schemas/users.json
@@ -221,7 +221,8 @@
                 "Project Manager",
                 "Collaborating PI",
                 "Key Personnel",
-                "ASAP Staff"
+                "ASAP Staff",
+                "Scientific Advisory Board"
               ],
               "isUnique": false,
               "inlineEditable": true,


### PR DESCRIPTION
### Context
Some users (Scientific Advisory Board) need to be moved out of the ASAP staff user role as these users should not have access to the ‘Share an Output’  button

### Requirement
This requirement is to create a new user Role for those people, who are neither Staff nor Grantees, and should therefore not have access to the create shared output functionality.

### Role Name
‘Scientific Advisory Board’ or ‘SAB’ if the full name is too long

### Note
There is no one who is ASAP staff role that should be listed on another team