### PR TITLE
CRN-1246 Migration to delete working groups from news

### DIFF
--- a/apps/crn-server/src/migrations/1673349371-remove-working-groups-from-news.ts
+++ b/apps/crn-server/src/migrations/1673349371-remove-working-groups-from-news.ts
@@ -1,0 +1,18 @@
+/* istanbul ignore file */
+import { Migration } from '@asap-hub/server-common';
+import { RestNews } from '@asap-hub/squidex';
+import { applyToAllItemsInCollection } from '../utils/migrations';
+
+export default class RemoveWorkingGroupsFromNews extends Migration {
+  up = async (): Promise<void> => {
+    await applyToAllItemsInCollection<RestNews>(
+      'news-and-events',
+      async (news, squidexClient) => {
+        if (news.data.type.iv === 'Working Groups') {
+          await squidexClient.delete(news.id);
+        }
+      },
+    );
+  };
+  down = async (): Promise<void> => {};
+}

--- a/apps/crn-server/src/migrations/1673349371-remove-working-groups-from-news.ts
+++ b/apps/crn-server/src/migrations/1673349371-remove-working-groups-from-news.ts
@@ -14,5 +14,7 @@ export default class RemoveWorkingGroupsFromNews extends Migration {
       },
     );
   };
-  down = async (): Promise<void> => {};
+  down = async (): Promise<void> => {
+    // this is not needed
+  };
 }


### PR DESCRIPTION
This PR introduces a migration that deletes the News that have type `Working Groups`.

I've ran the script in the PR env:

![us-east-1 console aws amazon com_lambda_home_region=us-east-1 (1)](https://user-images.githubusercontent.com/16595804/211771544-92c2963c-5e8c-4112-9ed5-79f97e4712ef.png)

And I could verify that there isn't any News with type `Working Groups` now:

![squidex-after](https://user-images.githubusercontent.com/16595804/211771696-3d92fdc8-a268-4f76-b78c-adaeb72fa043.png)

