### PR TITLE
CRN-1337 RichText component renders underline

### DIFF
--- a/packages/react-components/src/organisms/RichText.tsx
+++ b/packages/react-components/src/organisms/RichText.tsx
@@ -197,6 +197,7 @@ const RichText: React.FC<RichTextProps | PoorTextProps> = ({
           'sup',
           'i',
           'b',
+          'u',
           // lists with default UA styling
           'ul',
           'ol',

--- a/packages/react-components/src/organisms/__tests__/RichText.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/RichText.test.tsx
@@ -7,6 +7,11 @@ it('renders <p> as a paragraph', () => {
   expect(getByText('text').tagName).toBe('P');
 });
 
+it('renders <u> as a underline', () => {
+  const { getByText } = render(<RichText text={'<p><u>underline</u></p>'} />);
+  expect(getByText('underline').tagName).toBe('U');
+});
+
 it('renders <iframe>', () => {
   const { getByTitle } = render(
     <RichText text={'<iframe title="Some Frame" />'} />,


### PR DESCRIPTION
![Screenshot 2023-03-03 at 12 47 46](https://user-images.githubusercontent.com/16595804/222764828-5c53a68f-cb13-4656-b364-5b68a2dffa9f.png)
