### PR TITLE
Fix: TS issue in remove working groups from news migration

### DIFF
--- a/apps/crn-server/src/migrations/1673349371-remove-working-groups-from-news.ts
+++ b/apps/crn-server/src/migrations/1673349371-remove-working-groups-from-news.ts
@@ -8,6 +8,7 @@ export default class RemoveWorkingGroupsFromNews extends Migration {
     await applyToAllItemsInCollection<RestNews>(
       'news-and-events',
       async (news, squidexClient) => {
+        // @ts-ignore
         if (news.data.type.iv === 'Working Groups') {
           await squidexClient.delete(news.id);
         }

--- a/apps/crn-server/src/migrations/1673349371-remove-working-groups-from-news.ts
+++ b/apps/crn-server/src/migrations/1673349371-remove-working-groups-from-news.ts
@@ -1,4 +1,5 @@
 /* istanbul ignore file */
+
 import { Migration } from '@asap-hub/server-common';
 import { RestNews } from '@asap-hub/squidex';
 import { applyToAllItemsInCollection } from '../utils/migrations';
@@ -8,6 +9,7 @@ export default class RemoveWorkingGroupsFromNews extends Migration {
     await applyToAllItemsInCollection<RestNews>(
       'news-and-events',
       async (news, squidexClient) => {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
         if (news.data.type.iv === 'Working Groups') {
           await squidexClient.delete(news.id);


### PR DESCRIPTION
After this commit [CRN-1247 Adjust news entity to remove working groups references](https://github.com/yldio/asap-hub/commit/a77fc415e59d171c94bb1fc9654f177fa3ba269b) the remove working groups from news migration is giving the error below

<img width="1440" alt="Screenshot 2023-01-16 at 12 59 55" src="https://user-images.githubusercontent.com/16595804/212721215-13c37ab4-457e-45b1-ac38-96321c03cff4.png">

We could either delete this migration because it will never be run again, but another option is to ignore this TS check in this specific line so we can run `yarn build:typecheck` without problems.