### PR TITLE
CRN-1276 Fix: Validation error when choosing Sequency type in Research Output

### DIFF
--- a/packages/squidex/schema/crn/schemas/research-outputs.json
+++ b/packages/squidex/schema/crn/schemas/research-outputs.json
@@ -172,6 +172,7 @@
             "Sample Prep",
             "Shipment Procedure",
             "Software",
+            "Sequencing",
             "Spectroscopy",
             "Team meeting",
             "Viral Vector"


### PR DESCRIPTION
In [CRN-995 Add New Type to Protocol shared output form](https://github.com/yldio/asap-hub/pull/2454) I forgot to add `Sequencing` in the `Type` allowed values. 
<img width="1364" alt="Screenshot 2023-01-17 at 10 48 08" src="https://user-images.githubusercontent.com/16595804/212915580-3af098b4-b5b6-46e9-919f-3f765a0b773d.png">


This is causing a validation error when we try to publish a shared output with this type.
<img width="1369" alt="Screenshot 2023-01-17 at 10 36 37" src="https://user-images.githubusercontent.com/16595804/212915639-414a6971-690d-4473-a612-75a7155e0185.png">


So in this PR I am adding `Sequencing` to the allowed values in the file that creates the new env in squidex.