### PR TITLE
feat: TeamCreateOutputIdentifier handles no default values

### DIFF
--- a/apps/crn-frontend/src/network/teams/__tests__/TeamOutput.test.tsx
+++ b/apps/crn-frontend/src/network/teams/__tests__/TeamOutput.test.tsx
@@ -161,6 +161,10 @@ it('can submit a form when form data is valid', async () => {
   );
   userEvent.click(screen.getByText('Person A 3'));
 
+  fireEvent.change(screen.getByLabelText(/Identifier/i), {
+    target: { value: 'DOI' },
+  });
+
   const button = screen.getByRole('button', { name: /Share/i });
 
   userEvent.click(button);
@@ -220,6 +224,10 @@ it('will show server side validation error for link', async () => {
   });
   userEvent.type(screen.getByLabelText(/Select the option/i), 'Preprint');
 
+  fireEvent.change(screen.getByLabelText(/Identifier/i), {
+    target: { value: 'DOI' },
+  });
+
   const button = screen.getByRole('button', { name: /Share/i });
   userEvent.click(button);
 
@@ -263,6 +271,10 @@ it('will toast server side errors for unknown errors', async () => {
     target: { value: 'example description' },
   });
   userEvent.type(screen.getByLabelText(/Select the option/i), 'Preprint');
+
+  fireEvent.change(screen.getByLabelText(/Identifier/i), {
+    target: { value: 'DOI' },
+  });
 
   const button = screen.getByRole('button', { name: /Share/i });
   userEvent.click(button);

--- a/apps/storybook/src/TeamCreateOutputExtraInformationCard.stories.tsx
+++ b/apps/storybook/src/TeamCreateOutputExtraInformationCard.stories.tsx
@@ -1,7 +1,7 @@
 import { TeamCreateOutputExtraInformationCard } from '@asap-hub/react-components';
 import { ComponentProps } from 'react';
 import { researchOutputDocumentTypes } from '@asap-hub/model';
-import { boolean, select } from '@storybook/addon-knobs';
+import { select } from '@storybook/addon-knobs';
 
 export default {
   title: 'Organisms / Team Profile / Team Create Output Extra Information Card',

--- a/apps/storybook/src/TeamCreateOutputExtraInformationCard.stories.tsx
+++ b/apps/storybook/src/TeamCreateOutputExtraInformationCard.stories.tsx
@@ -1,7 +1,7 @@
 import { TeamCreateOutputExtraInformationCard } from '@asap-hub/react-components';
 import { ComponentProps } from 'react';
 import { researchOutputDocumentTypes } from '@asap-hub/model';
-import { select } from '@storybook/addon-knobs';
+import { boolean, select } from '@storybook/addon-knobs';
 
 export default {
   title: 'Organisms / Team Profile / Team Create Output Extra Information Card',

--- a/packages/model/src/research-output.ts
+++ b/packages/model/src/research-output.ts
@@ -129,6 +129,7 @@ export const researchOutputMapType = (
 };
 
 export enum ResearchOutputIdentifierType {
+  Empty = 'Empty',
   None = 'None',
   DOI = 'DOI',
   AccessionNumber = 'Accession Number',

--- a/packages/react-components/src/organisms/TeamCreateOutputForm.tsx
+++ b/packages/react-components/src/organisms/TeamCreateOutputForm.tsx
@@ -79,6 +79,7 @@ const identifierTypeToFieldName: Record<
   'doi' | 'accession' | 'labCatalogNumber' | 'rrid' | undefined
 > = {
   [ResearchOutputIdentifierType.None]: undefined,
+  [ResearchOutputIdentifierType.Empty]: undefined,
   [ResearchOutputIdentifierType.DOI]: 'doi',
   [ResearchOutputIdentifierType.AccessionNumber]: 'accession',
   [ResearchOutputIdentifierType.LabCatalogNumber]: 'labCatalogNumber',
@@ -144,7 +145,7 @@ const TeamCreateOutputForm: React.FC<TeamCreateOutputFormProps> = ({
   const [publishDate, setPublishDate] = useState<Date | undefined>(undefined);
 
   const [identifierType, setIdentifierType] =
-    useState<ResearchOutputIdentifierType>(ResearchOutputIdentifierType.None);
+    useState<ResearchOutputIdentifierType>(ResearchOutputIdentifierType.Empty);
   const [identifier, setIdentifier] = useState<string>('');
 
   return (

--- a/packages/react-components/src/organisms/TeamCreateOutputIdentifier.tsx
+++ b/packages/react-components/src/organisms/TeamCreateOutputIdentifier.tsx
@@ -70,6 +70,13 @@ const identifierMap = {
     errorMessage: undefined,
     required: false,
   },
+  [ResearchOutputIdentifierType.Empty]: {
+    helpText: '',
+    placeholder: '',
+    regex: ResearchOutputIdentifierValidationExpression.Empty,
+    errorMessage: undefined,
+    required: false,
+  },
 } as const;
 
 export interface TeamCreateOutputIdentifierProps {
@@ -83,25 +90,25 @@ export interface TeamCreateOutputIdentifierProps {
 
 export const TeamCreateOutputIdentifier: React.FC<TeamCreateOutputIdentifierProps> =
   ({
-    identifierType = ResearchOutputIdentifierType.None,
+    identifierType = ResearchOutputIdentifierType.Empty,
     setIdentifierType = noop,
     identifier = '',
     setIdentifier = noop,
     documentType,
     required,
   }) => {
-    const data = useMemo(() => identifierMap[identifierType], [identifierType]);
+    const data = useMemo(
+      () =>
+        identifierType === ResearchOutputIdentifierType.Empty ||
+        identifierType === ResearchOutputIdentifierType.None
+          ? null
+          : identifierMap[identifierType],
+      [identifierType],
+    );
     const identifiers = useMemo(
       () => getIdentifiers(documentType, required),
       [documentType, required],
     );
-
-    useEffect(() => {
-      if (required && identifierType === ResearchOutputIdentifierType.None) {
-        setIdentifierType(identifiers[0].value);
-      }
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [required, setIdentifierType]);
 
     useEffect(() => {
       setIdentifier('');
@@ -115,8 +122,6 @@ export const TeamCreateOutputIdentifier: React.FC<TeamCreateOutputIdentifierProp
           )
         ) {
           setIdentifierType(newType as ResearchOutputIdentifierType);
-        } else {
-          setIdentifierType(identifiers[0].value);
         }
       },
       [setIdentifierType, identifiers],
@@ -130,8 +135,11 @@ export const TeamCreateOutputIdentifier: React.FC<TeamCreateOutputIdentifierProp
           options={identifiers}
           value={identifierType}
           onChange={onChangeIdentifierType}
+          placeholder={'Choose an identifier'}
+          getValidationMessage={() => `Please choose an identifier`}
+          required
         />
-        {identifierType !== ResearchOutputIdentifierType.None && (
+        {data && (
           <LabeledTextField
             title={identifierType}
             description={data.helpText}

--- a/packages/react-components/src/organisms/__tests__/TeamCreateOutputForm.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/TeamCreateOutputForm.test.tsx
@@ -170,6 +170,8 @@ it('can submit a form when form data is valid', async () => {
   );
   userEvent.click(screen.getAllByText('Alex White')[1]);
 
+  userEvent.type(screen.getByLabelText(/identifier/i), 'DO');
+  userEvent.click(screen.getByText('DOI'));
   fireEvent.change(screen.getByLabelText(/doi/i), {
     target: { value: 'doi:12.1234' },
   });

--- a/packages/validation/src/research-output.ts
+++ b/packages/validation/src/research-output.ts
@@ -11,4 +11,5 @@ export const ResearchOutputIdentifierValidationExpression: Record<
   [ResearchOutputIdentifierType.RRID]: '^RRID:[a-zA-Z]+.+$',
   [ResearchOutputIdentifierType.LabCatalogNumber]: undefined,
   [ResearchOutputIdentifierType.None]: undefined,
+  [ResearchOutputIdentifierType.Empty]: undefined,
 };


### PR DESCRIPTION
https://asaphub.atlassian.net/jira/software/c/projects/CRN/boards/8?modal=detail&selectedIssue=CRN-802

1/When I land on the RO form, and navigate to the identifier field I do not want to see a default option of ‘None’ populated in the field. This should have a place holder ‘Choose an identifier’.

2/If I select ‘ASAP Fund' and ‘Used in a publication ' (radio buttons), then I want to remove ‘None’ from the drop down options AND I do not want to populate the field with a default of 'DOI’. DOI and Accession number should be available as options in the list (NO DEFAULTS) pre-populated

![image](https://user-images.githubusercontent.com/87698274/165554124-33d91c8c-f28f-45b6-a864-1aa1587ce0e4.png)

