### PR TITLE
CRN-1333 Fix Heading style errors

### DIFF
--- a/packages/react-components/src/__tests__/text.test.ts
+++ b/packages/react-components/src/__tests__/text.test.ts
@@ -74,7 +74,6 @@ describe.each([
   [{}],
   [Symbol('Forbidden primitive type')],
   [createElement('div')],
-  [createElement('b')],
   [createElement('i', { children: [createElement('div')] })],
   [createElement(Fragment, { children: {} })],
 ])('for the children %p', (children) => {

--- a/packages/react-components/src/organisms/__tests__/RichText.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/RichText.test.tsx
@@ -87,25 +87,38 @@ it.each([
   expect(heading.tagName).toBe(expected);
 });
 
-it.each([1, 2, 3])(
-  'displays error when disallowed <h%i> styling applied',
-  (i) => {
-    const { container } = render(
-      <RichText text={`<h${i}><strong>heading</strong></h${i}>`} />,
+it.each`
+  heading | tag         | tagName
+  ${`1`}  | ${`b`}      | ${`B`}
+  ${`2`}  | ${`b`}      | ${`B`}
+  ${`3`}  | ${`b`}      | ${`B`}
+  ${`1`}  | ${`strong`} | ${`STRONG`}
+  ${`2`}  | ${`strong`} | ${`STRONG`}
+  ${`3`}  | ${`strong`} | ${`STRONG`}
+  ${`1`}  | ${`i`}      | ${`I`}
+  ${`2`}  | ${`i`}      | ${`I`}
+  ${`3`}  | ${`i`}      | ${`I`}
+  ${`1`}  | ${`em`}     | ${`EM`}
+  ${`2`}  | ${`em`}     | ${`EM`}
+  ${`3`}  | ${`em`}     | ${`EM`}
+`(
+  'displays heading <h$heading> with nested tag <$tag>',
+  ({ heading, tag, tagName }) => {
+    const { getByText } = render(
+      <RichText text={`<h${heading}><${tag}>heading</${tag}></h${heading}>`} />,
     );
-    expect(container.textContent).toContain(`Invalid h${i} heading styling`);
+    expect(getByText('heading').tagName).toEqual(tagName);
   },
 );
 
-it.each([1, 2, 3])(
-  'displays heading when allowed <h%i> styling applied',
-  (i) => {
-    const { getByText } = render(
-      <RichText text={`<h${i}><i>heading</i></h${i}>`} />,
-    );
-    expect(getByText('heading').tagName).toEqual('I');
-  },
-);
+it.each([1, 2, 3])('displays error when <h%i> has invalid nested tag', (i) => {
+  const { container } = render(
+    <RichText text={`<h${i}><ul>heading</ul></h${i}>`} />,
+  );
+  expect(container.textContent).toContain(
+    `Styling Error Invalid h${i} heading styling`,
+  );
+});
 
 it('passes through image props', () => {
   const { getByRole } = render(<RichText text={'<img width="100%" />'} />);

--- a/packages/react-components/src/text.ts
+++ b/packages/react-components/src/text.ts
@@ -41,7 +41,7 @@ const isAllowedElement = (child: unknown): child is AllowedElement => {
     typeof child === 'object' &&
     isValidElement(child) &&
     typeof child.type === 'string' &&
-    ['i', 'em'].includes(child.type.toLowerCase())
+    ['i', 'em', 'b', 'strong'].includes(child.type.toLowerCase())
   )
     return true;
   return false;


### PR DESCRIPTION
RichText did not support nested `<b>` inside headings 1,2,3 the way it comes from contentful

![Screenshot 2023-03-03 at 08 16 35](https://user-images.githubusercontent.com/16595804/222711761-dca7d8bf-1bf8-4517-acba-d2653001ee2c.png)

---

After the fix

![Screenshot 2023-03-03 at 08 41 27](https://user-images.githubusercontent.com/16595804/222711817-761d91d7-841e-4347-9996-256025bb2a88.png)

