### PR TITLE
Remove inline timeout configuration for global config

### DIFF
--- a/apps/crn-frontend/extend-timeouts.js
+++ b/apps/crn-frontend/extend-timeouts.js
@@ -1,0 +1,2 @@
+import { configure } from '@testing-library/react';
+configure({ asyncUtilTimeout: 5000 });

--- a/apps/crn-frontend/jest.config.js
+++ b/apps/crn-frontend/jest.config.js
@@ -15,6 +15,7 @@ module.exports = {
     ...(setupFilesAfterEnv || []),
     require.resolve('../../jest/dom-extensions-setup-after-env.js'),
     require.resolve('./reset-recoil.js'),
+    require.resolve('./extend-timeouts.js'),
   ],
 
   transform: {

--- a/apps/crn-frontend/src/network/users/__tests__/UserProfile.test.tsx
+++ b/apps/crn-frontend/src/network/users/__tests__/UserProfile.test.tsx
@@ -124,9 +124,8 @@ const renderUserProfile = async (
       </Suspense>
     </RecoilRoot>,
   );
-  await waitFor(
-    () => expect(result.queryByText(/loading/i)).not.toBeInTheDocument(),
-    { timeout: 5000 },
+  await waitFor(() =>
+    expect(result.queryByText(/loading/i)).not.toBeInTheDocument(),
   );
   return result;
 };

--- a/apps/crn-frontend/src/shared-research/__tests__/Routes.test.tsx
+++ b/apps/crn-frontend/src/shared-research/__tests__/Routes.test.tsx
@@ -35,9 +35,8 @@ const renderSharedResearchPage = async (pathname: string, query = '') => {
       </Suspense>
     </RecoilRoot>,
   );
-  await waitFor(
-    () => expect(result.queryByText(/loading/i)).not.toBeInTheDocument(),
-    { timeout: 5000 },
+  await waitFor(() =>
+    expect(result.queryByText(/loading/i)).not.toBeInTheDocument(),
   );
   return result;
 };


### PR DESCRIPTION
The previous changes were to add longer timeouts for tests which had recently failed, but setting a global point of config should make all tests more reliable and avoid the need to add inline overrides when particular tests fail.