### PR TITLE
Increase timeout to 60s in TeamCreateOutputForm test

### DIFF
--- a/packages/react-components/src/organisms/__tests__/TeamCreateOutputForm.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/TeamCreateOutputForm.test.tsx
@@ -26,7 +26,7 @@ const props: ComponentProps<typeof TeamCreateOutputForm> = {
   team: createTeamResponse(),
 };
 
-jest.setTimeout(30000);
+jest.setTimeout(60000);
 describe('createIdentifierField', () => {
   it('maps the ResearchOutputIdentifierType to fields including the identifier', () => {
     expect(


### PR DESCRIPTION
Due to known bug in the test we have decided to increase the timeout to 60s 