### PR TITLE
feat: Remove redundant references in News

### DIFF
--- a/apps/crn-frontend/src/dashboard/__tests__/Dashboard.test.tsx
+++ b/apps/crn-frontend/src/dashboard/__tests__/Dashboard.test.tsx
@@ -77,8 +77,8 @@ it('renders dashboard with news', async () => {
       {
         id: '55724942-3408-4ad6-9a73-14b92226ffb77',
         created: '2020-09-07T17:36:54Z',
-        title: 'Event Title',
-        type: 'Event',
+        title: 'Tutorial Title',
+        type: 'Tutorial',
       },
     ],
     pages: [],

--- a/apps/crn-server/src/controllers/news.ts
+++ b/apps/crn-server/src/controllers/news.ts
@@ -19,7 +19,7 @@ export default class News implements NewsController {
       filter: {
         path: 'data.type.iv',
         op: 'ne',
-        value: 'Training',
+        value: 'Tutorial',
       },
       sort: [{ order: 'descending', path: 'created' }],
     });

--- a/apps/crn-server/src/migrations/1662632124-move-trainings-to-tutorial.ts
+++ b/apps/crn-server/src/migrations/1662632124-move-trainings-to-tutorial.ts
@@ -1,0 +1,35 @@
+/* istanbul ignore file */
+import { RestNews } from '@asap-hub/squidex';
+import { Migration } from '../handlers/webhooks/webhook-run-migrations';
+import { applyToAllItemsInCollection } from '../utils/migrations';
+
+export default class MoveResearchOutputTextToDescription extends Migration {
+  up = async (): Promise<void> => {
+    await applyToAllItemsInCollection<RestNews>(
+      'news-and-events',
+      async (news, squidexClient) => {
+        if (news.data.type.iv !== 'Training') return;
+
+        await squidexClient.patch(news.id, {
+          type: {
+            iv: 'Tutorial',
+          },
+        });
+      },
+    );
+  };
+  down = async (): Promise<void> => {
+    await applyToAllItemsInCollection<RestNews>(
+      'news-and-events',
+      async (news, squidexClient) => {
+        if (news.data.type.iv !== 'Tutorial') return;
+
+        await squidexClient.patch(news.id, {
+          type: {
+            iv: 'Training',
+          },
+        });
+      },
+    );
+  };
+}

--- a/apps/crn-server/test/controllers/news.test.ts
+++ b/apps/crn-server/test/controllers/news.test.ts
@@ -35,7 +35,7 @@ describe('News controller', () => {
           q: JSON.stringify({
             take: 8,
             skip: 5,
-            filter: { path: 'data.type.iv', op: 'ne', value: 'Training' },
+            filter: { path: 'data.type.iv', op: 'ne', value: 'Tutorial' },
             sort: [{ order: 'descending', path: 'created' }],
           }),
         })
@@ -56,7 +56,7 @@ describe('News controller', () => {
           q: JSON.stringify({
             take: 8,
             skip: 5,
-            filter: { path: 'data.type.iv', op: 'ne', value: 'Training' },
+            filter: { path: 'data.type.iv', op: 'ne', value: 'Tutorial' },
             sort: [{ order: 'descending', path: 'created' }],
           }),
         })
@@ -77,7 +77,7 @@ describe('News controller', () => {
           q: JSON.stringify({
             take: 8,
             skip: 5,
-            filter: { path: 'data.type.iv', op: 'ne', value: 'Training' },
+            filter: { path: 'data.type.iv', op: 'ne', value: 'Tutorial' },
             sort: [{ order: 'descending', path: 'created' }],
           }),
         })
@@ -110,7 +110,7 @@ describe('News controller', () => {
           q: JSON.stringify({
             take: 8,
             skip: 5,
-            filter: { path: 'data.type.iv', op: 'ne', value: 'Training' },
+            filter: { path: 'data.type.iv', op: 'ne', value: 'Tutorial' },
             sort: [{ order: 'descending', path: 'created' }],
           }),
         })

--- a/apps/crn-server/test/fixtures/dashboard.fixtures.ts
+++ b/apps/crn-server/test/fixtures/dashboard.fixtures.ts
@@ -27,9 +27,9 @@ export const squidexGraphqlDashboardFlatData = () => ({
       lastModified: '2020-10-15T17:55:21Z',
       version: 42,
       flatData: {
-        title: 'Event 2',
-        type: 'Event',
-        shortText: 'Short text of event 2',
+        title: 'News 2',
+        type: 'News',
+        shortText: 'Short text of news 2',
         text: '<p>text</p>',
         thumbnail: [
           {
@@ -64,11 +64,11 @@ export const squidexGraphqlDashboardResponse = (): DashboardResponse => ({
     {
       created: '2020-09-24T11:06:27.164Z',
       id: 'guid-news-2',
-      shortText: 'Short text of event 2',
+      shortText: 'Short text of news 2',
       text: '<p>text</p>',
       thumbnail: `${baseUrl}/api/assets/${appName}/thumbnail-uuid2`,
-      title: 'Event 2',
-      type: 'Event',
+      title: 'News 2',
+      type: 'News',
     },
   ],
   pages: [],

--- a/apps/crn-server/test/fixtures/news.fixtures.ts
+++ b/apps/crn-server/test/fixtures/news.fixtures.ts
@@ -35,13 +35,13 @@ export const newsSquidexApiResponse: {
       id: 'news-2',
       data: {
         title: {
-          iv: 'Event 2',
+          iv: 'Tutorial 2',
         },
         type: {
-          iv: 'Event',
+          iv: 'Tutorial',
         },
         shortText: {
-          iv: 'Short text of event 2',
+          iv: 'Short text of tutorial 2',
         },
         text: {
           iv: '<p>text</p>',
@@ -71,9 +71,9 @@ export const listNewsResponse: ListNewsResponse = {
     },
     {
       id: 'news-2',
-      title: 'Event 2',
-      type: 'Event',
-      shortText: 'Short text of event 2',
+      title: 'Tutorial 2',
+      type: 'Tutorial',
+      shortText: 'Short text of tutorial 2',
       text: '<p>text</p>',
       thumbnail: `${baseUrl}/api/assets/${appName}/thumbnail-uuid2`,
       created: '2020-09-16T14:31:19.000Z',

--- a/apps/gp2-frontend/src/dashboard/__tests__/Dashboard.test.tsx
+++ b/apps/gp2-frontend/src/dashboard/__tests__/Dashboard.test.tsx
@@ -54,8 +54,8 @@ it('renders dashboard with news', async () => {
       {
         id: '55724942-3408-4ad6-9a73-14b92226ffb77',
         created: '2020-09-07T17:36:54Z',
-        title: 'Event Title',
-        type: 'Event',
+        title: 'Tutorial Title',
+        type: 'Tutorial',
       },
     ],
     pages: [],

--- a/apps/gp2-server/test/fixtures/dashboard.fixtures.ts
+++ b/apps/gp2-server/test/fixtures/dashboard.fixtures.ts
@@ -27,9 +27,9 @@ export const squidexGraphqlDashboardFlatData = () => ({
       lastModified: '2020-10-15T17:55:21Z',
       version: 42,
       flatData: {
-        title: 'Event 2',
-        type: 'Event',
-        shortText: 'Short text of event 2',
+        title: 'Tutorial 2',
+        type: 'Tutorial',
+        shortText: 'Short text of tutorial 2',
         text: '<p>text</p>',
         thumbnail: [
           {
@@ -64,11 +64,11 @@ export const squidexGraphqlDashboardResponse = (): DashboardResponse => ({
     {
       created: '2020-09-24T11:06:27.164Z',
       id: 'guid-news-2',
-      shortText: 'Short text of event 2',
+      shortText: 'Short text of tutorial 2',
       text: '<p>text</p>',
       thumbnail: `${baseUrl}/api/assets/${appName}/thumbnail-uuid2`,
-      title: 'Event 2',
-      type: 'Event',
+      title: 'Tutorial 2',
+      type: 'Tutorial',
     },
   ],
   pages: [],

--- a/apps/storybook/src/DashboardPageBody.stories.tsx
+++ b/apps/storybook/src/DashboardPageBody.stories.tsx
@@ -18,7 +18,7 @@ const props = (): ComponentProps<typeof DashboardPageBody> => ({
     {
       id: 'uuid-2',
       created: new Date().toISOString(),
-      type: 'Event' as const,
+      type: 'Tutorial' as const,
       title:
         'Welcome to the ASAP Collaborative Initiative: The Science & the scientists',
     },

--- a/apps/storybook/src/NewsCard.stories.tsx
+++ b/apps/storybook/src/NewsCard.stories.tsx
@@ -25,10 +25,10 @@ const newsProps = (): ComponentProps<typeof NewsCard> => ({
   noPill: boolean('No Pill', false),
 });
 
-const eventProps = (): ComponentProps<typeof NewsCard> => ({
+const tutorialProps = (): ComponentProps<typeof NewsCard> => ({
   id: 'uuid-2',
   created: new Date().toISOString(),
-  type: 'Event' as const,
+  type: 'Tutorial' as const,
   title: text(
     'Title',
     'Welcome to the ASAP Collaborative Initiative: The Science & the scientists',
@@ -38,4 +38,4 @@ const eventProps = (): ComponentProps<typeof NewsCard> => ({
 
 export const News = () => <NewsCard {...newsProps()} />;
 
-export const Event = () => <NewsCard {...eventProps()} />;
+export const Tutorial = () => <NewsCard {...tutorialProps()} />;

--- a/packages/fixtures/src/dashboard.ts
+++ b/packages/fixtures/src/dashboard.ts
@@ -7,9 +7,7 @@ export const createDashboardResponse = (
 ): DashboardResponse => ({
   news: [
     ...Array.from({ length }).map((_, i) => createNewsResponse(`${i}`, 'News')),
-    ...Array.from({ length }).map((_, i) =>
-      createNewsResponse(`${i}`, 'Event'),
-    ),
+    ...Array.from({ length }).map((_, i) => createNewsResponse(`${i}`, 'News')),
   ],
   pages: ['content', 'about', 'slides'].map(createPageResponse),
 });

--- a/packages/gp2-components/src/templates/__tests__/DashboardPageBody.test.tsx
+++ b/packages/gp2-components/src/templates/__tests__/DashboardPageBody.test.tsx
@@ -15,8 +15,8 @@ const props: ComponentProps<typeof DashboardPageBody> = {
     {
       id: '55724942-3408-4ad6-9a73-14b92226ffb77',
       created: '2020-09-07T17:36:54Z',
-      title: 'Event Title',
-      type: 'Event',
+      title: 'Tutorial Title',
+      type: 'Tutorial',
     },
   ],
   pages: [createPageResponse('1'), createPageResponse('2')],
@@ -30,7 +30,7 @@ it('renders multiple news cards', () => {
     screen
       .queryAllByText(/title/i, { selector: 'h4' })
       .map(({ textContent }) => textContent),
-  ).toEqual(['Page 1 title', 'Page 2 title', 'News Title', 'Event Title']);
+  ).toEqual(['Page 1 title', 'Page 2 title', 'News Title', 'Tutorial Title']);
 });
 
 it('renders news section when there are no news', () => {
@@ -49,5 +49,5 @@ it('renders news section when there are no pages', () => {
   ).not.toBeInTheDocument();
   expect(
     screen.getAllByRole('heading').map(({ textContent }) => textContent),
-  ).toEqual(expect.arrayContaining(['News Title', 'Event Title']));
+  ).toEqual(expect.arrayContaining(['News Title', 'Tutorial Title']));
 });

--- a/packages/model/src/news.ts
+++ b/packages/model/src/news.ts
@@ -1,10 +1,10 @@
 import { ListResponse } from './common';
 
-/* istanbul ignore next */ export const newsType = [
+/* istanbul ignore next */
+export const newsType = [
   'News',
-  'Event',
-  'Training',
   'Tutorial',
+  'Training',
   'Working Groups',
 ] as const;
 

--- a/packages/react-components/src/organisms/NewsCard.tsx
+++ b/packages/react-components/src/organisms/NewsCard.tsx
@@ -5,11 +5,7 @@ import { news } from '@asap-hub/routing';
 import { Card, Paragraph, Headline4, Pill } from '../atoms';
 import { perRem, smallDesktopScreen } from '../pixels';
 import { formatDate } from '../date';
-import {
-  newsPlaceholder,
-  newsEventPlaceholderIcon,
-  trainingPlaceholderIcon,
-} from '../icons';
+import { newsPlaceholder, trainingPlaceholderIcon } from '../icons';
 import { ExternalLink, LinkHeadline, ImageLink } from '../molecules';
 import { lead } from '..';
 import { captionStyles } from '../text';
@@ -61,7 +57,6 @@ const footerStyles = css({
 
 const placeholders: Record<NewsType, JSX.Element> = {
   News: newsPlaceholder,
-  Event: newsEventPlaceholderIcon,
   Training: trainingPlaceholderIcon,
   Tutorial: trainingPlaceholderIcon,
   'Working Groups': trainingPlaceholderIcon,

--- a/packages/react-components/src/templates/__tests__/DashboardPageBody.test.tsx
+++ b/packages/react-components/src/templates/__tests__/DashboardPageBody.test.tsx
@@ -14,8 +14,8 @@ const props: ComponentProps<typeof DashboardPageBody> = {
     {
       id: '55724942-3408-4ad6-9a73-14b92226ffb77',
       created: '2020-09-07T17:36:54Z',
-      title: 'Event Title',
-      type: 'Event',
+      title: 'Tutorial Title',
+      type: 'Tutorial',
     },
   ],
   userId: '42',
@@ -38,8 +38,8 @@ it('renders multiple news cards', () => {
         {
           id: '55724942-3408-4ad6-9a73-14b92226ffb77',
           created: '2020-09-07T17:36:54Z',
-          title: 'Event Title 1',
-          type: 'Event',
+          title: 'Tutorial Title 1',
+          type: 'Tutorial',
         },
       ]}
     />,
@@ -48,7 +48,7 @@ it('renders multiple news cards', () => {
     screen
       .queryAllByText(/title/i, { selector: 'h4' })
       .map(({ textContent }) => textContent),
-  ).toEqual(['News Title 1', 'Event Title 1']);
+  ).toEqual(['News Title 1', 'Tutorial Title 1']);
 });
 
 it('renders news section when there are no news', () => {
@@ -62,7 +62,7 @@ it('renders news section', () => {
 
   expect(
     screen.getAllByRole('heading').map(({ textContent }) => textContent),
-  ).toEqual(expect.arrayContaining(['News Title', 'Event Title']));
+  ).toEqual(expect.arrayContaining(['News Title', 'Tutorial Title']));
 });
 
 it('hides add links to your work space section when user is not a member of a team', () => {

--- a/packages/squidex/schema/crn/schemas/news.json
+++ b/packages/squidex/schema/crn/schemas/news.json
@@ -53,7 +53,7 @@
         "partitioning": "invariant",
         "properties": {
           "fieldType": "String",
-          "allowedValues": ["News", "Event", "Training", "Working Groups"],
+          "allowedValues": ["News", "Training", "Tutorial", "Working Groups"],
           "isUnique": false,
           "inlineEditable": true,
           "contentType": "Unspecified",

--- a/packages/squidex/src/entities/crn/news.ts
+++ b/packages/squidex/src/entities/crn/news.ts
@@ -1,6 +1,6 @@
 import { Rest, Entity, Graphql } from '../common';
 
-export type NewsType = 'News' | 'Event' | 'Training';
+export type NewsType = 'News' | 'Training' | 'Tutorial' | 'Working Groups';
 
 export interface News<TThumbnail = string> {
   type: NewsType;


### PR DESCRIPTION
* Removes the Event news type (requires manual data removal)
* Adds a migration to map Training news type into a Tutorial news type