### PR TITLE
big/fix typing error when starting gp2 server locally

### DIFF
--- a/apps/gp2-frontend/src/working-groups/__tests__/Routes.test.tsx
+++ b/apps/gp2-frontend/src/working-groups/__tests__/Routes.test.tsx
@@ -15,7 +15,6 @@ import { getWorkingGroups } from '../api';
 import Routes from '../Routes';
 import { refreshWorkingGroupsState } from '../state';
 
-jest.setTimeout(30000);
 const renderRoutes = async () => {
   render(
     <RecoilRoot
@@ -36,7 +35,9 @@ const renderRoutes = async () => {
       </Suspense>
     </RecoilRoot>,
   );
-  await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
+  return waitForElementToBeRemoved(() => screen.queryByText(/loading/i), {
+    timeout: 30_000,
+  });
 };
 beforeEach(() => {
   jest.resetAllMocks();
@@ -66,5 +67,5 @@ describe('Routes', () => {
     expect(
       screen.getByRole('heading', { name: 'Working Group 11' }),
     ).toBeInTheDocument();
-  });
+  }, 30_000);
 });

--- a/apps/gp2-server/tsconfig.json
+++ b/apps/gp2-server/tsconfig.json
@@ -26,5 +26,8 @@
     { "path": "../../packages/server-common" },
     { "path": "../../packages/services-common" },
     { "path": "../../packages/squidex" }
-  ]
+  ],
+  "ts-node": {
+    "files": true
+  }
 }


### PR DESCRIPTION
When running `yarn start:backend:gp2`

The follow error occurs:

```
[ERROR] 11:12:34 TSError: ⨯ Unable to compile TypeScript:
src/utils/assign-user-to-context.ts:5:7 - error TS2339: Property 'loggedInUser' does not exist on type 'Request<ParamsDictionary, any, any, ParsedQs, Record<string, any>>'.

5   req.loggedInUser = user;
        ~~~~~~~~~~~~
```