### PR TITLE
fix: Contentful Pages text field validation

### DIFF
--- a/packages/contentful/migrations/pages/20230307163242-text-enabled-node-types.js
+++ b/packages/contentful/migrations/pages/20230307163242-text-enabled-node-types.js
@@ -1,0 +1,189 @@
+module.exports.description = 'Change Pages text field validation';
+
+module.exports.up = (migration) => {
+  const pages = migration.editContentType('pages');
+
+  pages
+    .editField('text')
+    .validations([
+      {
+        enabledMarks: [
+          'bold',
+          'italic',
+          'underline',
+          'code',
+          'superscript',
+          'subscript',
+        ],
+        message:
+          'Only bold, italic, underline, code, superscript, and subscript marks are allowed',
+      },
+      {
+        enabledNodeTypes: [
+          'heading-1',
+          'heading-2',
+          'heading-3',
+          'heading-4',
+          'heading-5',
+          'heading-6',
+          'ordered-list',
+          'unordered-list',
+          'hr',
+          'blockquote',
+          'table',
+          'hyperlink',
+          'entry-hyperlink',
+          'asset-hyperlink',
+          'embedded-entry-block',
+          'embedded-entry-inline',
+          'embedded-asset-block',
+        ],
+
+        message:
+          'Only heading 1, heading 2, heading 3, heading 4, heading 5, heading 6, ordered list, unordered list, horizontal rule, quote, table, link to Url, link to entry, link to asset, block entry, inline entry, and asset nodes are allowed',
+      },
+      {
+        nodes: {
+          'asset-hyperlink': [
+            {
+              size: {
+                max: 10,
+              },
+
+              message: null,
+            },
+          ],
+
+          'embedded-asset-block': [
+            {
+              size: {
+                max: 7,
+              },
+
+              message: null,
+            },
+          ],
+
+          'embedded-entry-block': [
+            {
+              size: {
+                max: 7,
+              },
+
+              message: null,
+            },
+          ],
+
+          'embedded-entry-inline': [
+            {
+              size: {
+                max: 10,
+              },
+
+              message: null,
+            },
+          ],
+
+          'entry-hyperlink': [
+            {
+              size: {
+                max: 8,
+              },
+
+              message: null,
+            },
+          ],
+        },
+      },
+    ])
+    .disabled(false)
+    .omitted(false);
+};
+
+module.exports.down = (migration) => {
+  const pages = migration.editContentType('pages');
+  pages
+    .editField('text')
+    .validations([
+      {
+        enabledMarks: ['bold', 'italic', 'underline', 'code'],
+        message: 'Only bold, italic, underline, and code marks are allowed',
+      },
+      {
+        enabledNodeTypes: [
+          'heading-1',
+          'heading-2',
+          'heading-3',
+          'heading-4',
+          'heading-5',
+          'heading-6',
+          'ordered-list',
+          'unordered-list',
+          'hr',
+          'blockquote',
+          'table',
+          'hyperlink',
+          'entry-hyperlink',
+          'asset-hyperlink',
+        ],
+
+        message:
+          'Only heading 1, heading 2, heading 3, heading 4, heading 5, heading 6, ordered list, unordered list, horizontal rule, quote, table, link to Url, link to entry, and link to asset nodes are allowed',
+      },
+      {
+        nodes: {
+          'asset-hyperlink': [
+            {
+              size: {
+                max: 10,
+              },
+
+              message: null,
+            },
+          ],
+
+          'embedded-asset-block': [
+            {
+              size: {
+                max: 7,
+              },
+
+              message: null,
+            },
+          ],
+
+          'embedded-entry-block': [
+            {
+              size: {
+                max: 7,
+              },
+
+              message: null,
+            },
+          ],
+
+          'embedded-entry-inline': [
+            {
+              size: {
+                max: 10,
+              },
+
+              message: null,
+            },
+          ],
+
+          'entry-hyperlink': [
+            {
+              size: {
+                max: 8,
+              },
+
+              message: null,
+            },
+          ],
+        },
+      },
+    ])
+    .disabled(false)
+    .omitted(false);
+};

--- a/packages/contentful/migrations/pages/20230307163242-text-enabled-node-types.js
+++ b/packages/contentful/migrations/pages/20230307163242-text-enabled-node-types.js
@@ -7,16 +7,8 @@ module.exports.up = (migration) => {
     .editField('text')
     .validations([
       {
-        enabledMarks: [
-          'bold',
-          'italic',
-          'underline',
-          'code',
-          'superscript',
-          'subscript',
-        ],
-        message:
-          'Only bold, italic, underline, code, superscript, and subscript marks are allowed',
+        enabledMarks: ['bold', 'italic', 'underline', 'code'],
+        message: 'Only bold, italic, underline, code marks are allowed',
       },
       {
         enabledNodeTypes: [


### PR DESCRIPTION
In the last squidex-contentful migration run (https://github.com/yldio/asap-hub/actions/runs/4354930475/jobs/7612848718#step:6:777)

![ga-actions](https://user-images.githubusercontent.com/16595804/223488944-8f62e7b3-8e97-4dfc-bc6a-3fc0c59e5e95.png)

The page with id `77ac91b8-6919-4157-b461-aa404e44a3c3` could not be published. Taking a look at Contentful

![error](https://user-images.githubusercontent.com/16595804/223489092-ea1732d9-20f5-4271-acd7-ce13b7cdc7d9.png)

I could see that the text was there but there was a validation problem. Looking at the Page schema in `Production` I saw that embeds were not allowed, that was causing the validation problem.

![embeds](https://user-images.githubusercontent.com/16595804/223489343-ae8f131b-68d4-4df0-bf25-752666c09a90.png)

So this PR adds a migration to add 

```
          'embedded-entry-block',
          'embedded-entry-inline',
          'embedded-asset-block',
```

to `enabledNodeTypes`.