### PR TITLE
fix: algolia sync pipeline env var

### DIFF
--- a/.github/workflows/on-push-master.yml
+++ b/.github/workflows/on-push-master.yml
@@ -97,6 +97,7 @@ jobs:
     with:
       environment-name: Development
       crn-contentful-env: Development
+      contentful-environment-id: Development
       entity: all
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -145,6 +146,7 @@ jobs:
       environment-name: Production
       entity: all
       crn-contentful-env: Production
+      contentful-environment-id: Production
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
It's giving an error because it does not have the value of environment id

<img width="1417" alt="Screenshot 2023-03-27 at 11 21 27" src="https://user-images.githubusercontent.com/16595804/227969803-302f2e80-e2fe-4dbf-aa12-125c35207f2c.png">

which is passed as input in the on-demand sync action