### PR TITLE
fix: Empty links in Contentful News

### DIFF
--- a/packages/cms-data-sync/src/news/news.data-migration.ts
+++ b/packages/cms-data-sync/src/news/news.data-migration.ts
@@ -48,7 +48,7 @@ export const migrateNews = async () => {
       title: title!,
       shortText,
       frequency: frequency || 'News Articles',
-      link: link!,
+      link: link?.length ? link : null,
       linkText: linkText!,
       text: null as Document | null,
       thumbnail: thumbnail?.length

--- a/packages/cms-data-sync/test/news/news.data-migration.test.ts
+++ b/packages/cms-data-sync/test/news/news.data-migration.test.ts
@@ -122,7 +122,7 @@ describe('Migrate news', () => {
         {
           fields: {
             frequency: { 'en-US': 'News Articles' },
-            link: { 'en-US': undefined },
+            link: { 'en-US': null },
             linkText: { 'en-US': undefined },
             shortText: { 'en-US': undefined },
             text: { 'en-US': null },
@@ -162,7 +162,7 @@ describe('Migrate news', () => {
         {
           fields: {
             frequency: { 'en-US': 'News Articles' },
-            link: { 'en-US': undefined },
+            link: { 'en-US': null },
             linkText: { 'en-US': undefined },
             shortText: { 'en-US': undefined },
             text: { 'en-US': null },
@@ -217,10 +217,43 @@ describe('Migrate news', () => {
         {
           fields: {
             frequency: { 'en-US': 'News Articles' },
-            link: { 'en-US': undefined },
+            link: { 'en-US': null },
             linkText: { 'en-US': undefined },
             shortText: { 'en-US': undefined },
             text: { 'en-US': textDocument },
+            thumbnail: { 'en-US': null },
+            title: { 'en-US': 'news' },
+            publishDate: { 'en-US': undefined },
+          },
+        },
+      );
+    });
+
+    it('for a news that contains empty string in link', async () => {
+      squidexGraphqlClientMock.request.mockResolvedValueOnce({
+        queryNewsAndEventsContents: [
+          {
+            id: 'news-1',
+            flatData: {
+              title: 'news',
+              link: '',
+            },
+          },
+        ],
+      });
+
+      await migrateNews();
+
+      expect(contenfulEnv.createEntryWithId).toHaveBeenCalledWith(
+        'news',
+        'news-1',
+        {
+          fields: {
+            frequency: { 'en-US': 'News Articles' },
+            link: { 'en-US': null },
+            linkText: { 'en-US': undefined },
+            shortText: { 'en-US': undefined },
+            text: { 'en-US': null },
             thumbnail: { 'en-US': null },
             title: { 'en-US': 'news' },
             publishDate: { 'en-US': undefined },
@@ -262,7 +295,7 @@ describe('Migrate news', () => {
         {
           fields: {
             frequency: { 'en-US': 'News Articles' },
-            link: { 'en-US': undefined },
+            link: { 'en-US': null },
             linkText: { 'en-US': undefined },
             shortText: { 'en-US': undefined },
             text: { 'en-US': null },


### PR DESCRIPTION
In the last squidex-contentful migration, the news with id `77d9e32d-ce79-492b-8a9e-7bf4e6b3fe0b` (https://github.com/yldio/asap-hub/actions/runs/4354930475/jobs/7612848718#step:6:660) was not published with an error of invalid url

![Screenshot 2023-03-07 at 13 46 43 (2)](https://user-images.githubusercontent.com/16595804/223506581-629333e4-9381-4e84-aabc-9d1ec5527728.png)

I saw in Squidex that if I type something in `link` and then erase it, `link` value becomes `""` and this empty string is not valid.

<img width="1281" alt="Screenshot 2023-03-07 at 13 46 43" src="https://user-images.githubusercontent.com/16595804/223507151-d2466f77-48ef-4b04-bb83-f7c9b2621e2f.png">

So this PR makes link to be `null` when it is an empty string in squidex