### PR TITLE
CRN-802 identifier field defaults

### DIFF
--- a/apps/crn-frontend/src/network/teams/__tests__/TeamOutput.test.tsx
+++ b/apps/crn-frontend/src/network/teams/__tests__/TeamOutput.test.tsx
@@ -2,6 +2,7 @@ import {
   Auth0Provider,
   WhenReady,
 } from '@asap-hub/crn-frontend/src/auth/test-utils';
+import { BackendError } from '@asap-hub/frontend-utils';
 import {
   ResearchOutputDocumentType,
   ValidationErrorResponse,
@@ -11,12 +12,16 @@ import {
   ToastContext,
 } from '@asap-hub/react-context';
 import { network, OutputDocumentTypeParameter } from '@asap-hub/routing';
-import { render, screen, waitFor } from '@testing-library/react';
+import {
+  render,
+  screen,
+  waitFor,
+  waitForElementToBeRemoved,
+} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ContextType, Suspense } from 'react';
 import { Route, StaticRouter } from 'react-router-dom';
 import { RecoilRoot } from 'recoil';
-import { BackendError } from '@asap-hub/frontend-utils';
 import { createTeamResearchOutput } from '../api';
 import { refreshTeamState } from '../state';
 import TeamOutput, {
@@ -26,114 +31,276 @@ import TeamOutput, {
 jest.mock('../api');
 jest.mock('../../users/api');
 
-const mockToast = jest.fn() as jest.MockedFunction<
-  ContextType<typeof ToastContext>
->;
-const mockCreateTeamResearchOutput =
-  createTeamResearchOutput as jest.MockedFunction<
-    typeof createTeamResearchOutput
+describe('TeamOutput', () => {
+  const mockToast = jest.fn() as jest.MockedFunction<
+    ContextType<typeof ToastContext>
   >;
+  const mockCreateTeamResearchOutput =
+    createTeamResearchOutput as jest.MockedFunction<
+      typeof createTeamResearchOutput
+    >;
 
-interface RenderPageOptions {
-  teamId: string;
-  outputDocumentType?: OutputDocumentTypeParameter;
-  canCreate?: boolean;
-}
+  interface RenderPageOptions {
+    teamId: string;
+    outputDocumentType?: OutputDocumentTypeParameter;
+    canCreate?: boolean;
+  }
 
-const renderPage = async ({
-  canCreate = true,
-  teamId,
-  outputDocumentType = 'bioinformatics',
-}: RenderPageOptions) => {
-  const path =
-    network.template +
-    network({}).teams.template +
-    network({}).teams({}).team.template +
-    network({}).teams({}).team({ teamId }).createOutput.template;
+  it('Renders the research output', async () => {
+    await renderPage({ teamId: '42', outputDocumentType: 'bioinformatics' });
 
-  const result = render(
-    <RecoilRoot
-      initializeState={({ set }) =>
-        set(refreshTeamState(teamId), Math.random())
-      }
-    >
-      <Suspense fallback="loading">
-        <ToastContext.Provider value={mockToast}>
-          <Auth0Provider user={{}}>
-            <WhenReady>
-              <StaticRouter
-                location={
-                  network({})
-                    .teams({})
-                    .team({ teamId })
-                    .createOutput({ outputDocumentType }).$
-                }
-              >
-                <ResearchOutputPermissionsContext.Provider
-                  value={{ canCreate }}
+    expect(
+      screen.getByRole('heading', { name: /Share bioinformatics/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('switches research output type based on parameter', async () => {
+    await renderPage({ teamId: '42', outputDocumentType: 'article' });
+
+    expect(
+      screen.getByRole('heading', { name: /Share an article/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('Shows NotFoundPage when canCreate in ResearchOutputPermissions is false', async () => {
+    await renderPage({ teamId: '42', canCreate: false });
+    expect(
+      screen.queryByRole('heading', { name: /Share/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', {
+        name: /Sorry! We can’t seem to find that page/i,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it('can submit a form when form data is valid', async () => {
+    const teamId = 'team-id';
+    const link = 'https://example.com';
+    const title = 'example title';
+    const description = 'example description';
+    const type = 'Animal Model';
+    const doi = '10.1234';
+
+    await renderPage({ teamId, outputDocumentType: 'lab-resource' });
+
+    await mandatoryFields({ link, title, description, type, doi });
+
+    userEvent.click(screen.getByRole('textbox', { name: /Labs/i }));
+    userEvent.click(screen.getByText('Example 1 Lab'));
+    userEvent.click(screen.getByRole('textbox', { name: /Authors/i }));
+    userEvent.click(screen.getByText('Person A 3'));
+
+    const button = screen.getByRole('button', { name: /Publish/i });
+    userEvent.click(button);
+
+    await waitFor(() => {
+      expect(button).toBeEnabled();
+    });
+    expect(mockCreateTeamResearchOutput).toHaveBeenCalledWith(
+      {
+        doi,
+        documentType: 'Lab Resource',
+        addedDate: expect.anything(),
+        tags: [],
+        asapFunded: false,
+        usedInPublication: false,
+        sharingStatus: 'Network Only',
+        teams: ['team-id'],
+        link,
+        title,
+        description,
+        type,
+        labs: ['l0'],
+        authors: [
+          {
+            userId: 'u2',
+          },
+        ],
+        methods: [],
+      },
+      expect.anything(),
+    );
+  });
+
+  it('will show server side validation error for link', async () => {
+    const validationResponse: ValidationErrorResponse = {
+      message: 'Validation error',
+      error: 'Bad Request',
+      statusCode: 400,
+      data: [
+        { instancePath: '/link', keyword: '', params: {}, schemaPath: 'link' },
+      ],
+    };
+
+    mockCreateTeamResearchOutput.mockRejectedValue(
+      new BackendError('example', validationResponse, 400),
+    );
+
+    await renderPage({ teamId: '42', outputDocumentType: 'article' });
+    await mandatoryFields(
+      {
+        link: 'http://example.com',
+        title: 'example title',
+        description: 'example description',
+        type: 'Preprint',
+        doi: '10.1234',
+      },
+      true,
+    );
+
+    const button = screen.getByRole('button', { name: /Publish/i });
+    userEvent.click(button);
+
+    await waitFor(() => {
+      expect(button).toBeEnabled();
+    });
+    expect(mockCreateTeamResearchOutput).toHaveBeenCalled();
+    expect(
+      screen.getByText(
+        'A Research Output with this URL already exists. Please enter a different URL.',
+      ),
+    ).toBeVisible();
+
+    const url = screen.getByRole('textbox', { name: /URL \(required\)/i });
+    userEvent.type(url, 'a');
+    url.blur();
+
+    expect(
+      screen.queryByText(
+        'A Research Output with this URL already exists. Please enter a different URL.',
+      ),
+    ).toBeNull();
+    expect(mockToast).not.toHaveBeenCalled();
+  });
+
+  it('will toast server side errors for unknown errors', async () => {
+    mockCreateTeamResearchOutput.mockRejectedValue(
+      new Error('Something went wrong'),
+    );
+
+    await renderPage({ teamId: '42', outputDocumentType: 'article' });
+
+    userEvent.type(
+      screen.getByRole('textbox', { name: /URL \(required\)/i }),
+      'http://example.com',
+    );
+    userEvent.type(
+      screen.getByRole('textbox', { name: /title/i }),
+      'example title',
+    );
+    userEvent.type(
+      screen.getByRole('textbox', { name: /description/i }),
+      'example description',
+    );
+    userEvent.type(
+      screen.getByRole('textbox', { name: /Select the option/i }),
+      'Preprint',
+    );
+
+    const identifier = screen.getByRole('textbox', { name: /identifier/i });
+    userEvent.type(identifier, 'DOI');
+    identifier.blur();
+    userEvent.type(
+      await screen.findByRole('textbox', {
+        name: /Your DOI must start with/i,
+      }),
+      '10.1234',
+    );
+
+    const button = screen.getByRole('button', { name: /Publish/i });
+    userEvent.click(button);
+
+    await waitFor(() => {
+      expect(button).toBeEnabled();
+    });
+    expect(mockCreateTeamResearchOutput).toHaveBeenCalled();
+    expect(mockToast).toHaveBeenCalledWith(
+      'There was an error and we were unable to save your changes. Please try again.',
+    );
+  });
+
+  it.each<{
+    param: OutputDocumentTypeParameter;
+    outputType: ResearchOutputDocumentType;
+  }>([
+    { param: 'article', outputType: 'Article' },
+    { param: 'bioinformatics', outputType: 'Bioinformatics' },
+    { param: 'dataset', outputType: 'Dataset' },
+    { param: 'lab-resource', outputType: 'Lab Resource' },
+    { param: 'protocol', outputType: 'Protocol' },
+    { param: 'unknown' as OutputDocumentTypeParameter, outputType: 'Article' },
+  ])('maps from $param to $outputType', ({ param, outputType }) => {
+    expect(paramOutputDocumentTypeToResearchOutputDocumentType(param)).toEqual(
+      outputType,
+    );
+  });
+
+  async function renderPage({
+    canCreate = true,
+    teamId,
+    outputDocumentType = 'bioinformatics',
+  }: RenderPageOptions) {
+    const path =
+      network.template +
+      network({}).teams.template +
+      network({}).teams({}).team.template +
+      network({}).teams({}).team({ teamId }).createOutput.template;
+
+    render(
+      <RecoilRoot
+        initializeState={({ set }) =>
+          set(refreshTeamState(teamId), Math.random())
+        }
+      >
+        <Suspense fallback="loading">
+          <ToastContext.Provider value={mockToast}>
+            <Auth0Provider user={{}}>
+              <WhenReady>
+                <StaticRouter
+                  location={
+                    network({})
+                      .teams({})
+                      .team({ teamId })
+                      .createOutput({ outputDocumentType }).$
+                  }
                 >
-                  <Route path={path}>
-                    <TeamOutput teamId={teamId} />
-                  </Route>
-                </ResearchOutputPermissionsContext.Provider>
-              </StaticRouter>
-            </WhenReady>
-          </Auth0Provider>
-        </ToastContext.Provider>
-      </Suspense>
-    </RecoilRoot>,
-  );
-  await waitFor(() =>
-    expect(result.queryByText(/loading/i)).not.toBeInTheDocument(),
-  );
-  return result;
-};
-
-it('Renders the research output', async () => {
-  const teamId = 'team-id';
-  await renderPage({ teamId, outputDocumentType: 'bioinformatics' });
-
-  expect(
-    screen.getByRole('heading', { name: /Share bioinformatics/i }),
-  ).toBeInTheDocument();
+                  <ResearchOutputPermissionsContext.Provider
+                    value={{ canCreate }}
+                  >
+                    <Route path={path}>
+                      <TeamOutput teamId={teamId} />
+                    </Route>
+                  </ResearchOutputPermissionsContext.Provider>
+                </StaticRouter>
+              </WhenReady>
+            </Auth0Provider>
+          </ToastContext.Provider>
+        </Suspense>
+      </RecoilRoot>,
+    );
+    await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
+  }
 });
-
-it('switches research output type based on parameter', async () => {
-  const teamId = 'team-id';
-  await renderPage({ teamId, outputDocumentType: 'article' });
-
-  expect(
-    screen.getByRole('heading', { name: /Share an article/i }),
-  ).toBeInTheDocument();
-});
-
-it('Shows NotFoundPage when canCreate in ResearchOutputPermissions is false', async () => {
-  const teamId = 'team-id';
-  await renderPage({ teamId, canCreate: false });
-  expect(
-    screen.queryByRole('heading', { name: /Share/i }),
-  ).not.toBeInTheDocument();
-  expect(
-    screen.getByRole('heading', {
-      name: /Sorry! We can’t seem to find that page/i,
-    }),
-  ).toBeInTheDocument();
-});
-
-it('can submit a form when form data is valid', async () => {
-  const teamId = 'team-id';
-  const link = 'https://example.com';
-  const title = 'example title';
-  const description = 'example description';
-  const type = 'Animal Model';
-  const doi = '10.1234';
-
-  await renderPage({ teamId, outputDocumentType: 'lab-resource' });
-
-  userEvent.type(
-    screen.getByRole('textbox', { name: /url \(optional\)/i }),
+async function mandatoryFields(
+  {
     link,
-  );
+    title,
+    description,
+    type,
+    doi,
+  }: {
+    link: string;
+    title: string;
+    description: string;
+    type: string;
+    doi: string;
+  },
+  isLinkRequired: boolean = false,
+) {
+  const url = isLinkRequired ? /url \(required\)/i : /url \(optional\)/i;
+
+  userEvent.type(screen.getByRole('textbox', { name: url }), link);
   userEvent.type(screen.getByRole('textbox', { name: /title/i }), title);
   userEvent.type(
     screen.getByRole('textbox', { name: /description/i }),
@@ -145,177 +312,13 @@ it('can submit a form when form data is valid', async () => {
     type,
   );
 
-  userEvent.click(screen.getByRole('textbox', { name: /Labs/i }));
-  userEvent.click(screen.getByText('Example 1 Lab'));
-  userEvent.click(screen.getByRole('textbox', { name: /Authors/i }));
-  userEvent.click(screen.getByText('Person A 3'));
-
-  userEvent.type(screen.getByRole('textbox', { name: /identifier/i }), 'DOI');
-  userEvent.tab();
-  const doiTextBox = await screen.findByRole('textbox', {
-    name: /Your DOI must start with/i,
-  });
-  userEvent.type(doiTextBox, doi);
-
-  const button = screen.getByRole('button', { name: /Publish/i });
-
-  userEvent.click(button);
-
-  await waitFor(() => {
-    expect(button).toBeEnabled();
-  });
-  expect(mockCreateTeamResearchOutput).toHaveBeenCalledWith(
-    {
-      doi,
-      documentType: 'Lab Resource',
-      addedDate: expect.anything(),
-      tags: [],
-      asapFunded: false,
-      usedInPublication: false,
-      sharingStatus: 'Network Only',
-      teams: ['team-id'],
-      link,
-      title,
-      description,
-      type,
-      labs: ['l0'],
-      authors: [
-        {
-          userId: 'u2',
-        },
-      ],
-      methods: [],
-    },
-    expect.anything(),
-  );
-});
-
-it('will show server side validation error for link', async () => {
-  const teamId = 'team-id';
-  const validationResponse: ValidationErrorResponse = {
-    message: 'Validation error',
-    error: 'Bad Request',
-    statusCode: 400,
-    data: [
-      { instancePath: '/link', keyword: '', params: {}, schemaPath: 'link' },
-    ],
-  };
-
-  mockCreateTeamResearchOutput.mockRejectedValue(
-    new BackendError('example', validationResponse, 400),
-  );
-
-  await renderPage({ teamId, outputDocumentType: 'article' });
-
+  const identifier = screen.getByRole('textbox', { name: /identifier/i });
+  userEvent.type(identifier, 'DOI');
+  identifier.blur();
   userEvent.type(
-    screen.getByRole('textbox', { name: /URL \(required\)/i }),
-    'http://example.com',
+    await screen.findByRole('textbox', {
+      name: /Your DOI must start with/i,
+    }),
+    doi,
   );
-  userEvent.type(
-    screen.getByRole('textbox', { name: /title/i }),
-    'example title',
-  );
-  userEvent.type(
-    screen.getByRole('textbox', { name: /description/i }),
-    'example description',
-  );
-
-  userEvent.type(
-    screen.getByRole('textbox', { name: /Select the option/i }),
-    'Preprint',
-  );
-
-  userEvent.type(screen.getByRole('textbox', { name: /identifier/i }), 'DOI');
-  userEvent.tab();
-  const doiTextBox = await screen.findByRole('textbox', {
-    name: /Your DOI must start with/i,
-  });
-  userEvent.type(doiTextBox, '10.1234');
-
-  const button = screen.getByRole('button', { name: /Publish/i });
-  userEvent.click(button);
-
-  await waitFor(() => {
-    expect(button).toBeEnabled();
-  });
-  expect(mockCreateTeamResearchOutput).toHaveBeenCalled();
-  expect(
-    screen.getByText(
-      'A Research Output with this URL already exists. Please enter a different URL.',
-    ),
-  ).toBeVisible();
-
-  userEvent.type(
-    screen.getByRole('textbox', { name: /URL \(required\)/i }),
-    'a',
-  );
-  userEvent.tab();
-
-  expect(
-    screen.queryByText(
-      'A Research Output with this URL already exists. Please enter a different URL.',
-    ),
-  ).toBeNull();
-  expect(mockToast).not.toHaveBeenCalled();
-});
-
-it('will toast server side errors for unknown errors', async () => {
-  const teamId = 'team-id';
-
-  mockCreateTeamResearchOutput.mockRejectedValue(
-    new Error('Something went wrong'),
-  );
-
-  await renderPage({ teamId, outputDocumentType: 'article' });
-
-  userEvent.type(
-    screen.getByRole('textbox', { name: /URL \(required\)/i }),
-    'http://example.com',
-  );
-  userEvent.type(
-    screen.getByRole('textbox', { name: /title/i }),
-    'example title',
-  );
-  userEvent.type(
-    screen.getByRole('textbox', { name: /description/i }),
-    'example description',
-  );
-  userEvent.type(
-    screen.getByRole('textbox', { name: /Select the option/i }),
-    'Preprint',
-  );
-
-  userEvent.type(screen.getByRole('textbox', { name: /identifier/i }), 'DOI');
-  userEvent.tab();
-  const doiTextBox = await screen.findByRole('textbox', {
-    name: /Your DOI must start with/i,
-  });
-  userEvent.type(doiTextBox, '10.1234');
-
-  const button = screen.getByRole('button', { name: /Publish/i });
-  userEvent.click(button);
-
-  await waitFor(() => {
-    expect(button).toBeEnabled();
-  });
-  expect(mockCreateTeamResearchOutput).toHaveBeenCalled();
-  expect(mockToast).toHaveBeenCalledWith(
-    'There was an error and we were unable to save your changes. Please try again.',
-  );
-});
-
-it.each<{
-  param: OutputDocumentTypeParameter;
-  outputType: ResearchOutputDocumentType;
-}>([
-  { param: 'article', outputType: 'Article' },
-  { param: 'bioinformatics', outputType: 'Bioinformatics' },
-  { param: 'dataset', outputType: 'Dataset' },
-  { param: 'lab-resource', outputType: 'Lab Resource' },
-  { param: 'protocol', outputType: 'Protocol' },
-  { param: 'unknown' as OutputDocumentTypeParameter, outputType: 'Article' },
-])('maps from $param to $outputType', ({ param, outputType }) => {
-  expect(paramOutputDocumentTypeToResearchOutputDocumentType(param)).toEqual(
-    outputType,
-  );
-});
+}

--- a/apps/crn-frontend/src/network/teams/__tests__/TeamOutput.test.tsx
+++ b/apps/crn-frontend/src/network/teams/__tests__/TeamOutput.test.tsx
@@ -28,6 +28,7 @@ import TeamOutput, {
   paramOutputDocumentTypeToResearchOutputDocumentType,
 } from '../TeamOutput';
 
+jest.setTimeout(30000);
 jest.mock('../api');
 jest.mock('../../users/api');
 

--- a/packages/model/src/research-output.ts
+++ b/packages/model/src/research-output.ts
@@ -1,8 +1,8 @@
-import { TeamResponse } from './team';
 import { ListResponse } from './common';
-import { UserResponse } from './user';
 import { ExternalAuthorInput, ExternalAuthorResponse } from './external-author';
 import { LabResponse } from './lab';
+import { TeamResponse } from './team';
+import { UserResponse } from './user';
 
 export const researchOutputDocumentTypes = [
   'Grant Document',
@@ -129,6 +129,7 @@ export const researchOutputMapType = (
 };
 
 export enum ResearchOutputIdentifierType {
+  Empty = 'Empty',
   None = 'None',
   DOI = 'DOI',
   AccessionNumber = 'Accession Number',

--- a/packages/react-components/src/organisms/TeamCreateOutputForm.tsx
+++ b/packages/react-components/src/organisms/TeamCreateOutputForm.tsx
@@ -160,7 +160,7 @@ const TeamCreateOutputForm: React.FC<TeamCreateOutputFormProps> = ({
         type !== '' ||
         labs.length !== 0 ||
         authors.length !== 0 ||
-        identifierType !== ResearchOutputIdentifierType.None ||
+        identifierType !== ResearchOutputIdentifierType.Empty ||
         identifier !== '' ||
         labCatalogNumber !== '' ||
         teams.length !== 1 // Original team

--- a/packages/react-components/src/organisms/TeamCreateOutputForm.tsx
+++ b/packages/react-components/src/organisms/TeamCreateOutputForm.tsx
@@ -79,6 +79,7 @@ const identifierTypeToFieldName: Record<
   'doi' | 'accession' | 'labCatalogNumber' | 'rrid' | undefined
 > = {
   [ResearchOutputIdentifierType.None]: undefined,
+  [ResearchOutputIdentifierType.Empty]: undefined,
   [ResearchOutputIdentifierType.DOI]: 'doi',
   [ResearchOutputIdentifierType.AccessionNumber]: 'accession',
   [ResearchOutputIdentifierType.RRID]: 'rrid',
@@ -145,7 +146,7 @@ const TeamCreateOutputForm: React.FC<TeamCreateOutputFormProps> = ({
   const [publishDate, setPublishDate] = useState<Date | undefined>(undefined);
 
   const [identifierType, setIdentifierType] =
-    useState<ResearchOutputIdentifierType>(ResearchOutputIdentifierType.None);
+    useState<ResearchOutputIdentifierType>(ResearchOutputIdentifierType.Empty);
   const [identifier, setIdentifier] = useState<string>('');
 
   return (

--- a/packages/react-components/src/organisms/TeamCreateOutputIdentifier.tsx
+++ b/packages/react-components/src/organisms/TeamCreateOutputIdentifier.tsx
@@ -1,10 +1,10 @@
-import { useCallback, useEffect, useMemo } from 'react';
 import {
   ResearchOutputDocumentType,
   ResearchOutputIdentifierType,
   researchOutputToIdentifierType,
 } from '@asap-hub/model';
 import { ResearchOutputIdentifierValidationExpression } from '@asap-hub/validation';
+import { useCallback, useEffect, useMemo } from 'react';
 import { LabeledDropdown, LabeledTextField } from '../molecules';
 import { noop } from '../utils';
 
@@ -63,6 +63,13 @@ const identifierMap = {
     errorMessage: undefined,
     required: false,
   },
+  [ResearchOutputIdentifierType.Empty]: {
+    helpText: '',
+    placeholder: '',
+    regex: ResearchOutputIdentifierValidationExpression.Empty,
+    errorMessage: undefined,
+    required: false,
+  },
 } as const;
 
 export interface TeamCreateOutputIdentifierProps {
@@ -76,25 +83,25 @@ export interface TeamCreateOutputIdentifierProps {
 
 export const TeamCreateOutputIdentifier: React.FC<TeamCreateOutputIdentifierProps> =
   ({
-    identifierType = ResearchOutputIdentifierType.None,
+    identifierType = ResearchOutputIdentifierType.Empty,
     setIdentifierType = noop,
     identifier = '',
     setIdentifier = noop,
     documentType,
     required,
   }) => {
-    const data = useMemo(() => identifierMap[identifierType], [identifierType]);
+    const data = useMemo(
+      () =>
+        identifierType === ResearchOutputIdentifierType.Empty ||
+        identifierType === ResearchOutputIdentifierType.None
+          ? null
+          : identifierMap[identifierType],
+      [identifierType],
+    );
     const identifiers = useMemo(
       () => getIdentifiers(documentType, required),
       [documentType, required],
     );
-
-    useEffect(() => {
-      if (required && identifierType === ResearchOutputIdentifierType.None) {
-        setIdentifierType(identifiers[0].value);
-      }
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [required, setIdentifierType]);
 
     useEffect(() => {
       setIdentifier('');
@@ -108,8 +115,6 @@ export const TeamCreateOutputIdentifier: React.FC<TeamCreateOutputIdentifierProp
           )
         ) {
           setIdentifierType(newType as ResearchOutputIdentifierType);
-        } else {
-          setIdentifierType(identifiers[0].value);
         }
       },
       [setIdentifierType, identifiers],
@@ -123,8 +128,11 @@ export const TeamCreateOutputIdentifier: React.FC<TeamCreateOutputIdentifierProp
           options={identifiers}
           value={identifierType}
           onChange={onChangeIdentifierType}
+          placeholder={'Choose an identifier'}
+          getValidationMessage={() => `Please choose an identifier`}
+          required
         />
-        {identifierType !== ResearchOutputIdentifierType.None && (
+        {data && (
           <LabeledTextField
             title={identifierType}
             description={data.helpText}

--- a/packages/react-components/src/organisms/__tests__/TeamCreateOutputForm.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/TeamCreateOutputForm.test.tsx
@@ -11,7 +11,7 @@ import {
   waitForElementToBeRemoved,
   within,
 } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import userEvent, { specialChars } from '@testing-library/user-event';
 import { createMemoryHistory, History } from 'history';
 import { ComponentProps } from 'react';
 import { Router, StaticRouter } from 'react-router-dom';
@@ -190,10 +190,13 @@ describe('on submit', () => {
       screen.getByRole('textbox', { name: /description/i }),
       data.description,
     );
-    userEvent.type(
-      screen.getByRole('textbox', { name: /Select the option/i }),
-      data.type,
-    );
+
+    const typeDropdown = screen.getByRole('textbox', {
+      name: /Select the option/i,
+    });
+    userEvent.type(typeDropdown, data.type);
+    userEvent.type(typeDropdown, specialChars.enter);
+
     const identifier = screen.getByRole('textbox', { name: /identifier/i });
     userEvent.type(identifier, 'DOI');
     identifier.blur();

--- a/packages/react-components/src/organisms/__tests__/TeamCreateOutputForm.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/TeamCreateOutputForm.test.tsx
@@ -98,7 +98,7 @@ it('displays current team within the form', async () => {
   expect(screen.getByText('example team')).toBeVisible();
 });
 
-it('if funded and publication are both yes, then the None option is removed.', async () => {
+it('is funded and publication are both yes, then the none option is removed', async () => {
   render(
     <StaticRouter>
       <TeamCreateOutputForm {...props} />

--- a/packages/react-components/src/organisms/__tests__/TeamCreateOutputIdentifier.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/TeamCreateOutputIdentifier.test.tsx
@@ -96,3 +96,13 @@ describe.each`
     assertError();
   });
 });
+
+it('If require, None should be unavailable', () => {
+  const { rerender } = render(<TeamCreateOutputIdentifier {...props} />);
+  const textbox = screen.getByRole('textbox', { name: /identifier/i });
+  userEvent.click(textbox);
+  expect(screen.getByText('None')).toBeVisible();
+  rerender(<TeamCreateOutputIdentifier {...props} required={true} />);
+  userEvent.click(textbox);
+  expect(screen.queryByText('None')).toBeNull();
+});

--- a/packages/react-components/src/organisms/__tests__/TeamCreateOutputIdentifier.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/TeamCreateOutputIdentifier.test.tsx
@@ -1,6 +1,6 @@
 import { ResearchOutputIdentifierType } from '@asap-hub/model';
 import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import userEvent, { specialChars } from '@testing-library/user-event';
 import { ComponentProps } from 'react';
 import { TeamCreateOutputIdentifier } from '../TeamCreateOutputIdentifier';
 
@@ -24,6 +24,7 @@ it('should reset the identifier to a valid value on entering something unknown',
   );
   const textbox = screen.getByRole('textbox', { name: /identifier/i });
   userEvent.type(textbox, 'UNKNOWN');
+  userEvent.type(textbox, specialChars.enter);
   textbox.blur();
 
   expect(screen.getByText('Choose an identifier')).toBeVisible();
@@ -40,6 +41,7 @@ it('should set the identifier to the selected value', () => {
   );
   const textbox = screen.getByRole('textbox', { name: /identifier/i });
   userEvent.type(textbox, 'DOI');
+  userEvent.type(textbox, specialChars.enter);
   textbox.blur();
 
   expect(setIdentifierType).toHaveBeenCalledWith(

--- a/packages/validation/src/research-output.ts
+++ b/packages/validation/src/research-output.ts
@@ -10,4 +10,5 @@ export const ResearchOutputIdentifierValidationExpression: Record<
     '^(\\w+\\d+(\\.\\d+)?)|(NP_\\d+)$',
   [ResearchOutputIdentifierType.RRID]: '^RRID:[a-zA-Z]+.+$',
   [ResearchOutputIdentifierType.None]: undefined,
+  [ResearchOutputIdentifierType.Empty]: undefined,
 };


### PR DESCRIPTION
https://asaphub.atlassian.net/jira/software/c/projects/CRN/boards/8?modal=detail&selectedIssue=CRN-802

1/When I land on the RO form, and navigate to the identifier field I do not want to see a default option of ‘None’ populated in the field. This should have a place holder ‘Choose an identifier’.

2/If I select ‘ASAP Fund' and ‘Used in a publication ' (radio buttons), then I want to remove ‘None’ from the drop down options AND I do not want to populate the field with a default of 'DOI’. DOI and Accession number should be available as options in the list (NO DEFAULTS) pre-populated

image