### PR TITLE
CRN-1072 adding active/inactiveSince fields to Teams

### DIFF
--- a/apps/asap-cli/src/import/users/insert.ts
+++ b/apps/asap-cli/src/import/users/insert.ts
@@ -61,6 +61,9 @@ const insertTeam = async (data: Data, cache: Cache): Promise<RestTeam> => {
     applicationNumber: {
       iv: application,
     },
+    active: {
+      iv: true,
+    },
     projectTitle: {
       iv: projectTitle,
     },

--- a/apps/asap-cli/test/import/users.fixtures.ts
+++ b/apps/asap-cli/test/import/users.fixtures.ts
@@ -10,6 +10,7 @@ export const fetchTeamsResponse: { total: number; items: RestTeam[] } = {
       created: '2020-09-24T11:06:27.164Z',
       data: {
         displayName: { iv: 'team' },
+        active: { iv: true },
         applicationNumber: { iv: 'app' },
         projectTitle: { iv: 'title' },
         expertiseAndResourceTags: { iv: [] },

--- a/apps/crn-server/src/autogenerated-gql/graphql.ts
+++ b/apps/crn-server/src/autogenerated-gql/graphql.ts
@@ -4465,6 +4465,16 @@ export type TeamsReferencingUsersContentsWithTotalArgs = {
   top: InputMaybe<Scalars['Int']>;
 };
 
+/** The structure of the The team is active field of the Teams content type. */
+export type TeamsDataActiveDto = {
+  iv: Maybe<Scalars['Boolean']>;
+};
+
+/** The structure of the The team is active field of the Teams content input type. */
+export type TeamsDataActiveInputDto = {
+  iv: InputMaybe<Scalars['Boolean']>;
+};
+
 /** The structure of the Application Number field of the Teams content type. */
 export type TeamsDataApplicationNumberDto = {
   iv: Maybe<Scalars['String']>;
@@ -4487,9 +4497,11 @@ export type TeamsDataDisplayNameInputDto = {
 
 /** The structure of the Teams data type. */
 export type TeamsDataDto = {
+  active: Maybe<TeamsDataActiveDto>;
   applicationNumber: Maybe<TeamsDataApplicationNumberDto>;
   displayName: Maybe<TeamsDataDisplayNameDto>;
   expertiseAndResourceTags: Maybe<TeamsDataExpertiseAndResourceTagsDto>;
+  inactiveSince: Maybe<TeamsDataInactiveSinceDto>;
   outputs: Maybe<TeamsDataOutputsDto>;
   projectSummary: Maybe<TeamsDataProjectSummaryDto>;
   projectTitle: Maybe<TeamsDataProjectTitleDto>;
@@ -4507,11 +4519,23 @@ export type TeamsDataExpertiseAndResourceTagsInputDto = {
   iv: InputMaybe<Array<Scalars['String']>>;
 };
 
+/** The structure of the The team is inactive since field of the Teams content type. */
+export type TeamsDataInactiveSinceDto = {
+  iv: Maybe<Scalars['Instant']>;
+};
+
+/** The structure of the The team is inactive since field of the Teams content input type. */
+export type TeamsDataInactiveSinceInputDto = {
+  iv: InputMaybe<Scalars['Instant']>;
+};
+
 /** The structure of the Teams data input type. */
 export type TeamsDataInputDto = {
+  active: InputMaybe<TeamsDataActiveInputDto>;
   applicationNumber: InputMaybe<TeamsDataApplicationNumberInputDto>;
   displayName: InputMaybe<TeamsDataDisplayNameInputDto>;
   expertiseAndResourceTags: InputMaybe<TeamsDataExpertiseAndResourceTagsInputDto>;
+  inactiveSince: InputMaybe<TeamsDataInactiveSinceInputDto>;
   outputs: InputMaybe<TeamsDataOutputsInputDto>;
   projectSummary: InputMaybe<TeamsDataProjectSummaryInputDto>;
   projectTitle: InputMaybe<TeamsDataProjectTitleInputDto>;
@@ -4585,9 +4609,11 @@ export type TeamsDataToolsInputDto = {
 
 /** The structure of the flat Teams data type. */
 export type TeamsFlatDataDto = {
+  active: Maybe<Scalars['Boolean']>;
   applicationNumber: Maybe<Scalars['String']>;
   displayName: Maybe<Scalars['String']>;
   expertiseAndResourceTags: Maybe<Array<Scalars['String']>>;
+  inactiveSince: Maybe<Scalars['Instant']>;
   outputs: Maybe<Array<ResearchOutputs>>;
   projectSummary: Maybe<Scalars['String']>;
   projectTitle: Maybe<Scalars['String']>;

--- a/apps/crn-server/src/data-providers/teams.data-provider.ts
+++ b/apps/crn-server/src/data-providers/teams.data-provider.ts
@@ -127,6 +127,7 @@ export class TeamSquidexDataProvider implements TeamDataProvider {
   async create(input: TeamCreateDataObject): Promise<string> {
     const inputTeam: InputTeam['data'] = {
       applicationNumber: { iv: input.applicationNumber },
+      active: { iv: input.active },
       displayName: { iv: input.displayName },
       expertiseAndResourceTags: { iv: input.expertiseAndResourceTags },
       projectTitle: { iv: input.projectTitle },

--- a/apps/crn-server/test/fixtures/teams.fixtures.ts
+++ b/apps/crn-server/test/fixtures/teams.fixtures.ts
@@ -115,6 +115,7 @@ export const getTeamsEvent = (
   eventName: string,
   data = {
     displayName: { iv: 'Team 1' },
+    active: { iv: true },
     applicationNumber: { iv: '12345' },
     expertiseAndResourceTags: { iv: [] },
     proposal: { iv: [] },
@@ -124,6 +125,7 @@ export const getTeamsEvent = (
   },
   dataOld = {
     displayName: { iv: 'Team 1' },
+    active: { iv: true },
     applicationNumber: { iv: '12345' },
     expertiseAndResourceTags: { iv: [] },
     proposal: { iv: [] },
@@ -191,6 +193,7 @@ export const updateEvent: TeamEventGenerator = (id: string) =>
 
 export const getTeamCreateDataObject = (): TeamCreateDataObject => ({
   applicationNumber: 'ASAP-000420',
+  active: true,
   displayName: 'Team A',
   projectSummary: 'project-summary',
   projectTitle:
@@ -210,6 +213,9 @@ export const getInputTeam = (): InputTeam['data'] => ({
   applicationNumber: { iv: 'ASAP-000420' },
   displayName: {
     iv: 'Team A',
+  },
+  active: {
+    iv: true,
   },
   projectSummary: { iv: 'project-summary' },
   projectTitle: {

--- a/packages/model/src/team.ts
+++ b/packages/model/src/team.ts
@@ -52,6 +52,7 @@ export type TeamDataObject = Omit<TeamCreateRequest, 'applicationNumber'> & {
 
 export type TeamCreateDataObject = {
   applicationNumber: string;
+  active: boolean;
   displayName: string;
   expertiseAndResourceTags: string[];
   researchOutputIds?: string[];

--- a/packages/squidex/schema/crn/schemas/teams.json
+++ b/packages/squidex/schema/crn/schemas/teams.json
@@ -7,9 +7,7 @@
       "label": "Teams",
       "validateOnPublish": false
     },
-    "scripts": {
-      "update": "const wasActive = !!ctx.oldData.active.iv\nconst isActive = !!ctx.data.active.iv\n\nconst becameInactive = wasActive && !isActive\n\nconst becameActive = !wasActive && isActive\n\nif (becameInactive) {\n    ctx.data.inactiveSince.iv = new Date().toISOString()\n    replace();\n} else if (becameActive) {\n    ctx.data.inactiveSince.iv = null\n    replace();\n}\n\n"
-    },
+    "scripts": {},
     "fieldsInReferences": ["displayName"],
     "fieldsInLists": [
       "meta.status.color",

--- a/packages/squidex/schema/crn/schemas/teams.json
+++ b/packages/squidex/schema/crn/schemas/teams.json
@@ -7,7 +7,9 @@
       "label": "Teams",
       "validateOnPublish": false
     },
-    "scripts": {},
+    "scripts": {
+      "update": "const wasActive = !!ctx.oldData.active.iv\nconst isActive = !!ctx.data.active.iv\n\nconst becameInactive = wasActive && !isActive\n\nconst becameActive = !wasActive && isActive\n\nif (becameInactive) {\n    ctx.data.inactiveSince.iv = new Date().toISOString()\n    replace();\n} else if (becameActive) {\n    ctx.data.inactiveSince.iv = null\n    replace();\n}\n\n"
+    },
     "fieldsInReferences": ["displayName"],
     "fieldsInLists": [
       "meta.status.color",
@@ -45,6 +47,38 @@
           "isRequiredOnPublish": false,
           "isHalfWidth": true
         }
+      },
+      {
+        "name": "active",
+        "properties": {
+          "isRequired": true,
+          "isRequiredOnPublish": true,
+          "isHalfWidth": true,
+          "fieldType": "Boolean",
+          "editor": "Checkbox",
+          "inlineEditable": true,
+          "defaultValue": true,
+          "label": "The team is active"
+        },
+        "isLocked": false,
+        "isHidden": false,
+        "isDisabled": false,
+        "partitioning": "invariant"
+      },
+      {
+        "name": "inactiveSince",
+        "properties": {
+          "isRequired": false,
+          "isRequiredOnPublish": false,
+          "isHalfWidth": true,
+          "fieldType": "DateTime",
+          "editor": "DateTime",
+          "label": "The team is inactive since"
+        },
+        "isLocked": false,
+        "isHidden": false,
+        "isDisabled": true,
+        "partitioning": "invariant"
       },
       {
         "name": "applicationNumber",

--- a/packages/squidex/src/entities/crn/team.ts
+++ b/packages/squidex/src/entities/crn/team.ts
@@ -10,6 +10,7 @@ import { GraphqlUser } from './user';
 export interface Team<T = string> {
   applicationNumber: string;
   displayName: string;
+  active: boolean;
   projectSummary?: string;
   projectTitle: string;
   proposal?: T[];


### PR DESCRIPTION
Jira ticket: https://asaphub.atlassian.net/browse/CRN-1072

This PR adds the field `active` and `inactiveSince` in Team schema

### Active

Name/Label          |  Validation
:-------------------------:|:-------------------------:
| <img width="771" alt="Screen Shot 2022-09-29 at 12 32 34" src="https://user-images.githubusercontent.com/16595804/193075065-14ff07ea-217b-44bd-8c37-37be049ad715.png"> | <img width="753" alt="Screen Shot 2022-09-29 at 12 32 40" src="https://user-images.githubusercontent.com/16595804/193075061-02895993-6b69-4c02-a3a1-f2d548e6dea9.png">

### Inactive Since

Name/Label          |  Validation
:-------------------------:|:-------------------------:
<img width="761" alt="Screen Shot 2022-09-29 at 12 32 52" src="https://user-images.githubusercontent.com/16595804/193075057-8979a629-3bc5-4313-b8e0-467b45cdea3d.png"> | <img width="759" alt="Screen Shot 2022-09-29 at 12 33 00" src="https://user-images.githubusercontent.com/16595804/193075047-4d942c0d-6456-45f3-b7b6-70410e1fd97f.png"> 

The field `inactiveSince` is not being updated yet. This will be done in another PR.
