### PR TITLE
Improvement: move fetch in events integration test inside retry loop

### DIFF
--- a/apps/crn-server/test/integration/reminders.integration-test.ts
+++ b/apps/crn-server/test/integration/reminders.integration-test.ts
@@ -969,20 +969,20 @@ describe('Reminders', () => {
             '2022-09-26T08:00:00.0Z',
           ).toISOString(),
         });
-        const event = await eventDataProvider.fetchById(eventId);
-
-        const expectedReminder = {
-          id: `${material.toLowerCase()}-event-updated-${eventId}`,
-          entity: 'Event',
-          type: `${material} Updated`,
-          data: {
-            eventId,
-            title: event!.title,
-            [materialUpdatedAtName]: event![materialUpdatedAtName],
-          },
-        };
 
         await retryable(async () => {
+          const event = await eventDataProvider.fetchById(eventId);
+
+          const expectedReminder = {
+            id: `${material.toLowerCase()}-event-updated-${eventId}`,
+            entity: 'Event',
+            type: `${material} Updated`,
+            data: {
+              eventId,
+              title: event!.title,
+              [materialUpdatedAtName]: event![materialUpdatedAtName],
+            },
+          };
           const reminders = await reminderDataProvider.fetch(
             fetchRemindersOptions,
           );


### PR DESCRIPTION
This test was occasionally failing because the first fetch wasn't always returning results immediately. Move it inside the retry loop so that it can take a few seconds to resolve.