### PR TITLE
Add poll for version match in Contentful user update

### DIFF
--- a/apps/crn-server/src/data-providers/contentful/users.data-provider.ts
+++ b/apps/crn-server/src/data-providers/contentful/users.data-provider.ts
@@ -32,6 +32,7 @@ import {
   Environment,
   Maybe,
 } from '@asap-hub/contentful';
+import retry from 'async-retry';
 import { isTeamRole } from '../../entities';
 import { UserDataProvider } from '../types';
 
@@ -128,7 +129,27 @@ export class UserContentfulDataProvider implements UserDataProvider {
     const fields = cleanUser(data);
     const environment = await this.getRestClient();
     const user = await environment.getEntry(id);
-    await patchAndPublish(user, fields);
+    const result = await patchAndPublish(user, fields);
+    await this.waitForUpdated(id, result.sys.publishedVersion || Infinity);
+  }
+
+  private async waitForUpdated(id: string, version: number) {
+    return retry(
+      // eslint-disable-next-line consistent-return
+      async (bail) => {
+        const { users } = await this.contentfulClient.request<
+          FetchUserByIdQuery,
+          FetchUserByIdQueryVariables
+        >(FETCH_USER_BY_ID, { id });
+        if (!users) {
+          return bail(new Error('Not found'));
+        }
+        if ((users.sys.publishedVersion || 0) < version) {
+          throw new Error('Not synced');
+        }
+      },
+      { minTimeout: 100 },
+    );
   }
 }
 

--- a/packages/contentful/src/utils.ts
+++ b/packages/contentful/src/utils.ts
@@ -124,7 +124,7 @@ export const updateEntryFields = (
 export const patchAndPublish = async (
   entry: Entry,
   fields: Record<string, unknown>,
-): Promise<void> => {
+): Promise<Entry> => {
   const patch: Parameters<Entry['patch']>[0] = Object.entries(fields).map(
     ([key, value]) => ({
       op: Object.prototype.hasOwnProperty.call(entry.fields, key)
@@ -137,5 +137,5 @@ export const patchAndPublish = async (
     }),
   );
   const result = await entry.patch(patch);
-  await result.publish();
+  return result.publish();
 };


### PR DESCRIPTION
To prevent a race condition where the CDN cache in front of the graphql endpoint is not reloaded and so subsequent fetch responds with stale data.