### PR TITLE
Address unstable tests

### DIFF
--- a/apps/crn-frontend/src/network/users/__tests__/UserProfile.test.tsx
+++ b/apps/crn-frontend/src/network/users/__tests__/UserProfile.test.tsx
@@ -124,8 +124,9 @@ const renderUserProfile = async (
       </Suspense>
     </RecoilRoot>,
   );
-  await waitFor(() =>
-    expect(result.queryByText(/loading/i)).not.toBeInTheDocument(),
+  await waitFor(
+    () => expect(result.queryByText(/loading/i)).not.toBeInTheDocument(),
+    { timeout: 5000 },
   );
   return result;
 };

--- a/apps/crn-frontend/src/shared-research/__tests__/Routes.test.tsx
+++ b/apps/crn-frontend/src/shared-research/__tests__/Routes.test.tsx
@@ -35,8 +35,9 @@ const renderSharedResearchPage = async (pathname: string, query = '') => {
       </Suspense>
     </RecoilRoot>,
   );
-  await waitFor(() =>
-    expect(result.queryByText(/loading/i)).not.toBeInTheDocument(),
+  await waitFor(
+    () => expect(result.queryByText(/loading/i)).not.toBeInTheDocument(),
+    { timeout: 5000 },
   );
   return result;
 };

--- a/apps/crn-server/test/integration/research-outputs.integration-test.ts
+++ b/apps/crn-server/test/integration/research-outputs.integration-test.ts
@@ -16,6 +16,7 @@ import {
 import { getUserCreateDataObject } from '../fixtures/users.fixtures';
 import { UserSquidexDataProvider } from '../../src/data-providers/users.data-provider';
 import { teardownHelper } from '../helpers/teardown';
+import { retryable } from '../helpers/retryable';
 
 const chance = new Chance();
 const squidexGraphqlClient = new SquidexGraphql(getAuthToken, {
@@ -83,16 +84,20 @@ describe('Research Outputs', () => {
       researchOutputInput,
     );
 
-    const result = await researchOutputDataProvider.fetchById(researchOutputId);
+    await retryable(async () => {
+      const result = await researchOutputDataProvider.fetchById(
+        researchOutputId,
+      );
 
-    const expectedResult = getResearchOutputDataObject();
-    expectedResult.title = randomTitle;
-    expect(result).toEqual(
-      expect.objectContaining({
-        id: researchOutputId,
-        title: randomTitle,
-        link: researchOutputInput.link,
-      }),
-    );
+      const expectedResult = getResearchOutputDataObject();
+      expectedResult.title = randomTitle;
+      expect(result).toEqual(
+        expect.objectContaining({
+          id: researchOutputId,
+          title: randomTitle,
+          link: researchOutputInput.link,
+        }),
+      );
+    });
   });
 });

--- a/apps/crn-server/test/integration/teams.integration-test.ts
+++ b/apps/crn-server/test/integration/teams.integration-test.ts
@@ -8,6 +8,7 @@ import {
   getTeamDataObject,
 } from '../fixtures/teams.fixtures';
 import { teardownHelper } from '../helpers/teardown';
+import { retryable } from '../helpers/retryable';
 
 const chance = new Chance();
 const squidexGraphqlClient = new SquidexGraphql(getAuthToken, {
@@ -35,11 +36,13 @@ describe('Teams', () => {
     teamCreateDataObject.applicationNumber = chance.name();
 
     const id = await teamDataProvider.create(teamCreateDataObject);
-    const result = await teamDataProvider.fetchById(id);
-
     const { displayName, projectTitle } = getTeamDataObject();
-    expect(result).toEqual(
-      expect.objectContaining({ id, displayName, projectTitle }),
-    );
+
+    await retryable(async () => {
+      const result = await teamDataProvider.fetchById(id);
+      expect(result).toEqual(
+        expect.objectContaining({ id, displayName, projectTitle }),
+      );
+    });
   });
 });


### PR DESCRIPTION
* Add wait/retry to all integration tests. There is a race condition with Squidex in the integration tests that is resolved with a wait/retry in the reminders tests, and should have been applied to the remaining tests as well.
* Extend timeout for UserProfile setup. This is failing sporadically with loading elements still appearing. Increase the default timeout from 1000ms to 5000ms to try to reduce failures.