### PR TITLE
[CRN-1181] Display Active and Past team associations on the user profile page

### DIFF
--- a/apps/crn-frontend/src/network/teams/state.ts
+++ b/apps/crn-frontend/src/network/teams/state.ts
@@ -84,7 +84,7 @@ const patchedTeamState = atomFamily<TeamResponse | undefined, string>({
   default: undefined,
 });
 
-const teamState = selectorFamily<TeamResponse | undefined, string>({
+export const teamState = selectorFamily<TeamResponse | undefined, string>({
   key: 'team',
   get:
     (id) =>

--- a/apps/crn-frontend/src/network/users/Research.tsx
+++ b/apps/crn-frontend/src/network/users/Research.tsx
@@ -6,6 +6,7 @@ import {
   RoleModal,
   UserProfileResearch,
   WorkingGroupsTabbedCard,
+  UserTeamsTabbedCard,
 } from '@asap-hub/react-components';
 import { useCurrentUserCRN } from '@asap-hub/react-context';
 import { network } from '@asap-hub/routing';
@@ -44,13 +45,15 @@ const Research: React.FC<ResearchProps> = ({ user }) => {
             />
           </Frame>
         }
-        teams={user.teams.map((team) => ({
-          ...team,
-          editHref:
-            id === user.id
-              ? route.editTeamMembership({ teamId: team.id }).$
-              : undefined,
-        }))}
+        userProfileTeamsCard={
+          <Frame title={null} fallback={null}>
+            <UserTeamsTabbedCard
+              userName={user.displayName}
+              isUserAlumni={!!user.alumniSinceDate}
+              teams={user.teams}
+            />
+          </Frame>
+        }
         editExpertiseAndResourcesHref={
           id === user.id ? route.editExpertiseAndResources({}).$ : undefined
         }

--- a/apps/crn-server/src/autogenerated-gql/graphql.ts
+++ b/apps/crn-server/src/autogenerated-gql/graphql.ts
@@ -6575,7 +6575,7 @@ export type EventContentFragment = Pick<
                                         Pick<Teams, 'id'> & {
                                           flatData: Pick<
                                             TeamsFlatDataDto,
-                                            'displayName'
+                                            'displayName' | 'inactiveSince'
                                           > & {
                                             proposal: Maybe<
                                               Array<Pick<ResearchOutputs, 'id'>>
@@ -6681,7 +6681,7 @@ export type EventContentFragment = Pick<
                                         Pick<Teams, 'id'> & {
                                           flatData: Pick<
                                             TeamsFlatDataDto,
-                                            'displayName'
+                                            'displayName' | 'inactiveSince'
                                           > & {
                                             proposal: Maybe<
                                               Array<Pick<ResearchOutputs, 'id'>>
@@ -7010,7 +7010,8 @@ export type FetchEventsQuery = {
                                                   Pick<Teams, 'id'> & {
                                                     flatData: Pick<
                                                       TeamsFlatDataDto,
-                                                      'displayName'
+                                                      | 'displayName'
+                                                      | 'inactiveSince'
                                                     > & {
                                                       proposal: Maybe<
                                                         Array<
@@ -7130,7 +7131,8 @@ export type FetchEventsQuery = {
                                                   Pick<Teams, 'id'> & {
                                                     flatData: Pick<
                                                       TeamsFlatDataDto,
-                                                      'displayName'
+                                                      | 'displayName'
+                                                      | 'inactiveSince'
                                                     > & {
                                                       proposal: Maybe<
                                                         Array<
@@ -7465,7 +7467,7 @@ export type FetchEventQuery = {
                                             Pick<Teams, 'id'> & {
                                               flatData: Pick<
                                                 TeamsFlatDataDto,
-                                                'displayName'
+                                                'displayName' | 'inactiveSince'
                                               > & {
                                                 proposal: Maybe<
                                                   Array<
@@ -7576,7 +7578,7 @@ export type FetchEventQuery = {
                                             Pick<Teams, 'id'> & {
                                               flatData: Pick<
                                                 TeamsFlatDataDto,
-                                                'displayName'
+                                                'displayName' | 'inactiveSince'
                                               > & {
                                                 proposal: Maybe<
                                                   Array<
@@ -7901,7 +7903,7 @@ export type GroupsContentFragment = Pick<
                             Pick<Teams, 'id'> & {
                               flatData: Pick<
                                 TeamsFlatDataDto,
-                                'displayName'
+                                'displayName' | 'inactiveSince'
                               > & {
                                 proposal: Maybe<
                                   Array<Pick<ResearchOutputs, 'id'>>
@@ -8002,7 +8004,7 @@ export type GroupsContentFragment = Pick<
                             Pick<Teams, 'id'> & {
                               flatData: Pick<
                                 TeamsFlatDataDto,
-                                'displayName'
+                                'displayName' | 'inactiveSince'
                               > & {
                                 proposal: Maybe<
                                   Array<Pick<ResearchOutputs, 'id'>>
@@ -8159,7 +8161,7 @@ export type FetchGroupsQuery = {
                                       Pick<Teams, 'id'> & {
                                         flatData: Pick<
                                           TeamsFlatDataDto,
-                                          'displayName'
+                                          'displayName' | 'inactiveSince'
                                         > & {
                                           proposal: Maybe<
                                             Array<Pick<ResearchOutputs, 'id'>>
@@ -8265,7 +8267,7 @@ export type FetchGroupsQuery = {
                                       Pick<Teams, 'id'> & {
                                         flatData: Pick<
                                           TeamsFlatDataDto,
-                                          'displayName'
+                                          'displayName' | 'inactiveSince'
                                         > & {
                                           proposal: Maybe<
                                             Array<Pick<ResearchOutputs, 'id'>>
@@ -8414,7 +8416,7 @@ export type FetchGroupQuery = {
                                 Pick<Teams, 'id'> & {
                                   flatData: Pick<
                                     TeamsFlatDataDto,
-                                    'displayName'
+                                    'displayName' | 'inactiveSince'
                                   > & {
                                     proposal: Maybe<
                                       Array<Pick<ResearchOutputs, 'id'>>
@@ -8515,7 +8517,7 @@ export type FetchGroupQuery = {
                                 Pick<Teams, 'id'> & {
                                   flatData: Pick<
                                     TeamsFlatDataDto,
-                                    'displayName'
+                                    'displayName' | 'inactiveSince'
                                   > & {
                                     proposal: Maybe<
                                       Array<Pick<ResearchOutputs, 'id'>>
@@ -8775,7 +8777,10 @@ export type ResearchOutputContentFragment = Pick<
                       id: Maybe<
                         Array<
                           Pick<Teams, 'id'> & {
-                            flatData: Pick<TeamsFlatDataDto, 'displayName'> & {
+                            flatData: Pick<
+                              TeamsFlatDataDto,
+                              'displayName' | 'inactiveSince'
+                            > & {
                               proposal: Maybe<
                                 Array<Pick<ResearchOutputs, 'id'>>
                               >;
@@ -8947,7 +8952,7 @@ export type FetchResearchOutputQuery = {
                               Pick<Teams, 'id'> & {
                                 flatData: Pick<
                                   TeamsFlatDataDto,
-                                  'displayName'
+                                  'displayName' | 'inactiveSince'
                                 > & {
                                   proposal: Maybe<
                                     Array<Pick<ResearchOutputs, 'id'>>
@@ -9137,7 +9142,7 @@ export type FetchResearchOutputsQuery = {
                                     Pick<Teams, 'id'> & {
                                       flatData: Pick<
                                         TeamsFlatDataDto,
-                                        'displayName'
+                                        'displayName' | 'inactiveSince'
                                       > & {
                                         proposal: Maybe<
                                           Array<Pick<ResearchOutputs, 'id'>>
@@ -9327,7 +9332,10 @@ export type TeamsContentFragment = Pick<
                 id: Maybe<
                   Array<
                     Pick<Teams, 'id'> & {
-                      flatData: Pick<TeamsFlatDataDto, 'displayName'> & {
+                      flatData: Pick<
+                        TeamsFlatDataDto,
+                        'displayName' | 'inactiveSince'
+                      > & {
                         proposal: Maybe<Array<Pick<ResearchOutputs, 'id'>>>;
                       };
                     }
@@ -9434,7 +9442,10 @@ export type FetchTeamQuery = {
                     id: Maybe<
                       Array<
                         Pick<Teams, 'id'> & {
-                          flatData: Pick<TeamsFlatDataDto, 'displayName'> & {
+                          flatData: Pick<
+                            TeamsFlatDataDto,
+                            'displayName' | 'inactiveSince'
+                          > & {
                             proposal: Maybe<Array<Pick<ResearchOutputs, 'id'>>>;
                           };
                         }
@@ -9555,7 +9566,7 @@ export type FetchTeamsQuery = {
                               Pick<Teams, 'id'> & {
                                 flatData: Pick<
                                   TeamsFlatDataDto,
-                                  'displayName'
+                                  'displayName' | 'inactiveSince'
                                 > & {
                                   proposal: Maybe<
                                     Array<Pick<ResearchOutputs, 'id'>>
@@ -9691,9 +9702,10 @@ export type UsersContentFragment = Pick<
           id: Maybe<
             Array<
               Pick<Teams, 'id'> & {
-                flatData: Pick<TeamsFlatDataDto, 'displayName'> & {
-                  proposal: Maybe<Array<Pick<ResearchOutputs, 'id'>>>;
-                };
+                flatData: Pick<
+                  TeamsFlatDataDto,
+                  'displayName' | 'inactiveSince'
+                > & { proposal: Maybe<Array<Pick<ResearchOutputs, 'id'>>> };
               }
             >
           >;
@@ -9793,9 +9805,10 @@ export type FetchUserQuery = {
               id: Maybe<
                 Array<
                   Pick<Teams, 'id'> & {
-                    flatData: Pick<TeamsFlatDataDto, 'displayName'> & {
-                      proposal: Maybe<Array<Pick<ResearchOutputs, 'id'>>>;
-                    };
+                    flatData: Pick<
+                      TeamsFlatDataDto,
+                      'displayName' | 'inactiveSince'
+                    > & { proposal: Maybe<Array<Pick<ResearchOutputs, 'id'>>> };
                   }
                 >
               >;
@@ -9911,7 +9924,10 @@ export type FetchUsersQuery = {
                     id: Maybe<
                       Array<
                         Pick<Teams, 'id'> & {
-                          flatData: Pick<TeamsFlatDataDto, 'displayName'> & {
+                          flatData: Pick<
+                            TeamsFlatDataDto,
+                            'displayName' | 'inactiveSince'
+                          > & {
                             proposal: Maybe<Array<Pick<ResearchOutputs, 'id'>>>;
                           };
                         }
@@ -10516,6 +10532,13 @@ export const TeamsContentFragmentDoc = {
                                           kind: 'Field',
                                           name: {
                                             kind: 'Name',
+                                            value: 'inactiveSince',
+                                          },
+                                        },
+                                        {
+                                          kind: 'Field',
+                                          name: {
+                                            kind: 'Name',
                                             value: 'proposal',
                                           },
                                           selectionSet: {
@@ -10943,6 +10966,13 @@ export const GroupsContentFragmentDoc = {
                                                             },
                                                           },
                                                         ],
+                                                      },
+                                                    },
+                                                    {
+                                                      kind: 'Field',
+                                                      name: {
+                                                        kind: 'Name',
+                                                        value: 'inactiveSince',
                                                       },
                                                     },
                                                   ],
@@ -12179,6 +12209,13 @@ export const ResearchOutputContentFragmentDoc = {
                                                         ],
                                                       },
                                                     },
+                                                    {
+                                                      kind: 'Field',
+                                                      name: {
+                                                        kind: 'Name',
+                                                        value: 'inactiveSince',
+                                                      },
+                                                    },
                                                   ],
                                                 },
                                               },
@@ -12933,6 +12970,13 @@ export const UsersContentFragmentDoc = {
                                     name: {
                                       kind: 'Name',
                                       value: 'displayName',
+                                    },
+                                  },
+                                  {
+                                    kind: 'Field',
+                                    name: {
+                                      kind: 'Name',
+                                      value: 'inactiveSince',
                                     },
                                   },
                                   {

--- a/apps/crn-server/src/data-providers/users.data-provider.ts
+++ b/apps/crn-server/src/data-providers/users.data-provider.ts
@@ -253,6 +253,7 @@ export const parseGraphQLUserTeamConnections = (
     }
     const team = item.id[0];
     const displayName = team.flatData?.displayName;
+    const teamInactiveSince = team.flatData?.inactiveSince ?? undefined;
     const proposal = team.flatData?.proposal;
     if (!item.role || !isTeamRole(item.role)) {
       logger.warn(`Invalid team role: ${item.role}`);
@@ -261,6 +262,7 @@ export const parseGraphQLUserTeamConnections = (
     return [
       ...acc,
       {
+        teamInactiveSince,
         id: team.id,
         role: item.role,
         proposal: proposal?.length ? proposal[0]?.id : undefined,

--- a/apps/crn-server/src/queries/groups.queries.ts
+++ b/apps/crn-server/src/queries/groups.queries.ts
@@ -68,6 +68,7 @@ export const groupContentQueryFragment = gql`
                   proposal {
                     id
                   }
+                  inactiveSince
                 }
               }
             }

--- a/apps/crn-server/src/queries/research-outputs.queries.ts
+++ b/apps/crn-server/src/queries/research-outputs.queries.ts
@@ -73,6 +73,7 @@ export const researchOutputContentQueryFragment = gql`
                   proposal {
                     id
                   }
+                  inactiveSince
                 }
               }
             }

--- a/apps/crn-server/src/queries/teams.queries.ts
+++ b/apps/crn-server/src/queries/teams.queries.ts
@@ -67,6 +67,7 @@ export const teamsContentQueryFragment = gql`
             id
             flatData {
               displayName
+              inactiveSince
               proposal {
                 id
               }

--- a/apps/crn-server/src/queries/users.queries.ts
+++ b/apps/crn-server/src/queries/users.queries.ts
@@ -69,6 +69,7 @@ export const usersContentQueryFragment = gql`
           id
           flatData {
             displayName
+            inactiveSince
             proposal {
               id
             }

--- a/apps/crn-server/test/entities/team.test.ts
+++ b/apps/crn-server/test/entities/team.test.ts
@@ -46,6 +46,7 @@ describe('parseGraphQLTeamMember', () => {
                 {
                   id: 'team-id-0',
                   flatData: {
+                    inactiveSince: '',
                     displayName: 'Team A',
                     proposal: [{ id: 'proposalId1' }],
                   },

--- a/apps/crn-server/test/fixtures/users.fixtures.ts
+++ b/apps/crn-server/test/fixtures/users.fixtures.ts
@@ -157,6 +157,7 @@ export const getGraphQLUser = (
             id: 'team-id-0',
             flatData: {
               displayName: 'Team A',
+              inactiveSince: '',
               proposal: [{ id: 'proposalId1' }],
             },
           },

--- a/packages/model/src/user.ts
+++ b/packages/model/src/user.ts
@@ -104,6 +104,7 @@ export interface OrcidWork {
 export interface UserTeam {
   id: string;
   displayName?: string;
+  teamInactiveSince?: string;
   proposal?: string;
   role: TeamRole;
   inactiveSinceDate?: string;

--- a/packages/react-components/src/index.ts
+++ b/packages/react-components/src/index.ts
@@ -156,6 +156,7 @@ export {
   UserProfilePlaceholderCard,
   UserProfileRecentWorks,
   UserProfileRole,
+  UserTeamsTabbedCard,
   WorkingGroupCard,
   WorkingGroupMembers,
   WorkingGroupsTabbedCard,

--- a/packages/react-components/src/molecules/UserProfilePersonalText.tsx
+++ b/packages/react-components/src/molecules/UserProfilePersonalText.tsx
@@ -1,14 +1,17 @@
-import { FC, Fragment, useContext } from 'react';
+import { FC, useContext } from 'react';
 import { css } from '@emotion/react';
 import { UserResponse } from '@asap-hub/model';
 import { network } from '@asap-hub/routing';
 import { UserProfileContext } from '@asap-hub/react-context';
 
-import { Link, Paragraph, Ellipsis } from '../atoms';
+import { Link, Paragraph, Ellipsis, Avatar, Anchor } from '../atoms';
 import { locationIcon } from '../icons';
-import { perRem, lineHeight } from '../pixels';
+import { perRem, lineHeight, rem, tabletScreen } from '../pixels';
 import { lead, tin } from '../colors';
 import { getUniqueCommaStringWithSuffix } from '../utils';
+
+const MAX_TEAMS = 3;
+const avatarSize = 24;
 
 const locationStyles = css({
   padding: `${6 / perRem}em 0`,
@@ -30,10 +33,22 @@ const paragraphStyles = css({
   color: lead.rgb,
 });
 
+const avatarStyles = css({
+  width: rem(avatarSize),
+  height: rem(avatarSize),
+  margin: 0,
+  marginLeft: `${6 / perRem}em`,
+  fontWeight: 700,
+  fontSize: `${20 / perRem}em`,
+  [`@media (max-width: ${tabletScreen.width - 1}px)`]: {
+    margin: 'auto',
+  },
+});
+
 type UserProfilePersonalTextProps = Pick<
   UserResponse,
   'institution' | 'jobTitle' | 'country' | 'city' | 'teams' | 'role' | 'labs'
->;
+> & { userActiveTeamsRoute?: string };
 const UserProfilePersonalText: FC<UserProfilePersonalTextProps> = ({
   institution,
   country,
@@ -42,6 +57,7 @@ const UserProfilePersonalText: FC<UserProfilePersonalTextProps> = ({
   teams,
   role,
   labs,
+  userActiveTeamsRoute,
 }) => {
   const { isOwnProfile } = useContext(UserProfileContext);
 
@@ -52,7 +68,7 @@ const UserProfilePersonalText: FC<UserProfilePersonalTextProps> = ({
 
   return (
     <div>
-      <p css={paragraphStyles}>
+      <div css={paragraphStyles}>
         {jobTitle || institution ? (
           <>
             {jobTitle}
@@ -71,16 +87,27 @@ const UserProfilePersonalText: FC<UserProfilePersonalTextProps> = ({
             <span>{labsList}</span>
           </>
         )}
-        {teams.map(({ id, role: teamRole, displayName }) => (
-          <Fragment key={id}>
-            <br />
-            {teamRole} on{' '}
-            <Link href={network({}).teams({}).team({ teamId: id }).$}>
-              Team {displayName}
-            </Link>
-          </Fragment>
-        ))}
-      </p>
+        {teams
+          .slice(0, MAX_TEAMS)
+          .map(({ id, role: teamRole, displayName }, idx) => (
+            <div style={{ display: 'flex' }} key={id}>
+              <div>{teamRole} on&nbsp;</div>
+              <Link href={network({}).teams({}).team({ teamId: id }).$}>
+                Team {displayName}
+              </Link>
+              {idx === MAX_TEAMS - 1 && teams.length > MAX_TEAMS && (
+                <span css={css({ gridRow: 1, gridColumn: 1 })}>
+                  <Anchor href={userActiveTeamsRoute}>
+                    <Avatar
+                      placeholder={`+${teams.length - MAX_TEAMS}`}
+                      overrideStyles={avatarStyles}
+                    />
+                  </Anchor>
+                </span>
+              )}
+            </div>
+          ))}
+      </div>
       {(country || city || isOwnProfile) && (
         <Paragraph accent="lead">
           <span css={locationStyles}>

--- a/packages/react-components/src/molecules/__tests__/UserProfilePersonalText.test.tsx
+++ b/packages/react-components/src/molecules/__tests__/UserProfilePersonalText.test.tsx
@@ -7,6 +7,7 @@ const props: ComponentProps<typeof UserProfilePersonalText> = {
   labs: [],
   teams: [],
   role: 'Grantee',
+  userActiveTeamsRoute: '#',
 };
 
 it.each`
@@ -58,6 +59,38 @@ it("generates information about the user's team", async () => {
     />,
   );
   expect(container).toHaveTextContent(/Lead PI \(Core Leadership\) on Team/);
+});
+
+it('renders no more than 3 teams and roles', async () => {
+  const { container, getByLabelText } = render(
+    <UserProfilePersonalText
+      {...props}
+      teams={[
+        {
+          id: '42',
+          displayName: 'Team',
+          role: 'Lead PI (Core Leadership)',
+        },
+        {
+          id: '1337',
+          displayName: 'Meat',
+          role: 'Collaborating PI',
+        },
+        {
+          id: '2',
+          displayName: 'Drink',
+          role: 'Collaborating PI',
+        },
+        {
+          id: '3',
+          displayName: 'Desert',
+          role: 'Collaborating PI',
+        },
+      ]}
+    />,
+  );
+  expect(container).toHaveTextContent(/Lead PI \(Core Leadership\) on Team/);
+  expect(getByLabelText(/\+1/)).toBeVisible();
 });
 it('does not show team information if the user is not on a team', async () => {
   const { container } = render(<UserProfilePersonalText {...props} />);

--- a/packages/react-components/src/organisms/UserProfileRole.tsx
+++ b/packages/react-components/src/organisms/UserProfileRole.tsx
@@ -1,61 +1,16 @@
-import React, { Fragment, useContext } from 'react';
+import React, { useContext } from 'react';
 import { css } from '@emotion/react';
 import { UserResponse } from '@asap-hub/model';
-import { network } from '@asap-hub/routing';
 import { UserProfileContext } from '@asap-hub/react-context';
 
-import { Card, Divider, Headline2, Headline3, Link } from '../atoms';
-import { perRem, tabletScreen } from '../pixels';
+import { Card, Headline2, Headline3 } from '../atoms';
+import { perRem } from '../pixels';
 import UserProfilePlaceholderCard from './UserProfilePlaceholderCard';
-import { getUniqueCommaStringWithSuffix } from '../utils';
 
 type UserProfileRoleProps = Pick<
   UserResponse,
-  | 'firstName'
-  | 'teams'
-  | 'researchInterests'
-  | 'responsibilities'
-  | 'role'
-  | 'reachOut'
-  | 'labs'
+  'firstName' | 'researchInterests' | 'responsibilities' | 'role' | 'reachOut'
 >;
-
-const containerStyle = css({
-  display: 'grid',
-
-  gridColumnGap: `${12 / perRem}em`,
-
-  margin: 0,
-  marginTop: `${24 / perRem}em`,
-
-  padding: 0,
-  listStyle: 'none',
-});
-
-const titleStyle = css({
-  fontWeight: 'bold',
-});
-
-const listItemStyle = css({
-  display: 'grid',
-
-  gridTemplateColumns: '1fr',
-  gridTemplateRows: '1fr 1fr',
-  gridRowGap: `${12 / perRem}em`,
-
-  [`@media (min-width: ${tabletScreen.min}px)`]: {
-    gridAutoFlow: 'column',
-    gridTemplateColumns: '1fr 1fr',
-
-    '&:not(:first-of-type)': {
-      gridTemplateRows: '1fr',
-    },
-
-    [`&:not(:first-of-type) > :nth-of-type(odd)`]: {
-      display: 'none',
-    },
-  },
-});
 
 const detailsContentStyle = css({
   marginBottom: `${24 / perRem}em`,
@@ -66,51 +21,18 @@ const textStyle = css({
 });
 
 const UserProfileRole: React.FC<UserProfileRoleProps> = ({
-  teams,
-  labs = [],
   firstName,
   researchInterests,
   responsibilities,
   role,
   reachOut,
 }) => {
-  const teamHref = (id: string) => network({}).teams({}).team({ teamId: id }).$;
   const { isOwnProfile } = useContext(UserProfileContext);
-  const labsList = getUniqueCommaStringWithSuffix(
-    labs.map((lab) => lab.name),
-    'Lab',
-  );
   return (
     <Card>
       <Headline2 styleAsHeading={3}>
         {firstName}'s Role on ASAP Network
       </Headline2>
-
-      {!!teams.length && (
-        <div css={detailsContentStyle}>
-          <ul css={containerStyle}>
-            {teams.map(({ displayName, role: teamRole, id }, idx) => (
-              <Fragment key={`team-${idx}`}>
-                {idx === 0 || <Divider />}
-                <li key={idx} css={listItemStyle}>
-                  <div css={[titleStyle]}>Team</div>
-                  <div>
-                    <Link href={teamHref(id)}>Team {displayName}</Link>
-                  </div>
-                  <div css={[titleStyle]}>Role</div>
-                  <div>{teamRole}</div>
-                </li>
-              </Fragment>
-            ))}
-          </ul>
-        </div>
-      )}
-      {!!labsList.length && (
-        <div css={detailsContentStyle}>
-          <Headline3 styleAsHeading={5}>Labs</Headline3>
-          <span>{labsList}</span>
-        </div>
-      )}
       {(researchInterests || isOwnProfile) && role !== 'Staff' && (
         <div css={detailsContentStyle}>
           <Headline3 styleAsHeading={5}>Main Research Interests</Headline3>

--- a/packages/react-components/src/organisms/UserTeamsTabbedCard.tsx
+++ b/packages/react-components/src/organisms/UserTeamsTabbedCard.tsx
@@ -1,0 +1,176 @@
+import { TeamRole, UserTeam } from '@asap-hub/model';
+import { network } from '@asap-hub/routing';
+import { css } from '@emotion/react';
+import React, { ComponentProps, Fragment } from 'react';
+import { formatISO, parseISO, parse, format } from 'date-fns';
+import { Divider, Link, Paragraph } from '../atoms';
+import { inactiveBadgeIcon } from '../icons';
+import { TabbedCard } from '../molecules';
+import { perRem, rem, tabletScreen } from '../pixels';
+import { splitListBy } from '../utils';
+import { formatDateToTimezone } from '../date';
+
+const MAX_TEAMS = 5;
+
+const inactiveBadgeStyles = css({
+  lineHeight: `${18 / perRem}em`,
+  verticalAlign: 'middle',
+  marginLeft: `${8 / perRem}em`,
+});
+
+const listItemStyle = css({
+  display: 'grid',
+
+  gridTemplateColumns: '1fr',
+  gridTemplateRows: '1fr 1fr',
+  rowGap: rem(12),
+
+  [`@media (min-width: ${tabletScreen.min}px)`]: {
+    gridAutoFlow: 'column',
+    gridTemplateColumns: '1fr 1fr',
+
+    '&:not(:first-of-type)': {
+      gridTemplateRows: '1fr',
+    },
+
+    [`&:not(:first-of-type) > :nth-of-type(odd)`]: {
+      display: 'none',
+    },
+  },
+});
+
+const containerStyle = css({
+  display: 'grid',
+
+  columnGap: rem(12),
+
+  margin: 0,
+  marginTop: `${24 / perRem}em`,
+
+  padding: 0,
+  listStyle: 'none',
+});
+
+const titleStyle = css({
+  fontWeight: 'bold',
+});
+
+const detailsContentStyle = css({
+  marginBottom: `${24 / perRem}em`,
+});
+
+const priorities: Record<TeamRole, number> = {
+  'Lead PI (Core Leadership)': 1,
+  'Co-PI (Core Leadership)': 2,
+  'Collaborating PI': 3,
+  'Project Manager': 4,
+  'Key Personnel': 5,
+  'ASAP Staff': 6,
+  'Scientific Advisory Board': 7,
+};
+
+type UserTeamsTabbedCardProps = Pick<
+  ComponentProps<typeof TabbedCard>,
+  'description'
+> & {
+  userName: string;
+  isUserAlumni: boolean;
+  teams: UserTeam[];
+};
+
+const UserTeamsTabbedCard: React.FC<UserTeamsTabbedCardProps> = ({
+  isUserAlumni,
+  userName,
+  teams,
+}) => {
+  console.log({ teams });
+  console.log({ parse, format, parseISO, formatISO });
+  const sortedTeams = [...teams].sort(
+    (a, b) => priorities[a.role] - priorities[b.role],
+  );
+  const teamHref = (id: string) => network({}).teams({}).team({ teamId: id }).$;
+  const [inactiveTeams, activeTeams] = splitListBy(
+    sortedTeams,
+    (team) =>
+      isUserAlumni || !!team?.teamInactiveSince || !!team?.inactiveSinceDate,
+  );
+  return (
+    <TabbedCard
+      title={`${userName}'s Teams`}
+      activeTabIndex={isUserAlumni ? 1 : 0}
+      tabs={[
+        {
+          tabTitle: `Current Teams (${activeTeams.length})`,
+          items: activeTeams,
+          truncateFrom: MAX_TEAMS,
+          empty: (
+            <Paragraph accent="lead">There are no current teams.</Paragraph>
+          ),
+        },
+        {
+          tabTitle: `Previous Teams (${inactiveTeams.length})`,
+          items: inactiveTeams,
+          truncateFrom: MAX_TEAMS,
+          empty: (
+            <Paragraph accent="lead">There are no previous teams.</Paragraph>
+          ),
+        },
+      ]}
+      getShowMoreText={(showMore) => `View ${showMore ? 'Less' : 'More'} Teams`}
+    >
+      {({ data }) => (
+        <div css={detailsContentStyle}>
+          <ul css={containerStyle}>
+            {data.map(
+              (
+                {
+                  id,
+                  displayName,
+                  teamInactiveSince,
+                  role: teamRole,
+                  inactiveSinceDate,
+                },
+                idx,
+              ) => {
+                const showDateLeftColumn =
+                  !!inactiveSinceDate || !!teamInactiveSince;
+                const formattedDateLeft =
+                  showDateLeftColumn &&
+                  formatDateToTimezone(
+                    (inactiveSinceDate || teamInactiveSince) as string,
+                    'eee, dd MMM yyyy',
+                  );
+                return (
+                  <Fragment key={`team-${idx}`}>
+                    {idx === 0 || <Divider />}
+                    <li key={idx} css={listItemStyle}>
+                      <div css={[titleStyle]}>Team</div>
+                      <div>
+                        <Link href={teamHref(id)}>Team {displayName}</Link>
+                        {teamInactiveSince && (
+                          <span css={inactiveBadgeStyles}>
+                            {inactiveBadgeIcon}
+                          </span>
+                        )}
+                      </div>
+                      <div css={[titleStyle]}>Role</div>
+                      <div>{teamRole}</div>
+                      {showDateLeftColumn && (
+                        <>
+                          <div css={[titleStyle]}>Date Left</div>
+                          <div>{formattedDateLeft}</div>
+                        </>
+                      )}
+                    </li>
+                  </Fragment>
+                );
+              },
+            )}
+          </ul>
+        </div>
+      )}
+    </TabbedCard>
+  );
+};
+
+export default UserTeamsTabbedCard;

--- a/packages/react-components/src/organisms/__tests__/UserProfileRole.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/UserProfileRole.test.tsx
@@ -5,8 +5,6 @@ import UserProfileRole from '../UserProfileRole';
 
 const defaultProps = {
   firstName: 'Phillip',
-  labs: [],
-  teams: [],
   researchInterests: 'These are my research interest',
   responsibilities: 'these are my responsibilities',
   role: 'Grantee' as const,
@@ -18,22 +16,6 @@ it('generates a heading', () => {
   expect(getByRole('heading', { level: 2 }).textContent).toMatchInlineSnapshot(
     `"Phillip's Role on ASAP Network"`,
   );
-});
-
-it('renders a link to team page', () => {
-  const { getByRole } = render(
-    <UserProfileRole
-      {...defaultProps}
-      teams={[
-        {
-          id: '42',
-          displayName: 'Team',
-          role: 'Lead PI (Core Leadership)',
-        },
-      ]}
-    />,
-  );
-  expect(getByRole('link')).toHaveAttribute('href', '/network/teams/42');
 });
 
 it('renders responsibilities if present', () => {
@@ -67,24 +49,6 @@ it('renders placeholder if no responsibilities provided for your own profile', (
   );
 
   expect(queryAllByText(/responsibilities/i).length).toBeGreaterThan(0);
-});
-
-it('renders the list of labs', () => {
-  const { queryByText } = render(
-    <UserProfileContext.Provider value={{ isOwnProfile: true }}>
-      <UserProfileRole
-        {...defaultProps}
-        labs={[
-          { name: 'LONDON', id: '0001' },
-          { name: 'Paris', id: '0002' },
-          { name: 'barcelona', id: '0003' },
-        ]}
-      />
-    </UserProfileContext.Provider>,
-  );
-
-  expect(queryByText(/labs/i)).toBeVisible();
-  expect(queryByText('LONDON Lab, Paris Lab and barcelona Lab')).toBeVisible();
 });
 
 describe('When the role is not Staff', () => {

--- a/packages/react-components/src/organisms/index.ts
+++ b/packages/react-components/src/organisms/index.ts
@@ -67,6 +67,7 @@ export { default as UserProfileGroups } from './UserProfileGroups';
 export { default as UserProfilePlaceholderCard } from './UserProfilePlaceholderCard';
 export { default as UserProfileRecentWorks } from './UserProfileRecentWorks';
 export { default as UserProfileRole } from './UserProfileRole';
+export { default as UserTeamsTabbedCard } from './UserTeamsTabbedCard';
 export { default as WelcomeCard } from './WelcomeCard';
 export { default as WorkingGroupCard } from './WorkingGroupCard';
 export { default as WorkingGroupMembers } from './WorkingGroupMembers';

--- a/packages/react-components/src/templates/UserProfileHeader.tsx
+++ b/packages/react-components/src/templates/UserProfileHeader.tsx
@@ -249,6 +249,7 @@ const UserProfileHeader: React.FC<UserProfileHeaderProps> = ({
               teams={teams}
               role={role}
               labs={labs}
+              userActiveTeamsRoute={tabRoutes.research({}).$}
             />
           </div>
           <div css={avatarContainer}>

--- a/packages/react-components/src/templates/UserProfileResearch.tsx
+++ b/packages/react-components/src/templates/UserProfileResearch.tsx
@@ -17,6 +17,7 @@ type UserProfileResearchProps = ComponentProps<typeof QuestionsSection> &
   ComponentProps<typeof UserProfileRole> & {
     userProfileGroupsCard?: ReactNode;
     userProfileWorkingGroupsCard?: ReactNode;
+    userProfileTeamsCard?: ReactNode;
     editExpertiseAndResourcesHref?: string;
     editQuestionsHref?: string;
     editRoleHref?: string;
@@ -34,6 +35,7 @@ const UserProfileResearch: React.FC<UserProfileResearchProps> = ({
   displayName,
   userProfileGroupsCard,
   userProfileWorkingGroupsCard,
+  userProfileTeamsCard,
   editExpertiseAndResourcesHref,
   editQuestionsHref,
   editRoleHref,
@@ -61,6 +63,9 @@ const UserProfileResearch: React.FC<UserProfileResearchProps> = ({
     userProfileWorkingGroupsCard !== undefined && {
       card: userProfileWorkingGroupsCard,
     },
+    userProfileTeamsCard !== undefined && {
+      card: userProfileTeamsCard,
+    },
     !isOwnProfile && {
       card: <HelpSection />,
     },
@@ -81,6 +86,9 @@ const UserProfileResearch: React.FC<UserProfileResearchProps> = ({
     },
     userProfileGroupsCard !== undefined && {
       card: userProfileGroupsCard,
+    },
+    userProfileTeamsCard !== undefined && {
+      card: userProfileTeamsCard,
     },
     !isOwnProfile && {
       card: (

--- a/packages/react-components/src/templates/UserProfileResearch.tsx
+++ b/packages/react-components/src/templates/UserProfileResearch.tsx
@@ -31,33 +31,22 @@ const UserProfileResearch: React.FC<UserProfileResearchProps> = ({
   expertiseAndResourceDescription,
   questions,
   isOwnProfile,
-  labs,
   displayName,
   userProfileGroupsCard,
   userProfileWorkingGroupsCard,
   editExpertiseAndResourcesHref,
   editQuestionsHref,
   editRoleHref,
-  teams,
   role,
   ...roleProps
 }) => {
   const isRoleEmpty =
-    !labs.length &&
-    !teams.length &&
-    !roleProps.researchInterests &&
-    !roleProps.responsibilities;
+    !roleProps.researchInterests && !roleProps.responsibilities;
   const showRoleSection = isOwnProfile ? true : !isRoleEmpty;
   const roleSection = [
     showRoleSection && {
       card: (
-        <UserProfileRole
-          firstName={firstName}
-          labs={labs}
-          teams={teams}
-          role={role}
-          {...roleProps}
-        />
+        <UserProfileRole firstName={firstName} role={role} {...roleProps} />
       ),
       editLink:
         editRoleHref === undefined

--- a/packages/react-components/src/templates/__tests__/UserProfileResearch.test.tsx
+++ b/packages/react-components/src/templates/__tests__/UserProfileResearch.test.tsx
@@ -7,10 +7,8 @@ const commonProps: ComponentProps<typeof UserProfileResearch> = {
   firstName: 'Phillip',
   displayName: 'Phillip Winter',
   email: 'test@example.com',
-  teams: [],
   expertiseAndResourceTags: [],
   questions: [],
-  labs: [],
   role: 'Grantee',
 };
 
@@ -29,23 +27,6 @@ it('renders the role on ASAP when labs, teams responsabilites or researchInteres
     <UserProfileResearch {...commonProps} />,
   );
   expect(queryByText(/role.+asap/i)).not.toBeInTheDocument();
-  rerender(
-    <UserProfileResearch {...commonProps} labs={[{ id: '1', name: 'Lab' }]} />,
-  );
-  expect(queryByText(/role.+asap/i)).toBeInTheDocument();
-  rerender(
-    <UserProfileResearch
-      {...commonProps}
-      teams={[
-        {
-          id: '42',
-          displayName: 'Team',
-          role: 'Lead PI (Core Leadership)',
-        },
-      ]}
-    />,
-  );
-  expect(queryByText(/role.+asap/i)).toBeInTheDocument();
   rerender(
     <UserProfileResearch
       {...commonProps}
@@ -73,18 +54,7 @@ it('renders the expertiseAndResourceTags list', () => {
   expect(getByText('Neurological Diseases')).toBeVisible();
 });
 it('does not render an edit button by default (REGRESSION)', () => {
-  const { queryByLabelText } = render(
-    <UserProfileResearch
-      {...commonProps}
-      teams={[
-        {
-          id: '42',
-          displayName: 'Team',
-          role: 'Lead PI (Core Leadership)',
-        },
-      ]}
-    />,
-  );
+  const { queryByLabelText } = render(<UserProfileResearch {...commonProps} />);
   expect(queryByLabelText(/edit/i)).not.toBeInTheDocument();
 });
 


### PR DESCRIPTION
https://asaphub.atlassian.net/browse/CRN-1181

- [x] Header should display a maximum of 3 current user roles

- [x] On the 1st card of the research tab, remove reference to team, role and labs. Only Research and Responsibilities should be displayed

- [ ] A new Teams card should be displayed below interest groups card

- [ ] Inactive badges should be included for any inactive teams

- [ ] For Alumni users <previous teams> tab should be selected by default and current team should be inactive