### PR TITLE
CRN-1226 Fix scroll to members section in Working Groups Header

### DIFF
--- a/packages/react-components/src/templates/WorkingGroupHeader.tsx
+++ b/packages/react-components/src/templates/WorkingGroupHeader.tsx
@@ -111,7 +111,10 @@ const WorkingGroupPageHeader: React.FC<WorkingGroupPageHeaderProps> = ({
       <UserAvatarList
         members={[...leaders, ...members].map((member) => member.user)}
         fullListRoute={`${
-          network({}).workingGroups({}).workingGroup({ workingGroupId: id }).$
+          network({})
+            .workingGroups({})
+            .workingGroup({ workingGroupId: id })
+            .about({}).$
         }#${membersListElementId}`}
       />
       {pointOfContact && (

--- a/packages/react-components/src/templates/__tests__/WorkingGroupHeader.test.tsx
+++ b/packages/react-components/src/templates/__tests__/WorkingGroupHeader.test.tsx
@@ -70,7 +70,7 @@ it('renders number of members exceeding the limit of 5 and anchors it to the rig
 
   expect(getByRole('link', { name: /\+1/ })).toHaveAttribute(
     'href',
-    `/network/working-groups/id#${baseProps.membersListElementId}`,
+    `/network/working-groups/id/about#${baseProps.membersListElementId}`,
   );
 });
 


### PR DESCRIPTION
After making the `About` tab as default https://github.com/yldio/asap-hub/pull/2317, the scroll to members section when the user clicks +n button stopped working. This PR fixes it.

![scroll](https://user-images.githubusercontent.com/16595804/209319746-143c1956-1d94-4770-a127-50804b8553d6.gif)
