### PR TITLE
CRN-1215 | Decommission Contentful Environment Correctly on Teardown

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -38,6 +38,9 @@ outputs:
   crn-auth0-domain:
     description: 'CRN Auth0 Domain'
     value: ${{ steps.vars.outputs.crn-auth0-domain }}
+  crn-contentful-env-id:
+    description: 'Environment ID for Contentful'
+    value: ${{ steps.vars.outputs.crn-contentful-env-id }}
   crn-ci-auth0-client-id:
     description: 'CRN CI Auth0 Client Id'
     value: ${{ steps.vars.outputs.crn-ci-auth0-client-id }}
@@ -194,6 +197,7 @@ runs:
           echo "::set-output name=sls-stage::$PR_NUMBER"
           echo "::set-output name=crn-squidex-app-name::crn-$PR_NUMBER"
           echo "::set-output name=crn-squidex-app-name-legacy::$PR_NUMBER"
+          echo "::set-output name=crn-contentful-env-id::crn-$PR_NUMBER"
           echo "::set-output name=gp2-squidex-app-name::gp2-$PR_NUMBER"
         elif [ "$ENVIRONMENT_NAME" = 'Development' ]; then
           echo "::set-output name=app-release::${{ github.run_id }}-dev"

--- a/.github/environment/Base
+++ b/.github/environment/Base
@@ -16,3 +16,4 @@ squidex-base-url=https://cloud.squidex.io
 contentful-space-id=5v6w5j61tndm
 contentful-environment=Production
 max-contentful-envs=6
+crn-contentful-env-id=Production

--- a/.github/environment/Development
+++ b/.github/environment/Development
@@ -29,3 +29,4 @@ ses-region=eu-west-1
 sls-stage=dev
 contentful-environment=Development
 is-contentful-enabled=true
+crn-contentful-env-id=Development

--- a/.github/scripts/contentful/teardown.sh
+++ b/.github/scripts/contentful/teardown.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+CONTENTFUL_ENV_ID=crn-${PR_NUMBER}
+
 if [[ "$CONTENTFUL_ENV_ID" == "Production" ]]; then
   echo "Target is Production branch; not deleting."
   exit 0

--- a/.github/scripts/contentful/teardown.sh
+++ b/.github/scripts/contentful/teardown.sh
@@ -10,6 +10,18 @@ if [[ "$CONTENTFUL_ENV_ID" == "Development" ]]; then
   exit 0
 fi
 
+STATUS_CODE_CHECK=$(curl --silent \
+                         --request GET \
+                         --output /dev/null \
+                         --write-out "%{http_code}" \
+                         --header "Authorization: Bearer ${CONTENTFUL_MANAGEMENT_ACCESS_TOKEN}" \
+                         https://api.contentful.com/spaces/${CONTENTFUL_SPACE_ID}/ENVIRONMENTS/${CONTENTFUL_ENV_ID})
+
+if [[ "$STATUS_CODE" != "200 "]]; then
+  echo "Environment for this branch not found -- nothing to delete."
+  exit 0
+fi
+
 STATUS_CODE=$(curl --silent \
                    --request DELETE \
                    --output /dev/null \

--- a/.github/scripts/contentful/teardown.sh
+++ b/.github/scripts/contentful/teardown.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-CONTENTFUL_ENV_ID=crn-${PR_NUMBER}
-
 if [[ "$CONTENTFUL_ENV_ID" == "Production" ]]; then
   echo "Target is Production branch; not deleting."
   exit 0

--- a/.github/scripts/contentful/teardown.sh
+++ b/.github/scripts/contentful/teardown.sh
@@ -17,7 +17,7 @@ STATUS_CODE_CHECK=$(curl --silent \
                          --header "Authorization: Bearer ${CONTENTFUL_MANAGEMENT_ACCESS_TOKEN}" \
                          https://api.contentful.com/spaces/${CONTENTFUL_SPACE_ID}/ENVIRONMENTS/${CONTENTFUL_ENV_ID})
 
-if [[ "$STATUS_CODE" != "200 "]]; then
+if [[ "$STATUS_CODE" != "200" ]]; then
   echo "Environment for this branch not found -- nothing to delete."
   exit 0
 fi

--- a/.github/scripts/contentful/teardown.sh
+++ b/.github/scripts/contentful/teardown.sh
@@ -17,7 +17,7 @@ STATUS_CODE_CHECK=$(curl --silent \
                          --output /dev/null \
                          --write-out "%{http_code}" \
                          --header "Authorization: Bearer ${CONTENTFUL_MANAGEMENT_ACCESS_TOKEN}" \
-                         https://api.contentful.com/spaces/${CONTENTFUL_SPACE_ID}/ENVIRONMENTS/${CONTENTFUL_ENV_ID})
+                         https://api.contentful.com/spaces/${CONTENTFUL_SPACE_ID}/environments/${CONTENTFUL_ENV_ID})
 
 if [[ "$STATUS_CODE_CHECK" == "404" ]]; then
   echo "Environment for this branch not found -- nothing to delete."

--- a/.github/scripts/contentful/teardown.sh
+++ b/.github/scripts/contentful/teardown.sh
@@ -12,6 +12,8 @@ if [[ "$CONTENTFUL_ENV_ID" == "Development" ]]; then
   exit 0
 fi
 
+echo "Contentful env to be deleted is ${CONTENTFUL_ENV_ID}."
+
 STATUS_CODE_CHECK=$(curl --silent \
                          --request GET \
                          --output /dev/null \

--- a/.github/scripts/contentful/teardown.sh
+++ b/.github/scripts/contentful/teardown.sh
@@ -19,7 +19,7 @@ STATUS_CODE_CHECK=$(curl --silent \
                          --header "Authorization: Bearer ${CONTENTFUL_MANAGEMENT_ACCESS_TOKEN}" \
                          https://api.contentful.com/spaces/${CONTENTFUL_SPACE_ID}/ENVIRONMENTS/${CONTENTFUL_ENV_ID})
 
-if [[ "$STATUS_CODE" != "200" ]]; then
+if [[ "$STATUS_CODE_CHECK" == "404" ]]; then
   echo "Environment for this branch not found -- nothing to delete."
   exit 0
 fi

--- a/.github/workflows/on-remove.yml
+++ b/.github/workflows/on-remove.yml
@@ -154,7 +154,7 @@ jobs:
         env:
           CONTENTFUL_SPACE_ID: ${{ steps.setup.outputs.contentful-space-id }}
           CONTENTFUL_MANAGEMENT_ACCESS_TOKEN: ${{ secrets.CONTENTFUL_MANAGEMENT_TOKEN }}
-          CONTENTFUL_ENV_ID: ${{ steps.setup.outputs.pr-number }}
+          CONTENTFUL_ENV_ID: ${{ steps.setup.outputs.crn-contentful-env-id }}
 
   algolia-index:
     if: ${{ github.event.inputs.pr-number || github.event.pull_request.head.repo.full_name == 'yldio/asap-hub' }}

--- a/.github/workflows/on-remove.yml
+++ b/.github/workflows/on-remove.yml
@@ -137,29 +137,24 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Check PR number
+        if: ${{ github.event.inputs.pr-number }}
+        uses: ./.github/actions/is-number
+        with:
+          number: ${{ github.event.inputs.pr-number }}
       - name: Setup
         id: setup
         uses: ./.github/actions/setup-environment
         with:
           environment-name: Branch
-      - name: Get Contentful Branch State
-        id: contentful-branch-state
-        uses: ./.github/actions/contentful-checks
-        with:
-          pr-number: ${{ github.event.inputs.pr-number }}
-          contentful-space-id: ${{ steps.setup.outputs.contentful-space-id }}
-          contentful-master-env: ${{ steps.setup.outputs.contentful-environment }}
-          contentful-token: ${{ secrets.CONTENTFUL_MANAGEMENT_TOKEN }}
-          max-contentful-envs: ${{ steps.setup.outputs.max-contentful-envs }}
       - name: Contentful Teardown
         id: contentful-teardown
-        if: ${{ steps.contentful-branch-state.outputs.contentful-env-exists == 'true' }}
         shell: bash
         run: bash .github/scripts/contentful/teardown.sh
         env:
           CONTENTFUL_SPACE_ID: ${{ steps.setup.outputs.contentful-space-id }}
           CONTENTFUL_MANAGEMENT_ACCESS_TOKEN: ${{ secrets.CONTENTFUL_MANAGEMENT_TOKEN }}
-          CONTENTFUL_ENV_ID: ${{ steps.contentful-branch-state.outputs.contentful-env }}
+          CONTENTFUL_ENV_ID: ${{ steps.setup.outputs.pr-number }}
 
   algolia-index:
     if: ${{ github.event.inputs.pr-number || github.event.pull_request.head.repo.full_name == 'yldio/asap-hub' }}


### PR DESCRIPTION
# CRN-1215 | Decommission Contentful Environment Correctly on Teardown

## Changes

- Introduces the PR number check same as Squidex & other teardowns;
- Doesn't run the whole suite of checks, just checks if env exists.

## Testing

- Create a contentful environment called `crn-5000` in Contentful UI;
- Run the workflow from Actions > Remove Environment;
- Pick this branch and put PR number to destroy as 5000;
- Observe that the Contentful environment is destroyed.

## Example Runs

- [Environment exists & is deleted](https://github.com/yldio/asap-hub/actions/runs/3767140161/jobs/6404384767)
- [No environment exists, nothing to delete](https://github.com/yldio/asap-hub/actions/runs/3767153273/jobs/6404412444)

Ignore failures on removing SLS, I am targeting a PR that doesn't exist and the remove SLS step errors when removing PR that doesn't exist.