### PR TITLE
fix: Save Draft type errors

### DIFF
--- a/packages/react-components/src/organisms/Form.tsx
+++ b/packages/react-components/src/organisms/Form.tsx
@@ -14,14 +14,14 @@ const styles = css({
 
 type FormProps<T> = {
   onSave: () => Promise<T | void>;
-  onSaveDraft: () => Promise<T | void>;
+  onSaveDraft?: () => Promise<T | void>;
   validate?: () => boolean;
   dirty: boolean; // mandatory so that it cannot be forgotten
   serverErrors?: ValidationErrorResponse['data'];
   children: (state: {
     isSaving: boolean;
     onSave: () => void | Promise<T | void>;
-    onSaveDraft: () => void | Promise<T | void>;
+    onSaveDraft?: () => void | Promise<T | void>;
     onCancel: () => void;
   }) => ReactNode;
 };
@@ -96,7 +96,9 @@ const Form = <T extends void | Record<string, unknown>>({
           onCancel,
           isSaving: status === 'isSaving',
           onSave: getWrappedOnSave(onSave),
-          onSaveDraft: getWrappedOnSave(onSaveDraft),
+          ...(onSaveDraft
+            ? { onSaveDraft: getWrappedOnSave(onSaveDraft) }
+            : {}),
         })}
       </form>
     </>

--- a/packages/react-components/src/organisms/__tests__/Form.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/Form.test.tsx
@@ -17,7 +17,6 @@ const props: ComponentProps<typeof Form> = {
   dirty: false,
   children: () => null,
   onSave: () => Promise.resolve(),
-  onSaveDraft: () => Promise.resolve(),
 };
 
 let getUserConfirmation!: jest.MockedFunction<
@@ -145,6 +144,26 @@ describe('when saving', () => {
       const { getByText } = render(
         <Form {...props} onSave={handleSave} dirty>
           {({ onSave: onSubmit }) => (
+            <>
+              <input type="text" required />
+              <Button primary onClick={onSubmit}>
+                save
+              </Button>
+            </>
+          )}
+        </Form>,
+        { wrapper: MemoryRouter },
+      );
+
+      userEvent.click(getByText(/^save/i));
+      expect(handleSave).not.toHaveBeenCalled();
+    });
+
+    it('does not call onSaveDraft', () => {
+      const handleSave = jest.fn();
+      const { getByText } = render(
+        <Form {...props} onSaveDraft={handleSave} dirty>
+          {({ onSaveDraft: onSubmit }) => (
             <>
               <input type="text" required />
               <Button primary onClick={onSubmit}>

--- a/packages/react-components/src/templates/ResearchOutputForm.tsx
+++ b/packages/react-components/src/templates/ResearchOutputForm.tsx
@@ -376,7 +376,7 @@ const ResearchOutputForm: React.FC<ResearchOutputFormProps> = ({
                 <Button enabled={!isSaving} fullWidth onClick={handleCancel}>
                   Cancel
                 </Button>
-                {showSaveDraftButton && (
+                {showSaveDraftButton && handleSaveDraft && (
                   <Button
                     enabled={!isSaving}
                     fullWidth


### PR DESCRIPTION
Making `onSaveDraft` optional as `packages/gp2-components/src/templates/OutputForm.tsx` does not require this props.

github error: https://github.com/yldio/asap-hub/actions/runs/4363587990/jobs/7629920136#step:6:109