### PR TITLE
Bug/Aloglia pagination bugfix

### DIFF
--- a/packages/algolia/algolia-schema.json
+++ b/packages/algolia/algolia-schema.json
@@ -46,7 +46,7 @@
   ],
   "attributesToSnippet": null,
   "attributesToHighlight": null,
-  "paginationLimitedTo": 1000,
+  "paginationLimitedTo": 10000,
   "attributeForDistinct": null,
   "exactOnSingleWordQuery": "word",
   "disablePrefixOnAttributes": [],


### PR DESCRIPTION
Increase limit from 1000 to 10000 as currently there is an error shown when the user selects page above 100 for search results.