### PR TITLE
fix(cms-migration): asset with id null

### DIFF
--- a/@types/contentful-html-rich-text-converter/index.d.ts
+++ b/@types/contentful-html-rich-text-converter/index.d.ts
@@ -16,10 +16,7 @@ declare module 'contentful-html-rich-text-converter' {
     html: string,
     getAssetId?: (url: string) => string | null,
   ): unknown;
-  function parseAssets(
-    html: string,
-    getAssetId?: (url: string) => string | null,
-  ): InlineAssetBody[];
+  function parseAssets(html: string): InlineAssetBody[];
   function parseIFrames(html: string): InlineIFrameBody[];
 
   export { parseHtml, parseAssets, parseIFrames };

--- a/packages/cms-data-sync/src/utils/assets.ts
+++ b/packages/cms-data-sync/src/utils/assets.ts
@@ -119,10 +119,3 @@ export const createAsset = async (
     },
   };
 };
-
-export const getAssetId = (url: string) => {
-  const regex =
-    /https:\/\/cloud\.squidex\.io\/api\/assets\/.*\/([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})\/.*/i;
-  const regexMatch = regex.exec(url);
-  return regexMatch?.length ? regexMatch[1] : null;
-};

--- a/packages/cms-data-sync/src/utils/rich-text.ts
+++ b/packages/cms-data-sync/src/utils/rich-text.ts
@@ -5,7 +5,6 @@ import {
   parseIFrames,
 } from 'contentful-html-rich-text-converter';
 import { logger } from './logs';
-import { getAssetId } from './assets';
 
 export const clearParsedHtmlOutput = (htmlDocument: Document) => ({
   ...htmlDocument,
@@ -43,8 +42,8 @@ export const convertHtmlToContentfulFormat = (html: string) => {
   logger(`HTML pre-parsed:\n${html}`, 'DEBUG');
   logger(`HTML post-parsed:\n${htmlWithoutDivTag}`, 'DEBUG');
 
-  const parsedHtml = parseHtml(htmlWithoutDivTag, getAssetId) as Document;
-  const inlineAssetBodies = parseAssets(htmlWithoutDivTag, getAssetId);
+  const parsedHtml = parseHtml(htmlWithoutDivTag) as Document;
+  const inlineAssetBodies = parseAssets(htmlWithoutDivTag);
   const inlineIFramesBodies = parseIFrames(htmlWithoutDivTag);
 
   logger(

--- a/packages/cms-data-sync/test/utils/assets.test.ts
+++ b/packages/cms-data-sync/test/utils/assets.test.ts
@@ -3,7 +3,6 @@ import {
   checkIfAssetAlreadyExistsInContentful,
   createAsset,
   createInlineAssets,
-  getAssetId,
   migrateAsset,
 } from '../../src/utils';
 import {
@@ -186,20 +185,5 @@ describe('createAsset', () => {
     expect(assetLinkPayload).toEqual({
       sys: { id: 'asset-id', linkType: 'Asset', type: 'Link' },
     });
-  });
-});
-
-describe('getAssetId', () => {
-  const assetId = '8ca5d37d-4bc1-4085-b05e-786c3e6f5a38';
-  const squidexAssetUrlSuffix = 'https://cloud.squidex.io/api/assets/crn-100';
-
-  it('returns the expect assetId', () => {
-    expect(
-      getAssetId(`${squidexAssetUrlSuffix}/${assetId}/example.jpg`),
-    ).toEqual(assetId);
-  });
-
-  it('returns null when it does not find the id', () => {
-    expect(getAssetId(`http://non-squidex-url.example.jpg`)).toBeNull();
   });
 });


### PR DESCRIPTION
It's possible to remove the function `getAssetId` without having duplication problem because the payload from `parseAssets` comes with the `id` so we can check in contentful if that id already exists and in the fork the generated id is always the same given the asset url.

### Before ([action](https://github.com/yldio/asap-hub/actions/runs/4085980145/jobs/7044679210#step:6:372))
<img width="827" alt="before" src="https://user-images.githubusercontent.com/16595804/217101999-fc56a5cd-51b4-4c2a-a05f-b16c2555d65d.png">


### After ([action](https://github.com/yldio/asap-hub/actions/runs/4107888571/jobs/7088928723#step:6:372))
<img width="809" alt="after" src="https://user-images.githubusercontent.com/16595804/217102246-f29b300a-f1a6-45e9-bd4c-371451d4b1f9.png">
