### PR TITLE
CRN-792 Shared Output: Save Draft

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -12233,6 +12233,8 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@asap-hub/dom-test-utils", "workspace:packages/dom-test-utils"],\
             ["@asap-hub/eslint-config-asap-hub", "workspace:packages/eslint-config-asap-hub"],\
             ["@asap-hub/flags", "workspace:packages/flags"],\
+            ["@asap-hub/model", "workspace:packages/model"],\
+            ["@asap-hub/validation", "workspace:packages/validation"],\
             ["@babel/core", "npm:7.21.0"],\
             ["@babel/preset-react", "virtual:d0e958afa23d83fcbe1e8341a17fed5245116729be9039e4a7f723d5645a3b4a0db7dc084c7f30fa2114faa4c170592f819708d736b1e487b4ae7cd58824e005#npm:7.18.6"],\
             ["@babel/runtime-corejs3", "npm:7.21.0"],\
@@ -12262,6 +12264,8 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@asap-hub/dom-test-utils", "workspace:packages/dom-test-utils"],\
             ["@asap-hub/eslint-config-asap-hub", "workspace:packages/eslint-config-asap-hub"],\
             ["@asap-hub/flags", "workspace:packages/flags"],\
+            ["@asap-hub/model", "workspace:packages/model"],\
+            ["@asap-hub/validation", "workspace:packages/validation"],\
             ["@babel/core", "npm:7.21.0"],\
             ["@babel/preset-react", "virtual:d0e958afa23d83fcbe1e8341a17fed5245116729be9039e4a7f723d5645a3b4a0db7dc084c7f30fa2114faa4c170592f819708d736b1e487b4ae7cd58824e005#npm:7.18.6"],\
             ["@babel/runtime-corejs3", "npm:7.21.0"],\

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -12532,6 +12532,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@asap-hub/auth", "workspace:packages/auth"],\
             ["@asap-hub/eslint-config-asap-hub", "workspace:packages/eslint-config-asap-hub"],\
             ["@asap-hub/fixtures", "workspace:packages/fixtures"],\
+            ["@asap-hub/flags", "workspace:packages/flags"],\
             ["@asap-hub/model", "workspace:packages/model"],\
             ["@babel/runtime-corejs3", "npm:7.21.0"]\
           ],\

--- a/apps/crn-frontend/src/network/teams/TeamOutput.tsx
+++ b/apps/crn-frontend/src/network/teams/TeamOutput.tsx
@@ -56,8 +56,7 @@ const TeamOutput: React.FC<TeamOutputProps> = ({
 
   const createResearchOutput = usePostResearchOutput({ publish: true });
   const createDraftResearchOutput = usePostResearchOutput({ publish: false });
-  const updateResearchOutput = usePutResearchOutput({ publish: true });
-  const updateDraftResearchOutput = usePutResearchOutput({ publish: false });
+  const updateResearchOutput = usePutResearchOutput();
 
   const getLabSuggestions = useLabSuggestions();
   const getAuthorSuggestions = useAuthorSuggestions();
@@ -123,7 +122,7 @@ const TeamOutput: React.FC<TeamOutputProps> = ({
           }
           onSaveDraft={(output) =>
             researchOutputData
-              ? updateDraftResearchOutput(researchOutputData.id, output).catch(
+              ? updateResearchOutput(researchOutputData.id, output).catch(
                   handleError(['/link', '/title'], setErrors),
                 )
               : createDraftResearchOutput(output).catch(

--- a/apps/crn-frontend/src/network/teams/TeamOutput.tsx
+++ b/apps/crn-frontend/src/network/teams/TeamOutput.tsx
@@ -9,13 +9,12 @@ import {
   ResearchOutputForm,
   ResearchOutputHeader,
 } from '@asap-hub/react-components';
-import { ResearchOutputPermissionsContext } from '@asap-hub/react-context';
 import {
   network,
   TeamOutputDocumentTypeParameter,
   useRouteParams,
 } from '@asap-hub/routing';
-import React, { useContext, useState } from 'react';
+import React, { useState } from 'react';
 import researchSuggestions from './research-suggestions';
 import { useTeamById } from './state';
 import {
@@ -28,6 +27,7 @@ import {
   usePutResearchOutput,
   usePostResearchOutput,
 } from '../../shared-research';
+import { useResearchOutputPermissions } from '../../shared-research/state';
 
 const useParamOutputDocumentType = (
   teamId: string,
@@ -54,10 +54,6 @@ const TeamOutput: React.FC<TeamOutputProps> = ({
   const team = useTeamById(teamId);
   const [errors, setErrors] = useState<ValidationErrorResponse['data']>([]);
 
-  const { canEditResearchOutput } = useContext(
-    ResearchOutputPermissionsContext,
-  );
-
   const createResearchOutput = usePostResearchOutput({ published: true });
   const createDraftResearchOutput = usePostResearchOutput({ published: false });
   const updateResearchOutput = usePutResearchOutput({ published: true });
@@ -70,7 +66,13 @@ const TeamOutput: React.FC<TeamOutputProps> = ({
 
   const published = researchOutputData ? !!researchOutputData.published : false;
 
-  if (canEditResearchOutput && team) {
+  const permissions = useResearchOutputPermissions(
+    'teams',
+    [teamId],
+    published,
+  );
+
+  if (permissions.canEditResearchOutput && team) {
     return (
       <Frame title="Share Research Output">
         <ResearchOutputHeader
@@ -109,6 +111,7 @@ const TeamOutput: React.FC<TeamOutputProps> = ({
             }),
           )}
           published={published}
+          permissions={permissions}
           onSave={(output) =>
             researchOutputData
               ? updateResearchOutput(researchOutputData.id, output).catch(

--- a/apps/crn-frontend/src/network/teams/TeamOutput.tsx
+++ b/apps/crn-frontend/src/network/teams/TeamOutput.tsx
@@ -54,7 +54,9 @@ const TeamOutput: React.FC<TeamOutputProps> = ({
   const team = useTeamById(teamId);
   const [errors, setErrors] = useState<ValidationErrorResponse['data']>([]);
 
-  const { permissions } = useContext(ResearchOutputPermissionsContext);
+  const { canEditResearchOutput } = useContext(
+    ResearchOutputPermissionsContext,
+  );
 
   const createResearchOutput = usePostResearchOutput({ published: true });
   const createDraftResearchOutput = usePostResearchOutput({ published: false });
@@ -68,11 +70,7 @@ const TeamOutput: React.FC<TeamOutputProps> = ({
 
   const published = researchOutputData ? !!researchOutputData.published : false;
 
-  const isForbidden =
-    (!permissions.saveDraft && !permissions.publish) ||
-    (published && permissions.saveDraft && !permissions.publish);
-
-  if (!isForbidden && team) {
+  if (canEditResearchOutput && team) {
     return (
       <Frame title="Share Research Output">
         <ResearchOutputHeader

--- a/apps/crn-frontend/src/network/teams/TeamOutput.tsx
+++ b/apps/crn-frontend/src/network/teams/TeamOutput.tsx
@@ -54,10 +54,10 @@ const TeamOutput: React.FC<TeamOutputProps> = ({
   const team = useTeamById(teamId);
   const [errors, setErrors] = useState<ValidationErrorResponse['data']>([]);
 
-  const createResearchOutput = usePostResearchOutput({ published: true });
-  const createDraftResearchOutput = usePostResearchOutput({ published: false });
-  const updateResearchOutput = usePutResearchOutput({ published: true });
-  const updateDraftResearchOutput = usePutResearchOutput({ published: false });
+  const createResearchOutput = usePostResearchOutput({ publish: true });
+  const createDraftResearchOutput = usePostResearchOutput({ publish: false });
+  const updateResearchOutput = usePutResearchOutput({ publish: true });
+  const updateDraftResearchOutput = usePutResearchOutput({ publish: false });
 
   const getLabSuggestions = useLabSuggestions();
   const getAuthorSuggestions = useAuthorSuggestions();

--- a/apps/crn-frontend/src/network/teams/TeamProfile.tsx
+++ b/apps/crn-frontend/src/network/teams/TeamProfile.tsx
@@ -10,7 +10,7 @@ import { network, useRouteParams } from '@asap-hub/routing';
 import { usePaginationParams } from '../../hooks';
 import {
   useResearchOutputs,
-  useUserPermissions,
+  useCanShareResearchOutput,
 } from '../../shared-research/state';
 
 import { useUpcomingAndPastEvents } from '../events';
@@ -55,10 +55,7 @@ const TeamProfile: FC<TeamProfileProps> = ({ currentTime }) => {
       .then(loadEventsList);
   }, [team]);
 
-  const permissions = useUserPermissions({
-    entity: 'teams',
-    entityIds: [teamId],
-  });
+  const canShareResearchOutput = useCanShareResearchOutput('teams', [teamId]);
 
   const [upcomingEvents, pastEvents] = useUpcomingAndPastEvents(currentTime, {
     teamId,
@@ -86,7 +83,9 @@ const TeamProfile: FC<TeamProfileProps> = ({ currentTime }) => {
     };
 
     return (
-      <ResearchOutputPermissionsContext.Provider value={{ permissions }}>
+      <ResearchOutputPermissionsContext.Provider
+        value={{ canShareResearchOutput }}
+      >
         <Switch>
           <Route path={path + createOutput.template}>
             <Frame title="Share Output">

--- a/apps/crn-frontend/src/network/teams/TeamProfile.tsx
+++ b/apps/crn-frontend/src/network/teams/TeamProfile.tsx
@@ -8,12 +8,15 @@ import { ResearchOutputPermissionsContext } from '@asap-hub/react-context';
 import { network, useRouteParams } from '@asap-hub/routing';
 
 import { usePaginationParams } from '../../hooks';
-import { useResearchOutputs } from '../../shared-research/state';
+import {
+  useResearchOutputs,
+  useUserPermissions,
+} from '../../shared-research/state';
 
 import { useUpcomingAndPastEvents } from '../events';
 import ProfileSwitch from '../ProfileSwitch';
 
-import { useCanCreateUpdateResearchOutput, useTeamById } from './state';
+import { useTeamById } from './state';
 
 const loadAbout = () =>
   import(/* webpackChunkName: "network-team-about" */ './About');
@@ -52,7 +55,10 @@ const TeamProfile: FC<TeamProfileProps> = ({ currentTime }) => {
       .then(loadEventsList);
   }, [team]);
 
-  const canCreateUpdate = useCanCreateUpdateResearchOutput([teamId]);
+  const permissions = useUserPermissions({
+    entity: 'teams',
+    entityIds: [teamId],
+  });
 
   const [upcomingEvents, pastEvents] = useUpcomingAndPastEvents(currentTime, {
     teamId,
@@ -80,7 +86,7 @@ const TeamProfile: FC<TeamProfileProps> = ({ currentTime }) => {
     };
 
     return (
-      <ResearchOutputPermissionsContext.Provider value={{ canCreateUpdate }}>
+      <ResearchOutputPermissionsContext.Provider value={{ permissions }}>
         <Switch>
           <Route path={path + createOutput.template}>
             <Frame title="Share Output">

--- a/apps/crn-frontend/src/network/teams/__tests__/TeamOutput.test.tsx
+++ b/apps/crn-frontend/src/network/teams/__tests__/TeamOutput.test.tsx
@@ -305,6 +305,44 @@ it('can edit a research output', async () => {
   );
 });
 
+it('can edit a draft research output', async () => {
+  const researchOutput = createResearchOutputResponse();
+  const teamId = researchOutput.teams[0].id;
+  const { type, description, title } = researchOutput;
+  const link = 'https://example42.com';
+  const doi = '10.0777';
+
+  await renderPage({
+    teamId: '42',
+    teamOutputDocumentType: 'article',
+    researchOutputData: { ...researchOutput, doi, published: false },
+  });
+
+  const { saveDraft } = await mandatoryFields(
+    {
+      link,
+      title: '',
+      description: '',
+      type,
+      doi,
+    },
+    true,
+    true,
+  );
+  await saveDraft();
+
+  expect(mockUpdateResearchOutput).toHaveBeenCalledWith(
+    researchOutput.id,
+    expect.objectContaining({
+      link,
+      title,
+      description,
+      teams: [teamId],
+    }),
+    expect.anything(),
+  );
+});
+
 test('displays sorry page when user does not have edit permission', async () => {
   await renderPage({
     user: {

--- a/apps/crn-frontend/src/network/teams/__tests__/TeamOutput.test.tsx
+++ b/apps/crn-frontend/src/network/teams/__tests__/TeamOutput.test.tsx
@@ -302,7 +302,6 @@ it('can edit a research output', async () => {
       teams: [teamId],
     }),
     expect.anything(),
-    true,
   );
 });
 

--- a/apps/crn-frontend/src/network/teams/__tests__/TeamProfile.test.tsx
+++ b/apps/crn-frontend/src/network/teams/__tests__/TeamProfile.test.tsx
@@ -92,6 +92,7 @@ it('share outputs page is rendered when user clicks share an output and chooses 
       teams: [
         {
           ...userResponse.teams[0],
+          id: teamResponse.id,
           role: 'ASAP Staff',
         },
       ],

--- a/apps/crn-frontend/src/network/teams/__tests__/api.test.ts
+++ b/apps/crn-frontend/src/network/teams/__tests__/api.test.ts
@@ -158,7 +158,7 @@ describe('Team Research Output', () => {
   };
   it('makes an authorized POST request to create a research output', async () => {
     nock(API_BASE_URL, { reqheaders: { authorization: 'Bearer x' } })
-      .post('/research-outputs?published=true', payload)
+      .post('/research-outputs?publish=true', payload)
       .reply(201, { id: 123 });
 
     await createResearchOutput(payload, 'Bearer x');
@@ -167,7 +167,7 @@ describe('Team Research Output', () => {
 
   it('makes an authorized PUT request to update a research output', async () => {
     nock(API_BASE_URL, { reqheaders: { authorization: 'Bearer x' } })
-      .put('/research-outputs/123?published=true', payload)
+      .put('/research-outputs/123', payload)
       .reply(200, { id: 123 });
 
     await updateTeamResearchOutput('123', payload, 'Bearer x');
@@ -175,7 +175,7 @@ describe('Team Research Output', () => {
   });
 
   it('errors for an error status', async () => {
-    nock(API_BASE_URL).post('/research-outputs?published=true').reply(500, {});
+    nock(API_BASE_URL).post('/research-outputs?publish=true').reply(500, {});
 
     await expect(
       createResearchOutput(payload, 'Bearer x'),
@@ -185,9 +185,7 @@ describe('Team Research Output', () => {
   });
 
   it('errors for an error status in edit mode', async () => {
-    nock(API_BASE_URL)
-      .put('/research-outputs/123?published=true')
-      .reply(500, {});
+    nock(API_BASE_URL).put('/research-outputs/123').reply(500, {});
 
     await expect(
       updateTeamResearchOutput('123', payload, 'Bearer x'),

--- a/apps/crn-frontend/src/network/teams/__tests__/api.test.ts
+++ b/apps/crn-frontend/src/network/teams/__tests__/api.test.ts
@@ -158,7 +158,7 @@ describe('Team Research Output', () => {
   };
   it('makes an authorized POST request to create a research output', async () => {
     nock(API_BASE_URL, { reqheaders: { authorization: 'Bearer x' } })
-      .post('/research-outputs', payload)
+      .post('/research-outputs?published=true', payload)
       .reply(201, { id: 123 });
 
     await createResearchOutput(payload, 'Bearer x');
@@ -167,7 +167,7 @@ describe('Team Research Output', () => {
 
   it('makes an authorized PUT request to update a research output', async () => {
     nock(API_BASE_URL, { reqheaders: { authorization: 'Bearer x' } })
-      .put('/research-outputs/123', payload)
+      .put('/research-outputs/123?published=true', payload)
       .reply(200, { id: 123 });
 
     await updateTeamResearchOutput('123', payload, 'Bearer x');
@@ -175,7 +175,7 @@ describe('Team Research Output', () => {
   });
 
   it('errors for an error status', async () => {
-    nock(API_BASE_URL).post('/research-outputs').reply(500, {});
+    nock(API_BASE_URL).post('/research-outputs?published=true').reply(500, {});
 
     await expect(
       createResearchOutput(payload, 'Bearer x'),
@@ -185,7 +185,9 @@ describe('Team Research Output', () => {
   });
 
   it('errors for an error status in edit mode', async () => {
-    nock(API_BASE_URL).put('/research-outputs/123').reply(500, {});
+    nock(API_BASE_URL)
+      .put('/research-outputs/123?published=true')
+      .reply(500, {});
 
     await expect(
       updateTeamResearchOutput('123', payload, 'Bearer x'),

--- a/apps/crn-frontend/src/network/teams/api.ts
+++ b/apps/crn-frontend/src/network/teams/api.ts
@@ -107,10 +107,9 @@ export const updateTeamResearchOutput = async (
   researchOutputId: string,
   researchOutput: ResearchOutputPostRequest,
   authorization: string,
-  publish: boolean = true,
 ): Promise<ResearchOutputResponse> => {
   const resp = await fetch(
-    `${API_BASE_URL}/research-outputs/${researchOutputId}?publish=${publish}`,
+    `${API_BASE_URL}/research-outputs/${researchOutputId}`,
     {
       method: 'PUT',
       headers: {

--- a/apps/crn-frontend/src/network/teams/api.ts
+++ b/apps/crn-frontend/src/network/teams/api.ts
@@ -74,10 +74,10 @@ export const patchTeam = async (
 export const createResearchOutput = async (
   researchOutput: ResearchOutputPostRequest,
   authorization: string,
-  published: boolean = true,
+  publish: boolean = true,
 ): Promise<ResearchOutputResponse> => {
   const resp = await fetch(
-    `${API_BASE_URL}/research-outputs?published=${published}`,
+    `${API_BASE_URL}/research-outputs?publish=${publish}`,
     {
       method: 'POST',
       headers: {
@@ -107,10 +107,10 @@ export const updateTeamResearchOutput = async (
   researchOutputId: string,
   researchOutput: ResearchOutputPostRequest,
   authorization: string,
-  published: boolean = true,
+  publish: boolean = true,
 ): Promise<ResearchOutputResponse> => {
   const resp = await fetch(
-    `${API_BASE_URL}/research-outputs/${researchOutputId}?published=${published}`,
+    `${API_BASE_URL}/research-outputs/${researchOutputId}?publish=${publish}`,
     {
       method: 'PUT',
       headers: {

--- a/apps/crn-frontend/src/network/teams/api.ts
+++ b/apps/crn-frontend/src/network/teams/api.ts
@@ -74,16 +74,20 @@ export const patchTeam = async (
 export const createResearchOutput = async (
   researchOutput: ResearchOutputPostRequest,
   authorization: string,
+  published: boolean = true,
 ): Promise<ResearchOutputResponse> => {
-  const resp = await fetch(`${API_BASE_URL}/research-outputs`, {
-    method: 'POST',
-    headers: {
-      authorization,
-      'content-type': 'application/json',
-      ...createSentryHeaders(),
+  const resp = await fetch(
+    `${API_BASE_URL}/research-outputs?published=${published}`,
+    {
+      method: 'POST',
+      headers: {
+        authorization,
+        'content-type': 'application/json',
+        ...createSentryHeaders(),
+      },
+      body: JSON.stringify(researchOutput),
     },
-    body: JSON.stringify(researchOutput),
-  });
+  );
   const response = await resp.json();
   if (!resp.ok) {
     throw new BackendError(
@@ -103,9 +107,10 @@ export const updateTeamResearchOutput = async (
   researchOutputId: string,
   researchOutput: ResearchOutputPostRequest,
   authorization: string,
+  published: boolean = true,
 ): Promise<ResearchOutputResponse> => {
   const resp = await fetch(
-    `${API_BASE_URL}/research-outputs/${researchOutputId}`,
+    `${API_BASE_URL}/research-outputs/${researchOutputId}?published=${published}`,
     {
       method: 'PUT',
       headers: {

--- a/apps/crn-frontend/src/network/teams/state.ts
+++ b/apps/crn-frontend/src/network/teams/state.ts
@@ -4,8 +4,6 @@ import {
   TeamPatchRequest,
   TeamResponse,
 } from '@asap-hub/model';
-import { useCurrentUserCRN } from '@asap-hub/react-context';
-import { hasCreateUpdateResearchOutputPermissions } from '@asap-hub/validation';
 import {
   atomFamily,
   DefaultValue,
@@ -127,12 +125,4 @@ export const usePatchTeamById = (id: string) => {
   return async (patch: TeamPatchRequest) => {
     setPatchedTeam(await patchTeam(id, patch, authorization));
   };
-};
-
-export const useCanCreateUpdateResearchOutput = (
-  teamIds: string[],
-): boolean => {
-  const user = useCurrentUserCRN();
-
-  return !!(user && hasCreateUpdateResearchOutputPermissions(user, teamIds));
 };

--- a/apps/crn-frontend/src/network/working-groups/WorkingGroupOutput.tsx
+++ b/apps/crn-frontend/src/network/working-groups/WorkingGroupOutput.tsx
@@ -45,8 +45,9 @@ const WorkingGroupOutput: React.FC<WorkingGroupOutputProps> = ({
 
   const [errors, setErrors] = useState<ValidationErrorResponse['data']>([]);
 
-  const { permissions } = useContext(ResearchOutputPermissionsContext);
-
+  const { canEditResearchOutput } = useContext(
+    ResearchOutputPermissionsContext,
+  );
   const createResearchOutput = usePostResearchOutput({ published: true });
   const createDraftResearchOutput = usePostResearchOutput({ published: false });
   const updateResearchOutput = usePutResearchOutput({ published: true });
@@ -59,11 +60,7 @@ const WorkingGroupOutput: React.FC<WorkingGroupOutputProps> = ({
 
   const published = researchOutputData ? !!researchOutputData.published : false;
 
-  const isForbidden =
-    (!permissions.saveDraft && !permissions.publish) ||
-    (published && permissions.saveDraft && !permissions.publish);
-
-  if (!isForbidden && workingGroup) {
+  if (canEditResearchOutput && workingGroup) {
     return (
       <Frame title="Share Working Group Research Output">
         <ResearchOutputHeader

--- a/apps/crn-frontend/src/network/working-groups/WorkingGroupOutput.tsx
+++ b/apps/crn-frontend/src/network/working-groups/WorkingGroupOutput.tsx
@@ -10,8 +10,7 @@ import {
   ResearchOutputHeader,
 } from '@asap-hub/react-components';
 import { network, useRouteParams } from '@asap-hub/routing';
-import React, { useContext, useState } from 'react';
-import { ResearchOutputPermissionsContext } from '@asap-hub/react-context';
+import React, { useState } from 'react';
 import researchSuggestions from '../teams/research-suggestions';
 import { useWorkingGroupById } from './state';
 import {
@@ -24,6 +23,7 @@ import {
   usePostResearchOutput,
   usePutResearchOutput,
 } from '../../shared-research';
+import { useResearchOutputPermissions } from '../../shared-research/state';
 
 type WorkingGroupOutputProps = {
   workingGroupId: string;
@@ -45,9 +45,6 @@ const WorkingGroupOutput: React.FC<WorkingGroupOutputProps> = ({
 
   const [errors, setErrors] = useState<ValidationErrorResponse['data']>([]);
 
-  const { canEditResearchOutput } = useContext(
-    ResearchOutputPermissionsContext,
-  );
   const createResearchOutput = usePostResearchOutput({ published: true });
   const createDraftResearchOutput = usePostResearchOutput({ published: false });
   const updateResearchOutput = usePutResearchOutput({ published: true });
@@ -60,7 +57,13 @@ const WorkingGroupOutput: React.FC<WorkingGroupOutputProps> = ({
 
   const published = researchOutputData ? !!researchOutputData.published : false;
 
-  if (canEditResearchOutput && workingGroup) {
+  const permissions = useResearchOutputPermissions(
+    'workingGroups',
+    [workingGroupId],
+    published,
+  );
+
+  if (permissions.canEditResearchOutput && workingGroup) {
     return (
       <Frame title="Share Working Group Research Output">
         <ResearchOutputHeader
@@ -98,6 +101,7 @@ const WorkingGroupOutput: React.FC<WorkingGroupOutputProps> = ({
           )}
           authorsRequired
           published={published}
+          permissions={permissions}
           onSave={(output) =>
             researchOutputData
               ? updateResearchOutput(researchOutputData.id, {

--- a/apps/crn-frontend/src/network/working-groups/WorkingGroupOutput.tsx
+++ b/apps/crn-frontend/src/network/working-groups/WorkingGroupOutput.tsx
@@ -47,8 +47,7 @@ const WorkingGroupOutput: React.FC<WorkingGroupOutputProps> = ({
 
   const createResearchOutput = usePostResearchOutput({ publish: true });
   const createDraftResearchOutput = usePostResearchOutput({ publish: false });
-  const updateResearchOutput = usePutResearchOutput({ publish: true });
-  const updateDraftResearchOutput = usePutResearchOutput({ publish: false });
+  const updateResearchOutput = usePutResearchOutput();
 
   const getLabSuggestions = useLabSuggestions();
   const getAuthorSuggestions = useAuthorSuggestions();
@@ -115,7 +114,7 @@ const WorkingGroupOutput: React.FC<WorkingGroupOutputProps> = ({
           }
           onSaveDraft={(output) =>
             researchOutputData
-              ? updateDraftResearchOutput(researchOutputData.id, {
+              ? updateResearchOutput(researchOutputData.id, {
                   ...output,
                   workingGroups: [workingGroupId],
                 }).catch(handleError(['/link', '/title'], setErrors))

--- a/apps/crn-frontend/src/network/working-groups/WorkingGroupOutput.tsx
+++ b/apps/crn-frontend/src/network/working-groups/WorkingGroupOutput.tsx
@@ -45,10 +45,10 @@ const WorkingGroupOutput: React.FC<WorkingGroupOutputProps> = ({
 
   const [errors, setErrors] = useState<ValidationErrorResponse['data']>([]);
 
-  const createResearchOutput = usePostResearchOutput({ published: true });
-  const createDraftResearchOutput = usePostResearchOutput({ published: false });
-  const updateResearchOutput = usePutResearchOutput({ published: true });
-  const updateDraftResearchOutput = usePutResearchOutput({ published: false });
+  const createResearchOutput = usePostResearchOutput({ publish: true });
+  const createDraftResearchOutput = usePostResearchOutput({ publish: false });
+  const updateResearchOutput = usePutResearchOutput({ publish: true });
+  const updateDraftResearchOutput = usePutResearchOutput({ publish: false });
 
   const getLabSuggestions = useLabSuggestions();
   const getAuthorSuggestions = useAuthorSuggestions();

--- a/apps/crn-frontend/src/network/working-groups/WorkingGroupProfile.tsx
+++ b/apps/crn-frontend/src/network/working-groups/WorkingGroupProfile.tsx
@@ -8,12 +8,15 @@ import { ResearchOutputPermissionsContext } from '@asap-hub/react-context';
 import { network, useRouteParams } from '@asap-hub/routing';
 
 import { usePaginationParams } from '../../hooks';
-import { useResearchOutputs } from '../../shared-research/state';
+import {
+  useResearchOutputs,
+  useUserPermissions,
+} from '../../shared-research/state';
 
 import { useUpcomingAndPastEvents } from '../events';
 import ProfileSwitch from '../ProfileSwitch';
 
-import { useCanCreateUpdateResearchOutput, useWorkingGroupById } from './state';
+import { useWorkingGroupById } from './state';
 
 const loadAbout = () =>
   import(/* webpackChunkName: "network-working-group-about" */ './About');
@@ -43,7 +46,10 @@ const WorkingGroupProfile: FC<WorkingGroupProfileProps> = ({ currentTime }) => {
   const { workingGroupId } = useRouteParams(route);
   const workingGroup = useWorkingGroupById(workingGroupId);
 
-  const canCreateUpdate = useCanCreateUpdateResearchOutput(workingGroup);
+  const permissions = useUserPermissions({
+    entity: 'workingGroups',
+    entityIds: [workingGroupId],
+  });
 
   useEffect(() => {
     loadAbout()
@@ -78,7 +84,7 @@ const WorkingGroupProfile: FC<WorkingGroupProfileProps> = ({ currentTime }) => {
       upcoming: path + upcoming.template,
     };
     return (
-      <ResearchOutputPermissionsContext.Provider value={{ canCreateUpdate }}>
+      <ResearchOutputPermissionsContext.Provider value={{ permissions }}>
         <Switch>
           <Route path={path + createOutput.template}>
             <Frame title="Share Output">

--- a/apps/crn-frontend/src/network/working-groups/WorkingGroupProfile.tsx
+++ b/apps/crn-frontend/src/network/working-groups/WorkingGroupProfile.tsx
@@ -10,7 +10,7 @@ import { network, useRouteParams } from '@asap-hub/routing';
 import { usePaginationParams } from '../../hooks';
 import {
   useResearchOutputs,
-  useUserPermissions,
+  useCanShareResearchOutput,
 } from '../../shared-research/state';
 
 import { useUpcomingAndPastEvents } from '../events';
@@ -46,10 +46,9 @@ const WorkingGroupProfile: FC<WorkingGroupProfileProps> = ({ currentTime }) => {
   const { workingGroupId } = useRouteParams(route);
   const workingGroup = useWorkingGroupById(workingGroupId);
 
-  const permissions = useUserPermissions({
-    entity: 'workingGroups',
-    entityIds: [workingGroupId],
-  });
+  const canShareResearchOutput = useCanShareResearchOutput('workingGroups', [
+    workingGroupId,
+  ]);
 
   useEffect(() => {
     loadAbout()
@@ -84,7 +83,9 @@ const WorkingGroupProfile: FC<WorkingGroupProfileProps> = ({ currentTime }) => {
       upcoming: path + upcoming.template,
     };
     return (
-      <ResearchOutputPermissionsContext.Provider value={{ permissions }}>
+      <ResearchOutputPermissionsContext.Provider
+        value={{ canShareResearchOutput }}
+      >
         <Switch>
           <Route path={path + createOutput.template}>
             <Frame title="Share Output">

--- a/apps/crn-frontend/src/network/working-groups/__tests__/WorkingGroupOutput.test.tsx
+++ b/apps/crn-frontend/src/network/working-groups/__tests__/WorkingGroupOutput.test.tsx
@@ -466,7 +466,6 @@ it.each([
         workingGroups: [workingGroupId],
       }),
       expect.anything(),
-      published,
     );
   },
 );

--- a/apps/crn-frontend/src/network/working-groups/__tests__/WorkingGroupProfile.test.tsx
+++ b/apps/crn-frontend/src/network/working-groups/__tests__/WorkingGroupProfile.test.tsx
@@ -114,8 +114,7 @@ describe('the share outputs page', () => {
       await renderWorkingGroupProfile(
         {
           ...createUserResponse({}, 1),
-          role: 'Project Manager',
-          id: workingGroupResponse.leaders[0].user.id,
+          workingGroups: [{ id: workingGroupId, role: 'Project Manager' }],
         },
         history,
       );

--- a/apps/crn-frontend/src/network/working-groups/__tests__/api.test.ts
+++ b/apps/crn-frontend/src/network/working-groups/__tests__/api.test.ts
@@ -100,7 +100,7 @@ describe('working group research output', () => {
   };
   it('makes an authorized POST request to create a research output', async () => {
     nock(API_BASE_URL, { reqheaders: { authorization: 'Bearer x' } })
-      .post('/research-outputs', payload)
+      .post('/research-outputs?published=true', payload)
       .reply(201, { id: 123 });
 
     await createResearchOutput(payload, 'Bearer x');
@@ -108,7 +108,7 @@ describe('working group research output', () => {
   });
 
   it('errors for an error status', async () => {
-    nock(API_BASE_URL).post('/research-outputs').reply(500, {});
+    nock(API_BASE_URL).post('/research-outputs?published=true').reply(500, {});
 
     await expect(
       createResearchOutput(payload, 'Bearer x'),

--- a/apps/crn-frontend/src/network/working-groups/__tests__/api.test.ts
+++ b/apps/crn-frontend/src/network/working-groups/__tests__/api.test.ts
@@ -100,7 +100,7 @@ describe('working group research output', () => {
   };
   it('makes an authorized POST request to create a research output', async () => {
     nock(API_BASE_URL, { reqheaders: { authorization: 'Bearer x' } })
-      .post('/research-outputs?published=true', payload)
+      .post('/research-outputs?publish=true', payload)
       .reply(201, { id: 123 });
 
     await createResearchOutput(payload, 'Bearer x');
@@ -108,7 +108,7 @@ describe('working group research output', () => {
   });
 
   it('errors for an error status', async () => {
-    nock(API_BASE_URL).post('/research-outputs?published=true').reply(500, {});
+    nock(API_BASE_URL).post('/research-outputs?publish=true').reply(500, {});
 
     await expect(
       createResearchOutput(payload, 'Bearer x'),

--- a/apps/crn-frontend/src/network/working-groups/state.ts
+++ b/apps/crn-frontend/src/network/working-groups/state.ts
@@ -2,10 +2,7 @@ import { GetListOptions } from '@asap-hub/frontend-utils';
 import {
   WorkingGroupListResponse,
   WorkingGroupResponse,
-  WorkingGroupDataObject,
 } from '@asap-hub/model';
-import { useCurrentUserCRN } from '@asap-hub/react-context';
-import { hasWorkingGroupsCreateUpdateResearchOutputPermissions } from '@asap-hub/validation';
 import {
   atomFamily,
   DefaultValue,
@@ -124,18 +121,4 @@ export const useWorkingGroups = (options: GetListOptions) => {
     throw workingGroups;
   }
   return workingGroups;
-};
-
-export const useCanCreateUpdateResearchOutput = (
-  workingGroup: WorkingGroupDataObject | undefined,
-): boolean => {
-  const user = useCurrentUserCRN();
-
-  if (user === null) return false;
-  if (user.role === 'Staff') return true;
-
-  return hasWorkingGroupsCreateUpdateResearchOutputPermissions(
-    user,
-    workingGroup,
-  );
 };

--- a/apps/crn-frontend/src/shared-research.ts
+++ b/apps/crn-frontend/src/shared-research.ts
@@ -137,7 +137,7 @@ export const usePostResearchOutput = ({ publish = true }) => {
   };
 };
 
-export const usePutResearchOutput = ({ publish = true }) => {
+export const usePutResearchOutput = () => {
   const authorization = useRecoilValue(authorizationState);
   const setResearchOutputItem = useSetResearchOutputItem();
   return async (id: string, payload: ResearchOutputPutRequest) => {
@@ -145,7 +145,6 @@ export const usePutResearchOutput = ({ publish = true }) => {
       id,
       payload,
       authorization,
-      publish,
     );
     setResearchOutputItem(researchOutput);
     return researchOutput;

--- a/apps/crn-frontend/src/shared-research.ts
+++ b/apps/crn-frontend/src/shared-research.ts
@@ -123,21 +123,21 @@ export const researchTagsSelector = selector({
 
 export const useResearchTags = () => useRecoilValue(researchTagsSelector);
 
-export const usePostResearchOutput = ({ published = true }) => {
+export const usePostResearchOutput = ({ publish = true }) => {
   const authorization = useRecoilValue(authorizationState);
   const setResearchOutputItem = useSetResearchOutputItem();
   return async (payload: ResearchOutputPostRequest) => {
     const researchOutput = await createResearchOutput(
       payload,
       authorization,
-      published,
+      publish,
     );
     setResearchOutputItem(researchOutput);
     return researchOutput;
   };
 };
 
-export const usePutResearchOutput = ({ published = true }) => {
+export const usePutResearchOutput = ({ publish = true }) => {
   const authorization = useRecoilValue(authorizationState);
   const setResearchOutputItem = useSetResearchOutputItem();
   return async (id: string, payload: ResearchOutputPutRequest) => {
@@ -145,7 +145,7 @@ export const usePutResearchOutput = ({ published = true }) => {
       id,
       payload,
       authorization,
-      published,
+      publish,
     );
     setResearchOutputItem(researchOutput);
     return researchOutput;

--- a/apps/crn-frontend/src/shared-research.ts
+++ b/apps/crn-frontend/src/shared-research.ts
@@ -123,17 +123,21 @@ export const researchTagsSelector = selector({
 
 export const useResearchTags = () => useRecoilValue(researchTagsSelector);
 
-export const usePostResearchOutput = () => {
+export const usePostResearchOutput = ({ published = true }) => {
   const authorization = useRecoilValue(authorizationState);
   const setResearchOutputItem = useSetResearchOutputItem();
   return async (payload: ResearchOutputPostRequest) => {
-    const researchOutput = await createResearchOutput(payload, authorization);
+    const researchOutput = await createResearchOutput(
+      payload,
+      authorization,
+      published,
+    );
     setResearchOutputItem(researchOutput);
     return researchOutput;
   };
 };
 
-export const usePutResearchOutput = () => {
+export const usePutResearchOutput = ({ published = true }) => {
   const authorization = useRecoilValue(authorizationState);
   const setResearchOutputItem = useSetResearchOutputItem();
   return async (id: string, payload: ResearchOutputPutRequest) => {
@@ -141,6 +145,7 @@ export const usePutResearchOutput = () => {
       id,
       payload,
       authorization,
+      published,
     );
     setResearchOutputItem(researchOutput);
     return researchOutput;

--- a/apps/crn-frontend/src/shared-research/ResearchOutput.tsx
+++ b/apps/crn-frontend/src/shared-research/ResearchOutput.tsx
@@ -5,12 +5,7 @@ import { ResearchOutputPermissionsContext } from '@asap-hub/react-context';
 import { useRouteMatch, Route } from 'react-router-dom';
 import { isResearchOutputWorkingGroup } from '@asap-hub/validation';
 
-import {
-  useResearchOutputById,
-  useCanEditResearchOutput,
-  useCanPublishResearchOutput,
-  useCanShareResearchOutput,
-} from './state';
+import { useResearchOutputById, useResearchOutputPermissions } from './state';
 import TeamOutput from '../network/teams/TeamOutput';
 import WorkingGroupOutput from '../network/working-groups/WorkingGroupOutput';
 
@@ -30,31 +25,15 @@ const ResearchOutput: React.FC = () => {
     ? researchOutputData?.workingGroups.map((wg) => wg.id) || []
     : researchOutputData?.teams.map((team) => team.id) || [];
 
-  const canShareResearchOutput = useCanShareResearchOutput(
+  const permissions = useResearchOutputPermissions(
     association,
     associationIds,
-  );
-
-  const canEditResearchOutput = useCanEditResearchOutput(
-    association,
-    associationIds,
-    !!researchOutputData?.published,
-  );
-
-  const canPublishResearchOutput = useCanPublishResearchOutput(
-    association,
-    associationIds,
+    researchOutputData ? researchOutputData.published : false,
   );
 
   if (researchOutputData) {
     return (
-      <ResearchOutputPermissionsContext.Provider
-        value={{
-          canShareResearchOutput,
-          canEditResearchOutput,
-          canPublishResearchOutput,
-        }}
-      >
+      <ResearchOutputPermissionsContext.Provider value={permissions}>
         <Route exact path={path}>
           <Frame title={researchOutputData.title}>
             <SharedResearchOutput {...researchOutputData} backHref={backHref} />

--- a/apps/crn-frontend/src/shared-research/ResearchOutput.tsx
+++ b/apps/crn-frontend/src/shared-research/ResearchOutput.tsx
@@ -5,7 +5,12 @@ import { ResearchOutputPermissionsContext } from '@asap-hub/react-context';
 import { useRouteMatch, Route } from 'react-router-dom';
 import { isResearchOutputWorkingGroup } from '@asap-hub/validation';
 
-import { useResearchOutputById, useUserPermissions } from './state';
+import {
+  useResearchOutputById,
+  useCanEditResearchOutput,
+  useCanPublishResearchOutput,
+  useCanShareResearchOutput,
+} from './state';
 import TeamOutput from '../network/teams/TeamOutput';
 import WorkingGroupOutput from '../network/working-groups/WorkingGroupOutput';
 
@@ -20,16 +25,36 @@ const ResearchOutput: React.FC = () => {
   const isLinkedToWorkingGroup =
     researchOutputData && isResearchOutputWorkingGroup(researchOutputData);
 
-  const permissions = useUserPermissions({
-    entity: isLinkedToWorkingGroup ? 'workingGroups' : 'teams',
-    entityIds: isLinkedToWorkingGroup
-      ? researchOutputData?.workingGroups.map((wg) => wg.id) || []
-      : researchOutputData?.teams.map((team) => team.id) || [],
-  });
+  const association = isLinkedToWorkingGroup ? 'workingGroups' : 'teams';
+  const associationIds = isLinkedToWorkingGroup
+    ? researchOutputData?.workingGroups.map((wg) => wg.id) || []
+    : researchOutputData?.teams.map((team) => team.id) || [];
+
+  const canShareResearchOutput = useCanShareResearchOutput(
+    association,
+    associationIds,
+  );
+
+  const canEditResearchOutput = useCanEditResearchOutput(
+    association,
+    associationIds,
+    !!researchOutputData?.published,
+  );
+
+  const canPublishResearchOutput = useCanPublishResearchOutput(
+    association,
+    associationIds,
+  );
 
   if (researchOutputData) {
     return (
-      <ResearchOutputPermissionsContext.Provider value={{ permissions }}>
+      <ResearchOutputPermissionsContext.Provider
+        value={{
+          canShareResearchOutput,
+          canEditResearchOutput,
+          canPublishResearchOutput,
+        }}
+      >
         <Route exact path={path}>
           <Frame title={researchOutputData.title}>
             <SharedResearchOutput {...researchOutputData} backHref={backHref} />

--- a/apps/crn-frontend/src/shared-research/ResearchOutput.tsx
+++ b/apps/crn-frontend/src/shared-research/ResearchOutput.tsx
@@ -17,13 +17,19 @@ const ResearchOutput: React.FC = () => {
   const researchOutputData = useResearchOutputById(researchOutputId);
   const backHref = useBackHref() ?? sharedResearch({}).$;
 
-  const permissions = useUserPermissions(researchOutputData);
+  const isLinkedToWorkingGroup =
+    researchOutputData && isResearchOutputWorkingGroup(researchOutputData);
+
+  const permissions = useUserPermissions({
+    entity: isLinkedToWorkingGroup ? 'workingGroups' : 'teams',
+    entityIds: isLinkedToWorkingGroup
+      ? researchOutputData?.workingGroups.map((wg) => wg.id) || []
+      : researchOutputData?.teams.map((team) => team.id) || [],
+  });
 
   if (researchOutputData) {
     return (
-      <ResearchOutputPermissionsContext.Provider
-        value={{ canCreateUpdate: permissions.editPublished }}
-      >
+      <ResearchOutputPermissionsContext.Provider value={{ permissions }}>
         <Route exact path={path}>
           <Frame title={researchOutputData.title}>
             <SharedResearchOutput {...researchOutputData} backHref={backHref} />
@@ -36,7 +42,7 @@ const ResearchOutput: React.FC = () => {
               .editResearchOutput.template
           }
         >
-          {isResearchOutputWorkingGroup(researchOutputData) ? (
+          {isLinkedToWorkingGroup ? (
             <WorkingGroupOutput
               workingGroupId={researchOutputData.workingGroups[0]?.id}
               researchOutputData={researchOutputData}

--- a/apps/crn-frontend/src/shared-research/__tests__/ResearchOutput.test.tsx
+++ b/apps/crn-frontend/src/shared-research/__tests__/ResearchOutput.test.tsx
@@ -113,7 +113,6 @@ describe('a grant document research output', () => {
           id: teams[0].id,
         },
       ],
-      workingGroups: [],
       title: 'Grant Document title!',
     });
     await renderComponent(researchOutputRoute.$);
@@ -133,7 +132,6 @@ describe('a grant document research output', () => {
           displayName: 'Sulzer, D',
         },
       ],
-      workingGroups: [],
     });
 
     const { getByText } = await renderComponent(researchOutputRoute.$);
@@ -197,7 +195,6 @@ describe('a not-grant-document research output', () => {
           displayName: 'Sulzer, D',
         },
       ],
-      workingGroups: [],
     });
     const { getByRole, getByText } = await renderComponent(
       researchOutputRoute.$,

--- a/apps/crn-frontend/src/shared-research/__tests__/ResearchOutput.test.tsx
+++ b/apps/crn-frontend/src/shared-research/__tests__/ResearchOutput.test.tsx
@@ -110,9 +110,10 @@ describe('a grant document research output', () => {
       teams: [
         {
           displayName: 'Grant Document Team',
-          id: '123',
+          id: teams[0].id,
         },
       ],
+      workingGroups: [],
       title: 'Grant Document title!',
     });
     await renderComponent(researchOutputRoute.$);
@@ -128,16 +129,17 @@ describe('a grant document research output', () => {
       documentType: 'Grant Document',
       teams: [
         {
-          id: '0d074988-60c3-41e4-9f3a-e40cc65e5f4a',
+          id: teams[0].id,
           displayName: 'Sulzer, D',
         },
       ],
+      workingGroups: [],
     });
 
     const { getByText } = await renderComponent(researchOutputRoute.$);
     expect(getByText('Team Sulzer, D')).toHaveAttribute(
       'href',
-      expect.stringMatching(/0d074988-60c3-41e4-9f3a-e40cc65e5f4a/),
+      expect.stringMatching(teams[0].id),
     );
   });
 
@@ -152,6 +154,7 @@ describe('a grant document research output', () => {
         },
       ],
       workingGroups: undefined,
+      published: true,
     });
 
     await renderComponent(researchOutputRoute.editResearchOutput({}).$);
@@ -188,6 +191,13 @@ describe('a not-grant-document research output', () => {
       documentType: 'Protocol',
       tags: ['Example Tag'],
       title: 'Not-Grant-Document title!',
+      teams: [
+        {
+          id: teams[0].id,
+          displayName: 'Sulzer, D',
+        },
+      ],
+      workingGroups: [],
     });
     const { getByRole, getByText } = await renderComponent(
       researchOutputRoute.$,
@@ -257,7 +267,7 @@ describe('a working group research output', () => {
     );
   });
 
-  it('renders the sorry page if you are not a project manager', async () => {
+  it('renders the sorry page if you are not a member of the working group', async () => {
     mockGetResearchOutput.mockResolvedValue({
       ...createResearchOutputResponse(),
       documentType: 'Article',
@@ -269,9 +279,9 @@ describe('a working group research output', () => {
         ...defaultUser,
         workingGroups: [
           {
-            id: 'wg0',
+            id: 'not-related-to-research-output',
             name: 'Example Working Group',
-            role: 'Chair',
+            role: 'Project Manager',
             active: true,
           },
         ],

--- a/apps/crn-frontend/src/shared-research/__tests__/export.test.ts
+++ b/apps/crn-frontend/src/shared-research/__tests__/export.test.ts
@@ -68,6 +68,7 @@ describe('researchOutputToCSV', () => {
       organisms: 'C. Elegans,Rat',
       environments: 'In Cellulo,In Vivo',
       subtype: 'Metabolite',
+      published: true,
     });
   });
   it('flattens authors, preserves order, displays orcid and external status when available', () => {

--- a/apps/crn-frontend/src/shared-research/export.ts
+++ b/apps/crn-frontend/src/shared-research/export.ts
@@ -82,6 +82,7 @@ export const researchOutputToCSV = (
   id: output.id,
   created: output.created,
   lastModifiedDate: output.lastModifiedDate,
+  published: output.published,
 });
 
 export const algoliaResultsToStream = async <T extends keyof EntityResponses>(

--- a/apps/crn-frontend/src/shared-research/state.ts
+++ b/apps/crn-frontend/src/shared-research/state.ts
@@ -1,7 +1,7 @@
 import {
   ListResearchOutputResponse,
   ResearchOutputResponse,
-  userPermissions,
+  UserPermissions,
 } from '@asap-hub/model';
 import { useCurrentUserCRN } from '@asap-hub/react-context';
 import { getUserPermissions } from '@asap-hub/validation';
@@ -153,10 +153,14 @@ export const useSetResearchOutputItem = () => {
   );
 };
 
-export const useUserPermissions = (
-  researchOutputData: ResearchOutputResponse | undefined,
-): userPermissions => {
+export const useUserPermissions = ({
+  entity,
+  entityIds,
+}: {
+  entity: 'teams' | 'workingGroups';
+  entityIds: string[];
+}): UserPermissions => {
   const user = useCurrentUserCRN();
 
-  return getUserPermissions(user, researchOutputData);
+  return getUserPermissions(user, entity, entityIds);
 };

--- a/apps/crn-frontend/src/shared-research/state.ts
+++ b/apps/crn-frontend/src/shared-research/state.ts
@@ -1,10 +1,14 @@
 import {
   ListResearchOutputResponse,
   ResearchOutputResponse,
-  UserPermissions,
 } from '@asap-hub/model';
 import { useCurrentUserCRN } from '@asap-hub/react-context';
-import { getUserPermissions } from '@asap-hub/validation';
+import {
+  getUserRole,
+  hasShareResearchOutputPermission,
+  hasEditResearchOutputPermission,
+  hasPublishResearchOutputPermission,
+} from '@asap-hub/validation';
 import {
   atom,
   atomFamily,
@@ -153,14 +157,30 @@ export const useSetResearchOutputItem = () => {
   );
 };
 
-export const useUserPermissions = ({
-  entity,
-  entityIds,
-}: {
-  entity: 'teams' | 'workingGroups';
-  entityIds: string[];
-}): UserPermissions => {
+export const useCanShareResearchOutput = (
+  association: 'teams' | 'workingGroups',
+  associationIds: string[],
+): boolean => {
   const user = useCurrentUserCRN();
+  const userRole = getUserRole(user, association, associationIds);
+  return hasShareResearchOutputPermission(userRole);
+};
 
-  return getUserPermissions(user, entity, entityIds);
+export const useCanEditResearchOutput = (
+  association: 'teams' | 'workingGroups',
+  associationIds: string[],
+  published: boolean,
+): boolean => {
+  const user = useCurrentUserCRN();
+  const userRole = getUserRole(user, association, associationIds);
+  return hasEditResearchOutputPermission(userRole, published);
+};
+
+export const useCanPublishResearchOutput = (
+  association: 'teams' | 'workingGroups',
+  associationIds: string[],
+): boolean => {
+  const user = useCurrentUserCRN();
+  const userRole = getUserRole(user, association, associationIds);
+  return hasPublishResearchOutputPermission(userRole);
 };

--- a/apps/crn-frontend/src/shared-research/state.ts
+++ b/apps/crn-frontend/src/shared-research/state.ts
@@ -166,25 +166,6 @@ export const useCanShareResearchOutput = (
   return hasShareResearchOutputPermission(userRole);
 };
 
-export const useCanEditResearchOutput = (
-  association: 'teams' | 'workingGroups',
-  associationIds: string[],
-  published: boolean,
-): boolean => {
-  const user = useCurrentUserCRN();
-  const userRole = getUserRole(user, association, associationIds);
-  return hasEditResearchOutputPermission(userRole, published);
-};
-
-export const useCanPublishResearchOutput = (
-  association: 'teams' | 'workingGroups',
-  associationIds: string[],
-): boolean => {
-  const user = useCurrentUserCRN();
-  const userRole = getUserRole(user, association, associationIds);
-  return hasPublishResearchOutputPermission(userRole);
-};
-
 export const useResearchOutputPermissions = (
   association: 'teams' | 'workingGroups',
   associationIds: string[],

--- a/apps/crn-frontend/src/shared-research/state.ts
+++ b/apps/crn-frontend/src/shared-research/state.ts
@@ -184,3 +184,21 @@ export const useCanPublishResearchOutput = (
   const userRole = getUserRole(user, association, associationIds);
   return hasPublishResearchOutputPermission(userRole);
 };
+
+export const useResearchOutputPermissions = (
+  association: 'teams' | 'workingGroups',
+  associationIds: string[],
+  published: boolean,
+): {
+  canEditResearchOutput: boolean;
+  canPublishResearchOutput: boolean;
+  canShareResearchOutput: boolean;
+} => {
+  const user = useCurrentUserCRN();
+  const userRole = getUserRole(user, association, associationIds);
+  return {
+    canEditResearchOutput: hasEditResearchOutputPermission(userRole, published),
+    canPublishResearchOutput: hasPublishResearchOutputPermission(userRole),
+    canShareResearchOutput: hasShareResearchOutputPermission(userRole),
+  };
+};

--- a/apps/crn-server/src/controllers/research-outputs.ts
+++ b/apps/crn-server/src/controllers/research-outputs.ts
@@ -377,7 +377,7 @@ export interface ResearchOutputController {
   fetchById: (id: string) => Promise<ResearchOutputResponse>;
   create: (
     researchOutputRequest: ResearchOutputCreateData,
-    createOptions?: { publish: boolean },
+    createOptions?: { publish?: boolean },
   ) => Promise<ResearchOutputResponse | null>;
   update: (
     id: string,

--- a/apps/crn-server/src/controllers/research-outputs.ts
+++ b/apps/crn-server/src/controllers/research-outputs.ts
@@ -82,7 +82,7 @@ export default class ResearchOutputs implements ResearchOutputController {
 
   async create(
     researchOutputCreateData: ResearchOutputCreateData,
-    published = true,
+    createOptions = { publish: true },
   ): Promise<ResearchOutputResponse | null> {
     await this.validateResearchOutput(researchOutputCreateData);
     const { methods, organisms, environments, subtype } =
@@ -120,7 +120,7 @@ export default class ResearchOutputs implements ResearchOutputController {
 
     const researchOutputId = await this.researchOutputDataProvider.create(
       researchOutputCreateDataObject,
-      published,
+      createOptions,
     );
 
     return this.fetchById(researchOutputId);
@@ -377,7 +377,7 @@ export interface ResearchOutputController {
   fetchById: (id: string) => Promise<ResearchOutputResponse>;
   create: (
     researchOutputRequest: ResearchOutputCreateData,
-    published?: boolean,
+    createOptions?: { publish: boolean },
   ) => Promise<ResearchOutputResponse | null>;
   update: (
     id: string,

--- a/apps/crn-server/src/controllers/research-outputs.ts
+++ b/apps/crn-server/src/controllers/research-outputs.ts
@@ -82,9 +82,9 @@ export default class ResearchOutputs implements ResearchOutputController {
 
   async create(
     researchOutputCreateData: ResearchOutputCreateData,
+    published = true,
   ): Promise<ResearchOutputResponse | null> {
     await this.validateResearchOutput(researchOutputCreateData);
-
     const { methods, organisms, environments, subtype } =
       await this.parseResearchTags(researchOutputCreateData);
 
@@ -120,6 +120,7 @@ export default class ResearchOutputs implements ResearchOutputController {
 
     const researchOutputId = await this.researchOutputDataProvider.create(
       researchOutputCreateDataObject,
+      published,
     );
 
     return this.fetchById(researchOutputId);
@@ -376,6 +377,7 @@ export interface ResearchOutputController {
   fetchById: (id: string) => Promise<ResearchOutputResponse>;
   create: (
     researchOutputRequest: ResearchOutputCreateData,
+    published?: boolean,
   ) => Promise<ResearchOutputResponse | null>;
   update: (
     id: string,

--- a/apps/crn-server/src/controllers/research-outputs.ts
+++ b/apps/crn-server/src/controllers/research-outputs.ts
@@ -377,7 +377,7 @@ export interface ResearchOutputController {
   fetchById: (id: string) => Promise<ResearchOutputResponse>;
   create: (
     researchOutputRequest: ResearchOutputCreateData,
-    createOptions?: { publish?: boolean },
+    createOptions?: { publish: boolean },
   ) => Promise<ResearchOutputResponse | null>;
   update: (
     id: string,

--- a/apps/crn-server/src/data-providers/research-outputs.data-provider.ts
+++ b/apps/crn-server/src/data-providers/research-outputs.data-provider.ts
@@ -59,7 +59,7 @@ export interface ResearchOutputDataProvider {
   ): Promise<ListResearchOutputDataObject>;
   create(
     input: ResearchOutputCreateDataObject,
-    published?: boolean,
+    createOptions?: { publish: boolean },
   ): Promise<string>;
   update(id: string, input: ResearchOutputUpdateDataObject): Promise<string>;
 }
@@ -175,7 +175,7 @@ export class ResearchOutputSquidexDataProvider
 
   async create(
     input: ResearchOutputCreateDataObject,
-    published = true,
+    createOptions = { publish: true },
   ): Promise<string> {
     const {
       authors,
@@ -216,7 +216,7 @@ export class ResearchOutputSquidexDataProvider
           ...researchOutput,
           usedInAPublication: usedInPublication,
         },
-        published,
+        createOptions.publish,
       );
 
     return researchOutputId;

--- a/apps/crn-server/src/data-providers/research-outputs.data-provider.ts
+++ b/apps/crn-server/src/data-providers/research-outputs.data-provider.ts
@@ -57,7 +57,10 @@ export interface ResearchOutputDataProvider {
   fetch(
     options: FetchResearchOutputOptions,
   ): Promise<ListResearchOutputDataObject>;
-  create(input: ResearchOutputCreateDataObject): Promise<string>;
+  create(
+    input: ResearchOutputCreateDataObject,
+    published?: boolean,
+  ): Promise<string>;
   update(id: string, input: ResearchOutputUpdateDataObject): Promise<string>;
 }
 
@@ -170,7 +173,10 @@ export class ResearchOutputSquidexDataProvider
     };
   }
 
-  async create(input: ResearchOutputCreateDataObject): Promise<string> {
+  async create(
+    input: ResearchOutputCreateDataObject,
+    published = true,
+  ): Promise<string> {
     const {
       authors,
       teamIds,
@@ -202,13 +208,16 @@ export class ResearchOutputSquidexDataProvider
     });
 
     const { id: researchOutputId } =
-      await this.researchOutputSquidexRestClient.create({
-        doi: { iv: null },
-        accession: { iv: null },
-        rrid: { iv: null },
-        ...researchOutput,
-        usedInAPublication: usedInPublication,
-      });
+      await this.researchOutputSquidexRestClient.create(
+        {
+          doi: { iv: null },
+          accession: { iv: null },
+          rrid: { iv: null },
+          ...researchOutput,
+          usedInAPublication: usedInPublication,
+        },
+        published,
+      );
 
     return researchOutputId;
   }

--- a/apps/crn-server/src/entities/research-output.ts
+++ b/apps/crn-server/src/entities/research-output.ts
@@ -115,6 +115,7 @@ export const parseGraphQLResearchOutput = (
         id: group.id,
         title: group.flatData.title || '',
       })) || [],
+    published: true,
   };
 };
 

--- a/apps/crn-server/src/routes/research-outputs.route.ts
+++ b/apps/crn-server/src/routes/research-outputs.route.ts
@@ -4,7 +4,10 @@ import {
   UserResponse,
 } from '@asap-hub/model';
 import { validateFetchOptions } from '@asap-hub/server-common';
-import { getUserRole, hasUpsertPermission } from '@asap-hub/validation';
+import {
+  getUserRole,
+  hasEditResearchOutputPermission,
+} from '@asap-hub/validation';
 import Boom from '@hapi/boom';
 import { Response, Router } from 'express';
 import { ResearchOutputController } from '../controllers/research-outputs';
@@ -60,7 +63,7 @@ export const researchOutputRouteFactory = (
     const options = validateResearchOutputRequestQueryParameters(query);
     const publish = options.publish ?? true;
 
-    if (!loggedInUser || !hasUpsertPermission(userRole, false)) {
+    if (!loggedInUser || !hasEditResearchOutputPermission(userRole, false)) {
       throw Boom.forbidden();
     }
 
@@ -90,9 +93,9 @@ export const researchOutputRouteFactory = (
         updateRequest.teams,
       );
 
-      // TODO: update the published value in hasUpsertPermission in
+      // TODO: update the published value in hasEditResearchOutputPermission in
       // display draft task. Currently we are not sending the value published
-      if (!loggedInUser || !hasUpsertPermission(userRole, false)) {
+      if (!loggedInUser || !hasEditResearchOutputPermission(userRole, false)) {
         throw Boom.forbidden();
       }
 

--- a/apps/crn-server/src/routes/research-outputs.route.ts
+++ b/apps/crn-server/src/routes/research-outputs.route.ts
@@ -58,11 +58,10 @@ export const researchOutputRouteFactory = (
     );
 
     const options = validateResearchOutputRequestQueryParameters(query);
-    const published = options.published ?? true;
+    const publish = options.publish ?? true;
 
     const isRequestAllowed =
-      (permissions.saveDraft && !published) ||
-      (permissions.publish && published);
+      (permissions.saveDraft && !publish) || (permissions.publish && publish);
 
     if (!loggedInUser || !isRequestAllowed) {
       throw Boom.forbidden();
@@ -74,7 +73,7 @@ export const researchOutputRouteFactory = (
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         createdBy: loggedInUser!.id,
       },
-      published,
+      { publish },
     );
 
     res.status(201).json(researchOutput);
@@ -95,11 +94,10 @@ export const researchOutputRouteFactory = (
       );
 
       const options = validateResearchOutputRequestQueryParameters(query);
-      const published = options.published ?? true;
+      const publish = options.publish ?? true;
 
       const isRequestAllowed =
-        (permissions.saveDraft && !published) ||
-        (permissions.publish && published);
+        (permissions.saveDraft && !publish) || (permissions.publish && publish);
 
       if (!loggedInUser || !isRequestAllowed) {
         throw Boom.forbidden();

--- a/apps/crn-server/src/validation/research-output.validation.ts
+++ b/apps/crn-server/src/validation/research-output.validation.ts
@@ -154,6 +154,24 @@ export const validateResearchOutputPostRequestParameters = validateInput(
   },
 );
 
+const researchOutputRequestQueryParametersSchema: JSONSchemaType<{
+  published?: boolean;
+}> = {
+  type: 'object',
+  properties: {
+    published: { type: 'boolean', nullable: true },
+  },
+  additionalProperties: false,
+};
+
+export const validateResearchOutputRequestQueryParameters = validateInput(
+  researchOutputRequestQueryParametersSchema,
+  {
+    skipNull: true,
+    coerce: true,
+  },
+);
+
 export const validateResearchOutputPostRequestParametersIdentifiers = (
   data: ResearchOutputPostRequest,
 ): void => {

--- a/apps/crn-server/src/validation/research-output.validation.ts
+++ b/apps/crn-server/src/validation/research-output.validation.ts
@@ -155,11 +155,11 @@ export const validateResearchOutputPostRequestParameters = validateInput(
 );
 
 const researchOutputRequestQueryParametersSchema: JSONSchemaType<{
-  published?: boolean;
+  publish?: boolean;
 }> = {
   type: 'object',
   properties: {
-    published: { type: 'boolean', nullable: true },
+    publish: { type: 'boolean', nullable: true },
   },
   additionalProperties: false,
 };

--- a/apps/crn-server/test/controllers/research-outputs.test.ts
+++ b/apps/crn-server/test/controllers/research-outputs.test.ts
@@ -153,12 +153,57 @@ describe('ResearchOutputs controller', () => {
 
       const researchOutputCreateDataObject =
         getResearchOutputCreateDataObject();
-      expect(researchOutputDataProviderMock.create).toBeCalledWith({
-        ...researchOutputCreateDataObject,
-        addedDate: mockDate.toISOString(),
-      });
+      expect(researchOutputDataProviderMock.create).toBeCalledWith(
+        {
+          ...researchOutputCreateDataObject,
+          addedDate: mockDate.toISOString(),
+        },
+        true,
+      );
       spy.mockRestore();
     });
+
+    test.each`
+      publishedValue | situation               | expected
+      ${true}        | ${'publish is true'}    | ${true}
+      ${false}       | ${'publish is false'}   | ${false}
+      ${undefined}   | ${'publish is not set'} | ${true}
+    `(
+      'Should call data provider with published equals $expected when $situation',
+      async ({ publishedValue, expected }) => {
+        const mockDate = new Date('2010-01-01');
+        const spy = jest
+          .spyOn(global, 'Date')
+          .mockImplementation(() => mockDate);
+
+        const researchOutputCreateData = getResearchOutputCreateData();
+        const researchOutputId = 'research-output-id-1';
+        researchOutputDataProviderMock.create.mockResolvedValueOnce(
+          researchOutputId,
+        );
+
+        const result =
+          publishedValue === undefined
+            ? await researchOutputs.create(researchOutputCreateData)
+            : await researchOutputs.create(
+                researchOutputCreateData,
+                publishedValue,
+              );
+
+        expect(result).toEqual(getResearchOutputResponse());
+
+        const researchOutputCreateDataObject =
+          getResearchOutputCreateDataObject();
+        expect(researchOutputDataProviderMock.create).toBeCalledWith(
+          {
+            ...researchOutputCreateDataObject,
+            addedDate: mockDate.toISOString(),
+          },
+          expected,
+        );
+        spy.mockRestore();
+      },
+    );
 
     describe('Validating uniqueness', () => {
       const researchOutputRequest = getResearchOutputCreateData();
@@ -312,6 +357,7 @@ describe('ResearchOutputs controller', () => {
           expect.objectContaining({
             subtypeId: undefined,
           }),
+          true,
         );
       });
 
@@ -454,6 +500,7 @@ describe('ResearchOutputs controller', () => {
               },
             ],
           }),
+          true,
         );
       });
     });

--- a/apps/crn-server/test/controllers/research-outputs.test.ts
+++ b/apps/crn-server/test/controllers/research-outputs.test.ts
@@ -158,19 +158,13 @@ describe('ResearchOutputs controller', () => {
           ...researchOutputCreateDataObject,
           addedDate: mockDate.toISOString(),
         },
-        true,
+        { publish: true },
       );
       spy.mockRestore();
     });
 
-    test.each`
-      publishedValue | situation               | expected
-      ${true}        | ${'publish is true'}    | ${true}
-      ${false}       | ${'publish is false'}   | ${false}
-      ${undefined}   | ${'publish is not set'} | ${true}
-    `(
-      'Should call data provider with published equals $expected when $situation',
-      async ({ publishedValue, expected }) => {
+    describe('create options param', () => {
+      test('Should call data provider with published equals false when it is passed as false', async () => {
         const mockDate = new Date('2010-01-01');
         const spy = jest
           .spyOn(global, 'Date')
@@ -182,13 +176,9 @@ describe('ResearchOutputs controller', () => {
           researchOutputId,
         );
 
-        const result =
-          publishedValue === undefined
-            ? await researchOutputs.create(researchOutputCreateData)
-            : await researchOutputs.create(
-                researchOutputCreateData,
-                publishedValue,
-              );
+        const result = await researchOutputs.create(researchOutputCreateData, {
+          publish: false,
+        });
 
         expect(result).toEqual(getResearchOutputResponse());
 
@@ -199,11 +189,39 @@ describe('ResearchOutputs controller', () => {
             ...researchOutputCreateDataObject,
             addedDate: mockDate.toISOString(),
           },
-          expected,
+          { publish: false },
         );
         spy.mockRestore();
-      },
-    );
+      });
+
+      test('Should call data provider with published equals true when create options is not passed', async () => {
+        const mockDate = new Date('2010-01-01');
+        const spy = jest
+          .spyOn(global, 'Date')
+          .mockImplementation(() => mockDate);
+
+        const researchOutputCreateData = getResearchOutputCreateData();
+        const researchOutputId = 'research-output-id-1';
+        researchOutputDataProviderMock.create.mockResolvedValueOnce(
+          researchOutputId,
+        );
+
+        const result = await researchOutputs.create(researchOutputCreateData);
+
+        expect(result).toEqual(getResearchOutputResponse());
+
+        const researchOutputCreateDataObject =
+          getResearchOutputCreateDataObject();
+        expect(researchOutputDataProviderMock.create).toBeCalledWith(
+          {
+            ...researchOutputCreateDataObject,
+            addedDate: mockDate.toISOString(),
+          },
+          { publish: true },
+        );
+        spy.mockRestore();
+      });
+    });
 
     describe('Validating uniqueness', () => {
       const researchOutputRequest = getResearchOutputCreateData();
@@ -357,7 +375,7 @@ describe('ResearchOutputs controller', () => {
           expect.objectContaining({
             subtypeId: undefined,
           }),
-          true,
+          { publish: true },
         );
       });
 
@@ -500,7 +518,7 @@ describe('ResearchOutputs controller', () => {
               },
             ],
           }),
-          true,
+          { publish: true },
         );
       });
     });

--- a/apps/crn-server/test/data-providers/research-outputs.data-provider.test.ts
+++ b/apps/crn-server/test/data-providers/research-outputs.data-provider.test.ts
@@ -83,7 +83,7 @@ describe('ResearchOutputs data provider', () => {
       );
       const expectedResult = getResearchOutputDataObject();
 
-      expect(result).toEqual(expectedResult);
+      expect(result).toEqual({ ...expectedResult, published: true });
     });
 
     test('Should throw a Not Found error when the research output is not found', async () => {
@@ -349,7 +349,7 @@ describe('ResearchOutputs data provider', () => {
       expectedResult.teams = [];
       expectedResult.contactEmails = []; // as there are no referencing teams, there won't be any PMs
 
-      expect(result).toEqual(expectedResult);
+      expect(result).toEqual({ ...expectedResult, published: true });
     });
 
     test('Should return a mix of internal and external authors', async () => {

--- a/apps/crn-server/test/data-providers/research-outputs.data-provider.test.ts
+++ b/apps/crn-server/test/data-providers/research-outputs.data-provider.test.ts
@@ -83,7 +83,7 @@ describe('ResearchOutputs data provider', () => {
       );
       const expectedResult = getResearchOutputDataObject();
 
-      expect(result).toEqual({ ...expectedResult, published: true });
+      expect(result).toEqual(expectedResult);
     });
 
     test('Should throw a Not Found error when the research output is not found', async () => {
@@ -349,7 +349,7 @@ describe('ResearchOutputs data provider', () => {
       expectedResult.teams = [];
       expectedResult.contactEmails = []; // as there are no referencing teams, there won't be any PMs
 
-      expect(result).toEqual({ ...expectedResult, published: true });
+      expect(result).toEqual(expectedResult);
     });
 
     test('Should return a mix of internal and external authors', async () => {

--- a/apps/crn-server/test/fixtures/research-output.fixtures.ts
+++ b/apps/crn-server/test/fixtures/research-output.fixtures.ts
@@ -161,6 +161,7 @@ export const getResearchOutputDataObject = (): ResearchOutputDataObject => ({
   organisms: ['Rat'],
   environments: ['In Vitro'],
   subtype: 'Metabolite',
+  published: true,
 });
 
 export const getListResearchOutputDataObject =
@@ -241,6 +242,7 @@ export const getResearchOutputPostRequest = (): ResearchOutputPostRequest => {
     authors,
     teams,
     workingGroups,
+    published: _published,
     ...researchOutputResponse
   } = getResearchOutputResponse();
   return {
@@ -277,6 +279,7 @@ export const getResearchOutputCreateDataObject =
       created: _created,
       contactEmails: _contactEmails,
       workingGroups: _workingGroups, // @TODO send this data to squidex once the schema has changed (1/2)
+      published: _published,
       ...researchOutputPostRequest
     } = getResearchOutputResponse();
 

--- a/apps/crn-server/test/routes/research-outputs.route.test.ts
+++ b/apps/crn-server/test/routes/research-outputs.route.test.ts
@@ -137,11 +137,15 @@ describe('/research-outputs/ route', () => {
         .send(createResearchOutputRequest)
         .set('Accept', 'application/json');
 
+      const published = true;
       expect(response.status).toBe(201);
-      expect(researchOutputControllerMock.create).toBeCalledWith({
-        ...createResearchOutputRequest,
-        createdBy: 'user-id-0',
-      });
+      expect(researchOutputControllerMock.create).toBeCalledWith(
+        {
+          ...createResearchOutputRequest,
+          createdBy: 'user-id-0',
+        },
+        published,
+      );
 
       expect(response.body).toEqual(researchOutputResponse);
     });
@@ -170,6 +174,61 @@ describe('/research-outputs/ route', () => {
         .send({ ...researchOutput })
         .set('Accept', 'application/json')
         .expect(500);
+    });
+
+    describe('Query Param validation', () => {
+      test('Should return a validation error when query param is not valid', async () => {
+        const createResearchOutputRequest = getResearchOutputPostRequest();
+
+        const response = await supertest(app)
+          .post('/research-outputs')
+          .send(createResearchOutputRequest)
+          .set('Accept', 'application/json')
+          .query('draft=true');
+
+        expect(response.status).toBe(400);
+      });
+
+      test.each([{ published: false }, { published: true }])(
+        'Should get the correct value for publish when it is $published',
+        async ({ published }) => {
+          const createResearchOutputRequest = getResearchOutputPostRequest();
+
+          const response = await supertest(app)
+            .post('/research-outputs')
+            .send(createResearchOutputRequest)
+            .set('Accept', 'application/json')
+            .query(`published=${published}`);
+
+          expect(response.status).toBe(201);
+          expect(researchOutputControllerMock.create).toBeCalledWith(
+            {
+              ...createResearchOutputRequest,
+              createdBy: 'user-id-0',
+            },
+            published,
+          );
+        },
+      );
+
+      test('Should send published as true if query param is not set', async () => {
+        const createResearchOutputRequest = getResearchOutputPostRequest();
+
+        const response = await supertest(app)
+          .post('/research-outputs')
+          .send(createResearchOutputRequest)
+          .set('Accept', 'application/json');
+
+        const published = true;
+        expect(response.status).toBe(201);
+        expect(researchOutputControllerMock.create).toBeCalledWith(
+          {
+            ...createResearchOutputRequest,
+            createdBy: 'user-id-0',
+          },
+          published,
+        );
+      });
     });
 
     describe('Parameter validation', () => {

--- a/apps/crn-server/test/routes/research-outputs.route.test.ts
+++ b/apps/crn-server/test/routes/research-outputs.route.test.ts
@@ -137,14 +137,13 @@ describe('/research-outputs/ route', () => {
         .send(createResearchOutputRequest)
         .set('Accept', 'application/json');
 
-      const published = true;
       expect(response.status).toBe(201);
       expect(researchOutputControllerMock.create).toBeCalledWith(
         {
           ...createResearchOutputRequest,
           createdBy: 'user-id-0',
         },
-        published,
+        { publish: true },
       );
 
       expect(response.body).toEqual(researchOutputResponse);
@@ -189,16 +188,16 @@ describe('/research-outputs/ route', () => {
         expect(response.status).toBe(400);
       });
 
-      test.each([{ published: false }, { published: true }])(
-        'Should get the correct value for publish when it is $published',
-        async ({ published }) => {
+      test.each([{ publish: false }, { publish: true }])(
+        'Should get the correct value for publish when it is $publish',
+        async ({ publish }) => {
           const createResearchOutputRequest = getResearchOutputPostRequest();
 
           const response = await supertest(app)
             .post('/research-outputs')
             .send(createResearchOutputRequest)
             .set('Accept', 'application/json')
-            .query(`published=${published}`);
+            .query(`publish=${publish}`);
 
           expect(response.status).toBe(201);
           expect(researchOutputControllerMock.create).toBeCalledWith(
@@ -206,12 +205,12 @@ describe('/research-outputs/ route', () => {
               ...createResearchOutputRequest,
               createdBy: 'user-id-0',
             },
-            published,
+            { publish },
           );
         },
       );
 
-      test('Should send published as true if query param is not set', async () => {
+      test('Should send publish as true if query param is not set', async () => {
         const createResearchOutputRequest = getResearchOutputPostRequest();
 
         const response = await supertest(app)
@@ -219,14 +218,14 @@ describe('/research-outputs/ route', () => {
           .send(createResearchOutputRequest)
           .set('Accept', 'application/json');
 
-        const published = true;
+        const publish = true;
         expect(response.status).toBe(201);
         expect(researchOutputControllerMock.create).toBeCalledWith(
           {
             ...createResearchOutputRequest,
             createdBy: 'user-id-0',
           },
-          published,
+          { publish },
         );
       });
     });

--- a/apps/storybook/src/ResearchOutputForm.stories.tsx
+++ b/apps/storybook/src/ResearchOutputForm.stories.tsx
@@ -16,6 +16,11 @@ export default {
 export const Normal = () => (
   <StaticRouter>
     <ResearchOutputForm
+      permissions={{
+        canEditResearchOutput: true,
+        canPublishResearchOutput: true,
+        canShareResearchOutput: true,
+      }}
       onSave={() => Promise.resolve()}
       onSaveDraft={() => Promise.resolve()}
       tagSuggestions={['A53T', 'Activity assay']}
@@ -58,6 +63,11 @@ const researchOutputData = {
 export const EditMode = () => (
   <StaticRouter>
     <ResearchOutputForm
+      permissions={{
+        canEditResearchOutput: true,
+        canPublishResearchOutput: true,
+        canShareResearchOutput: true,
+      }}
       researchOutputData={researchOutputData}
       onSave={() => Promise.resolve()}
       onSaveDraft={() => Promise.resolve()}

--- a/apps/storybook/src/ResearchOutputForm.stories.tsx
+++ b/apps/storybook/src/ResearchOutputForm.stories.tsx
@@ -5,6 +5,7 @@ import {
 } from '@asap-hub/fixtures';
 import { researchOutputDocumentTypeToType } from '@asap-hub/model';
 import { ResearchOutputForm } from '@asap-hub/react-components';
+import { boolean } from '@storybook/addon-knobs';
 import { StaticRouter } from 'react-router-dom';
 
 export default {
@@ -16,6 +17,7 @@ export const Normal = () => (
   <StaticRouter>
     <ResearchOutputForm
       onSave={() => Promise.resolve()}
+      onSaveDraft={() => Promise.resolve()}
       tagSuggestions={['A53T', 'Activity assay']}
       documentType="Article"
       getLabSuggestions={() =>
@@ -44,6 +46,7 @@ export const Normal = () => (
         })
       }
       researchTags={[researchTagMethodResponse]}
+      published={boolean('Published', true)}
     />
   </StaticRouter>
 );
@@ -57,6 +60,7 @@ export const EditMode = () => (
     <ResearchOutputForm
       researchOutputData={researchOutputData}
       onSave={() => Promise.resolve()}
+      onSaveDraft={() => Promise.resolve()}
       tagSuggestions={['A53T', 'Activity assay']}
       documentType="Dataset"
       getLabSuggestions={() =>
@@ -85,6 +89,7 @@ export const EditMode = () => (
         })
       }
       researchTags={[researchTagMethodResponse]}
+      published={boolean('Published', true)}
     />
   </StaticRouter>
 );

--- a/apps/storybook/src/SharedResearchOutput.stories.tsx
+++ b/apps/storybook/src/SharedResearchOutput.stories.tsx
@@ -3,12 +3,13 @@ import { SharedResearchOutput } from '@asap-hub/react-components';
 import { ResearchOutputPermissionsContext } from '@asap-hub/react-context';
 
 import {
-  text,
-  date,
   array,
-  number,
-  select,
   boolean,
+  date,
+  number,
+  object,
+  select,
+  text,
 } from '@storybook/addon-knobs';
 
 import {
@@ -87,7 +88,12 @@ const props = (): ComponentProps<typeof SharedResearchOutput> => ({
 
 export const Normal = () => (
   <ResearchOutputPermissionsContext.Provider
-    value={{ canCreateUpdate: boolean('Can Edit', false) }}
+    value={{
+      permissions: object('Permissions', {
+        publish: true,
+        saveDraft: true,
+      }),
+    }}
   >
     <SharedResearchOutput
       {...props()}
@@ -102,7 +108,12 @@ export const Normal = () => (
 );
 export const GrantDocument = () => (
   <ResearchOutputPermissionsContext.Provider
-    value={{ canCreateUpdate: boolean('Can Edit', false) }}
+    value={{
+      permissions: object('Permissions', {
+        publish: true,
+        saveDraft: true,
+      }),
+    }}
   >
     <SharedResearchOutput
       {...props()}

--- a/apps/storybook/src/SharedResearchOutput.stories.tsx
+++ b/apps/storybook/src/SharedResearchOutput.stories.tsx
@@ -7,7 +7,6 @@ import {
   boolean,
   date,
   number,
-  object,
   select,
   text,
 } from '@storybook/addon-knobs';

--- a/apps/storybook/src/SharedResearchOutput.stories.tsx
+++ b/apps/storybook/src/SharedResearchOutput.stories.tsx
@@ -89,10 +89,9 @@ const props = (): ComponentProps<typeof SharedResearchOutput> => ({
 export const Normal = () => (
   <ResearchOutputPermissionsContext.Provider
     value={{
-      permissions: object('Permissions', {
-        publish: true,
-        saveDraft: true,
-      }),
+      canShareResearchOutput: true,
+      canEditResearchOutput: true,
+      canPublishResearchOutput: true,
     }}
   >
     <SharedResearchOutput
@@ -109,10 +108,9 @@ export const Normal = () => (
 export const GrantDocument = () => (
   <ResearchOutputPermissionsContext.Provider
     value={{
-      permissions: object('Permissions', {
-        publish: true,
-        saveDraft: true,
-      }),
+      canShareResearchOutput: true,
+      canEditResearchOutput: true,
+      canPublishResearchOutput: true,
     }}
   >
     <SharedResearchOutput

--- a/packages/fixtures/src/research-outputs.ts
+++ b/packages/fixtures/src/research-outputs.ts
@@ -43,6 +43,7 @@ const researchOutputResponse: Omit<
   organisms: ['Rat', 'C. Elegans'],
   environments: ['In Vivo', 'In Cellulo'],
   subtype: 'Metabolite',
+  published: true,
 };
 
 export const createResearchOutputResponse = (

--- a/packages/flags/src/index.ts
+++ b/packages/flags/src/index.ts
@@ -1,9 +1,13 @@
-export type Flag = 'PERSISTENT_EXAMPLE';
+export type Flag =
+  | 'PERSISTENT_EXAMPLE'
+  | 'DRAFT_RESEARCH_OUTPUT'
+  | 'ASAP_DRAFT_RESEARCH_OUTPUT';
 
 export type Flags = Partial<Record<Flag, boolean | undefined>>;
 let overrides: Flags = {
   // flags already live in prod:
   // can also be used to manually disable a flag in development:
+  ASAP_DRAFT_RESEARCH_OUTPUT: false,
 };
 
 const envDefaults: Record<string, boolean> = {

--- a/packages/model/src/research-output.ts
+++ b/packages/model/src/research-output.ts
@@ -218,6 +218,7 @@ export type ResearchOutputDataObject = ResearchOutputCoreObject & {
   subtype?: string;
   teams: Pick<TeamResponse, 'id' | 'displayName'>[];
   workingGroups: Pick<WorkingGroupResponse, 'id' | 'title'>[];
+  published?: boolean;
 };
 
 export type ListResearchOutputDataObject =
@@ -261,7 +262,7 @@ export type ResearchOutputTeamResponse = ResearchOutputBaseResponse & {
 };
 
 export type ResearchOutputWorkingGroupResponse = ResearchOutputBaseResponse & {
-  workingGroups: [Pick<WorkingGroupResponse, 'id' | 'title'>];
+  workingGroups: Pick<WorkingGroupResponse, 'id' | 'title'>[];
 };
 
 export type ResearchOutputResponse =

--- a/packages/model/src/research-output.ts
+++ b/packages/model/src/research-output.ts
@@ -262,7 +262,7 @@ export type ResearchOutputTeamResponse = ResearchOutputBaseResponse & {
 };
 
 export type ResearchOutputWorkingGroupResponse = ResearchOutputBaseResponse & {
-  workingGroups: Pick<WorkingGroupResponse, 'id' | 'title'>[];
+  workingGroups: [Pick<WorkingGroupResponse, 'id' | 'title'>];
 };
 
 export type ResearchOutputResponse =

--- a/packages/model/src/research-output.ts
+++ b/packages/model/src/research-output.ts
@@ -218,7 +218,7 @@ export type ResearchOutputDataObject = ResearchOutputCoreObject & {
   subtype?: string;
   teams: Pick<TeamResponse, 'id' | 'displayName'>[];
   workingGroups: Pick<WorkingGroupResponse, 'id' | 'title'>[];
-  published?: boolean;
+  published: boolean;
 };
 
 export type ListResearchOutputDataObject =

--- a/packages/model/src/user.ts
+++ b/packages/model/src/user.ts
@@ -230,9 +230,7 @@ export type FetchUsersFilter = {
 
 export type FetchUsersOptions = FetchOptions<FetchUsersFilter>;
 
-export type userPermissions = {
-  createDraft: boolean;
-  editDraft: boolean;
-  publishDraft: boolean;
-  editPublished: boolean;
+export type UserPermissions = {
+  saveDraft: boolean;
+  publish: boolean;
 };

--- a/packages/model/src/user.ts
+++ b/packages/model/src/user.ts
@@ -230,4 +230,7 @@ export type FetchUsersFilter = {
 
 export type FetchUsersOptions = FetchOptions<FetchUsersFilter>;
 
-export type UserPermissionsLevel = 'None' | 'Member' | 'Admin';
+export type UserPermissions = {
+  saveDraft: boolean;
+  publish: boolean;
+};

--- a/packages/model/src/user.ts
+++ b/packages/model/src/user.ts
@@ -230,7 +230,4 @@ export type FetchUsersFilter = {
 
 export type FetchUsersOptions = FetchOptions<FetchUsersFilter>;
 
-export type UserPermissions = {
-  saveDraft: boolean;
-  publish: boolean;
-};
+export type UserRole = 'Staff' | 'Member' | 'None';

--- a/packages/model/src/user.ts
+++ b/packages/model/src/user.ts
@@ -230,7 +230,4 @@ export type FetchUsersFilter = {
 
 export type FetchUsersOptions = FetchOptions<FetchUsersFilter>;
 
-export type UserPermissions = {
-  saveDraft: boolean;
-  publish: boolean;
-};
+export type UserPermissionsLevel = 'None' | 'Member' | 'Admin';

--- a/packages/react-components/src/organisms/Form.tsx
+++ b/packages/react-components/src/organisms/Form.tsx
@@ -14,12 +14,14 @@ const styles = css({
 
 type FormProps<T> = {
   onSave: () => Promise<T | void>;
+  onSaveDraft: () => Promise<T | void>;
   validate?: () => boolean;
   dirty: boolean; // mandatory so that it cannot be forgotten
   serverErrors?: ValidationErrorResponse['data'];
   children: (state: {
     isSaving: boolean;
     onSave: () => void | Promise<T | void>;
+    onSaveDraft: () => void | Promise<T | void>;
     onCancel: () => void;
   }) => ReactNode;
 };
@@ -28,6 +30,7 @@ const Form = <T extends void | Record<string, unknown>>({
   children,
   validate = () => true,
   onSave,
+  onSaveDraft,
   serverErrors = [],
 }: FormProps<T>): React.ReactElement => {
   const toast = useContext(ToastContext);
@@ -46,28 +49,29 @@ const Form = <T extends void | Record<string, unknown>>({
       formRef.current.reportValidity();
     }
   }, [serverErrors]);
-  const wrappedOnSave = async () => {
-    const parentValidation = validate();
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    if (formRef.current!.reportValidity() && parentValidation) {
-      setStatus('isSaving');
-      try {
-        const result = await onSave();
-        if (formRef.current) {
-          setStatus('hasSaved');
-        }
-        return result;
-      } catch {
-        if (formRef.current) {
-          setStatus('hasError');
-          toast(
-            'There was an error and we were unable to save your changes. Please try again.',
-          );
+  const getWrappedOnSave =
+    (onSaveFunction: () => Promise<T | void>) => async () => {
+      const parentValidation = validate();
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      if (formRef.current!.reportValidity() && parentValidation) {
+        setStatus('isSaving');
+        try {
+          const result = await onSaveFunction();
+          if (formRef.current) {
+            setStatus('hasSaved');
+          }
+          return result;
+        } catch {
+          if (formRef.current) {
+            setStatus('hasError');
+            toast(
+              'There was an error and we were unable to save your changes. Please try again.',
+            );
+          }
         }
       }
-    }
-    return Promise.resolve();
-  };
+      return Promise.resolve();
+    };
 
   const onCancel = () => {
     setStatus('initial');
@@ -91,7 +95,8 @@ const Form = <T extends void | Record<string, unknown>>({
         {children({
           onCancel,
           isSaving: status === 'isSaving',
-          onSave: wrappedOnSave,
+          onSave: getWrappedOnSave(onSave),
+          onSaveDraft: getWrappedOnSave(onSaveDraft),
         })}
       </form>
     </>

--- a/packages/react-components/src/organisms/__tests__/Form.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/Form.test.tsx
@@ -17,6 +17,7 @@ const props: ComponentProps<typeof Form> = {
   dirty: false,
   children: () => null,
   onSave: () => Promise.resolve(),
+  onSaveDraft: () => Promise.resolve(),
 };
 
 let getUserConfirmation!: jest.MockedFunction<

--- a/packages/react-components/src/templates/ResearchOutputForm.tsx
+++ b/packages/react-components/src/templates/ResearchOutputForm.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { isEnabled } from '@asap-hub/flags';
 import {
   DecisionOption,
   ResearchOutputDocumentType,
@@ -152,7 +153,8 @@ const ResearchOutputForm: React.FC<ResearchOutputFormProps> = ({
   const historyPush = usePushFromHere();
   const { canShareResearchOutput, canPublishResearchOutput } = permissions;
 
-  const showSaveDraftButton = !published && canShareResearchOutput;
+  const showSaveDraftButton =
+    isEnabled('DRAFT_RESEARCH_OUTPUT') && !published && canShareResearchOutput;
   const showPublishButton = canPublishResearchOutput;
   const displayThreeButtons = showSaveDraftButton && showPublishButton;
 

--- a/packages/react-components/src/templates/ResearchOutputForm.tsx
+++ b/packages/react-components/src/templates/ResearchOutputForm.tsx
@@ -7,8 +7,9 @@ import {
   ResearchOutputResponse,
   ResearchTagResponse,
 } from '@asap-hub/model';
+import { ResearchOutputPermissionsContext } from '@asap-hub/react-context';
 import { sharedResearch } from '@asap-hub/routing';
-import React, { ComponentProps, useState } from 'react';
+import React, { ComponentProps, useContext, useState } from 'react';
 import equal from 'fast-deep-equal';
 import { contentSidePaddingWithNavigation } from '../layout';
 import {
@@ -45,6 +46,10 @@ type ResearchOutputFormProps = Pick<
     onSave: (
       output: ResearchOutputPostRequest,
     ) => Promise<ResearchOutputResponse | void>;
+    onSaveDraft: (
+      output: ResearchOutputPostRequest,
+    ) => Promise<ResearchOutputResponse | void>;
+    published: boolean;
     documentType: ResearchOutputDocumentType;
     researchTags: ResearchTagResponse[];
     selectedTeams: NonNullable<
@@ -73,9 +78,13 @@ const formControlsContainerStyles = css({
   display: 'flex',
   justifyContent: 'end',
   paddingBottom: `${200 / perRem}em`, // Hack for labs selector
+  [`@media (max-width: 810px)`]: {
+    justifySelf: 'end',
+    width: '100%',
+  },
 });
 
-const formControlsStyles = css({
+const formControlsTwoButtonsStyles = css({
   display: 'grid',
   alignItems: 'end',
   gridGap: `${24 / perRem}em`,
@@ -94,10 +103,34 @@ const formControlsStyles = css({
   },
 });
 
+const formControlsThreeButtonsStyles = css({
+  display: 'grid',
+  alignItems: 'end',
+  gridGap: `${24 / perRem}em`,
+  gridTemplateColumns: '1fr 1fr 1fr',
+  [`@media (max-width: 810px)`]: {
+    gridTemplateColumns: '1fr',
+    width: '100%',
+    'button:nth-of-type(1)': {
+      order: 3,
+      margin: '0',
+    },
+    'button:nth-of-type(2)': {
+      order: 2,
+      margin: '0',
+    },
+    'button:nth-of-type(3)': {
+      order: 1,
+      margin: '0',
+    },
+  },
+});
+
 const ResearchOutputForm: React.FC<ResearchOutputFormProps> = ({
   documentType,
   researchOutputData,
   onSave,
+  onSaveDraft,
   tagSuggestions,
   urlRequired = true,
   authorsRequired = false,
@@ -109,8 +142,14 @@ const ResearchOutputForm: React.FC<ResearchOutputFormProps> = ({
   researchTags,
   serverValidationErrors,
   clearServerValidationError,
+  published,
 }) => {
   const historyPush = usePushFromHere();
+  const { permissions } = useContext(ResearchOutputPermissionsContext);
+
+  const showSaveDraftButton = !published && permissions.saveDraft;
+  const showPublishButton = permissions.publish;
+  const displayThreeButtons = showSaveDraftButton && showPublishButton;
 
   const [tags, setTags] = useState<ResearchOutputPostRequest['tags']>(
     (researchOutputData?.tags as string[]) || [],
@@ -236,8 +275,14 @@ const ResearchOutputForm: React.FC<ResearchOutputFormProps> = ({
         serverErrors={serverValidationErrors}
         dirty={!equal(remotePayload, currentPayload)}
         onSave={() => onSave(currentPayload)}
+        onSaveDraft={() => onSaveDraft(currentPayload)}
       >
-        {({ isSaving, onSave: handleSave, onCancel: handleCancel }) => (
+        {({
+          isSaving,
+          onSave: handleSave,
+          onSaveDraft: handleSaveDraft,
+          onCancel: handleCancel,
+        }) => (
           <div css={contentStyles}>
             <ResearchOutputFormSharingCard
               serverValidationErrors={serverValidationErrors}
@@ -314,27 +359,56 @@ const ResearchOutputForm: React.FC<ResearchOutputFormProps> = ({
               authorsRequired={authorsRequired}
             />
             <div css={formControlsContainerStyles}>
-              <div css={formControlsStyles}>
-                <Button enabled={!isSaving} onClick={handleCancel}>
+              <div
+                css={
+                  displayThreeButtons
+                    ? formControlsThreeButtonsStyles
+                    : formControlsTwoButtonsStyles
+                }
+              >
+                <Button enabled={!isSaving} fullWidth onClick={handleCancel}>
                   Cancel
                 </Button>
-                <Button
-                  enabled={!isSaving}
-                  primary
-                  onClick={async () => {
-                    const researchOutput = await handleSave();
-                    if (researchOutput) {
-                      const { id } = researchOutput;
-                      const path = sharedResearch({}).researchOutput({
-                        researchOutputId: id,
-                      }).$;
-                      historyPush(path);
-                    }
-                    return researchOutput;
-                  }}
-                >
-                  {!researchOutputData ? 'Publish' : 'Save'}
-                </Button>
+                {showSaveDraftButton && (
+                  <Button
+                    enabled={!isSaving}
+                    fullWidth
+                    onClick={async () => {
+                      const researchOutput = await handleSaveDraft();
+                      if (researchOutput) {
+                        const { id } = researchOutput;
+                        const path = sharedResearch({}).researchOutput({
+                          researchOutputId: id,
+                        }).$;
+                        historyPush(path);
+                      }
+                      return researchOutput;
+                    }}
+                    primary={permissions.saveDraft && !permissions.publish}
+                  >
+                    Save Draft
+                  </Button>
+                )}
+                {showPublishButton && (
+                  <Button
+                    enabled={!isSaving}
+                    fullWidth
+                    primary
+                    onClick={async () => {
+                      const researchOutput = await handleSave();
+                      if (researchOutput) {
+                        const { id } = researchOutput;
+                        const path = sharedResearch({}).researchOutput({
+                          researchOutputId: id,
+                        }).$;
+                        historyPush(path);
+                      }
+                      return researchOutput;
+                    }}
+                  >
+                    {published ? 'Save' : 'Publish'}
+                  </Button>
+                )}
               </div>
             </div>
           </div>

--- a/packages/react-components/src/templates/ResearchOutputForm.tsx
+++ b/packages/react-components/src/templates/ResearchOutputForm.tsx
@@ -145,10 +145,12 @@ const ResearchOutputForm: React.FC<ResearchOutputFormProps> = ({
   published,
 }) => {
   const historyPush = usePushFromHere();
-  const { permissions } = useContext(ResearchOutputPermissionsContext);
+  const { canShareResearchOutput, canPublishResearchOutput } = useContext(
+    ResearchOutputPermissionsContext,
+  );
 
-  const showSaveDraftButton = !published && permissions.saveDraft;
-  const showPublishButton = permissions.publish;
+  const showSaveDraftButton = !published && canShareResearchOutput;
+  const showPublishButton = canPublishResearchOutput;
   const displayThreeButtons = showSaveDraftButton && showPublishButton;
 
   const [tags, setTags] = useState<ResearchOutputPostRequest['tags']>(
@@ -384,7 +386,7 @@ const ResearchOutputForm: React.FC<ResearchOutputFormProps> = ({
                       }
                       return researchOutput;
                     }}
-                    primary={permissions.saveDraft && !permissions.publish}
+                    primary={showSaveDraftButton && !showPublishButton}
                   >
                     Save Draft
                   </Button>

--- a/packages/react-components/src/templates/ResearchOutputForm.tsx
+++ b/packages/react-components/src/templates/ResearchOutputForm.tsx
@@ -7,9 +7,8 @@ import {
   ResearchOutputResponse,
   ResearchTagResponse,
 } from '@asap-hub/model';
-import { ResearchOutputPermissionsContext } from '@asap-hub/react-context';
 import { sharedResearch } from '@asap-hub/routing';
-import React, { ComponentProps, useContext, useState } from 'react';
+import React, { ComponentProps, useState } from 'react';
 import equal from 'fast-deep-equal';
 import { contentSidePaddingWithNavigation } from '../layout';
 import {
@@ -57,6 +56,11 @@ type ResearchOutputFormProps = Pick<
     >;
     researchOutputData?: ResearchOutputResponse;
     tagSuggestions: string[];
+    permissions: {
+      canEditResearchOutput: boolean;
+      canPublishResearchOutput: boolean;
+      canShareResearchOutput: boolean;
+    };
   };
 
 const mainStyles = css({
@@ -143,11 +147,10 @@ const ResearchOutputForm: React.FC<ResearchOutputFormProps> = ({
   serverValidationErrors,
   clearServerValidationError,
   published,
+  permissions,
 }) => {
   const historyPush = usePushFromHere();
-  const { canShareResearchOutput, canPublishResearchOutput } = useContext(
-    ResearchOutputPermissionsContext,
-  );
+  const { canShareResearchOutput, canPublishResearchOutput } = permissions;
 
   const showSaveDraftButton = !published && canShareResearchOutput;
   const showPublishButton = canPublishResearchOutput;

--- a/packages/react-components/src/templates/SharedResearchOutput.tsx
+++ b/packages/react-components/src/templates/SharedResearchOutput.tsx
@@ -42,7 +42,6 @@ type SharedResearchOutputProps = Pick<
   | 'environments'
   | 'subtype'
   | 'id'
-  | 'published'
 > &
   ComponentProps<typeof SharedResearchOutputHeaderCard> & {
     backHref: string;
@@ -54,7 +53,6 @@ const SharedResearchOutput: React.FC<SharedResearchOutputProps> = ({
   usageNotes,
   contactEmails,
   id,
-  published,
   ...props
 }) => {
   const isGrantDocument = ['Grant Document', 'Presentation'].includes(

--- a/packages/react-components/src/templates/SharedResearchOutput.tsx
+++ b/packages/react-components/src/templates/SharedResearchOutput.tsx
@@ -1,6 +1,5 @@
 import React, { ComponentProps, useContext } from 'react';
 import { css } from '@emotion/react';
-import { isEnabled } from '@asap-hub/flags';
 import { ResearchOutputResponse } from '@asap-hub/model';
 import { ResearchOutputPermissionsContext } from '@asap-hub/react-context';
 import { sharedResearch } from '@asap-hub/routing';
@@ -70,18 +69,15 @@ const SharedResearchOutput: React.FC<SharedResearchOutputProps> = ({
     ...props.tags,
   ];
 
-  const { permissions } = useContext(ResearchOutputPermissionsContext);
+  const { canEditResearchOutput } = useContext(
+    ResearchOutputPermissionsContext,
+  );
 
-  const canEdit =
-    (isEnabled('DRAFT_RESEARCH_OUTPUT') &&
-      permissions.saveDraft &&
-      !published) ||
-    (permissions.publish && published);
   return (
     <div css={containerStyles}>
       <div css={buttonsContainer}>
         <BackLink href={backHref} />
-        {canEdit && !isGrantDocument && (
+        {canEditResearchOutput && !isGrantDocument && (
           <div css={editButtonContainer}>
             <Link
               href={

--- a/packages/react-components/src/templates/SharedResearchOutput.tsx
+++ b/packages/react-components/src/templates/SharedResearchOutput.tsx
@@ -1,5 +1,6 @@
 import React, { ComponentProps, useContext } from 'react';
 import { css } from '@emotion/react';
+import { isEnabled } from '@asap-hub/flags';
 import { ResearchOutputResponse } from '@asap-hub/model';
 import { ResearchOutputPermissionsContext } from '@asap-hub/react-context';
 import { sharedResearch } from '@asap-hub/routing';
@@ -42,6 +43,7 @@ type SharedResearchOutputProps = Pick<
   | 'environments'
   | 'subtype'
   | 'id'
+  | 'published'
 > &
   ComponentProps<typeof SharedResearchOutputHeaderCard> & {
     backHref: string;
@@ -53,6 +55,7 @@ const SharedResearchOutput: React.FC<SharedResearchOutputProps> = ({
   usageNotes,
   contactEmails,
   id,
+  published,
   ...props
 }) => {
   const isGrantDocument = ['Grant Document', 'Presentation'].includes(
@@ -67,13 +70,18 @@ const SharedResearchOutput: React.FC<SharedResearchOutputProps> = ({
     ...props.tags,
   ];
 
-  const { canCreateUpdate } = useContext(ResearchOutputPermissionsContext);
+  const { permissions } = useContext(ResearchOutputPermissionsContext);
 
+  const canEdit =
+    (isEnabled('DRAFT_RESEARCH_OUTPUT') &&
+      permissions.saveDraft &&
+      !published) ||
+    (permissions.publish && published);
   return (
     <div css={containerStyles}>
       <div css={buttonsContainer}>
         <BackLink href={backHref} />
-        {canCreateUpdate && !isGrantDocument && (
+        {canEdit && !isGrantDocument && (
           <div css={editButtonContainer}>
             <Link
               href={

--- a/packages/react-components/src/templates/TeamProfileHeader.tsx
+++ b/packages/react-components/src/templates/TeamProfileHeader.tsx
@@ -1,5 +1,4 @@
 import { TeamResponse, TeamTool } from '@asap-hub/model';
-import { isEnabled } from '@asap-hub/flags';
 import { ResearchOutputPermissionsContext } from '@asap-hub/react-context';
 import { network } from '@asap-hub/routing';
 import { css } from '@emotion/react';
@@ -136,10 +135,9 @@ const TeamProfileHeader: React.FC<TeamProfileHeaderProps> = ({
   pastEventsCount,
 }) => {
   const route = network({}).teams({}).team({ teamId: id });
-  const { permissions } = useContext(ResearchOutputPermissionsContext);
-  const showShareResearchOutputButton =
-    (isEnabled('DRAFT_RESEARCH_OUTPUT') && permissions.saveDraft) ||
-    permissions.publish;
+  const { canShareResearchOutput } = useContext(
+    ResearchOutputPermissionsContext,
+  );
 
   const isActive = !inactiveSince;
 
@@ -152,16 +150,14 @@ const TeamProfileHeader: React.FC<TeamProfileHeaderProps> = ({
 
       <section
         css={
-          showShareResearchOutputButton
-            ? createSectionStyles
-            : contactSectionStyles
+          canShareResearchOutput ? createSectionStyles : contactSectionStyles
         }
       >
         <UserAvatarList
           members={members}
           fullListRoute={`${route.about({}).$}#${teamListElementId}`}
         />
-        {pointOfContact && !showShareResearchOutputButton && (
+        {pointOfContact && !canShareResearchOutput && (
           <div css={pointOfContactStyles}>
             <Link
               buttonStyle
@@ -179,7 +175,7 @@ const TeamProfileHeader: React.FC<TeamProfileHeaderProps> = ({
             <span>{getCounterString(labCount, 'Lab')}</span>
           </div>
         )}
-        {showShareResearchOutputButton && (
+        {canShareResearchOutput && (
           <div css={createStyles}>
             <DropdownButton
               buttonChildren={() => (

--- a/packages/react-components/src/templates/TeamProfileHeader.tsx
+++ b/packages/react-components/src/templates/TeamProfileHeader.tsx
@@ -1,4 +1,5 @@
 import { TeamResponse, TeamTool } from '@asap-hub/model';
+import { isEnabled } from '@asap-hub/flags';
 import { ResearchOutputPermissionsContext } from '@asap-hub/react-context';
 import { network } from '@asap-hub/routing';
 import { css } from '@emotion/react';
@@ -135,7 +136,11 @@ const TeamProfileHeader: React.FC<TeamProfileHeaderProps> = ({
   pastEventsCount,
 }) => {
   const route = network({}).teams({}).team({ teamId: id });
-  const { canCreateUpdate } = useContext(ResearchOutputPermissionsContext);
+  const { permissions } = useContext(ResearchOutputPermissionsContext);
+  const showShareResearchOutputButton =
+    (isEnabled('DRAFT_RESEARCH_OUTPUT') && permissions.saveDraft) ||
+    permissions.publish;
+
   const isActive = !inactiveSince;
 
   return (
@@ -146,13 +151,17 @@ const TeamProfileHeader: React.FC<TeamProfileHeaderProps> = ({
       </div>
 
       <section
-        css={canCreateUpdate ? createSectionStyles : contactSectionStyles}
+        css={
+          showShareResearchOutputButton
+            ? createSectionStyles
+            : contactSectionStyles
+        }
       >
         <UserAvatarList
           members={members}
           fullListRoute={`${route.about({}).$}#${teamListElementId}`}
         />
-        {pointOfContact && !canCreateUpdate && (
+        {pointOfContact && !showShareResearchOutputButton && (
           <div css={pointOfContactStyles}>
             <Link
               buttonStyle
@@ -170,7 +179,7 @@ const TeamProfileHeader: React.FC<TeamProfileHeaderProps> = ({
             <span>{getCounterString(labCount, 'Lab')}</span>
           </div>
         )}
-        {canCreateUpdate && (
+        {showShareResearchOutputButton && (
           <div css={createStyles}>
             <DropdownButton
               buttonChildren={() => (

--- a/packages/react-components/src/templates/WorkingGroupPageHeader.tsx
+++ b/packages/react-components/src/templates/WorkingGroupPageHeader.tsx
@@ -1,6 +1,5 @@
 import { css } from '@emotion/react';
 import { formatDistance } from 'date-fns';
-import { isEnabled } from '@asap-hub/flags';
 import { ResearchOutputPermissionsContext } from '@asap-hub/react-context';
 import { WorkingGroupResponse } from '@asap-hub/model';
 import { network } from '@asap-hub/routing';
@@ -140,10 +139,9 @@ const WorkingGroupPageHeader: React.FC<WorkingGroupPageHeaderProps> = ({
   upcomingEventsCount,
   pastEventsCount,
 }) => {
-  const { permissions } = useContext(ResearchOutputPermissionsContext);
-  const showShareResearchOutputButton =
-    (isEnabled('DRAFT_RESEARCH_OUTPUT') && permissions.saveDraft) ||
-    permissions.publish;
+  const { canShareResearchOutput } = useContext(
+    ResearchOutputPermissionsContext,
+  );
 
   const route = network({})
     .workingGroups({})
@@ -167,7 +165,7 @@ const WorkingGroupPageHeader: React.FC<WorkingGroupPageHeaderProps> = ({
               .about({}).$
           }#${membersListElementId}`}
         />
-        {pointOfContact && !showShareResearchOutputButton && (
+        {pointOfContact && !canShareResearchOutput && (
           <div css={pointOfContactStyles}>
             <Link
               buttonStyle
@@ -180,7 +178,7 @@ const WorkingGroupPageHeader: React.FC<WorkingGroupPageHeaderProps> = ({
           </div>
         )}
 
-        {showShareResearchOutputButton && (
+        {canShareResearchOutput && (
           <div css={createStyles}>
             <DropdownButton
               buttonChildren={() => (

--- a/packages/react-components/src/templates/__tests__/ResearchOutputForm.test.tsx
+++ b/packages/react-components/src/templates/__tests__/ResearchOutputForm.test.tsx
@@ -17,6 +17,7 @@ import {
   ResearchOutputType,
   ResearchTagResponse,
 } from '@asap-hub/model';
+import { disable } from '@asap-hub/flags';
 import { fireEvent } from '@testing-library/dom';
 import {
   render,
@@ -797,6 +798,25 @@ describe('form buttons', () => {
     const cancelButton = screen.getByRole('button', { name: /Cancel/i });
     expect(cancelButton).toBeInTheDocument();
     expect(cancelButton).toHaveStyle(`background-color:${notPrimaryButtonBg}`);
+  });
+
+  it('shows only Cancel and Publish buttons when user has editing and publishing permissions, the research output has not been published yet and feature flag is disabled', async () => {
+    disable('DRAFT_RESEARCH_OUTPUT');
+    await setupForm({
+      canEditResearchOutput: true,
+      canPublishResearchOutput: true,
+      published: false,
+    });
+
+    const publishButton = screen.getByRole('button', {
+      name: /Publish/i,
+    });
+    expect(publishButton).toBeInTheDocument();
+    expect(publishButton).toHaveStyle(`background-color:${primaryButtonBg}`);
+
+    expect(
+      screen.queryByRole('button', { name: /Save Draft/i }),
+    ).not.toBeInTheDocument();
   });
 
   it('shows only Cancel and Save buttons when user has editing and publishing permission and the research output has already been published', async () => {

--- a/packages/react-components/src/templates/__tests__/ResearchOutputForm.test.tsx
+++ b/packages/react-components/src/templates/__tests__/ResearchOutputForm.test.tsx
@@ -1,4 +1,3 @@
-import { ResearchOutputPermissionsContext } from '@asap-hub/react-context';
 import userEvent from '@testing-library/user-event';
 import { ComponentProps } from 'react';
 import { StaticRouter, Router } from 'react-router-dom';
@@ -41,12 +40,11 @@ const props: ComponentProps<typeof ResearchOutputForm> = {
   documentType: 'Article',
   selectedTeams: [],
   typeOptions: Array.from(researchOutputDocumentTypeToType.Article.values()),
-};
-
-const permissions = {
-  canEditResearchOutput: true,
-  canPublishResearchOutput: true,
-  canShareResearchOutput: true,
+  permissions: {
+    canEditResearchOutput: true,
+    canPublishResearchOutput: true,
+    canShareResearchOutput: true,
+  },
 };
 
 jest.setTimeout(60000);
@@ -93,9 +91,7 @@ describe('createIdentifierField', () => {
 it('renders the form', async () => {
   render(
     <StaticRouter>
-      <ResearchOutputPermissionsContext.Provider value={permissions}>
-        <ResearchOutputForm {...props} />
-      </ResearchOutputPermissionsContext.Provider>
+      <ResearchOutputForm {...props} />
     </StaticRouter>,
   );
   expect(
@@ -107,12 +103,10 @@ it('renders the form', async () => {
 it('renders the edit form button when research output data is present', async () => {
   render(
     <StaticRouter>
-      <ResearchOutputPermissionsContext.Provider value={permissions}>
-        <ResearchOutputForm
-          {...props}
-          researchOutputData={createResearchOutputResponse()}
-        />
-      </ResearchOutputPermissionsContext.Provider>
+      <ResearchOutputForm
+        {...props}
+        researchOutputData={createResearchOutputResponse()}
+      />
     </StaticRouter>,
   );
 
@@ -136,14 +130,12 @@ it('pre populates the form with provided backend response', async () => {
   };
   await render(
     <StaticRouter>
-      <ResearchOutputPermissionsContext.Provider value={permissions}>
-        <ResearchOutputForm
-          {...props}
-          documentType={'Dataset'}
-          typeOptions={Array.from(researchOutputDocumentTypeToType.Dataset)}
-          researchOutputData={researchOutputData}
-        />
-      </ResearchOutputPermissionsContext.Provider>
+      <ResearchOutputForm
+        {...props}
+        documentType={'Dataset'}
+        typeOptions={Array.from(researchOutputDocumentTypeToType.Dataset)}
+        researchOutputData={researchOutputData}
+      />
     </StaticRouter>,
   );
 
@@ -282,24 +274,21 @@ describe('on submit', () => {
     },
   ) => {
     render(
-      <ResearchOutputPermissionsContext.Provider value={permissions}>
-        <Router history={history}>
-          <ResearchOutputForm
-            {...props}
-            selectedTeams={[{ value: 'TEAMID', label: 'Example Team' }]}
-            documentType={documentType}
-            typeOptions={Array.from(
-              researchOutputDocumentTypeToType[documentType],
-            )}
-            onSave={saveFn}
-            onSaveDraft={saveDraftFn}
-            getLabSuggestions={getLabSuggestions}
-            getAuthorSuggestions={getAuthorSuggestions}
-            researchTags={researchTags}
-          />
-        </Router>
-        ,
-      </ResearchOutputPermissionsContext.Provider>,
+      <Router history={history}>
+        <ResearchOutputForm
+          {...props}
+          selectedTeams={[{ value: 'TEAMID', label: 'Example Team' }]}
+          documentType={documentType}
+          typeOptions={Array.from(
+            researchOutputDocumentTypeToType[documentType],
+          )}
+          onSave={saveFn}
+          onSaveDraft={saveDraftFn}
+          getLabSuggestions={getLabSuggestions}
+          getAuthorSuggestions={getAuthorSuggestions}
+          researchTags={researchTags}
+        />
+      </Router>,
     );
 
     fireEvent.change(screen.getByLabelText(/url/i), {
@@ -760,30 +749,26 @@ describe('form buttons', () => {
     },
   ) => {
     render(
-      <ResearchOutputPermissionsContext.Provider
-        value={{
-          canEditResearchOutput,
-          canPublishResearchOutput,
-          canShareResearchOutput: true,
-        }}
-      >
-        <Router history={history}>
-          <ResearchOutputForm
-            {...props}
-            selectedTeams={[{ value: 'TEAMID', label: 'Example Team' }]}
-            documentType={documentType}
-            typeOptions={Array.from(
-              researchOutputDocumentTypeToType[documentType],
-            )}
-            onSave={saveFn}
-            getLabSuggestions={getLabSuggestions}
-            getAuthorSuggestions={getAuthorSuggestions}
-            researchTags={researchTags}
-            published={published}
-          />
-        </Router>
-        ,
-      </ResearchOutputPermissionsContext.Provider>,
+      <Router history={history}>
+        <ResearchOutputForm
+          {...props}
+          selectedTeams={[{ value: 'TEAMID', label: 'Example Team' }]}
+          documentType={documentType}
+          typeOptions={Array.from(
+            researchOutputDocumentTypeToType[documentType],
+          )}
+          onSave={saveFn}
+          getLabSuggestions={getLabSuggestions}
+          getAuthorSuggestions={getAuthorSuggestions}
+          researchTags={researchTags}
+          published={published}
+          permissions={{
+            canEditResearchOutput,
+            canPublishResearchOutput,
+            canShareResearchOutput: true,
+          }}
+        />
+      </Router>,
     );
   };
 

--- a/packages/react-components/src/templates/__tests__/SharedResearchOutput.test.tsx
+++ b/packages/react-components/src/templates/__tests__/SharedResearchOutput.test.tsx
@@ -1,7 +1,13 @@
 import { ComponentProps } from 'react';
 import { render } from '@testing-library/react';
 import { createResearchOutputResponse } from '@asap-hub/fixtures';
+import { disable } from '@asap-hub/flags';
 import { ResearchOutputPermissionsContext } from '@asap-hub/react-context';
+import {
+  fullPermissions,
+  noPermissions,
+  partialPermissions,
+} from '@asap-hub/validation';
 
 import SharedResearchOutput from '../SharedResearchOutput';
 
@@ -31,7 +37,7 @@ describe('Grant Documents', () => {
   it('displays edit button when user has permission', () => {
     const { queryByTitle, rerender } = render(
       <ResearchOutputPermissionsContext.Provider
-        value={{ canCreateUpdate: false }}
+        value={{ permissions: noPermissions }}
       >
         <SharedResearchOutput {...props} documentType="Article" />,
       </ResearchOutputPermissionsContext.Provider>,
@@ -40,7 +46,7 @@ describe('Grant Documents', () => {
 
     rerender(
       <ResearchOutputPermissionsContext.Provider
-        value={{ canCreateUpdate: true }}
+        value={{ permissions: fullPermissions }}
       >
         <SharedResearchOutput {...props} documentType="Grant Document" />,
       </ResearchOutputPermissionsContext.Provider>,
@@ -49,12 +55,37 @@ describe('Grant Documents', () => {
 
     rerender(
       <ResearchOutputPermissionsContext.Provider
-        value={{ canCreateUpdate: true }}
+        value={{ permissions: fullPermissions }}
       >
         <SharedResearchOutput {...props} documentType="Article" />,
       </ResearchOutputPermissionsContext.Provider>,
     );
     expect(queryByTitle('Edit')).toBeInTheDocument();
+  });
+
+  it('displays edit button when user has partial permission', () => {
+    const { queryByTitle } = render(
+      <ResearchOutputPermissionsContext.Provider
+        value={{ permissions: partialPermissions }}
+      >
+        <SharedResearchOutput {...props} documentType="Article" />,
+      </ResearchOutputPermissionsContext.Provider>,
+    );
+
+    expect(queryByTitle('Edit')).toBeInTheDocument();
+  });
+
+  it('does not display edit button when user has partial permission and feature flag is disable', () => {
+    disable('DRAFT_RESEARCH_OUTPUT');
+    const { queryByTitle } = render(
+      <ResearchOutputPermissionsContext.Provider
+        value={{ permissions: partialPermissions }}
+      >
+        <SharedResearchOutput {...props} documentType="Article" />,
+      </ResearchOutputPermissionsContext.Provider>,
+    );
+
+    expect(queryByTitle('Edit')).toBeNull();
   });
 
   it('handles tags and separate RTF description', () => {

--- a/packages/react-components/src/templates/__tests__/SharedResearchOutput.test.tsx
+++ b/packages/react-components/src/templates/__tests__/SharedResearchOutput.test.tsx
@@ -1,13 +1,7 @@
 import { ComponentProps } from 'react';
 import { render } from '@testing-library/react';
 import { createResearchOutputResponse } from '@asap-hub/fixtures';
-import { disable } from '@asap-hub/flags';
 import { ResearchOutputPermissionsContext } from '@asap-hub/react-context';
-import {
-  fullPermissions,
-  noPermissions,
-  partialPermissions,
-} from '@asap-hub/validation';
 
 import SharedResearchOutput from '../SharedResearchOutput';
 
@@ -37,7 +31,11 @@ describe('Grant Documents', () => {
   it('displays edit button when user has permission', () => {
     const { queryByTitle, rerender } = render(
       <ResearchOutputPermissionsContext.Provider
-        value={{ permissions: noPermissions }}
+        value={{
+          canEditResearchOutput: false,
+          canPublishResearchOutput: false,
+          canShareResearchOutput: false,
+        }}
       >
         <SharedResearchOutput {...props} documentType="Article" />,
       </ResearchOutputPermissionsContext.Provider>,
@@ -46,7 +44,11 @@ describe('Grant Documents', () => {
 
     rerender(
       <ResearchOutputPermissionsContext.Provider
-        value={{ permissions: fullPermissions }}
+        value={{
+          canEditResearchOutput: false,
+          canPublishResearchOutput: false,
+          canShareResearchOutput: false,
+        }}
       >
         <SharedResearchOutput {...props} documentType="Grant Document" />,
       </ResearchOutputPermissionsContext.Provider>,
@@ -55,37 +57,16 @@ describe('Grant Documents', () => {
 
     rerender(
       <ResearchOutputPermissionsContext.Provider
-        value={{ permissions: fullPermissions }}
+        value={{
+          canEditResearchOutput: true,
+          canPublishResearchOutput: false,
+          canShareResearchOutput: false,
+        }}
       >
         <SharedResearchOutput {...props} documentType="Article" />,
       </ResearchOutputPermissionsContext.Provider>,
     );
     expect(queryByTitle('Edit')).toBeInTheDocument();
-  });
-
-  it('displays edit button when user has partial permission', () => {
-    const { queryByTitle } = render(
-      <ResearchOutputPermissionsContext.Provider
-        value={{ permissions: partialPermissions }}
-      >
-        <SharedResearchOutput {...props} documentType="Article" />,
-      </ResearchOutputPermissionsContext.Provider>,
-    );
-
-    expect(queryByTitle('Edit')).toBeInTheDocument();
-  });
-
-  it('does not display edit button when user has partial permission and feature flag is disable', () => {
-    disable('DRAFT_RESEARCH_OUTPUT');
-    const { queryByTitle } = render(
-      <ResearchOutputPermissionsContext.Provider
-        value={{ permissions: partialPermissions }}
-      >
-        <SharedResearchOutput {...props} documentType="Article" />,
-      </ResearchOutputPermissionsContext.Provider>,
-    );
-
-    expect(queryByTitle('Edit')).toBeNull();
   });
 
   it('handles tags and separate RTF description', () => {

--- a/packages/react-components/src/templates/__tests__/TeamProfileHeader.test.tsx
+++ b/packages/react-components/src/templates/__tests__/TeamProfileHeader.test.tsx
@@ -1,12 +1,5 @@
 import { createTeamResponseMembers } from '@asap-hub/fixtures';
-import { disable } from '@asap-hub/flags';
-import { UserPermissions } from '@asap-hub/model';
 import { ResearchOutputPermissionsContext } from '@asap-hub/react-context';
-import {
-  fullPermissions,
-  noPermissions,
-  partialPermissions,
-} from '@asap-hub/validation';
 import { fireEvent } from '@testing-library/dom';
 import { render, screen } from '@testing-library/react';
 import { formatISO } from 'date-fns';
@@ -163,16 +156,22 @@ it('renders workspace tabs when tools provided', () => {
 
 describe('Share an output button dropdown', () => {
   const renderWithPermissionsContext = (
-    permissions: UserPermissions = fullPermissions,
+    canShareResearchOutput: boolean = true,
   ) =>
     render(
-      <ResearchOutputPermissionsContext.Provider value={{ permissions }}>
+      <ResearchOutputPermissionsContext.Provider
+        value={{
+          canShareResearchOutput,
+          canEditResearchOutput: true,
+          canPublishResearchOutput: true,
+        }}
+      >
         <TeamProfileHeader {...boilerplateProps} />,
       </ResearchOutputPermissionsContext.Provider>,
     );
 
-  it('renders share an output button when user has full permission', () => {
-    renderWithPermissionsContext(fullPermissions);
+  it('renders share an output button when user can share research output', () => {
+    renderWithPermissionsContext();
 
     expect(
       screen.queryByText(/article/i, { selector: 'span' }),
@@ -184,30 +183,8 @@ describe('Share an output button dropdown', () => {
     ).toHaveAttribute('href', '/network/teams/42/create-output/article');
   });
 
-  it('renders share an output button dropdown when user has partial permission', () => {
-    renderWithPermissionsContext(partialPermissions);
-
-    expect(
-      screen.queryByText(/article/i, { selector: 'span' }),
-    ).not.toBeVisible();
-    fireEvent.click(screen.getByRole('button', { name: /Share an output/i }));
-    expect(screen.getByText(/article/i, { selector: 'span' })).toBeVisible();
-    expect(
-      screen.getByText(/article/i, { selector: 'span' }).closest('a'),
-    ).toHaveAttribute('href', '/network/teams/42/create-output/article');
-  });
-
-  it('does not render share an output button dropdown when user has partial permission and feature flag is disabled', () => {
-    disable('DRAFT_RESEARCH_OUTPUT');
-    renderWithPermissionsContext(partialPermissions);
-
-    expect(
-      screen.queryByRole('button', { name: /Share an output/i }),
-    ).not.toBeInTheDocument();
-  });
-
-  it('does not render share an output button dropdown when user has no permissions', () => {
-    renderWithPermissionsContext(noPermissions);
+  it('does not render share an output button dropdown when user cannot share research output', () => {
+    renderWithPermissionsContext(false);
 
     expect(
       screen.queryByRole('button', { name: /Share an output/i }),

--- a/packages/react-components/src/templates/__tests__/WorkingGroupPageHeader.test.tsx
+++ b/packages/react-components/src/templates/__tests__/WorkingGroupPageHeader.test.tsx
@@ -1,13 +1,17 @@
-import { ComponentProps, ReactElement } from 'react';
+import { ComponentProps } from 'react';
 import {
   createWorkingGroupMembers,
   createWorkingGroupPointOfContact,
 } from '@asap-hub/fixtures';
-import { fireEvent, render } from '@testing-library/react';
-import { renderHook } from '@testing-library/react-hooks';
-import { Auth0ContextCRN, useAuth0CRN } from '@asap-hub/react-context';
-import { Auth0User } from '@asap-hub/auth';
-import { WorkingGroupResponseLeader } from '@asap-hub/model';
+import { disable } from '@asap-hub/flags';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ResearchOutputPermissionsContext } from '@asap-hub/react-context';
+import { UserPermissions } from '@asap-hub/model';
+import {
+  fullPermissions,
+  noPermissions,
+  partialPermissions,
+} from '@asap-hub/validation';
 
 import WorkingGroupHeader from '../WorkingGroupPageHeader';
 
@@ -23,26 +27,6 @@ const baseProps: ComponentProps<typeof WorkingGroupHeader> = {
   members: [],
   workingGroupsOutputsCount: 0,
 };
-
-const userProvider =
-  (user: Auth0User | undefined): React.FC =>
-  (props) => {
-    const { result } = renderHook(useAuth0CRN);
-    const ctx = result.current;
-
-    return (
-      <Auth0ContextCRN.Provider
-        value={{
-          ...ctx,
-          loading: false,
-          isAuthenticated: true,
-          user,
-        }}
-      >
-        <WorkingGroupHeader {...baseProps} {...props} title="A test group" />
-      </Auth0ContextCRN.Provider>
-    );
-  };
 
 it('renders the title', () => {
   const { getByText } = render(
@@ -62,57 +46,64 @@ it('renders CTA when pointOfContact is provided', () => {
   rerender(<WorkingGroupHeader {...baseProps} />);
   expect(queryAllByText('Contact PM')).toHaveLength(0);
 });
-describe('share an output button', () => {
-  const testUser = {
-    id: 'testuser',
-    email: 'john.doe@example.com',
-    firstName: 'John',
-    lastName: 'Doe',
-    displayName: 'John Doe',
-  };
 
-  const testLeader = {
-    role: 'Project Manager',
-    user: testUser,
-    workstreamRole: 'aWorkstreamRole',
-    isActive: true,
-  } as WorkingGroupResponseLeader;
-
-  const renderWithUser = (props: ComponentProps<typeof WorkingGroupHeader>) =>
+describe('Share an output button dropdown', () => {
+  const renderWithPermissionsContext = (
+    permissions: UserPermissions = fullPermissions,
+  ) =>
     render(
-      userProvider({
-        sub: '42',
-        aud: 'Av2psgVspAN00Kez9v1vR2c496a9zCW3',
-        [`${window.location.origin}/user`]: {
-          ...testUser,
-          onboarded: true,
-          teams: [],
-          algoliaApiKey: 'asdasda',
-          workingGroups: [],
-          role: 'Staff',
-        },
-      })({ ...props }) as ReactElement,
+      <ResearchOutputPermissionsContext.Provider value={{ permissions }}>
+        <WorkingGroupHeader {...baseProps} title="A test group" />
+      </ResearchOutputPermissionsContext.Provider>,
     );
 
-  it('does not render share an output button dropdown when feature flag is enabled but user has no permission', () => {
-    const { queryByText } = render(<WorkingGroupHeader {...baseProps} />);
-    expect(queryByText('Share an output')).toBeNull();
-  });
+  it('renders share an output button when user has full permission', () => {
+    renderWithPermissionsContext(fullPermissions);
 
-  it('renders share an output button dropdown when user is project manager and feature flag is enabled', () => {
-    const { queryByText, getByText } = renderWithUser({
-      ...baseProps,
-      leaders: [testLeader],
-    });
-    expect(queryByText(/article/i, { selector: 'span' })).not.toBeVisible();
-    fireEvent.click(getByText('Share an output'));
-    expect(getByText(/article/i, { selector: 'span' })).toBeVisible();
     expect(
-      getByText(/article/i, { selector: 'span' }).closest('a'),
+      screen.queryByText(/article/i, { selector: 'span' }),
+    ).not.toBeVisible();
+    fireEvent.click(screen.getByRole('button', { name: /Share an output/i }));
+    expect(screen.getByText(/article/i, { selector: 'span' })).toBeVisible();
+    expect(
+      screen.getByText(/article/i, { selector: 'span' }).closest('a'),
     ).toHaveAttribute(
       'href',
       '/network/working-groups/id/create-output/article',
     );
+  });
+
+  it('renders share an output button dropdown when user has partial permission', () => {
+    renderWithPermissionsContext(partialPermissions);
+
+    expect(
+      screen.queryByText(/article/i, { selector: 'span' }),
+    ).not.toBeVisible();
+    fireEvent.click(screen.getByRole('button', { name: /Share an output/i }));
+    expect(screen.getByText(/article/i, { selector: 'span' })).toBeVisible();
+    expect(
+      screen.getByText(/article/i, { selector: 'span' }).closest('a'),
+    ).toHaveAttribute(
+      'href',
+      '/network/working-groups/id/create-output/article',
+    );
+  });
+
+  it('does not render share an output button dropdown when user has partial permission and feature flag is disabled', () => {
+    disable('DRAFT_RESEARCH_OUTPUT');
+    renderWithPermissionsContext(partialPermissions);
+
+    expect(
+      screen.queryByRole('button', { name: /Share an output/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not render share an output button dropdown when user has no permissions', () => {
+    renderWithPermissionsContext(noPermissions);
+
+    expect(
+      screen.queryByRole('button', { name: /Share an output/i }),
+    ).not.toBeInTheDocument();
   });
 });
 

--- a/packages/react-components/src/templates/__tests__/WorkingGroupPageHeader.test.tsx
+++ b/packages/react-components/src/templates/__tests__/WorkingGroupPageHeader.test.tsx
@@ -3,15 +3,8 @@ import {
   createWorkingGroupMembers,
   createWorkingGroupPointOfContact,
 } from '@asap-hub/fixtures';
-import { disable } from '@asap-hub/flags';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { ResearchOutputPermissionsContext } from '@asap-hub/react-context';
-import { UserPermissions } from '@asap-hub/model';
-import {
-  fullPermissions,
-  noPermissions,
-  partialPermissions,
-} from '@asap-hub/validation';
 
 import WorkingGroupHeader from '../WorkingGroupPageHeader';
 
@@ -49,16 +42,22 @@ it('renders CTA when pointOfContact is provided', () => {
 
 describe('Share an output button dropdown', () => {
   const renderWithPermissionsContext = (
-    permissions: UserPermissions = fullPermissions,
+    canShareResearchOutput: boolean = true,
   ) =>
     render(
-      <ResearchOutputPermissionsContext.Provider value={{ permissions }}>
+      <ResearchOutputPermissionsContext.Provider
+        value={{
+          canShareResearchOutput,
+          canEditResearchOutput: true,
+          canPublishResearchOutput: true,
+        }}
+      >
         <WorkingGroupHeader {...baseProps} title="A test group" />
       </ResearchOutputPermissionsContext.Provider>,
     );
 
-  it('renders share an output button when user has full permission', () => {
-    renderWithPermissionsContext(fullPermissions);
+  it('renders share an output button when user can share research output', () => {
+    renderWithPermissionsContext();
 
     expect(
       screen.queryByText(/article/i, { selector: 'span' }),
@@ -72,34 +71,8 @@ describe('Share an output button dropdown', () => {
       '/network/working-groups/id/create-output/article',
     );
   });
-
-  it('renders share an output button dropdown when user has partial permission', () => {
-    renderWithPermissionsContext(partialPermissions);
-
-    expect(
-      screen.queryByText(/article/i, { selector: 'span' }),
-    ).not.toBeVisible();
-    fireEvent.click(screen.getByRole('button', { name: /Share an output/i }));
-    expect(screen.getByText(/article/i, { selector: 'span' })).toBeVisible();
-    expect(
-      screen.getByText(/article/i, { selector: 'span' }).closest('a'),
-    ).toHaveAttribute(
-      'href',
-      '/network/working-groups/id/create-output/article',
-    );
-  });
-
-  it('does not render share an output button dropdown when user has partial permission and feature flag is disabled', () => {
-    disable('DRAFT_RESEARCH_OUTPUT');
-    renderWithPermissionsContext(partialPermissions);
-
-    expect(
-      screen.queryByRole('button', { name: /Share an output/i }),
-    ).not.toBeInTheDocument();
-  });
-
-  it('does not render share an output button dropdown when user has no permissions', () => {
-    renderWithPermissionsContext(noPermissions);
+  it('does not render share an output button dropdown when user cannot share research output', () => {
+    renderWithPermissionsContext(false);
 
     expect(
       screen.queryByRole('button', { name: /Share an output/i }),

--- a/packages/react-context/package.json
+++ b/packages/react-context/package.json
@@ -18,6 +18,8 @@
   "dependencies": {
     "@asap-hub/auth": "workspace:*",
     "@asap-hub/flags": "workspace:*",
+    "@asap-hub/model": "workspace:*",
+    "@asap-hub/validation": "workspace:*",
     "@babel/runtime-corejs3": "7.21.0",
     "core-js": "3.29.0"
   },

--- a/packages/react-context/src/__tests__/permissions/research-output.test.tsx
+++ b/packages/react-context/src/__tests__/permissions/research-output.test.tsx
@@ -3,17 +3,29 @@ import { render } from '@testing-library/react';
 import { useResearchOutputPermissionsContext } from '../../permissions/research-output';
 
 const TestComponent: React.FC<{ index?: number }> = () => {
-  const { permissions } = useResearchOutputPermissionsContext();
+  const {
+    canShareResearchOutput,
+    canEditResearchOutput,
+    canPublishResearchOutput,
+  } = useResearchOutputPermissionsContext();
   return (
     <>
-      <span>saveDraft: {permissions.saveDraft ? 'true' : 'false'}</span>
-      <span>publish: {permissions.publish ? 'true' : 'false'}</span>
+      <span>
+        canShareResearchOutput: {canShareResearchOutput ? 'true' : 'false'}
+      </span>
+      <span>
+        canEditResearchOutput: {canEditResearchOutput ? 'true' : 'false'}
+      </span>
+      <span>
+        canPublishResearchOutput: {canPublishResearchOutput ? 'true' : 'false'}
+      </span>
     </>
   );
 };
 
 it('passes through default profile context', () => {
   const { getByText } = render(<TestComponent />);
-  expect(getByText('saveDraft: false')).toBeVisible();
-  expect(getByText('publish: false')).toBeVisible();
+  expect(getByText('canShareResearchOutput: false')).toBeVisible();
+  expect(getByText('canEditResearchOutput: false')).toBeVisible();
+  expect(getByText('canPublishResearchOutput: false')).toBeVisible();
 });

--- a/packages/react-context/src/__tests__/permissions/research-output.test.tsx
+++ b/packages/react-context/src/__tests__/permissions/research-output.test.tsx
@@ -3,11 +3,17 @@ import { render } from '@testing-library/react';
 import { useResearchOutputPermissionsContext } from '../../permissions/research-output';
 
 const TestComponent: React.FC<{ index?: number }> = () => {
-  const { canCreateUpdate } = useResearchOutputPermissionsContext();
-  return <>canCreateUpdate: {canCreateUpdate ? 'true' : 'false'}</>;
+  const { permissions } = useResearchOutputPermissionsContext();
+  return (
+    <>
+      <span>saveDraft: {permissions.saveDraft ? 'true' : 'false'}</span>
+      <span>publish: {permissions.publish ? 'true' : 'false'}</span>
+    </>
+  );
 };
 
 it('passes through default profile context', () => {
   const { getByText } = render(<TestComponent />);
-  expect(getByText('canCreateUpdate: false')).toBeVisible();
+  expect(getByText('saveDraft: false')).toBeVisible();
+  expect(getByText('publish: false')).toBeVisible();
 });

--- a/packages/react-context/src/permissions/research-output.ts
+++ b/packages/react-context/src/permissions/research-output.ts
@@ -1,12 +1,14 @@
 import { createContext, useContext } from 'react';
+import { UserPermissions } from '@asap-hub/model';
+import { noPermissions } from '@asap-hub/validation';
 
 type ResearchOutputPermissions = {
-  canCreateUpdate: boolean;
+  permissions: UserPermissions;
 };
 
 export const ResearchOutputPermissionsContext =
   createContext<ResearchOutputPermissions>({
-    canCreateUpdate: false,
+    permissions: noPermissions,
   });
 
 export const useResearchOutputPermissionsContext =

--- a/packages/react-context/src/permissions/research-output.ts
+++ b/packages/react-context/src/permissions/research-output.ts
@@ -1,14 +1,16 @@
 import { createContext, useContext } from 'react';
-import { UserPermissions } from '@asap-hub/model';
-import { noPermissions } from '@asap-hub/validation';
 
 type ResearchOutputPermissions = {
-  permissions: UserPermissions;
+  canShareResearchOutput?: boolean;
+  canEditResearchOutput?: boolean;
+  canPublishResearchOutput?: boolean;
 };
 
 export const ResearchOutputPermissionsContext =
   createContext<ResearchOutputPermissions>({
-    permissions: noPermissions,
+    canShareResearchOutput: false,
+    canEditResearchOutput: false,
+    canPublishResearchOutput: false,
   });
 
 export const useResearchOutputPermissionsContext =

--- a/packages/react-context/tsconfig.json
+++ b/packages/react-context/tsconfig.json
@@ -11,6 +11,8 @@
   "references": [
     { "path": "../auth" },
     { "path": "../dom-test-utils" },
-    { "path": "../flags" }
+    { "path": "../flags" },
+    { "path": "../../packages/model" },
+    { "path": "../../packages/validation" }
   ]
 }

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@asap-hub/auth": "workspace:*",
     "@asap-hub/fixtures": "workspace:*",
-    "@asap-hub/flags": "workspace:^",
+    "@asap-hub/flags": "workspace:*",
     "@asap-hub/model": "workspace:*",
     "@babel/runtime-corejs3": "7.21.0"
   },

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@asap-hub/auth": "workspace:*",
     "@asap-hub/fixtures": "workspace:*",
-    "@asap-hub/flags": "workspace:*",
+    "@asap-hub/flags": "workspace:^",
     "@asap-hub/model": "workspace:*",
     "@babel/runtime-corejs3": "7.21.0"
   },

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@asap-hub/auth": "workspace:*",
     "@asap-hub/fixtures": "workspace:*",
+    "@asap-hub/flags": "workspace:*",
     "@asap-hub/model": "workspace:*",
     "@babel/runtime-corejs3": "7.21.0"
   },

--- a/packages/validation/src/permissions/research-output.ts
+++ b/packages/validation/src/permissions/research-output.ts
@@ -50,5 +50,3 @@ export const hasEditResearchOutputPermission = (
 ): boolean =>
   userRole === 'Staff' ||
   (isEnabled('DRAFT_RESEARCH_OUTPUT') && userRole === 'Member' && !published);
-
-export const hasUpsertPermission = hasEditResearchOutputPermission;

--- a/packages/validation/src/permissions/research-output.ts
+++ b/packages/validation/src/permissions/research-output.ts
@@ -1,32 +1,17 @@
 import { User } from '@asap-hub/auth';
-import { UserPermissions, UserResponse } from '@asap-hub/model';
+import { UserPermissionsLevel, UserResponse } from '@asap-hub/model';
 
-export const noPermissions: UserPermissions = {
-  saveDraft: false,
-  publish: false,
-};
-
-export const partialPermissions: UserPermissions = {
-  saveDraft: true,
-  publish: false,
-};
-
-export const fullPermissions: UserPermissions = {
-  saveDraft: true,
-  publish: true,
-};
-
-export const getUserPermissions = (
+export const getUserPermissionLevel = (
   user: Omit<User, 'algoliaApiKey'> | UserResponse | null,
   entity: 'teams' | 'workingGroups',
   entityIds: string[],
-): UserPermissions => {
+): UserPermissionsLevel => {
   if (user === null) {
-    return noPermissions;
+    return 'None';
   }
 
   if (user.role === 'Staff') {
-    return fullPermissions;
+    return 'Admin';
   }
 
   const isUserProjectManager = user[entity].some(
@@ -36,7 +21,7 @@ export const getUserPermissions = (
   );
 
   if (isUserProjectManager) {
-    return fullPermissions;
+    return 'Admin';
   }
 
   const isUserMember = user[entity].some((teamOrWorkingGroup) =>
@@ -44,8 +29,23 @@ export const getUserPermissions = (
   );
 
   if (isUserMember) {
-    return partialPermissions;
+    return 'Member';
   }
 
-  return noPermissions;
+  return 'None';
+};
+
+export const hasCreateUpdateResearchOutputPermissions = (
+  userPermissionLevel: UserPermissionsLevel,
+  publish: boolean,
+): boolean => {
+  if (userPermissionLevel === 'Admin') {
+    return true;
+  }
+
+  if (userPermissionLevel === 'Member') {
+    return !publish;
+  }
+
+  return false;
 };

--- a/packages/validation/src/permissions/research-output.ts
+++ b/packages/validation/src/permissions/research-output.ts
@@ -1,17 +1,32 @@
 import { User } from '@asap-hub/auth';
-import { UserPermissionsLevel, UserResponse } from '@asap-hub/model';
+import { UserPermissions, UserResponse } from '@asap-hub/model';
 
-export const getUserPermissionLevel = (
+export const noPermissions: UserPermissions = {
+  saveDraft: false,
+  publish: false,
+};
+
+export const partialPermissions: UserPermissions = {
+  saveDraft: true,
+  publish: false,
+};
+
+export const fullPermissions: UserPermissions = {
+  saveDraft: true,
+  publish: true,
+};
+
+export const getUserPermissions = (
   user: Omit<User, 'algoliaApiKey'> | UserResponse | null,
   entity: 'teams' | 'workingGroups',
   entityIds: string[],
-): UserPermissionsLevel => {
+): UserPermissions => {
   if (user === null) {
-    return 'None';
+    return noPermissions;
   }
 
   if (user.role === 'Staff') {
-    return 'Admin';
+    return fullPermissions;
   }
 
   const isUserProjectManager = user[entity].some(
@@ -21,7 +36,7 @@ export const getUserPermissionLevel = (
   );
 
   if (isUserProjectManager) {
-    return 'Admin';
+    return fullPermissions;
   }
 
   const isUserMember = user[entity].some((teamOrWorkingGroup) =>
@@ -29,23 +44,8 @@ export const getUserPermissionLevel = (
   );
 
   if (isUserMember) {
-    return 'Member';
+    return partialPermissions;
   }
 
-  return 'None';
-};
-
-export const hasCreateUpdateResearchOutputPermissions = (
-  userPermissionLevel: UserPermissionsLevel,
-  publish: boolean,
-): boolean => {
-  if (userPermissionLevel === 'Admin') {
-    return true;
-  }
-
-  if (userPermissionLevel === 'Member') {
-    return !publish;
-  }
-
-  return false;
+  return noPermissions;
 };

--- a/packages/validation/test/permissions/research-output.test.ts
+++ b/packages/validation/test/permissions/research-output.test.ts
@@ -1,399 +1,120 @@
+import { createUserResponse } from '@asap-hub/fixtures';
+import { UserResponse } from '@asap-hub/model';
 import {
-  hasCreateUpdateResearchOutputPermissions,
-  hasWorkingGroupsCreateUpdateResearchOutputPermissions,
-  isUserProjectManagerOfTeams,
-  isUserProjectManagerOfWorkingGroups,
+  fullPermissions,
   getUserPermissions,
   noPermissions,
+  partialPermissions,
 } from '../../src/permissions/research-output';
-import {
-  createResearchOutputResponse,
-  createUserResponse,
-  createWorkingGroupResponse,
-} from '@asap-hub/fixtures';
 
-describe('hasCreateUpdateResearchOutputPermissions', () => {
-  test('Should not have permissions when there are no teams assigned to the user', () => {
-    expect(
-      hasCreateUpdateResearchOutputPermissions(
-        {
-          ...createUserResponse(),
-          teams: [],
-        },
-        ['team-1', 'team-2'],
-      ),
-    ).toEqual(false);
-  });
-
-  test('Should have the permission when the user has a Project Manager role inside the team that this resource belongs to', () => {
-    expect(
-      hasCreateUpdateResearchOutputPermissions(
-        {
-          ...createUserResponse(),
-          teams: [
-            {
-              id: 'team-1',
-              role: 'Lead PI (Core Leadership)',
-              displayName: 'Team A',
-              proposal: 'proposalId1',
-            },
-          ],
-        },
-        ['team-1', 'team-2'],
-      ),
-    ).toEqual(false);
-  });
-
-  test('Should have the permission when the user has a Project Manager role inside the team that this resource belongs to', () => {
-    expect(
-      hasCreateUpdateResearchOutputPermissions(
-        {
-          ...createUserResponse(),
-          teams: [
-            {
-              id: 'team-1',
-              role: 'Project Manager',
-              displayName: 'Team A',
-              proposal: 'proposalId1',
-            },
-          ],
-        },
-        ['team-1', 'team-2'],
-      ),
-    ).toEqual(true);
-  });
-
-  test('Should have the permissions when the user has a Staff role in any team', () => {
-    expect(
-      hasCreateUpdateResearchOutputPermissions(
-        {
-          ...createUserResponse(),
-          teams: [
-            {
-              id: 'team-id-3',
-              role: 'ASAP Staff',
-              displayName: 'Team A',
-              proposal: 'proposalId1',
-            },
-          ],
-        },
-        ['team-1', 'team-2'],
-      ),
-    ).toEqual(true);
-  });
-});
-
-describe('hasWorkingGroupsCreateUpdateResearchOutputPermissions', () => {
-  test('Should not have permissions when there is no working group', () => {
-    expect(
-      hasWorkingGroupsCreateUpdateResearchOutputPermissions(
-        {
-          ...createUserResponse(),
-          teams: [],
-        },
-        undefined,
-      ),
-    ).toEqual(false);
-  });
-
-  test('Should have the permission when the user has a Project Manager role inside the working group', () => {
-    expect(
-      hasWorkingGroupsCreateUpdateResearchOutputPermissions(
-        {
-          ...createUserResponse(),
-          id: 'leader-1',
-        },
-        {
-          ...createWorkingGroupResponse({}),
-          leaders: [
-            {
-              user: {
-                ...createUserResponse(),
-                id: 'leader-1',
-              },
-              role: 'Project Manager',
-              workstreamRole: 'Project Manager',
-            },
-          ],
-        },
-      ),
-    ).toEqual(true);
-  });
-
-  test('Should not have the permission when the user has a role that differs from Project Manager', () => {
-    expect(
-      hasWorkingGroupsCreateUpdateResearchOutputPermissions(
-        {
-          ...createUserResponse(),
-          id: 'leader-1',
-        },
-        {
-          ...createWorkingGroupResponse({}),
-          leaders: [
-            {
-              user: {
-                ...createUserResponse(),
-                id: 'not-leader-1',
-              },
-              role: 'Chair',
-              workstreamRole: 'not a project manager',
-            },
-          ],
-        },
-      ),
-    ).toEqual(false);
-  });
-});
-
-describe('getUserPermissions', () => {
+describe.each`
+  entity             | entityId
+  ${'teams'}         | ${'team-id'}
+  ${'workingGroups'} | ${'working-group-id'}
+`('getUserPermissions - $entity', ({ entity, entityId }) => {
   test('Should not have permissions when there is no user data', () => {
-    expect(getUserPermissions(null, createResearchOutputResponse())).toEqual(
-      noPermissions,
-    );
+    expect(getUserPermissions(null, entity, [entityId])).toEqual(noPermissions);
   });
-  test('Should not have permissions when there is no research output data', () => {
-    expect(getUserPermissions(createUserResponse(), undefined)).toEqual(
-      noPermissions,
-    );
-  });
-  test('Should not have permission if the user is not a project manager or asap staff', () => {
-    expect(
-      getUserPermissions(
-        {
-          ...createUserResponse(),
-          teams: [
-            {
-              id: 'team-id-3',
-              role: 'Project Manager',
-              displayName: 'Team A',
-              proposal: 'proposalId1',
-            },
-          ],
-          workingGroups: [
-            {
-              id: 'wg-1',
-              role: 'Member',
-              active: true,
-              name: 'wg A',
-            },
-          ],
-        },
-        {
-          ...createResearchOutputResponse(),
-          teams: [{ id: 'team-id-3', displayName: 'Team A' }],
-          workingGroups: [{ id: 'wg-1', title: 'wg A' }],
-        },
-      ),
-    ).toEqual(noPermissions);
-  });
-  test('Should have permission if the user is a project manager on a team', () => {
-    expect(
-      getUserPermissions(
-        {
-          ...createUserResponse(),
-          teams: [
-            {
-              id: 'team-id-3',
-              role: 'Project Manager',
-              displayName: 'Team A',
-              proposal: 'proposalId1',
-            },
-          ],
-        },
-        {
-          ...createResearchOutputResponse(),
-          teams: [{ id: 'team-id-3', displayName: 'Team A' }],
-          workingGroups: undefined,
-        },
-      ),
-    ).toEqual({
-      createDraft: true,
-      editDraft: true,
-      publishDraft: true,
-      editPublished: true,
-    });
-  });
-  test('Should have permission if the user is a project manager on a working groups', () => {
-    expect(
-      getUserPermissions(
-        {
-          ...createUserResponse(),
-          workingGroups: [
-            {
-              id: 'wg-1',
-              role: 'Project Manager',
-              active: true,
-              name: 'wg A',
-            },
-          ],
-        },
-        {
-          ...createResearchOutputResponse(),
-          workingGroups: [{ id: 'wg-1', title: 'wg A' }],
-        },
-      ),
-    ).toEqual({
-      createDraft: true,
-      editDraft: true,
-      publishDraft: true,
-      editPublished: true,
-    });
-  });
-  test('Should have permission if the user is asap staff', () => {
-    expect(
-      getUserPermissions(
-        {
-          ...createUserResponse(),
-          role: 'Staff',
-          teams: [
-            {
-              id: 'team-id-3',
-              role: 'Key Personnel',
-              displayName: 'Team A',
-              proposal: 'proposalId1',
-            },
-          ],
-        },
-        {
-          ...createResearchOutputResponse(),
-          teams: [{ id: 'team-id-3', displayName: 'Team A' }],
-        },
-      ),
-    ).toEqual({
-      createDraft: true,
-      editDraft: true,
-      publishDraft: true,
-      editPublished: true,
-    });
-  });
-});
 
-describe('isUserProjectManagerOfTeams', () => {
-  test('Should not have permissions when there are no teams assigned to the user', () => {
-    expect(
-      isUserProjectManagerOfTeams(
-        {
-          ...createUserResponse(),
-          teams: [],
-        },
-        [
-          {
-            id: 'team-1',
-            displayName: 'Team A',
-          },
-        ],
-      ),
-    ).toEqual(false);
-  });
-  test('Should not have permissions when the user is not a PM', () => {
-    expect(
-      isUserProjectManagerOfTeams(
-        {
-          ...createUserResponse(),
-          teams: [
-            {
-              id: 'team-1',
-              role: 'Key Personnel',
-              displayName: 'Team A',
-              proposal: 'proposalId1',
-            },
-          ],
-        },
-        [
-          {
-            id: 'team-1',
-            displayName: 'Team A',
-          },
-        ],
-      ),
-    ).toEqual(false);
-  });
-  test('Should have the permission when the user has a Project Manager role inside the team', () => {
-    expect(
-      isUserProjectManagerOfTeams(
-        {
-          ...createUserResponse(),
-          teams: [
-            {
-              id: 'team-1',
-              role: 'Project Manager',
-              displayName: 'Team A',
-              proposal: 'proposalId1',
-            },
-          ],
-        },
-        [
-          {
-            id: 'team-1',
-            displayName: 'Team A',
-          },
-        ],
-      ),
-    ).toEqual(true);
-  });
-});
+  describe('when asap-hub role is staff', () => {
+    const staffUser: UserResponse = {
+      ...createUserResponse(),
+      role: 'Staff',
+    };
 
-describe('isUserProjectManagerOfWorkingGroups', () => {
-  test('Should not have permissions when there are no working groups assigned to the user', () => {
-    expect(
-      isUserProjectManagerOfWorkingGroups(
-        {
-          ...createUserResponse(),
-          workingGroups: [],
-        },
-        [
-          {
-            id: 'WG-1',
-            title: 'WG A',
-          },
-        ],
-      ),
-    ).toEqual(false);
+    test('Should have full permission', () => {
+      expect(getUserPermissions(staffUser, entity, [entityId])).toEqual(
+        fullPermissions,
+      );
+    });
   });
-  test('Should not have permissions when the user is not a PM', () => {
-    expect(
-      isUserProjectManagerOfWorkingGroups(
-        {
-          ...createUserResponse(),
-          workingGroups: [
-            {
-              id: 'wg-1',
-              role: 'Member',
-              active: true,
-              name: 'wg A',
-            },
-          ],
-        },
-        [
+
+  describe('when asap-hub role is not staff', () => {
+    const nonStaffUser: UserResponse = {
+      ...createUserResponse(),
+      role: 'Grantee',
+    };
+
+    test('Should not have permissions when there is no entity ids', () => {
+      expect(getUserPermissions(nonStaffUser, entity, [])).toEqual(
+        noPermissions,
+      );
+    });
+
+    test(`Should not have permissions if the user does not belong to the ${entity} and it is not a PM`, () => {
+      expect(
+        getUserPermissions(
           {
-            id: 'wg-1',
-            title: 'wg A',
+            ...nonStaffUser,
+            [entity]: [
+              {
+                ...nonStaffUser[entity][0],
+                id: 'entityId',
+                role: 'Member',
+              },
+            ],
           },
-        ],
-      ),
-    ).toEqual(false);
-  });
-  test('Should have the permission when the user has a Project Manager role inside the working group', () => {
-    expect(
-      isUserProjectManagerOfWorkingGroups(
-        {
-          ...createUserResponse(),
-          workingGroups: [
-            {
-              id: 'wg-1',
-              role: 'Project Manager',
-              name: 'wg A',
-              active: true,
-            },
-          ],
-        },
-        [
+          entity,
+          ['do-not-belong'],
+        ),
+      ).toEqual(noPermissions);
+    });
+
+    test(`Should not have permissions if the user does not belong to the ${entity} and it is a PM`, () => {
+      expect(
+        getUserPermissions(
           {
-            id: 'wg-1',
-            title: 'wg A',
+            ...nonStaffUser,
+            [entity]: [
+              {
+                ...nonStaffUser[entity][0],
+                id: 'entityId',
+                role: 'Project Manager',
+              },
+            ],
           },
-        ],
-      ),
-    ).toEqual(true);
+          entity,
+          ['do-not-belong'],
+        ),
+      ).toEqual(noPermissions);
+    });
+
+    test(`Should have partial permissions if the user is not a project manager but belongs to ${entity}`, () => {
+      expect(
+        getUserPermissions(
+          {
+            ...nonStaffUser,
+            [entity]: [
+              {
+                ...nonStaffUser[entity][0],
+                id: entityId,
+                role: 'Member',
+              },
+            ],
+          },
+          entity,
+          [entityId],
+        ),
+      ).toEqual(partialPermissions);
+    });
+
+    test(`Should have full permission if the user is a project manager of the ${entity}`, () => {
+      expect(
+        getUserPermissions(
+          {
+            ...nonStaffUser,
+            [entity]: [
+              {
+                ...nonStaffUser[entity][0],
+                id: entityId,
+                role: 'Project Manager',
+              },
+            ],
+          },
+          entity,
+          [entityId],
+        ),
+      ).toEqual(fullPermissions);
+    });
   });
 });

--- a/packages/validation/test/permissions/research-output.test.ts
+++ b/packages/validation/test/permissions/research-output.test.ts
@@ -80,6 +80,10 @@ describe.each`
       ),
     ).toEqual('None');
   });
+
+  test(`returns None when user data is null`, () => {
+    expect(getUserRole(null, association, [associationId])).toEqual('None');
+  });
 });
 
 describe('hasShareResearchOutputPermission', () => {

--- a/packages/validation/tsconfig.json
+++ b/packages/validation/tsconfig.json
@@ -8,6 +8,7 @@
   "references": [
     { "path": "../../packages/auth" },
     { "path": "../../packages/model" },
-    { "path": "../../packages/fixtures" }
+    { "path": "../../packages/fixtures" },
+    { "path": "../../packages/flags" }
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -775,7 +775,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@asap-hub/flags@workspace:*, @asap-hub/flags@workspace:packages/flags":
+"@asap-hub/flags@workspace:*, @asap-hub/flags@workspace:^, @asap-hub/flags@workspace:packages/flags":
   version: 0.0.0-use.local
   resolution: "@asap-hub/flags@workspace:packages/flags"
   dependencies:
@@ -1487,6 +1487,7 @@ __metadata:
     "@asap-hub/auth": "workspace:*"
     "@asap-hub/eslint-config-asap-hub": "workspace:*"
     "@asap-hub/fixtures": "workspace:*"
+    "@asap-hub/flags": "workspace:^"
     "@asap-hub/model": "workspace:*"
     "@babel/runtime-corejs3": 7.21.0
   languageName: unknown

--- a/yarn.lock
+++ b/yarn.lock
@@ -1266,6 +1266,8 @@ __metadata:
     "@asap-hub/dom-test-utils": "workspace:*"
     "@asap-hub/eslint-config-asap-hub": "workspace:*"
     "@asap-hub/flags": "workspace:*"
+    "@asap-hub/model": "workspace:*"
+    "@asap-hub/validation": "workspace:*"
     "@babel/core": 7.21.0
     "@babel/preset-react": 7.18.6
     "@babel/runtime-corejs3": 7.21.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -775,7 +775,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@asap-hub/flags@workspace:*, @asap-hub/flags@workspace:^, @asap-hub/flags@workspace:packages/flags":
+"@asap-hub/flags@workspace:*, @asap-hub/flags@workspace:packages/flags":
   version: 0.0.0-use.local
   resolution: "@asap-hub/flags@workspace:packages/flags"
   dependencies:
@@ -1487,7 +1487,7 @@ __metadata:
     "@asap-hub/auth": "workspace:*"
     "@asap-hub/eslint-config-asap-hub": "workspace:*"
     "@asap-hub/fixtures": "workspace:*"
-    "@asap-hub/flags": "workspace:^"
+    "@asap-hub/flags": "workspace:*"
     "@asap-hub/model": "workspace:*"
     "@babel/runtime-corejs3": 7.21.0
   languageName: unknown


### PR DESCRIPTION
Jira ticket: https://asaphub.atlassian.net/browse/CRN-792

---

This PR:

#### Refactors and unifies the logic of permissions in [permissions/research-output.ts](https://github.com/yldio/asap-hub/pull/2667/files#diff-a2d2c48ee4a62b3c20507554b499f65dc16e6f96181a49c97a193640ebef232a)

The role permission now is handled by `getUserRole` and it was created 3 small functions to get the permissions: `hasShareResearchOutputPermission`, `hasEditResearchOutputPermission` and `hasPublishResearchOutputPermission`.

#### Makes it possible to submit a draft research output

In squidex, if we call the `create` method from the rest client passing `published` as `false` it creates the entry as draft. So some files were changed in order to be able to pass this `published` value as false.

In the backend:
- Data Provider: [research-outputs.data-provider.ts](https://github.com/yldio/asap-hub/pull/2667/files#diff-335d39a6d3239d2e50e6d49644deed3e455234cd469fe6a10c150aaf6fb6d55b)
- Controller: [controllers/research-outputs.ts](https://github.com/yldio/asap-hub/pull/2667/files#diff-0844f18f1195226c257bc5b66c57d291c8724b24d84daa78559542734e2be16d)
- Routes: [research-outputs.route.ts](https://github.com/yldio/asap-hub/pull/2667/files#diff-3e0d42e033394d10aea4f686a57853792c297de218f3d6953a843a4bb92ea63a)

In the frontend:
- Create and edit requests to backend in api.ts: [api.ts](https://github.com/yldio/asap-hub/pull/2667/files#diff-0392bae59e98156dbdeb1a6c8282988298487d7a608550327976e9dfc2d43190)
- Functions that pass `published` as props to be linked to `Save`/`Publish` or `Save Draft` buttons: [TeamOutput.tsx](https://github.com/yldio/asap-hub/pull/2667/files#diff-d5a475e3660bbdce7b7935b0ec9ef76091eceb2fe44e3ffb47a20654f4ec5620) and [WorkingGroupOutput.tsx](https://github.com/yldio/asap-hub/pull/2667/files#diff-f7fbc1c6db856f0b7fc204ce0a5d6ed5fb32a6ed896ec53c82fc6ae79e510481)

#### Makes Share an Output and Edit buttons visible by team/wg members behind a feature flag

- Share an Output button: [WorkingGroupPageHeader.tsx](https://github.com/yldio/asap-hub/pull/2667/files#diff-5eb46f54f93b38fd5ec9982f0a550b480fb6e58361d5bf8defbf6d0935fce8b3) and [TeamProfileHeader.tsx](https://github.com/yldio/asap-hub/pull/2667/files#diff-46d379951376a2e3edc84f65ba24113afee04c2dd13f0e956d48ce359d93b963)
- Edit button: [SharedResearchOutput.tsx](https://github.com/yldio/asap-hub/pull/2667/files#diff-941f382146f83a4f7dfda62eff635275030346a7f17846770572dd7b76aba2b4)


#### Displays form buttons accordingly to permissions and research output status

To do that, it was introduced a `published` field in the research output model [packages/model/src/research-output.ts](https://github.com/yldio/asap-hub/pull/2667/files#diff-20e35ac4b9b198b232ec54b753925d8b9c4a3825d1ef24e44bd553586b68b241). That currently **is not** being retrieved properly from the backend, it is hardcoded now, the requirement to bring draft from the backend is not part of this ticket, so this was not added.
 
<img width="1078" alt="Screenshot 2023-02-28 at 12 34 20" src="https://user-images.githubusercontent.com/16595804/221901668-6bb4cf8f-49c7-40bd-b63e-536e2ae9012b.png">

---

#### Note

If you click Save Draft it will give an error for now because right after saving the RO, it fetches the same RO but since it is a draft, it can’t be found yet. The part of fetching draft is part of another ticket. But you can still verify that the draft was created in squidex.