### PR TITLE
CRN-1313 Display <a> with nested <i>/<b> & Fix color of <b>

### DIFF
--- a/packages/react-components/src/organisms/__tests__/RichText.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/RichText.test.tsx
@@ -22,20 +22,59 @@ it('renders <a> as a link', () => {
   expect(getByText('anchor')).toHaveAttribute('href', 'https://localhost/');
 });
 
+it('renders <a> as link with italic text', () => {
+  const { getByRole } = render(
+    <RichText text={'<a href="https://localhost/"><i>anchor</i></a>'} />,
+  );
+  const link = getByRole('link');
+
+  expect(link).toHaveAttribute('href', 'https://localhost/');
+  expect(link.firstElementChild?.innerHTML).toEqual(
+    '<i style="color:inherit">anchor</i>',
+  );
+});
+
+it('renders <a> as link with bold text', () => {
+  const { getByRole } = render(
+    <RichText text={'<a href="https://localhost/"><b>anchor</b></a>'} />,
+  );
+  const link = getByRole('link');
+
+  expect(link).toHaveAttribute('href', 'https://localhost/');
+  expect(link.firstElementChild?.innerHTML).toEqual(
+    '<b style="color:inherit">anchor</b>',
+  );
+});
+
+it('renders <a> as link with bold and italic text', () => {
+  const { getByRole } = render(
+    <RichText text={'<a href="https://localhost/"><b><i>anchor</i></b></a>'} />,
+  );
+  const link = getByRole('link');
+
+  expect(link).toHaveAttribute('href', 'https://localhost/');
+  expect(link.firstElementChild?.innerHTML).toEqual(
+    '<i style="color:inherit"><b style="color:inherit">anchor</b></i>',
+  );
+});
+
+it('renders <a> as link with formatting in the middle', () => {
+  const { getByRole } = render(
+    <RichText
+      text={'<a href="https://localhost/"><b>bold</b> normal <i>italic</i></a>'}
+    />,
+  );
+  const link = getByRole('link');
+
+  expect(link).toHaveAttribute('href', 'https://localhost/');
+  expect(link.firstElementChild?.innerHTML).toEqual(
+    '<b style="color:inherit">bold</b> normal <i style="color:inherit">italic</i>',
+  );
+});
+
 it('displays error when <a> without an href', () => {
   const { container } = render(<RichText text={'<a>anchor</a>'} />);
   expect(container.textContent).toContain('"anchor" is missing href');
-});
-
-it('displays error when styling applied within <a>', () => {
-  const { container } = render(
-    <RichText
-      text={'<a href="https://localhost/"><strong>anchor</strong></a>'}
-    />,
-  );
-  expect(container.textContent).toContain(
-    'Invalid link styling with href https://localhost/',
-  );
 });
 
 it.each([


### PR DESCRIPTION
RichText component would display an error like the one below when we have tags `i` or `b` inside `a`.


![Screenshot 2023-02-17 at 07 45 51](https://user-images.githubusercontent.com/16595804/219623643-9bb5f9c4-ed3e-4a41-be60-890c1ea758a5.png)

This PR makes it possible to render the variations below:

![Screenshot 2023-02-17 at 10 59 55](https://user-images.githubusercontent.com/16595804/219675815-bd602226-0a63-46b7-a053-feece512404e.png)


---

This also fixes the color of `<b>` tag

![Screenshot 2023-02-17 at 07 53 17](https://user-images.githubusercontent.com/16595804/219627700-85039402-9d4c-4cae-a274-ef21b5b567fe.png)
