### PR TITLE
[CRN-1147] handle complete working groups in members tabs

### DIFF
--- a/packages/react-components/src/organisms/WorkingGroupMembers.tsx
+++ b/packages/react-components/src/organisms/WorkingGroupMembers.tsx
@@ -28,20 +28,22 @@ type GroupLeadersTabbedCardProps = {
     Pick<WorkingGroupLeader, 'user' | 'role' | 'workstreamRole'>
   >;
   members: ReadonlyArray<Pick<WorkingGroupMember, 'user'>>;
+  isComplete: boolean;
 };
 
 const GroupLeadersTabbedCard: React.FC<GroupLeadersTabbedCardProps> = ({
   leaders,
   members,
+  isComplete,
 }) => {
   const [inactiveLeaders, activeLeaders] = splitListBy(
     leaders,
-    (leader) => !!leader?.user?.alumniSinceDate,
+    (leader) => isComplete || !!leader?.user?.alumniSinceDate,
   );
 
   const [inactiveMembers, activeMembers] = splitListBy(
     members,
-    (member) => !!member?.user?.alumniSinceDate,
+    (member) => isComplete || !!member?.user?.alumniSinceDate,
   );
 
   return (
@@ -51,11 +53,12 @@ const GroupLeadersTabbedCard: React.FC<GroupLeadersTabbedCardProps> = ({
         <Subtitle>Leaders</Subtitle>
       </div>
       <TabbedContent
-        activeTabIndex={0}
+        activeTabIndex={isComplete ? 1 : 0}
         tabs={[
           {
             tabTitle: `Active Leaders (${activeLeaders.length})`,
             items: activeLeaders,
+            disabled: isComplete,
             empty: (
               <Paragraph accent="lead">There are no active leaders.</Paragraph>
             ),
@@ -88,12 +91,13 @@ const GroupLeadersTabbedCard: React.FC<GroupLeadersTabbedCardProps> = ({
         <Subtitle>Members</Subtitle>
       </div>
       <TabbedContent
-        activeTabIndex={0}
+        activeTabIndex={isComplete ? 1 : 0}
         tabs={[
           {
             tabTitle: `Active Members (${activeMembers.length})`,
             items: activeMembers,
             truncateFrom: 8,
+            disabled: isComplete,
             empty: (
               <Paragraph accent="lead">There are no active members.</Paragraph>
             ),

--- a/packages/react-components/src/organisms/__tests__/WorkingGroupMembers.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/WorkingGroupMembers.test.tsx
@@ -6,6 +6,7 @@ import WorkingGroupMembers from '../WorkingGroupMembers';
 const props: ComponentProps<typeof WorkingGroupMembers> = {
   leaders: [],
   members: [],
+  isComplete: false,
 };
 
 describe('leaders section', () => {
@@ -59,6 +60,35 @@ describe('leaders section', () => {
 
     activeTabButton.click();
     expect(queryByText('Test User 1')).toBeNull();
+  });
+
+  it('renders both active and past leaders in past tab when working group is complete', () => {
+    const { getByText } = render(
+      <WorkingGroupMembers
+        {...props}
+        isComplete
+        leaders={createListUserResponse(3).items.map((item, index) => ({
+          user: {
+            ...item,
+            displayName: `Test User ${index}`,
+            alumniSinceDate:
+              index % 2 === 0 ? new Date().toISOString() : undefined,
+          },
+          role: 'Chair',
+          workstreamRole: 'A test role',
+        }))}
+      />,
+    );
+
+    const pastTabButton = getByText('Past Leaders (3)');
+    const activeTabButton = getByText('Active Leaders (0)');
+
+    expect(pastTabButton).toBeVisible();
+    expect(activeTabButton).toBeVisible();
+
+    expect(getByText('Test User 0')).toBeVisible();
+    expect(getByText('Test User 1')).toBeVisible();
+    expect(getByText('Test User 2')).toBeVisible();
   });
 });
 
@@ -123,5 +153,32 @@ describe('member section', () => {
     );
     fireEvent.click(getByText('View More Members'));
     expect(getByText(/View Less Members/)).toBeVisible();
+  });
+
+  it('renders both active and past members in past tab when working group is complete', () => {
+    const { getByText } = render(
+      <WorkingGroupMembers
+        {...props}
+        isComplete
+        members={createListUserResponse(3).items.map((item, index) => ({
+          user: {
+            ...item,
+            displayName: `Test User ${index}`,
+            alumniSinceDate:
+              index % 2 === 0 ? new Date().toISOString() : undefined,
+          },
+        }))}
+      />,
+    );
+
+    const pastTabButton = getByText('Past Members (3)');
+    const activeTabButton = getByText('Active Members (0)');
+
+    expect(pastTabButton).toBeVisible();
+    expect(activeTabButton).toBeVisible();
+
+    expect(getByText('Test User 0')).toBeVisible();
+    expect(getByText('Test User 1')).toBeVisible();
+    expect(getByText('Test User 2')).toBeVisible();
   });
 });

--- a/packages/react-components/src/templates/WorkingGroupAbout.tsx
+++ b/packages/react-components/src/templates/WorkingGroupAbout.tsx
@@ -11,7 +11,12 @@ type WorkingGroupAboutProps = {
   readonly membersListElementId: string;
 } & Pick<
   WorkingGroupResponse,
-  'description' | 'deliverables' | 'pointOfContact' | 'members' | 'leaders'
+  | 'description'
+  | 'deliverables'
+  | 'pointOfContact'
+  | 'members'
+  | 'leaders'
+  | 'complete'
 >;
 const containerStyles = css({
   display: 'flex',
@@ -26,6 +31,7 @@ const WorkingGroupAbout: React.FC<WorkingGroupAboutProps> = ({
   pointOfContact,
   members,
   leaders,
+  complete,
 }) => (
   <div css={containerStyles}>
     <DeliverablesCard deliverables={deliverables} />
@@ -67,7 +73,11 @@ const WorkingGroupAbout: React.FC<WorkingGroupAboutProps> = ({
       )}
     </Card>
     <section id={membersListElementId}>
-      <WorkingGroupMembers leaders={leaders} members={members} />
+      <WorkingGroupMembers
+        leaders={leaders}
+        members={members}
+        isComplete={complete}
+      />
     </section>
   </div>
 );

--- a/packages/react-components/src/templates/__tests__/WorkingGroupAbout.test.tsx
+++ b/packages/react-components/src/templates/__tests__/WorkingGroupAbout.test.tsx
@@ -11,6 +11,7 @@ const baseProps: ComponentProps<typeof WorkingGroupAbout> = {
   deliverables: [],
   members: [],
   leaders: [],
+  complete: false,
 };
 
 it('renders the description', () => {


### PR DESCRIPTION
Where a WG is in Complete status:

- the Past Leaders tab should be displayed as default 
- The Active Leaders tab should be inactive with a total of zero #0 leaders 
- All users of the WG should be displayed in the past tab, for both leaders and members
- Any Alumni users should be displayed with the correct badge
- Any Inactive teams should be displayed with the correct badge (if implemented) **[which is not]**













