### PR TITLE
CRN-1223 Removing Working Groups feature flag in Networks

### DIFF
--- a/packages/flags/src/index.ts
+++ b/packages/flags/src/index.ts
@@ -1,7 +1,4 @@
-export type Flag =
-  | 'PERSISTENT_EXAMPLE'
-  | 'WORKING_GROUPS'
-  | 'WORKING_GROUP_SHARED_OUTPUT_BTN';
+export type Flag = 'PERSISTENT_EXAMPLE' | 'WORKING_GROUP_SHARED_OUTPUT_BTN';
 
 export type Flags = Partial<Record<Flag, boolean | undefined>>;
 let overrides: Flags = {

--- a/packages/react-components/src/templates/NetworkPageHeader.tsx
+++ b/packages/react-components/src/templates/NetworkPageHeader.tsx
@@ -7,7 +7,6 @@ import {
   inactiveUserTag,
 } from '@asap-hub/model';
 import { network } from '@asap-hub/routing';
-import { isEnabled } from '@asap-hub/flags';
 
 import { Display, Paragraph, TabLink } from '../atoms';
 import { perRem } from '../pixels';
@@ -158,20 +157,16 @@ const NetworkPageHeader: React.FC<NetworkPageHeaderProps> = ({
           </span>
           Interest Groups
         </TabLink>
-        {isEnabled('WORKING_GROUPS') && (
-          <TabLink
-            href={
-              network({}).workingGroups({}).$ + queryParamString(searchQuery)
-            }
-          >
-            <span css={iconStyles}>
-              <WorkingGroupsIcon
-                color={page === 'working-groups' ? charcoal.rgb : lead.rgb}
-              />
-            </span>
-            Working Groups
-          </TabLink>
-        )}
+        <TabLink
+          href={network({}).workingGroups({}).$ + queryParamString(searchQuery)}
+        >
+          <span css={iconStyles}>
+            <WorkingGroupsIcon
+              color={page === 'working-groups' ? charcoal.rgb : lead.rgb}
+            />
+          </span>
+          Working Groups
+        </TabLink>
       </TabNav>
     </div>
     {showSearch && (

--- a/packages/react-components/src/templates/__tests__/NetworkPageHeader.test.tsx
+++ b/packages/react-components/src/templates/__tests__/NetworkPageHeader.test.tsx
@@ -1,9 +1,8 @@
 import { ComponentProps } from 'react';
 import { MemoryRouter, StaticRouter } from 'react-router-dom';
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { findParentWithStyle } from '@asap-hub/dom-test-utils';
 import { network } from '@asap-hub/routing';
-import { disable } from '@asap-hub/flags';
 
 import NetworkPageHeader from '../NetworkPageHeader';
 
@@ -149,12 +148,4 @@ it('does not render the search box based on props', () => {
     <NetworkPageHeader {...props} showSearch={false} />,
   );
   expect(queryByRole('searchbox')).not.toBeInTheDocument();
-});
-
-it('does not show the working groups tab when feature flag disabled ((REGRESSION))', () => {
-  const { rerender } = render(<NetworkPageHeader {...props} />);
-  expect(screen.getByTitle('Working Groups')).toBeInTheDocument();
-  disable('WORKING_GROUPS');
-  rerender(<NetworkPageHeader {...props} />);
-  expect(screen.queryByTitle('Working Groups')).toBeNull();
 });


### PR DESCRIPTION
This PR undoes the changes made in https://github.com/yldio/asap-hub/pull/2334