### PR TITLE
Crn 1359 team outputs search bar is not accepting words

### DIFF
--- a/apps/crn-frontend/src/network/ProfileSwitch.tsx
+++ b/apps/crn-frontend/src/network/ProfileSwitch.tsx
@@ -1,4 +1,4 @@
-import { ComponentProps, FC, lazy } from 'react';
+import { ComponentProps, FC, lazy, ReactElement } from 'react';
 import { Switch, Route, Redirect } from 'react-router-dom';
 
 import { NoEvents } from '@asap-hub/react-components';
@@ -22,8 +22,8 @@ type ProfileSwitchProps = {
   displayName: string;
   eventConstraint: EventConstraint;
   isActive?: boolean;
-  Outputs?: FC;
-  DraftOutputs?: FC;
+  Outputs?: ReactElement;
+  DraftOutputs?: ReactElement;
   paths: Record<RequiredPaths, string> & Partial<Record<OptionalPaths, string>>;
   type: ComponentProps<typeof NoEvents>['type'];
   Workspace?: FC;
@@ -56,16 +56,12 @@ const ProfileSwitch: FC<ProfileSwitchProps> = ({
       )}
       {Outputs && (
         <Route path={paths.outputs}>
-          <SearchFrame title="Outputs">
-            <Outputs />
-          </SearchFrame>
+          <SearchFrame title="Outputs">{Outputs}</SearchFrame>
         </Route>
       )}
       {DraftOutputs && (
         <Route path={paths.draftOutputs}>
-          <SearchFrame title="Draft Outputs">
-            <DraftOutputs />
-          </SearchFrame>
+          <SearchFrame title="Draft Outputs">{DraftOutputs}</SearchFrame>
         </Route>
       )}
       {Workspace && (

--- a/apps/crn-frontend/src/network/teams/TeamProfile.tsx
+++ b/apps/crn-frontend/src/network/teams/TeamProfile.tsx
@@ -128,19 +128,19 @@ const TeamProfile: FC<TeamProfileProps> = ({ currentTime }) => {
               displayName={team.displayName}
               eventConstraint={{ teamId }}
               isActive={!team?.inactiveSince}
-              Outputs={() => (
+              Outputs={
                 <Outputs
                   userAssociationMember={canShareResearchOutput}
                   team={team}
                 />
-              )}
-              DraftOutputs={() => (
+              }
+              DraftOutputs={
                 <Outputs
                   team={team}
                   draftOutputs
                   userAssociationMember={canShareResearchOutput}
                 />
-              )}
+              }
               paths={paths}
               type="team"
               Workspace={() => (

--- a/apps/crn-frontend/src/network/teams/__tests__/TeamProfile.test.tsx
+++ b/apps/crn-frontend/src/network/teams/__tests__/TeamProfile.test.tsx
@@ -112,6 +112,25 @@ it('navigates to the outputs tab', async () => {
   expect(await screen.findByText(/Output 1/i)).toBeVisible();
 });
 
+it('navigates to the outputs tab and is able to search', async () => {
+  const mockGetResearchOutputs = getResearchOutputs as jest.MockedFunction<
+    typeof getResearchOutputs
+  >;
+  mockGetResearchOutputs.mockResolvedValue({
+    ...createResearchOutputListAlgoliaResponse(1),
+  });
+  await renderPage();
+
+  userEvent.click(screen.getByText(/outputs/i, { selector: 'nav *' }));
+  expect(await screen.findByText(/Output 1/i)).toBeVisible();
+  expect(await screen.findByRole('searchbox')).toHaveAttribute(
+    'placeholder',
+    'Enter a keyword, method, resource…',
+  );
+  userEvent.type(screen.getByRole('searchbox'), 'test');
+  expect(await screen.findByRole('searchbox')).toHaveAttribute('value', 'test');
+});
+
 it('navigates to the workspace tab', async () => {
   await renderPage({
     ...createTeamResponse(),

--- a/apps/crn-frontend/src/network/working-groups/WorkingGroupProfile.tsx
+++ b/apps/crn-frontend/src/network/working-groups/WorkingGroupProfile.tsx
@@ -133,23 +133,23 @@ const WorkingGroupProfile: FC<WorkingGroupProfileProps> = ({ currentTime }) => {
                   groupType="working"
                 />
               )}
-              DraftOutputs={() => (
+              DraftOutputs={
                 <Outputs
                   workingGroup={workingGroup}
                   draftOutputs
                   userAssociationMember={canShareResearchOutput}
                 />
-              )}
+              }
               currentTime={currentTime}
               displayName={workingGroup.title}
               eventConstraint={{ workingGroupId }}
               isActive={!workingGroup.complete}
-              Outputs={() => (
+              Outputs={
                 <Outputs
                   userAssociationMember={canShareResearchOutput}
                   workingGroup={workingGroup}
                 />
-              )}
+              }
               paths={paths}
               type="working group"
             />


### PR DESCRIPTION
Thank you @gabiayako for the help you provided.

This bug would have also applied to working group once we enabled the outputs search bar there.

I initially tried keeping the functionality of ProfileSwitch as unchanged as possible, tried wrapping the OutputsComponent in a useCallback hook but this resulted in code coverage issues since team and working group could be undefined yet it's not allowed to have them undefined in the Outputs component. @kmaid I tried passing the team to the hook but it would still re-render that way.
 Then I tried pulling them out of the Profile switch and just having the routs outside that component but it would mean having to control the Redirect.
