### PR TITLE
Fix: remove type from News

### DIFF
--- a/packages/squidex/schema/crn/schemas/news-and-events.json
+++ b/packages/squidex/schema/crn/schemas/news-and-events.json
@@ -12,7 +12,6 @@
     "fieldsInLists": [
       "meta.status.color",
       "thumbnail",
-      "type",
       "title",
       "shortText",
       "text",


### PR DESCRIPTION
The field `type` was removed from `fields` but not from `fieldsInLists` in `packages/squidex/schema/crn/schemas/news-and-events.json` in https://github.com/yldio/asap-hub/pull/2442.

So the schema was being created with `type` and this gives a schema error when running `yarn schema:update:crn`