### PR TITLE
CRN-843 Create an API to send speakers details from the CMS to FE application

### DIFF
--- a/apps/crn-server/src/autogenerated-gql/graphql.ts
+++ b/apps/crn-server/src/autogenerated-gql/graphql.ts
@@ -2106,6 +2106,14 @@ export type Events = Content & {
   referencesCalendarsContents: Maybe<Array<Calendars>>;
   /** Query Calendars content items with total count. */
   referencesCalendarsContentsWithTotal: Maybe<CalendarsResultDto>;
+  /** Query Teams content items. */
+  referencesTeamsContents: Maybe<Array<Teams>>;
+  /** Query Teams content items with total count. */
+  referencesTeamsContentsWithTotal: Maybe<TeamsResultDto>;
+  /** Query Users content items. */
+  referencesUsersContents: Maybe<Array<Users>>;
+  /** Query Users content items with total count. */
+  referencesUsersContentsWithTotal: Maybe<UsersResultDto>;
   /** The status of the content. */
   status: Scalars['String'];
   /** The status color of the content. */
@@ -2127,6 +2135,42 @@ export type EventsReferencesCalendarsContentsArgs = {
 
 /** The structure of a Events content type. */
 export type EventsReferencesCalendarsContentsWithTotalArgs = {
+  filter: Maybe<Scalars['String']>;
+  orderby: Maybe<Scalars['String']>;
+  search: Maybe<Scalars['String']>;
+  skip?: Maybe<Scalars['Int']>;
+  top: Maybe<Scalars['Int']>;
+};
+
+/** The structure of a Events content type. */
+export type EventsReferencesTeamsContentsArgs = {
+  filter: Maybe<Scalars['String']>;
+  orderby: Maybe<Scalars['String']>;
+  search: Maybe<Scalars['String']>;
+  skip?: Maybe<Scalars['Int']>;
+  top: Maybe<Scalars['Int']>;
+};
+
+/** The structure of a Events content type. */
+export type EventsReferencesTeamsContentsWithTotalArgs = {
+  filter: Maybe<Scalars['String']>;
+  orderby: Maybe<Scalars['String']>;
+  search: Maybe<Scalars['String']>;
+  skip?: Maybe<Scalars['Int']>;
+  top: Maybe<Scalars['Int']>;
+};
+
+/** The structure of a Events content type. */
+export type EventsReferencesUsersContentsArgs = {
+  filter: Maybe<Scalars['String']>;
+  orderby: Maybe<Scalars['String']>;
+  search: Maybe<Scalars['String']>;
+  skip?: Maybe<Scalars['Int']>;
+  top: Maybe<Scalars['Int']>;
+};
+
+/** The structure of a Events content type. */
+export type EventsReferencesUsersContentsWithTotalArgs = {
   filter: Maybe<Scalars['String']>;
   orderby: Maybe<Scalars['String']>;
   search: Maybe<Scalars['String']>;
@@ -2171,6 +2215,7 @@ export type EventsDataDto = {
   notesPermanentlyUnavailable: Maybe<EventsDataNotesPermanentlyUnavailableDto>;
   presentation: Maybe<EventsDataPresentationDto>;
   presentationPermanentlyUnavailable: Maybe<EventsDataPresentationPermanentlyUnavailableDto>;
+  speakers: Maybe<EventsDataSpeakersDto>;
   startDate: Maybe<EventsDataStartDateDto>;
   startDateTimeZone: Maybe<EventsDataStartDateTimeZoneDto>;
   status: Maybe<EventsDataStatusDto>;
@@ -2260,6 +2305,7 @@ export type EventsDataInputDto = {
   notesPermanentlyUnavailable: Maybe<EventsDataNotesPermanentlyUnavailableInputDto>;
   presentation: Maybe<EventsDataPresentationInputDto>;
   presentationPermanentlyUnavailable: Maybe<EventsDataPresentationPermanentlyUnavailableInputDto>;
+  speakers: Maybe<EventsDataSpeakersInputDto>;
   startDate: Maybe<EventsDataStartDateInputDto>;
   startDateTimeZone: Maybe<EventsDataStartDateTimeZoneInputDto>;
   status: Maybe<EventsDataStatusInputDto>;
@@ -2362,6 +2408,28 @@ export type EventsDataPresentationPermanentlyUnavailableDto = {
 export type EventsDataPresentationPermanentlyUnavailableInputDto = {
   /** This box is automatically ticked if no output is added after 14 days from the event's end date. */
   iv: Maybe<Scalars['Boolean']>;
+};
+
+/** The structure of the Speakers nested schema. */
+export type EventsDataSpeakersChildDto = {
+  team: Maybe<Array<Teams>>;
+  user: Maybe<Array<Users>>;
+};
+
+/** The structure of the Speakers nested schema. */
+export type EventsDataSpeakersChildInputDto = {
+  team: Maybe<Array<Scalars['String']>>;
+  user: Maybe<Array<Scalars['String']>>;
+};
+
+/** The structure of the Speakers field of the Events content type. */
+export type EventsDataSpeakersDto = {
+  iv: Maybe<Array<EventsDataSpeakersChildDto>>;
+};
+
+/** The structure of the Speakers field of the Events content input type. */
+export type EventsDataSpeakersInputDto = {
+  iv: Maybe<Array<EventsDataSpeakersChildInputDto>>;
 };
 
 /** The structure of the Start Date field of the Events content type. */
@@ -2472,6 +2540,7 @@ export type EventsFlatDataDto = {
   presentation: Maybe<Scalars['String']>;
   /** This box is automatically ticked if no output is added after 14 days from the event's end date. */
   presentationPermanentlyUnavailable: Maybe<Scalars['Boolean']>;
+  speakers: Maybe<Array<EventsDataSpeakersChildDto>>;
   startDate: Maybe<Scalars['Instant']>;
   startDateTimeZone: Maybe<Scalars['String']>;
   status: Maybe<Scalars['String']>;
@@ -4078,6 +4147,10 @@ export type Teams = Content & {
   referencesResearchOutputsContents: Maybe<Array<ResearchOutputs>>;
   /** Query Research Outputs content items with total count. */
   referencesResearchOutputsContentsWithTotal: Maybe<ResearchOutputsResultDto>;
+  /** Query Events content items. */
+  referencingEventsContents: Maybe<Array<Events>>;
+  /** Query Events content items with total count. */
+  referencingEventsContentsWithTotal: Maybe<EventsResultDto>;
   /** Query Groups content items. */
   referencingGroupsContents: Maybe<Array<Groups>>;
   /** Query Groups content items with total count. */
@@ -4107,6 +4180,24 @@ export type TeamsReferencesResearchOutputsContentsArgs = {
 
 /** The structure of a Teams content type. */
 export type TeamsReferencesResearchOutputsContentsWithTotalArgs = {
+  filter: Maybe<Scalars['String']>;
+  orderby: Maybe<Scalars['String']>;
+  search: Maybe<Scalars['String']>;
+  skip?: Maybe<Scalars['Int']>;
+  top: Maybe<Scalars['Int']>;
+};
+
+/** The structure of a Teams content type. */
+export type TeamsReferencingEventsContentsArgs = {
+  filter: Maybe<Scalars['String']>;
+  orderby: Maybe<Scalars['String']>;
+  search: Maybe<Scalars['String']>;
+  skip?: Maybe<Scalars['Int']>;
+  top: Maybe<Scalars['Int']>;
+};
+
+/** The structure of a Teams content type. */
+export type TeamsReferencingEventsContentsWithTotalArgs = {
   filter: Maybe<Scalars['String']>;
   orderby: Maybe<Scalars['String']>;
   search: Maybe<Scalars['String']>;
@@ -4336,6 +4427,10 @@ export type Users = Content & {
   referencingDiscoverContents: Maybe<Array<Discover>>;
   /** Query Discover ASAP content items with total count. */
   referencingDiscoverContentsWithTotal: Maybe<DiscoverResultDto>;
+  /** Query Events content items. */
+  referencingEventsContents: Maybe<Array<Events>>;
+  /** Query Events content items with total count. */
+  referencingEventsContentsWithTotal: Maybe<EventsResultDto>;
   /** Query Groups content items. */
   referencingGroupsContents: Maybe<Array<Groups>>;
   /** Query Groups content items with total count. */
@@ -4401,6 +4496,24 @@ export type UsersReferencingDiscoverContentsArgs = {
 
 /** The structure of a Users content type. */
 export type UsersReferencingDiscoverContentsWithTotalArgs = {
+  filter: Maybe<Scalars['String']>;
+  orderby: Maybe<Scalars['String']>;
+  search: Maybe<Scalars['String']>;
+  skip?: Maybe<Scalars['Int']>;
+  top: Maybe<Scalars['Int']>;
+};
+
+/** The structure of a Users content type. */
+export type UsersReferencingEventsContentsArgs = {
+  filter: Maybe<Scalars['String']>;
+  orderby: Maybe<Scalars['String']>;
+  search: Maybe<Scalars['String']>;
+  skip?: Maybe<Scalars['Int']>;
+  top: Maybe<Scalars['Int']>;
+};
+
+/** The structure of a Users content type. */
+export type UsersReferencingEventsContentsWithTotalArgs = {
   filter: Maybe<Scalars['String']>;
   orderby: Maybe<Scalars['String']>;
   search: Maybe<Scalars['String']>;

--- a/apps/crn-server/src/schema/autogenerated-schema.graphql
+++ b/apps/crn-server/src/schema/autogenerated-schema.graphql
@@ -2188,6 +2188,58 @@ type Events implements Content {
     """Optional number of contents to take."""
     top: Int
   ): CalendarsResultDto
+  """Query Teams content items."""
+  referencesTeamsContents(
+    """Optional OData filter."""
+    filter: String
+    """Optional OData order definition."""
+    orderby: String
+    """Optional OData full text search."""
+    search: String
+    """Optional number of contents to skip."""
+    skip: Int = 0
+    """Optional number of contents to take."""
+    top: Int
+  ): [Teams!]
+  """Query Teams content items with total count."""
+  referencesTeamsContentsWithTotal(
+    """Optional OData filter."""
+    filter: String
+    """Optional OData order definition."""
+    orderby: String
+    """Optional OData full text search."""
+    search: String
+    """Optional number of contents to skip."""
+    skip: Int = 0
+    """Optional number of contents to take."""
+    top: Int
+  ): TeamsResultDto
+  """Query Users content items."""
+  referencesUsersContents(
+    """Optional OData filter."""
+    filter: String
+    """Optional OData order definition."""
+    orderby: String
+    """Optional OData full text search."""
+    search: String
+    """Optional number of contents to skip."""
+    skip: Int = 0
+    """Optional number of contents to take."""
+    top: Int
+  ): [Users!]
+  """Query Users content items with total count."""
+  referencesUsersContentsWithTotal(
+    """Optional OData filter."""
+    filter: String
+    """Optional OData order definition."""
+    orderby: String
+    """Optional OData full text search."""
+    search: String
+    """Optional number of contents to skip."""
+    skip: Int = 0
+    """Optional number of contents to take."""
+    top: Int
+  ): UsersResultDto
   """The status of the content."""
   status: String!
   """The status color of the content."""
@@ -2235,6 +2287,7 @@ type EventsDataDto {
   notesPermanentlyUnavailable: EventsDataNotesPermanentlyUnavailableDto
   presentation: EventsDataPresentationDto
   presentationPermanentlyUnavailable: EventsDataPresentationPermanentlyUnavailableDto
+  speakers: EventsDataSpeakersDto
   startDate: EventsDataStartDateDto
   startDateTimeZone: EventsDataStartDateTimeZoneDto
   status: EventsDataStatusDto
@@ -2324,6 +2377,7 @@ input EventsDataInputDto {
   notesPermanentlyUnavailable: EventsDataNotesPermanentlyUnavailableInputDto
   presentation: EventsDataPresentationInputDto
   presentationPermanentlyUnavailable: EventsDataPresentationPermanentlyUnavailableInputDto
+  speakers: EventsDataSpeakersInputDto
   startDate: EventsDataStartDateInputDto
   startDateTimeZone: EventsDataStartDateTimeZoneInputDto
   status: EventsDataStatusInputDto
@@ -2426,6 +2480,28 @@ type EventsDataPresentationPermanentlyUnavailableDto {
 input EventsDataPresentationPermanentlyUnavailableInputDto {
   """This box is automatically ticked if no output is added after 14 days from the event's end date."""
   iv: Boolean
+}
+
+"""The structure of the Speakers nested schema."""
+type EventsDataSpeakersChildDto {
+  team: [Teams!]
+  user: [Users!]
+}
+
+"""The structure of the Speakers nested schema."""
+input EventsDataSpeakersChildInputDto {
+  team: [String!]
+  user: [String!]
+}
+
+"""The structure of the Speakers field of the Events content type."""
+type EventsDataSpeakersDto {
+  iv: [EventsDataSpeakersChildDto!]
+}
+
+"""The structure of the Speakers field of the Events content input type."""
+input EventsDataSpeakersInputDto {
+  iv: [EventsDataSpeakersChildInputDto!]
 }
 
 """The structure of the Start Date field of the Events content type."""
@@ -2536,6 +2612,7 @@ type EventsFlatDataDto {
   presentation: String
   """This box is automatically ticked if no output is added after 14 days from the event's end date."""
   presentationPermanentlyUnavailable: Boolean
+  speakers: [EventsDataSpeakersChildDto!]
   startDate: Instant
   startDateTimeZone: String
   status: String
@@ -4254,6 +4331,32 @@ type Teams implements Content {
     """Optional number of contents to take."""
     top: Int
   ): ResearchOutputsResultDto
+  """Query Events content items."""
+  referencingEventsContents(
+    """Optional OData filter."""
+    filter: String
+    """Optional OData order definition."""
+    orderby: String
+    """Optional OData full text search."""
+    search: String
+    """Optional number of contents to skip."""
+    skip: Int = 0
+    """Optional number of contents to take."""
+    top: Int
+  ): [Events!]
+  """Query Events content items with total count."""
+  referencingEventsContentsWithTotal(
+    """Optional OData filter."""
+    filter: String
+    """Optional OData order definition."""
+    orderby: String
+    """Optional OData full text search."""
+    search: String
+    """Optional number of contents to skip."""
+    skip: Int = 0
+    """Optional number of contents to take."""
+    top: Int
+  ): EventsResultDto
   """Query Groups content items."""
   referencingGroupsContents(
     """Optional OData filter."""
@@ -4568,6 +4671,32 @@ type Users implements Content {
     """Optional number of contents to take."""
     top: Int
   ): DiscoverResultDto
+  """Query Events content items."""
+  referencingEventsContents(
+    """Optional OData filter."""
+    filter: String
+    """Optional OData order definition."""
+    orderby: String
+    """Optional OData full text search."""
+    search: String
+    """Optional number of contents to skip."""
+    skip: Int = 0
+    """Optional number of contents to take."""
+    top: Int
+  ): [Events!]
+  """Query Events content items with total count."""
+  referencingEventsContentsWithTotal(
+    """Optional OData filter."""
+    filter: String
+    """Optional OData order definition."""
+    orderby: String
+    """Optional OData full text search."""
+    search: String
+    """Optional number of contents to skip."""
+    skip: Int = 0
+    """Optional number of contents to take."""
+    top: Int
+  ): EventsResultDto
   """Query Groups content items."""
   referencingGroupsContents(
     """Optional OData filter."""

--- a/packages/squidex/schema/schemas/events.json
+++ b/packages/squidex/schema/schemas/events.json
@@ -230,6 +230,77 @@
         }
       },
       {
+        "name": "separatorSpeakers",
+        "isHidden": false,
+        "isLocked": false,
+        "isDisabled": false,
+        "partitioning": "invariant",
+        "properties": {
+          "fieldType": "UI",
+          "editor": "Separator",
+          "label": "Speakers",
+          "isRequired": false,
+          "isRequiredOnPublish": false,
+          "isHalfWidth": false
+        }
+      },
+      {
+        "name": "speakers",
+        "properties": {
+          "isRequired": false,
+          "isRequiredOnPublish": false,
+          "isHalfWidth": false,
+          "fieldType": "Array",
+          "maxItems": 20,
+          "label": "Speakers"
+        },
+        "isLocked": false,
+        "isHidden": false,
+        "isDisabled": false,
+        "partitioning": "invariant",
+        "nested": [
+          {
+            "name": "team",
+            "properties": {
+              "isRequired": true,
+              "isRequiredOnPublish": false,
+              "isHalfWidth": false,
+              "fieldType": "References",
+              "editor": "List",
+              "minItems": 1,
+              "maxItems": 1,
+              "allowDuplicates": false,
+              "resolveReference": false,
+              "mustBePublished": false,
+              "schemaIds": ["teams"],
+              "label": "Team"
+            },
+            "isLocked": false,
+            "isHidden": false,
+            "isDisabled": false
+          },
+          {
+            "name": "user",
+            "properties": {
+              "isRequired": false,
+              "isRequiredOnPublish": false,
+              "isHalfWidth": false,
+              "fieldType": "References",
+              "editor": "List",
+              "maxItems": 1,
+              "allowDuplicates": false,
+              "resolveReference": false,
+              "mustBePublished": false,
+              "schemaIds": ["users"],
+              "label": "User"
+            },
+            "isLocked": false,
+            "isHidden": false,
+            "isDisabled": false
+          }
+        ]
+      },
+      {
         "name": "separatorMeetingMaterials",
         "isHidden": false,
         "isLocked": false,


### PR DESCRIPTION
### Requirement
- Create an API to send speakers details from the CMS to the FE. 
-- The API should include the team name, user name and the user role (user object, inc. avatar)
- This response should be sent to the FE in the order that is specified in the CMS
- Maximum of 20 speakers to be provided in the response

### Note
- Can only be tested when the FE is completed - dev tests in first instance
