### PR TITLE
CRN-1124 Remove tutorials from news query condition

### DIFF
--- a/apps/crn-server/src/data-providers/news.data-provider.ts
+++ b/apps/crn-server/src/data-providers/news.data-provider.ts
@@ -7,7 +7,6 @@ import {
   NewsFrequency,
 } from '@asap-hub/model';
 import {
-  Filter,
   parseDate,
   Query,
   RestNews,
@@ -70,12 +69,6 @@ const parseRestNews = (item: RestNews): NewsDataObject => ({
   type: item.data.type.iv,
 });
 
-const notTutorialFilter: Filter = {
-  path: 'data.type.iv',
-  op: 'ne',
-  value: 'Tutorial',
-};
-
 const getFrequencyFilter = (frequencyFilter: NewsFrequency[]) => {
   const selectByFrequencyFilter = {
     path: 'data.frequency.iv',
@@ -93,17 +86,12 @@ const getFrequencyFilter = (frequencyFilter: NewsFrequency[]) => {
 
   if (frequencyFilter.includes('News Articles')) {
     return {
-      and: [
-        notTutorialFilter,
-        {
-          or: [selectNewsArticlesFilter, selectByFrequencyFilter],
-        },
-      ],
+      or: [selectNewsArticlesFilter, selectByFrequencyFilter],
     };
   }
 
   return {
-    and: [notTutorialFilter, selectByFrequencyFilter],
+    ...selectByFrequencyFilter,
   };
 };
 
@@ -118,10 +106,8 @@ const getFiltersQuery = (options?: FetchNewsProviderOptions) => {
     const filterQuery = getFrequencyFilter(options.filter.frequency);
 
     return options?.filter?.title
-      ? { and: [...filterQuery.and, textSearchFilter] }
+      ? { and: [filterQuery, textSearchFilter] }
       : filterQuery;
   }
-  return options?.filter?.title
-    ? { and: [notTutorialFilter, textSearchFilter] }
-    : notTutorialFilter;
+  return options?.filter?.title && textSearchFilter;
 };

--- a/apps/crn-server/test/data-providers/news.data-provider.test.ts
+++ b/apps/crn-server/test/data-providers/news.data-provider.test.ts
@@ -39,6 +39,7 @@ describe('News data provider', () => {
           q: JSON.stringify({
             take: 8,
             skip: 5,
+            filter: undefined,
             sort: [{ order: 'descending', path: 'created' }],
           }),
         })
@@ -59,6 +60,7 @@ describe('News data provider', () => {
           q: JSON.stringify({
             take: 8,
             skip: 5,
+            filter: undefined,
             sort: [{ order: 'descending', path: 'created' }],
           }),
         })
@@ -79,6 +81,7 @@ describe('News data provider', () => {
           q: JSON.stringify({
             take: 8,
             skip: 5,
+            filter: undefined,
             sort: [{ order: 'descending', path: 'created' }],
           }),
         })
@@ -111,6 +114,7 @@ describe('News data provider', () => {
           q: JSON.stringify({
             take: 8,
             skip: 5,
+            filter: undefined,
             sort: [{ order: 'descending', path: 'created' }],
           }),
         })
@@ -127,6 +131,7 @@ describe('News data provider', () => {
         .query({
           q: JSON.stringify({
             take: 8,
+            filter: undefined,
             sort: [{ order: 'descending', path: 'created' }],
           }),
         })

--- a/apps/crn-server/test/data-providers/news.data-provider.test.ts
+++ b/apps/crn-server/test/data-providers/news.data-provider.test.ts
@@ -39,7 +39,6 @@ describe('News data provider', () => {
           q: JSON.stringify({
             take: 8,
             skip: 5,
-            filter: { path: 'data.type.iv', op: 'ne', value: 'Tutorial' },
             sort: [{ order: 'descending', path: 'created' }],
           }),
         })
@@ -53,14 +52,13 @@ describe('News data provider', () => {
       });
     });
 
-    test('Should return an empty result when resource does not exists', async () => {
+    test('Should return an empty result when resource does not exist', async () => {
       nock(baseUrl)
         .get(`/api/content/${appName}/news-and-events`)
         .query({
           q: JSON.stringify({
             take: 8,
             skip: 5,
-            filter: { path: 'data.type.iv', op: 'ne', value: 'Tutorial' },
             sort: [{ order: 'descending', path: 'created' }],
           }),
         })
@@ -81,7 +79,6 @@ describe('News data provider', () => {
           q: JSON.stringify({
             take: 8,
             skip: 5,
-            filter: { path: 'data.type.iv', op: 'ne', value: 'Tutorial' },
             sort: [{ order: 'descending', path: 'created' }],
           }),
         })
@@ -114,7 +111,6 @@ describe('News data provider', () => {
           q: JSON.stringify({
             take: 8,
             skip: 5,
-            filter: { path: 'data.type.iv', op: 'ne', value: 'Tutorial' },
             sort: [{ order: 'descending', path: 'created' }],
           }),
         })
@@ -131,7 +127,6 @@ describe('News data provider', () => {
         .query({
           q: JSON.stringify({
             take: 8,
-            filter: { path: 'data.type.iv', op: 'ne', value: 'Tutorial' },
             sort: [{ order: 'descending', path: 'created' }],
           }),
         })
@@ -151,14 +146,9 @@ describe('News data provider', () => {
               take: 8,
               skip: 5,
               filter: {
-                and: [
-                  { path: 'data.type.iv', op: 'ne', value: 'Tutorial' },
-                  {
-                    path: 'data.frequency.iv',
-                    op: 'in',
-                    value: ['CRN Quarterly'],
-                  },
-                ],
+                path: 'data.frequency.iv',
+                op: 'in',
+                value: ['CRN Quarterly'],
               },
               sort: [{ order: 'descending', path: 'created' }],
             }),
@@ -176,7 +166,7 @@ describe('News data provider', () => {
         expect(result).toEqual(getListNewsDataObject());
       });
 
-      test('Should query data properly when CRN Quarterly and News Articles frequency is selected', async () => {
+      test('Should query data properly when CRN Quarterly and News Articles frequency are selected', async () => {
         nock(baseUrl)
           .get(`/api/content/${appName}/news-and-events`)
           .query({
@@ -184,21 +174,16 @@ describe('News data provider', () => {
               take: 8,
               skip: 5,
               filter: {
-                and: [
-                  { path: 'data.type.iv', op: 'ne', value: 'Tutorial' },
+                or: [
                   {
-                    or: [
-                      {
-                        path: 'data.frequency.iv',
-                        op: 'empty',
-                        value: null,
-                      },
-                      {
-                        path: 'data.frequency.iv',
-                        op: 'in',
-                        value: ['CRN Quarterly', 'News Articles'],
-                      },
-                    ],
+                    path: 'data.frequency.iv',
+                    op: 'empty',
+                    value: null,
+                  },
+                  {
+                    path: 'data.frequency.iv',
+                    op: 'in',
+                    value: ['CRN Quarterly', 'News Articles'],
                   },
                 ],
               },
@@ -228,10 +213,9 @@ describe('News data provider', () => {
               take: 8,
               skip: 5,
               filter: {
-                and: [
-                  { path: 'data.type.iv', op: 'ne', value: 'Tutorial' },
-                  { path: 'data.title.iv', op: 'contains', value: 'hey' },
-                ],
+                path: 'data.title.iv',
+                op: 'contains',
+                value: 'hey',
               },
               sort: [{ order: 'descending', path: 'created' }],
             }),
@@ -256,7 +240,6 @@ describe('News data provider', () => {
               skip: 5,
               filter: {
                 and: [
-                  { path: 'data.type.iv', op: 'ne', value: 'Tutorial' },
                   {
                     path: 'data.frequency.iv',
                     op: 'in',


### PR DESCRIPTION
Since we moved all news of type `Tutorial` from `News` to `Tutorials` in squidex, we don't need to filter the news that have type `Tutorial` from news anymore. This PR removes this condition.