### PR TITLE
fix(crn-server): sending errors to sentry

### DIFF
--- a/apps/crn-server/src/app.ts
+++ b/apps/crn-server/src/app.ts
@@ -141,6 +141,7 @@ import { workingGroupRouteFactory } from './routes/working-groups.route';
 import assignUserToContext from './utils/assign-user-to-context';
 import { getAuthToken } from './utils/auth';
 import pinoLogger from './utils/logger';
+import { shouldHandleError } from './utils/should-handle-error';
 
 export const appFactory = (libs: Libs = {}): Express => {
   const app = express();
@@ -417,7 +418,7 @@ export const appFactory = (libs: Libs = {}): Express => {
 
   /* istanbul ignore next */
   if (libs.sentryErrorHandler) {
-    app.use(libs.sentryErrorHandler());
+    app.use(libs.sentryErrorHandler({ shouldHandleError }));
   }
 
   app.use(errorHandler);

--- a/apps/crn-server/src/utils/should-handle-error.ts
+++ b/apps/crn-server/src/utils/should-handle-error.ts
@@ -1,0 +1,32 @@
+import { GenericError } from '@asap-hub/errors';
+
+interface MiddlewareError extends Error {
+  status?: number | string;
+  statusCode?: number | string;
+  status_code?: number | string;
+  output?: {
+    statusCode?: number | string;
+  };
+  response?: {
+    statusCode?: number | string;
+  };
+}
+
+// adapted from https://github.com/getsentry/sentry-javascript/blob/a88a8bf0f26d12adde87738a3c9f56658397af9a/packages/node/src/handlers.ts#L237
+const getStatusCodeFromResponse = (error: MiddlewareError): number => {
+  const statusCode =
+    error.status ||
+    error.statusCode ||
+    error.status_code ||
+    (error.output && error.output.statusCode) ||
+    (error.response && error.response.statusCode) ||
+    (error instanceof GenericError ? '400' : '500');
+
+  return parseInt(statusCode as string, 10);
+};
+
+export const shouldHandleError = (error: MiddlewareError) => {
+  const statusCode = getStatusCodeFromResponse(error);
+
+  return statusCode >= 500;
+};

--- a/apps/crn-server/test/middleware/sentry-error-handler.test.ts
+++ b/apps/crn-server/test/middleware/sentry-error-handler.test.ts
@@ -1,0 +1,51 @@
+import { Router } from 'express';
+import supertest from 'supertest';
+import * as Sentry from '@sentry/serverless';
+import { appFactory } from '../../src/app';
+import { authHandlerMock } from '../mocks/auth-handler.mock';
+import { loggerMock } from '../mocks/logger.mock';
+import * as util from '../../src/utils/should-handle-error';
+
+describe('Sentry Error middleware', () => {
+  test('Should handle any thrown error', async () => {
+    const mockRoutes = Router();
+    const err = new Error('error');
+    mockRoutes.get('/example', async (req, res) => {
+      throw err;
+    });
+
+    const spy = jest.spyOn(util, 'shouldHandleError');
+    const app = appFactory({
+      logger: loggerMock,
+      mockRequestHandlers: [mockRoutes],
+      authHandler: authHandlerMock,
+      sentryErrorHandler: Sentry.Handlers.errorHandler,
+    });
+
+    const response = await supertest(app).get('/example');
+
+    expect(spy).toHaveBeenCalledWith(err);
+    expect(response.status).toBe(500);
+  });
+
+  test('Should handle any unhandled rejection', async () => {
+    const mockRoutes = Router();
+    const err = new Error('error');
+    mockRoutes.get('/example', async (req, res) => {
+      return Promise.reject(err);
+    });
+
+    const spy = jest.spyOn(util, 'shouldHandleError');
+    const app = appFactory({
+      logger: loggerMock,
+      mockRequestHandlers: [mockRoutes],
+      authHandler: authHandlerMock,
+      sentryErrorHandler: Sentry.Handlers.errorHandler,
+    });
+
+    const response = await supertest(app).get('/example');
+
+    expect(spy).toHaveBeenCalledWith(err);
+    expect(response.status).toBe(500);
+  });
+});

--- a/apps/crn-server/test/utils/should-handle-error.test.ts
+++ b/apps/crn-server/test/utils/should-handle-error.test.ts
@@ -1,0 +1,65 @@
+import { NotFoundError, ValidationError } from '@asap-hub/errors';
+import { Boom } from '@hapi/boom';
+import { HTTPError, Response } from 'got/dist/source';
+import { shouldHandleError } from '../../src/utils/should-handle-error';
+
+describe('shouldHandleError', () => {
+  test.each`
+    statusCode | expected
+    ${500}     | ${true}
+    ${501}     | ${true}
+    ${502}     | ${true}
+    ${503}     | ${true}
+    ${400}     | ${false}
+    ${401}     | ${false}
+    ${402}     | ${false}
+    ${403}     | ${false}
+    ${404}     | ${false}
+  `(
+    `should return $expected for $statusCode HTTPError`,
+    ({ statusCode, expected }) => {
+      const errResponse = {
+        statusCode,
+      } as unknown as Response;
+      const httpError = new HTTPError(errResponse);
+      // @ts-ignore
+      // https://github.com/sindresorhus/got/issues/1210#issuecomment-623534449
+      httpError.response = errResponse;
+      expect(shouldHandleError(httpError)).toBe(expected);
+    },
+  );
+
+  test.each`
+    statusCode | expected
+    ${500}     | ${true}
+    ${501}     | ${true}
+    ${502}     | ${true}
+    ${503}     | ${true}
+    ${400}     | ${false}
+    ${401}     | ${false}
+    ${402}     | ${false}
+    ${403}     | ${false}
+    ${404}     | ${false}
+  `(
+    `should return $expected for $statusCode Boom Error`,
+    ({ statusCode, expected }) => {
+      const error = new Boom(`${statusCode} error`, { statusCode });
+      expect(shouldHandleError(error)).toBe(expected);
+    },
+  );
+
+  test('should return false for NotFoundError', async () => {
+    const error = new NotFoundError(undefined, `NotFoundError`);
+    expect(shouldHandleError(error)).toBe(false);
+  });
+
+  test('should return false for ValidationError', async () => {
+    const error = new ValidationError(undefined, undefined, 'ValidationError');
+    expect(shouldHandleError(error)).toBe(false);
+  });
+
+  test('should return true for Error', async () => {
+    const error = new Error('Error');
+    expect(shouldHandleError(error)).toBe(true);
+  });
+});

--- a/packages/server-common/src/middleware/auth-handler.ts
+++ b/packages/server-common/src/middleware/auth-handler.ts
@@ -2,6 +2,7 @@ import Boom from '@hapi/boom';
 import Intercept from 'apr-intercept';
 import { createHash } from 'crypto';
 import { Request, RequestHandler } from 'express';
+import { GenericError } from '@asap-hub/errors';
 import { CacheClient } from '../clients/cache.client';
 import { Logger } from '../utils/logger';
 import { DecodeToken } from '../utils/validate-token';
@@ -51,7 +52,12 @@ export const authHandlerFactory =
         user = await fetchByCode(payload.sub);
       } catch (error) {
         logger.error(error, 'Error fetching user details');
-        throw Boom.unauthorized();
+
+        if (error instanceof GenericError) {
+          throw Boom.unauthorized();
+        }
+
+        throw error;
       }
 
       cacheClient.set(tokenHash, user);


### PR DESCRIPTION
Override Sentry's default `shouldHandleError` function as `got` and our own Errors class do not match what Sentry is expecting so error are not being reported.

# How to Test

1. Login to  https://2656.hub.asap.science
2. Change lambda env var  `SQUIDEX_BASE_URL=http://httpstat.us/500
3. Navigate to any page on the site e.g https://2656.hub.asap.science/network/working-groups/1d87a6f5-94e6-4ae6-89dc-c12d2e591dec/about
4. Check sentry for report error
