### PR TITLE
CRN-1124 Removing Tutorials from allowed type values  in News

### DIFF
--- a/packages/squidex/schema/crn/schemas/news-and-events.json
+++ b/packages/squidex/schema/crn/schemas/news-and-events.json
@@ -52,7 +52,7 @@
         "partitioning": "invariant",
         "properties": {
           "fieldType": "String",
-          "allowedValues": ["News", "Tutorial", "Working Groups"],
+          "allowedValues": ["News", "Working Groups"],
           "isUnique": false,
           "isEmbeddable": false,
           "inlineEditable": true,


### PR DESCRIPTION
This PR removes `Tutorial` from allowed values for type in News in squidex

Before          |  After
:-------------------------:|:-------------------------:
![Screen Shot 2022-10-20 at 08 43 48](https://user-images.githubusercontent.com/16595804/196939782-f6d21f47-4ad6-4e24-8b3e-0b8f01ccf952.png) |  ![Screen Shot 2022-10-20 at 08 42 32](https://user-images.githubusercontent.com/16595804/196939806-4ef1f84a-0d46-49ba-908c-66ad6cc2df17.png)

