### PR TITLE
fix(pipeline): algolia sync env var

### DIFF
--- a/.github/workflows/on-push-master.yml
+++ b/.github/workflows/on-push-master.yml
@@ -96,7 +96,6 @@ jobs:
     uses: ./.github/workflows/reusable-algolia-sync.yml
     with:
       environment-name: Development
-      crn-contentful-env: Development
       contentful-environment-id: Development
       entity: all
     secrets:
@@ -145,7 +144,6 @@ jobs:
     with:
       environment-name: Production
       entity: all
-      crn-contentful-env: Production
       contentful-environment-id: Production
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
This var was renamed here https://github.com/yldio/asap-hub/blame/0d224391c6f0bb59b6ce110af8c79842d2e0c16c/.github/workflows/reusable-algolia-sync.yml#L20
so this `crn-contentful-env` is not needed
<img width="1415" alt="Screenshot 2023-03-27 at 12 08 04" src="https://user-images.githubusercontent.com/16595804/227982164-083937ef-eda2-4a60-bc3a-82af9dc8dd26.png">
