### PR TITLE
Improve Algolia search ranking & results

### DIFF
--- a/apps/asap-cli/package.json
+++ b/apps/asap-cli/package.json
@@ -7,6 +7,12 @@
     "node": "18.x"
   },
   "scripts": {
+    "algolia:delete-index": "ts-node src/cli.ts algolia:delete-index",
+    "algolia:clear-index": "ts-node src/cli.ts algolia:clear-index",
+    "algolia:get-settings": "ts-node src/cli.ts algolia:get-settings",
+    "algolia:move-index": "ts-node src/cli.ts algolia:move-index",
+    "algolia:remove-records": "ts-node src/cli.ts algolia:remove-records",
+    "algolia:set-settings": "ts-node src/cli.ts algolia:set-settings",
     "build:babel": "../../scripts/build-babel.sh build",
     "watch:babel": "../../scripts/build-babel.sh watch",
     "typecheck": "tsc"

--- a/apps/asap-cli/package.json
+++ b/apps/asap-cli/package.json
@@ -7,12 +7,12 @@
     "node": "18.x"
   },
   "scripts": {
-    "algolia:delete-index": "ts-node src/cli.ts algolia:delete-index",
-    "algolia:clear-index": "ts-node src/cli.ts algolia:clear-index",
-    "algolia:get-settings": "ts-node src/cli.ts algolia:get-settings",
-    "algolia:move-index": "ts-node src/cli.ts algolia:move-index",
-    "algolia:remove-records": "ts-node src/cli.ts algolia:remove-records",
-    "algolia:set-settings": "ts-node src/cli.ts algolia:set-settings",
+    "algolia:delete-index": "ts-node --transpile-only src/cli.ts algolia:delete-index",
+    "algolia:clear-index": "ts-node --transpile-only src/cli.ts algolia:clear-index",
+    "algolia:get-settings": "ts-node --transpile-only src/cli.ts algolia:get-settings",
+    "algolia:move-index": "ts-node --transpile-only src/cli.ts algolia:move-index",
+    "algolia:remove-records": "ts-node --transpile-only src/cli.ts algolia:remove-records",
+    "algolia:set-settings": "ts-node --transpile-only src/cli.ts algolia:set-settings",
     "build:babel": "../../scripts/build-babel.sh build",
     "watch:babel": "../../scripts/build-babel.sh watch",
     "typecheck": "tsc"

--- a/apps/crn-frontend/src/events/EventList.tsx
+++ b/apps/crn-frontend/src/events/EventList.tsx
@@ -41,7 +41,7 @@ const EventList: React.FC<EventListProps> = ({
 }) => {
   const { currentPage, pageSize } = usePaginationParams();
 
-  const { items, total } = useEvents(
+  const { items, total, algoliaIndexName, algoliaQueryId } = useEvents(
     getEventListOptions(currentTime, {
       past,
       searchQuery,
@@ -63,6 +63,8 @@ const EventList: React.FC<EventListProps> = ({
   const { numberOfPages, renderPageHref } = usePagination(total, pageSize);
   return (
     <EventsList
+      algoliaIndexName={algoliaIndexName}
+      algoliaQueryId={algoliaQueryId}
       currentPageIndex={currentPage}
       numberOfItems={total}
       renderPageHref={renderPageHref}

--- a/apps/crn-frontend/src/events/__tests__/EventList.test.tsx
+++ b/apps/crn-frontend/src/events/__tests__/EventList.test.tsx
@@ -90,3 +90,29 @@ it('sets before to an hour before date provided for past events', async () => {
     }),
   );
 });
+
+it('renders an algolia tagged result list and hit', async () => {
+  const events = createListEventResponse(1);
+  mockGetEvents.mockClear().mockResolvedValue({
+    ...events,
+    items: events.items.map((item) => ({ ...item, id: 'hitId' })),
+    algoliaIndexName: 'index',
+    algoliaQueryId: 'queryId',
+  });
+
+  const { container } = await renderEventsListPage(
+    '',
+    new Date('2020-01-01T12:00:00Z'),
+    true,
+  );
+  const resultListHtml = container.querySelector('*[data-insights-index]');
+  expect(resultListHtml?.getAttribute('data-insights-index')).toEqual('index');
+  const hitHtml = resultListHtml?.querySelector('*[data-insights-object-id]');
+  expect(hitHtml?.attributes).toMatchInlineSnapshot(`
+    NamedNodeMap {
+      "data-insights-object-id": "hitId",
+      "data-insights-position": "1",
+      "data-insights-query-id": "queryId",
+    }
+  `);
+});

--- a/apps/crn-frontend/src/events/api.ts
+++ b/apps/crn-frontend/src/events/api.ts
@@ -31,7 +31,12 @@ export const getEvents = async (
     !!before,
   );
 
-  return { items: result.hits, total: result.nbHits };
+  return {
+    items: result.hits,
+    total: result.nbHits,
+    algoliaIndexName: result.index,
+    algoliaQueryId: result.queryID,
+  };
 };
 
 export const getSquidexUrl = (options: GetEventListOptions): URL =>

--- a/apps/crn-frontend/src/events/state.ts
+++ b/apps/crn-frontend/src/events/state.ts
@@ -15,7 +15,14 @@ import { useAlgolia } from '../hooks/algolia';
 import { getEvent, getEvents } from './api';
 
 const eventIndexState = atomFamily<
-  { ids: ReadonlyArray<string>; total: number } | Error | undefined,
+  | {
+      ids: ReadonlyArray<string>;
+      total: number;
+      algoliaQueryId?: string;
+      algoliaIndexName?: string;
+    }
+  | Error
+  | undefined,
   GetEventListOptions
 >({
   key: 'eventIndex',
@@ -37,7 +44,12 @@ export const eventsState = selectorFamily<
         if (event === undefined) return undefined;
         events.push(event);
       }
-      return { total: index.total, items: events };
+      return {
+        total: index.total,
+        items: events,
+        algoliaIndexName: index.algoliaIndexName,
+        algoliaQueryId: index.algoliaQueryId,
+      };
     },
   set:
     (options) =>
@@ -55,6 +67,8 @@ export const eventsState = selectorFamily<
         set(eventIndexState(options), {
           total: newEvents.total,
           ids: newEvents.items.map((event) => event.id),
+          algoliaIndexName: newEvents.algoliaIndexName,
+          algoliaQueryId: newEvents.algoliaQueryId,
         });
       }
     },

--- a/apps/crn-frontend/src/hooks/__tests__/algolia.test.tsx
+++ b/apps/crn-frontend/src/hooks/__tests__/algolia.test.tsx
@@ -21,6 +21,16 @@ jest.mock('@asap-hub/algolia', () => {
     algoliaSearchClientFactory: mockAlgoliaSearchClientFactory,
   };
 });
+beforeEach(() => {
+  Object.defineProperty(window, 'dataLayer', {
+    configurable: true,
+    value: [],
+  });
+});
+afterEach(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  delete (window as any).dataLayer;
+});
 
 describe('useAlgolia', () => {
   it('throws when user is not provided', () => {
@@ -29,7 +39,7 @@ describe('useAlgolia', () => {
       new Error('Algolia unavailable while not logged in'),
     );
   });
-  it('constructs algolia client', async () => {
+  it('constructs algolia client linking GTM and Algolia with Auth0 user id', async () => {
     setCurrentOverrides({ CONTENTFUL: false });
 
     const { result, waitForNextUpdate } = renderHook(() => useAlgolia(), {
@@ -44,6 +54,14 @@ describe('useAlgolia', () => {
       ),
     });
     await waitForNextUpdate();
+
+    expect(window.dataLayer).toEqual(
+      expect.arrayContaining([
+        {
+          algoliaUserToken: 'usertoken',
+        },
+      ]),
+    );
     expect(mockAlgoliaSearchClientFactory).toHaveBeenCalledWith({
       algoliaIndex: ALGOLIA_INDEX,
       algoliaAppId: ALGOLIA_APP_ID,

--- a/apps/crn-frontend/src/hooks/__tests__/algolia.test.tsx
+++ b/apps/crn-frontend/src/hooks/__tests__/algolia.test.tsx
@@ -35,7 +35,9 @@ describe('useAlgolia', () => {
     const { result, waitForNextUpdate } = renderHook(() => useAlgolia(), {
       wrapper: ({ children }) => (
         <RecoilRoot>
-          <Auth0Provider user={{ algoliaApiKey: 'algolia key' }}>
+          <Auth0Provider
+            user={{ algoliaApiKey: 'algolia key', id: 'usertoken' }}
+          >
             <WhenReady>{children}</WhenReady>
           </Auth0Provider>
         </RecoilRoot>
@@ -46,6 +48,8 @@ describe('useAlgolia', () => {
       algoliaIndex: ALGOLIA_INDEX,
       algoliaAppId: ALGOLIA_APP_ID,
       algoliaApiKey: 'algolia key',
+      clickAnalytics: true,
+      userToken: 'usertoken',
     });
     expect(result.current.client).toBeDefined();
   });

--- a/apps/crn-frontend/src/hooks/algolia.ts
+++ b/apps/crn-frontend/src/hooks/algolia.ts
@@ -27,6 +27,9 @@ export const useAlgolia = () => {
       clickAnalytics: true,
       userToken: user.id,
     });
+    window.dataLayer?.push({
+      algoliaUserToken: user.id,
+    });
 
     return {
       client,

--- a/apps/crn-frontend/src/hooks/algolia.ts
+++ b/apps/crn-frontend/src/hooks/algolia.ts
@@ -24,6 +24,8 @@ export const useAlgolia = () => {
         (isEnabled('CONTENTFUL') && `${ALGOLIA_INDEX}-contentful`) ||
         ALGOLIA_INDEX,
       algoliaApiKey: user.algoliaApiKey,
+      clickAnalytics: true,
+      userToken: user.id,
     });
 
     return {

--- a/apps/crn-frontend/src/network/teams/Outputs.tsx
+++ b/apps/crn-frontend/src/network/teams/Outputs.tsx
@@ -120,6 +120,8 @@ const OutputsList: React.FC<OutputsListProps> = ({
         );
   return (
     <ProfileOutputs
+      algoliaIndexName={result.algoliaIndexName}
+      algoliaQueryId={result.algoliaQueryId}
       researchOutputs={result.items}
       exportResults={exportResults}
       numberOfItems={result.total}

--- a/apps/crn-frontend/src/network/users/UserList.tsx
+++ b/apps/crn-frontend/src/network/users/UserList.tsx
@@ -46,9 +46,10 @@ const UserList: React.FC<UserListProps> = ({
     result.total,
     pageSize,
   );
-
   return (
     <NetworkPeople
+      algoliaIndexName={result.algoliaIndexName}
+      algoliaQueryId={result.algoliaQueryId}
       people={result.items}
       numberOfItems={result.total}
       numberOfPages={numberOfPages}

--- a/apps/crn-frontend/src/network/users/__tests__/UserList.test.tsx
+++ b/apps/crn-frontend/src/network/users/__tests__/UserList.test.tsx
@@ -67,3 +67,28 @@ it('renders a list of people when searching with algolia', async () => {
   expect(container.textContent).toContain('Person A');
   expect(container.textContent).toContain('Person B');
 });
+
+it('renders an algolia tagged result list and hit', async () => {
+  const listUserResponse = createListUserResponse(1);
+  mockGetUsers.mockResolvedValue({
+    ...listUserResponse,
+    algoliaIndexName: 'index',
+    algoliaQueryId: 'queryId',
+    items: listUserResponse.items.map((item, itemIndex) => ({
+      ...item,
+      id: 'hitId',
+    })),
+  });
+
+  const { container } = await renderUserList();
+  const resultListHtml = container.querySelector('*[data-insights-index]');
+  expect(resultListHtml?.getAttribute('data-insights-index')).toEqual('index');
+  const hitHtml = resultListHtml?.querySelector('*[data-insights-object-id]');
+  expect(hitHtml?.attributes).toMatchInlineSnapshot(`
+    NamedNodeMap {
+      "data-insights-object-id": "hitId",
+      "data-insights-position": "1",
+      "data-insights-query-id": "queryId",
+    }
+  `);
+});

--- a/apps/crn-frontend/src/network/users/api.ts
+++ b/apps/crn-frontend/src/network/users/api.ts
@@ -69,7 +69,12 @@ export const getUsers = async (
     hitsPerPage: pageSize ?? undefined,
   });
 
-  return { items: result.hits, total: result.nbHits };
+  return {
+    items: result.hits,
+    total: result.nbHits,
+    algoliaIndexName: result.index,
+    algoliaQueryId: result.queryID,
+  };
 };
 
 export const getUsersAndExternalAuthors = async (
@@ -87,7 +92,12 @@ export const getUsersAndExternalAuthors = async (
     },
   );
 
-  return { items: result.hits, total: result.nbHits };
+  return {
+    items: result.hits,
+    total: result.nbHits,
+    algoliaIndexName: result.index,
+    algoliaQueryId: result.queryID,
+  };
 };
 
 export const patchUser = async (

--- a/apps/crn-frontend/src/network/users/state.ts
+++ b/apps/crn-frontend/src/network/users/state.ts
@@ -18,7 +18,14 @@ import { useAlgolia } from '../../hooks/algolia';
 import { getUser, getUsers, patchUser, postUserAvatar } from './api';
 
 const userIndexState = atomFamily<
-  { ids: ReadonlyArray<string>; total: number } | Error | undefined,
+  | {
+      ids: ReadonlyArray<string>;
+      total: number;
+      algoliaQueryId?: string;
+      algoliaIndexName?: string;
+    }
+  | Error
+  | undefined,
   GetListOptions
 >({
   key: 'userIndex',
@@ -40,7 +47,12 @@ export const usersState = selectorFamily<
         if (user === undefined) return undefined;
         users.push(user);
       }
-      return { total: index.total, items: users };
+      return {
+        total: index.total,
+        items: users,
+        algoliaIndexName: index.algoliaIndexName,
+        algoliaQueryId: index.algoliaQueryId,
+      };
     },
   set:
     (options) =>
@@ -58,6 +70,8 @@ export const usersState = selectorFamily<
         set(userIndexState(options), {
           total: newUsers.total,
           ids: newUsers.items.map((user) => user.id),
+          algoliaIndexName: newUsers.algoliaIndexName,
+          algoliaQueryId: newUsers.algoliaQueryId,
         });
       }
     },

--- a/apps/crn-frontend/src/network/working-groups/Outputs.tsx
+++ b/apps/crn-frontend/src/network/working-groups/Outputs.tsx
@@ -119,6 +119,8 @@ const OutputsList: React.FC<OutputsListProps> = ({
   );
   return (
     <ProfileOutputs
+      algoliaIndexName={result.algoliaIndexName}
+      algoliaQueryId={result.algoliaQueryId}
       researchOutputs={result.items}
       numberOfItems={result.total}
       numberOfPages={numberOfPages}

--- a/apps/crn-frontend/src/shared-research/ResearchOutputList.tsx
+++ b/apps/crn-frontend/src/shared-research/ResearchOutputList.tsx
@@ -49,6 +49,8 @@ const ResearchOutputList: React.FC<ResearchOutputListProps> = ({
 
   return (
     <SharedResearchList
+      algoliaIndexName={result.algoliaIndexName}
+      algoliaQueryId={result.algoliaQueryId}
       researchOutputs={result.items}
       numberOfItems={result.total}
       numberOfPages={numberOfPages}

--- a/apps/crn-frontend/src/shared-research/__tests__/ResearchOutputList.test.tsx
+++ b/apps/crn-frontend/src/shared-research/__tests__/ResearchOutputList.test.tsx
@@ -105,3 +105,26 @@ it('triggers and export with the same parameters', async () => {
     pageSize: MAX_ALGOLIA_RESULTS,
   });
 });
+
+it('renders an algolia tagged result list and hit', async () => {
+  const listResearchOutput = createResearchOutputListAlgoliaResponse(1);
+
+  mockGetResearchOutputs.mockResolvedValue({
+    ...listResearchOutput,
+    queryID: 'queryId',
+    index: 'index',
+    hits: listResearchOutput.hits.map((hit) => ({ ...hit, id: 'hitId' })),
+  });
+
+  const { container } = await renderResearchOutputList();
+  const resultListHtml = container.querySelector('*[data-insights-index]');
+  expect(resultListHtml?.getAttribute('data-insights-index')).toEqual('index');
+  const hitHtml = resultListHtml?.querySelector('*[data-insights-object-id]');
+  expect(hitHtml?.attributes).toMatchInlineSnapshot(`
+    NamedNodeMap {
+      "data-insights-object-id": "hitId",
+      "data-insights-position": "1",
+      "data-insights-query-id": "queryId",
+    }
+  `);
+});

--- a/apps/crn-frontend/src/shared-research/state.ts
+++ b/apps/crn-frontend/src/shared-research/state.ts
@@ -32,7 +32,14 @@ type RefreshResearchOutputListOptions = ResearchOutputListOptions & {
 };
 
 const researchOutputIndexState = atomFamily<
-  { ids: ReadonlyArray<string>; total: number } | Error | undefined,
+  | {
+      ids: ReadonlyArray<string>;
+      total: number;
+      algoliaQueryId?: string;
+      algoliaIndexName?: string;
+    }
+  | Error
+  | undefined,
   RefreshResearchOutputListOptions
 >({
   key: 'researchOutputIndex',
@@ -66,7 +73,12 @@ export const researchOutputsState = selectorFamily<
         if (researchOutput === undefined) return undefined;
         researchOutputs.push(researchOutput);
       }
-      return { total: index.total, items: researchOutputs };
+      return {
+        total: index.total,
+        items: researchOutputs,
+        algoliaQueryId: index.algoliaQueryId,
+        algoliaIndexName: index.algoliaIndexName,
+      };
     },
   set:
     (options) =>
@@ -91,6 +103,8 @@ export const researchOutputsState = selectorFamily<
         set(researchOutputIndexState(indexStateOptions), {
           total: researchOutputs.total,
           ids: researchOutputs.items.map(({ id }) => id),
+          algoliaIndexName: researchOutputs.algoliaIndexName,
+          algoliaQueryId: researchOutputs.algoliaQueryId,
         });
       }
     },
@@ -139,6 +153,8 @@ export const useResearchOutputs = (options: ResearchOutputListOptions) => {
             (data): ListResearchOutputResponse => ({
               total: data.nbHits,
               items: data.hits,
+              algoliaQueryId: data.queryID,
+              algoliaIndexName: data.index,
             }),
           )
     )

--- a/package.json
+++ b/package.json
@@ -15,12 +15,12 @@
     "url": "https://github.com/yldio/asap-hub.git"
   },
   "scripts": {
-    "algolia:clear-index": "yarn node apps/asap-cli/build-cjs/cli.js algolia:clear-index",
-    "algolia:delete-index": "TS_NODE_COMPILER_OPTIONS='{\"module\": \"commonjs\"}' yarn ts-node --transpile-only apps/asap-cli/src/cli.ts algolia:delete-index",
-    "algolia:get-settings": "TS_NODE_COMPILER_OPTIONS='{\"module\": \"commonjs\"}' yarn ts-node --transpile-only apps/asap-cli/src/cli.ts algolia:get-settings",
-    "algolia:move-index": "yarn node apps/asap-cli/build-cjs/cli.js algolia:move-index",
-    "algolia:remove-records": "yarn node apps/asap-cli/build-cjs/cli.js algolia:remove-records",
-    "algolia:set-settings": "TS_NODE_COMPILER_OPTIONS='{\"module\": \"commonjs\"}' yarn ts-node --transpile-only apps/asap-cli/src/cli.ts algolia:set-settings",
+    "algolia:clear-index": "yarn workspace @asap-hub/asap-cli algolia:clear-index",
+    "algolia:delete-index": "yarn workspace @asap-hub/asap-cli algolia:delete-index",
+    "algolia:get-settings": "yarn workspace @asap-hub/asap-cli algolia:get-settings",
+    "algolia:move-index": "yarn workspace @asap-hub/asap-cli algolia:move-index",
+    "algolia:remove-records": "yarn workspace @asap-hub/asap-cli algolia:remove-records",
+    "algolia:set-settings": "yarn workspace @asap-hub/asap-cli algolia:set-settings",
     "build": "yarn build:typecheck && yarn build:babel && yarn typecheck && yarn build:frontend",
     "build:babel": "yarn workspaces foreach -vp -j 2 run build:babel",
     "build:frontend": "yarn workspaces foreach -j 2 --exclude asap-hub -vp run build",

--- a/packages/algolia/src/client.ts
+++ b/packages/algolia/src/client.ts
@@ -65,6 +65,8 @@ export class AlgoliaSearchClient {
   public constructor(
     private index: SearchIndex,
     private reverseEventsIndex: SearchIndex,
+    private userToken?: SearchOptions['userToken'],
+    private clickAnalytics?: SearchOptions['clickAnalytics'],
   ) {
     // do nothing
   }
@@ -99,6 +101,8 @@ export class AlgoliaSearchClient {
 
     const options: SearchOptions = {
       ...requestOptions,
+      clickAnalytics: this.clickAnalytics,
+      userToken: this.userToken,
       filters: requestOptions?.filters
         ? `${requestOptions.filters} AND (${entityTypesFilter})`
         : entityTypesFilter,

--- a/packages/algolia/src/client.ts
+++ b/packages/algolia/src/client.ts
@@ -107,13 +107,23 @@ export class AlgoliaSearchClient {
         ? `${requestOptions.filters} AND (${entityTypesFilter})`
         : entityTypesFilter,
     };
-
-    return descendingEvents
-      ? this.reverseEventsIndex.search<DistributeToEntityRecords<T>>(
-          query,
-          options,
-        )
-      : this.index.search<DistributeToEntityRecords<T>>(query, options);
+    if (descendingEvents) {
+      const result = await this.reverseEventsIndex.search<
+        DistributeToEntityRecords<T>
+      >(query, options);
+      return {
+        ...result,
+        index: this.reverseEventsIndex.indexName,
+      };
+    }
+    const result = await this.index.search<DistributeToEntityRecords<T>>(
+      query,
+      options,
+    );
+    return {
+      ...result,
+      index: this.index.indexName,
+    };
   }
 
   private static getAlgoliaObject(

--- a/packages/algolia/src/index.ts
+++ b/packages/algolia/src/index.ts
@@ -19,12 +19,16 @@ export const algoliaSearchClientNativeFactory = ({
 type AlgoliaSearchClientFactoryParams =
   AlgoliaSearchClientNativeFactoryParams & {
     algoliaIndex: string;
+    userToken?: ConstructorParameters<typeof AlgoliaSearchClient>['2'];
+    clickAnalytics?: ConstructorParameters<typeof AlgoliaSearchClient>['3'];
   };
 
 export const algoliaSearchClientFactory = ({
   algoliaIndex,
   algoliaApiKey,
   algoliaAppId,
+  userToken,
+  clickAnalytics,
 }: AlgoliaSearchClientFactoryParams): AlgoliaSearchClient => {
   const algoliaSearchClient = algoliasearch(algoliaAppId, algoliaApiKey);
 
@@ -33,5 +37,10 @@ export const algoliaSearchClientFactory = ({
     `${algoliaIndex}-reverse-timestamp`,
   );
 
-  return new AlgoliaSearchClient(index, reverseIndex);
+  return new AlgoliaSearchClient(
+    index,
+    reverseIndex,
+    userToken,
+    clickAnalytics,
+  );
 };

--- a/packages/model/src/common.ts
+++ b/packages/model/src/common.ts
@@ -1,6 +1,8 @@
 export interface ListResponse<T> {
   readonly total: number;
   readonly items: T[];
+  readonly algoliaQueryId?: string;
+  readonly algoliaIndexName?: string;
 }
 
 export const decisionOptions = ['Yes', 'No', 'Not Sure'] as const;

--- a/packages/react-components/src/atoms/AlgoliaHit.tsx
+++ b/packages/react-components/src/atoms/AlgoliaHit.tsx
@@ -1,18 +1,18 @@
 interface AlgoliaHitProps {
   objectId?: string;
+  algoliaQueryId?: string;
   index?: number;
-  queryId?: string;
 }
 const AlgoliaHit: React.FC<AlgoliaHitProps> = ({
   objectId,
-  queryId,
   index,
+  algoliaQueryId,
   children,
 }) => (
   <div
     data-insights-object-id={objectId}
-    data-insights-position={queryId}
-    data-insights-query-id={index}
+    data-insights-position={index ? index + 1 : undefined}
+    data-insights-query-id={algoliaQueryId}
   >
     {children}
   </div>

--- a/packages/react-components/src/atoms/AlgoliaHit.tsx
+++ b/packages/react-components/src/atoms/AlgoliaHit.tsx
@@ -1,7 +1,7 @@
 interface AlgoliaHitProps {
   objectId?: string;
   algoliaQueryId?: string;
-  index?: number;
+  index: number;
 }
 const AlgoliaHit: React.FC<AlgoliaHitProps> = ({
   objectId,

--- a/packages/react-components/src/atoms/AlgoliaHit.tsx
+++ b/packages/react-components/src/atoms/AlgoliaHit.tsx
@@ -1,0 +1,21 @@
+interface AlgoliaHitProps {
+  objectId?: string;
+  index?: number;
+  queryId?: string;
+}
+const AlgoliaHit: React.FC<AlgoliaHitProps> = ({
+  objectId,
+  queryId,
+  index,
+  children,
+}) => (
+  <div
+    data-insights-object-id={objectId}
+    data-insights-position={queryId}
+    data-insights-query-id={index}
+  >
+    {children}
+  </div>
+);
+
+export default AlgoliaHit;

--- a/packages/react-components/src/atoms/AlgoliaHit.tsx
+++ b/packages/react-components/src/atoms/AlgoliaHit.tsx
@@ -11,7 +11,7 @@ const AlgoliaHit: React.FC<AlgoliaHitProps> = ({
 }) => (
   <div
     data-insights-object-id={objectId}
-    data-insights-position={index ? index + 1 : undefined}
+    data-insights-position={index !== undefined ? index + 1 : undefined}
     data-insights-query-id={algoliaQueryId}
   >
     {children}

--- a/packages/react-components/src/organisms/ResultList.tsx
+++ b/packages/react-components/src/organisms/ResultList.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentProps, useContext } from 'react';
+import React, { ComponentProps, useContext, useEffect } from 'react';
 import { css } from '@emotion/react';
 import { ToastContext } from '@asap-hub/react-context';
 
@@ -73,6 +73,11 @@ const ResultList: React.FC<ResultListProps> = ({
   ...pageControlsProps
 }) => {
   const toast = useContext(ToastContext);
+  useEffect(() => {
+    if (algoliaIndexName) {
+      window.dataLayer?.push({ event: 'Hits Viewed' });
+    }
+  }, [algoliaIndexName, pageControlsProps.currentPageIndex]);
   return (
     <article data-insights-index={algoliaIndexName}>
       <header

--- a/packages/react-components/src/organisms/ResultList.tsx
+++ b/packages/react-components/src/organisms/ResultList.tsx
@@ -1,4 +1,4 @@
-import { ComponentProps, useContext } from 'react';
+import React, { ComponentProps, useContext } from 'react';
 import { css } from '@emotion/react';
 import { ToastContext } from '@asap-hub/react-context';
 
@@ -59,6 +59,7 @@ type ResultListProps = ComponentProps<typeof PageControls> & {
   readonly listViewHref?: string;
   readonly noEventsComponent?: React.ReactNode;
   readonly children: React.ReactNode;
+  readonly algoliaIndexName?: string;
 };
 const ResultList: React.FC<ResultListProps> = ({
   numberOfItems,
@@ -68,11 +69,12 @@ const ResultList: React.FC<ResultListProps> = ({
   listViewHref,
   children,
   noEventsComponent,
+  algoliaIndexName,
   ...pageControlsProps
 }) => {
   const toast = useContext(ToastContext);
   return (
-    <article>
+    <article data-insights-index={algoliaIndexName}>
       <header
         css={[headerStyles, numberOfItems === 0 && headerNoResultsStyles]}
       >

--- a/packages/react-components/src/organisms/SharedResearchListCard.tsx
+++ b/packages/react-components/src/organisms/SharedResearchListCard.tsx
@@ -6,6 +6,7 @@ import { Card, Anchor, Headline2 } from '../atoms';
 import { steel } from '../colors';
 import { paddingStyles } from '../card';
 import SharedResearchMetadata from './SharedResearchMetadata';
+import AlgoliaHit from '../atoms/AlgoliaHit';
 
 const containerStyles = css({
   margin: 0,
@@ -22,6 +23,7 @@ const itemStyles = css({
 });
 
 type SharedResearchListCardProps = {
+  algoliaQueryId?: string;
   researchOutputs: ReadonlyArray<
     Pick<
       ResearchOutputResponse,
@@ -32,27 +34,34 @@ type SharedResearchListCardProps = {
 
 const SharedResearchListCard: React.FC<SharedResearchListCardProps> = ({
   researchOutputs,
+  algoliaQueryId,
 }) => (
   <Card padding={false}>
     <ul css={containerStyles}>
       {researchOutputs.map(
-        ({ title, id, workingGroups, documentType, type, link }) => (
+        ({ title, id, workingGroups, documentType, type, link }, index) => (
           <li key={`output-${id}`} css={[itemStyles, paddingStyles]}>
-            <SharedResearchMetadata
-              pills={[
-                workingGroups ? 'Working Group' : 'Team',
-                ...(documentType ? [documentType] : []),
-                ...(type ? [type] : []),
-              ]}
-              link={link}
-            />
-            <Anchor
-              href={
-                sharedResearch({}).researchOutput({ researchOutputId: id }).$
-              }
+            <AlgoliaHit
+              index={index}
+              algoliaQueryId={algoliaQueryId}
+              objectId={id}
             >
-              <Headline2 styleAsHeading={5}>{title}</Headline2>
-            </Anchor>
+              <SharedResearchMetadata
+                pills={[
+                  workingGroups ? 'Working Group' : 'Team',
+                  ...(documentType ? [documentType] : []),
+                  ...(type ? [type] : []),
+                ]}
+                link={link}
+              />
+              <Anchor
+                href={
+                  sharedResearch({}).researchOutput({ researchOutputId: id }).$
+                }
+              >
+                <Headline2 styleAsHeading={5}>{title}</Headline2>
+              </Anchor>
+            </AlgoliaHit>
           </li>
         ),
       )}

--- a/packages/react-components/src/organisms/__tests__/ResultList.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/ResultList.test.tsx
@@ -13,6 +13,17 @@ const props: Omit<ComponentProps<typeof ResultList>, 'children'> = {
   renderPageHref: () => '',
 };
 
+beforeEach(() => {
+  Object.defineProperty(window, 'dataLayer', {
+    configurable: true,
+    value: [],
+  });
+});
+afterEach(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  delete (window as any).dataLayer;
+});
+
 it.each([
   [1, /(^|\D)1 result($|\W)/i],
   [5, /(^|\D)5 results($|\W)/i],
@@ -109,4 +120,24 @@ it('renders custom component when no results found', () => {
     </ResultList>,
   );
   expect(screen.queryByText(/Custom No Events Component/i)).toBeInTheDocument();
+});
+
+it('triggers algolia hits viewed on render', () => {
+  render(
+    <ResultList {...props} algoliaIndexName={undefined}>
+      Hits rendered
+    </ResultList>,
+  );
+  expect(window.dataLayer).toEqual([]);
+
+  render(
+    <ResultList {...props} algoliaIndexName="Example">
+      Hits rendered
+    </ResultList>,
+  );
+  expect(window.dataLayer).toEqual([
+    {
+      event: 'Hits Viewed',
+    },
+  ]);
 });

--- a/packages/react-components/src/templates/EventsList.tsx
+++ b/packages/react-components/src/templates/EventsList.tsx
@@ -1,8 +1,9 @@
-import { Fragment, FC, ComponentProps } from 'react';
+import { FC, ComponentProps } from 'react';
 import { css } from '@emotion/react';
 
 import { rem } from '../pixels';
 import { ResultList, EventCard } from '../organisms';
+import AlgoliaHit from '../atoms/AlgoliaHit';
 
 const containerStyles = css({
   display: 'grid',
@@ -11,15 +12,24 @@ const containerStyles = css({
 
 type EventsListProps = Omit<ComponentProps<typeof ResultList>, 'children'> & {
   events: ComponentProps<typeof EventCard>[];
-};
+} & Pick<ComponentProps<typeof AlgoliaHit>, 'algoliaQueryId'>;
 
-const EventsListPage: FC<EventsListProps> = ({ events, ...props }) => (
+const EventsListPage: FC<EventsListProps> = ({
+  events,
+  algoliaQueryId,
+  ...props
+}) => (
   <div css={containerStyles}>
     <ResultList {...props}>
-      {events.map(({ ...event }) => (
-        <Fragment key={event.id}>
+      {events.map(({ ...event }, index) => (
+        <AlgoliaHit
+          key={event.id}
+          algoliaQueryId={algoliaQueryId}
+          objectId={event.id}
+          index={index}
+        >
           <EventCard {...event} />
-        </Fragment>
+        </AlgoliaHit>
       ))}
     </ResultList>
   </div>

--- a/packages/react-components/src/templates/NetworkPeople.tsx
+++ b/packages/react-components/src/templates/NetworkPeople.tsx
@@ -1,4 +1,5 @@
-import { ComponentProps, Fragment, FC } from 'react';
+import { ComponentProps, FC } from 'react';
+import AlgoliaHit from '../atoms/AlgoliaHit';
 
 import { ResultList, PeopleCard } from '../organisms';
 
@@ -9,17 +10,23 @@ type NetworkPeopleProps = Omit<
   readonly people: ReadonlyArray<
     { readonly id: string } & ComponentProps<typeof PeopleCard>
   >;
-};
+} & Pick<ComponentProps<typeof AlgoliaHit>, 'algoliaQueryId'>;
 
 const NetworkPeople: FC<NetworkPeopleProps> = ({
   people,
+  algoliaQueryId,
   ...cardListProps
 }) => (
   <ResultList {...cardListProps}>
-    {people.map((person) => (
-      <Fragment key={person.id}>
+    {people.map((person, index) => (
+      <AlgoliaHit
+        key={person.id}
+        algoliaQueryId={algoliaQueryId}
+        objectId={person.id}
+        index={index}
+      >
         <PeopleCard {...person} />
-      </Fragment>
+      </AlgoliaHit>
     ))}
   </ResultList>
 );

--- a/packages/react-components/src/templates/ProfileOutputs.tsx
+++ b/packages/react-components/src/templates/ProfileOutputs.tsx
@@ -22,6 +22,8 @@ export type ProfileOutputsProps = Omit<
 };
 
 const ProfileOutputs: React.FC<ProfileOutputsProps> = ({
+  algoliaIndexName,
+  algoliaQueryId,
   researchOutputs,
   numberOfItems,
   numberOfPages,
@@ -40,6 +42,8 @@ const ProfileOutputs: React.FC<ProfileOutputsProps> = ({
   <div css={containerStyles}>
     {numberOfItems ? (
       <SharedResearchList
+        algoliaIndexName={algoliaIndexName}
+        algoliaQueryId={algoliaQueryId}
         exportResults={exportResults}
         researchOutputs={researchOutputs}
         numberOfItems={numberOfItems}

--- a/packages/react-components/src/templates/SharedResearchList.tsx
+++ b/packages/react-components/src/templates/SharedResearchList.tsx
@@ -28,7 +28,10 @@ const SharedResearchList: React.FC<SharedResearchListProps> = ({
 }) => (
   <ResultList {...cardListProps}>
     {cardListProps.isListView ? (
-      <SharedResearchListCard researchOutputs={researchOutputs} />
+      <SharedResearchListCard
+        algoliaQueryId={algoliaQueryId}
+        researchOutputs={researchOutputs}
+      />
     ) : (
       researchOutputs.map((output, index) => (
         <AlgoliaHit

--- a/packages/react-components/src/templates/SharedResearchList.tsx
+++ b/packages/react-components/src/templates/SharedResearchList.tsx
@@ -19,10 +19,11 @@ type SharedResearchListProps = Omit<
   >;
   readonly listViewHref: string;
   readonly cardViewHref: string;
-};
+} & Pick<ComponentProps<typeof AlgoliaHit>, 'algoliaQueryId'>;
 
 const SharedResearchList: React.FC<SharedResearchListProps> = ({
   researchOutputs,
+  algoliaQueryId,
   ...cardListProps
 }) => (
   <ResultList {...cardListProps}>
@@ -30,7 +31,12 @@ const SharedResearchList: React.FC<SharedResearchListProps> = ({
       <SharedResearchListCard researchOutputs={researchOutputs} />
     ) : (
       researchOutputs.map((output, index) => (
-        <AlgoliaHit key={output.id} index={index}>
+        <AlgoliaHit
+          key={output.id}
+          index={index}
+          algoliaQueryId={algoliaQueryId}
+          objectId={output.id}
+        >
           <SharedResearchCard {...output} />
         </AlgoliaHit>
       ))

--- a/packages/react-components/src/templates/SharedResearchList.tsx
+++ b/packages/react-components/src/templates/SharedResearchList.tsx
@@ -1,4 +1,5 @@
 import { ComponentProps } from 'react';
+import AlgoliaHit from '../atoms/AlgoliaHit';
 
 import {
   ResultList,
@@ -28,8 +29,10 @@ const SharedResearchList: React.FC<SharedResearchListProps> = ({
     {cardListProps.isListView ? (
       <SharedResearchListCard researchOutputs={researchOutputs} />
     ) : (
-      researchOutputs.map((output) => (
-        <SharedResearchCard key={output.id} {...output} />
+      researchOutputs.map((output, index) => (
+        <AlgoliaHit key={output.id} index={index}>
+          <SharedResearchCard {...output} />
+        </AlgoliaHit>
       ))
     )}
   </ResultList>


### PR DESCRIPTION
This PR is to implement the website side of https://www.algolia.com/doc/guides/sending-events/connectors/google-tag-manager/

Algolia Client and GTM are both tagged with UserId so queries can be related to a user.
Result lists rendered from algolia data should be tagged with the index they were run on

- Events
- Users
- Research Outputs

Hits should be tagged with QueryId, Position and Object ID which is the same as our ID's 
I have written very high level unit tests to ensure tags are present on the relevant result lists to prevent regressions.

I have also refactored the algolia scripts to be within the algolia package. 