### PR TITLE
Add support for Contentful invitation/onboarding journey

### DIFF
--- a/apps/crn-server/serverless.ts
+++ b/apps/crn-server/serverless.ts
@@ -414,7 +414,7 @@ const serverlessConfig: AWS = {
         },
       ],
       environment: {
-        SES_REGION: `\${ssm:ses-region-${envAlias}}`,
+        SES_REGION: `\${ssm:ses-region-dev}`,
         EMAIL_SENDER: `\${ssm:email-invite-sender-${envAlias}}`,
         EMAIL_BCC: `\${ssm:email-invite-bcc-${envAlias}}`,
         EMAIL_RETURN: `\${ssm:email-invite-return-${envAlias}}`,

--- a/apps/crn-server/serverless.ts
+++ b/apps/crn-server/serverless.ts
@@ -95,6 +95,9 @@ const offlinePlugins = [
 const offlineSSM =
   SLS_STAGE === 'local'
     ? {
+        'algolia-app-id-dev': '${env:ALGOLIA_APP_ID}',
+        'algolia-index-api-key-dev': '${env:ALGOLIA_API_KEY}',
+        'algolia-search-api-key-dev': '${env:ALGOLIA_API_KEY}',
         'crn-algolia-app-id-dev': '${env:ALGOLIA_APP_ID}',
         'crn-algolia-index-api-key-dev': '${env:ALGOLIA_API_KEY}',
         'crn-algolia-search-api-key-dev': '${env:ALGOLIA_API_KEY}',
@@ -369,7 +372,7 @@ const serverlessConfig: AWS = {
         SENTRY_DSN: sentryDsnHandlers,
       },
     },
-    inviteUser: {
+    inviteUserSquidex: {
       handler: './src/handlers/user/invite-handler.handler',
       events: [
         {
@@ -391,6 +394,32 @@ const serverlessConfig: AWS = {
         EMAIL_BCC: `\${ssm:email-invite-bcc-${envAlias}}`,
         EMAIL_RETURN: `\${ssm:email-invite-return-${envAlias}}`,
         SENTRY_DSN: sentryDsnHandlers,
+        IS_CONTENTFUL_ENABLED_V2: 'false',
+      },
+    },
+    inviteUserContentful: {
+      handler: './src/handlers/user/invite-handler.handler',
+      events: [
+        {
+          eventBridge: {
+            eventBus: 'asap-events-${self:provider.stage}',
+            pattern: {
+              source: [eventBusSourceContentful],
+              'detail-type': ['UsersPublished'],
+            },
+            retryPolicy: {
+              maximumRetryAttempts: 2,
+            },
+          },
+        },
+      ],
+      environment: {
+        SES_REGION: `\${ssm:ses-region-${envAlias}}`,
+        EMAIL_SENDER: `\${ssm:email-invite-sender-${envAlias}}`,
+        EMAIL_BCC: `\${ssm:email-invite-bcc-${envAlias}}`,
+        EMAIL_RETURN: `\${ssm:email-invite-return-${envAlias}}`,
+        SENTRY_DSN: sentryDsnHandlers,
+        IS_CONTENTFUL_ENABLED_V2: 'true',
       },
     },
     indexResearchOutput: {

--- a/apps/crn-server/src/data-providers/contentful/users.data-provider.ts
+++ b/apps/crn-server/src/data-providers/contentful/users.data-provider.ts
@@ -183,6 +183,13 @@ const cleanUser = (userToUpdate: UserUpdateDataObject) =>
         ...(value as UserSocialLinks),
       };
     }
+    if (key === 'connections') {
+      const connections = userToUpdate.connections || [];
+      return {
+        ...acc,
+        connections: connections.map(({ code }) => code),
+      };
+    }
     return { ...acc, [key]: value };
   }, {} as { [key: string]: unknown });
 

--- a/apps/crn-server/src/handlers/event/index-user-events-handler.ts
+++ b/apps/crn-server/src/handlers/event/index-user-events-handler.ts
@@ -45,7 +45,7 @@ export const indexUserEventsHandler =
       eventController.fetch({
         skip,
         take,
-        filter: { userId: event.detail.payload.id },
+        filter: { userId: event.detail.resourceId },
       });
 
     const processingFunction = async (

--- a/apps/crn-server/src/handlers/user/index-handler.ts
+++ b/apps/crn-server/src/handlers/user/index-handler.ts
@@ -25,7 +25,7 @@ export const indexUserHandler =
     logger.debug(`Event ${event['detail-type']}`);
 
     try {
-      const user = await userController.fetchById(event.detail.payload.id);
+      const user = await userController.fetchById(event.detail.resourceId);
 
       logger.debug(`Fetched user ${user.id}`);
 
@@ -37,15 +37,15 @@ export const indexUserHandler =
 
         logger.debug(`User saved ${user.id}`);
       } else {
-        await algoliaClient.remove(event.detail.payload.id);
+        await algoliaClient.remove(event.detail.resourceId);
 
         logger.debug(`User removed ${user.id}`);
       }
     } catch (e) {
       if (isBoom(e) && (e as Boom).output.statusCode === 404) {
-        await algoliaClient.remove(event.detail.payload.id);
+        await algoliaClient.remove(event.detail.resourceId);
 
-        logger.debug(`User removed ${event.detail.payload.id}`);
+        logger.debug(`User removed ${event.detail.resourceId}`);
         return;
       }
 

--- a/apps/crn-server/src/handlers/user/invite-handler.ts
+++ b/apps/crn-server/src/handlers/user/invite-handler.ts
@@ -1,23 +1,25 @@
+/* istanbul ignore file */
 import { inviteHandlerFactory } from '@asap-hub/server-common';
-import { RestUser, SquidexRest } from '@asap-hub/squidex';
 import { SES } from '@aws-sdk/client-ses';
-import { appName, baseUrl, origin, sesRegion } from '../../config';
-import { getAuthToken } from '../../utils/auth';
+import { origin, sesRegion } from '../../config';
 import logger from '../../utils/logger';
 import { sendEmailFactory } from '../../utils/send-email';
 import { sentryWrapper } from '../../utils/sentry-wrapper';
+import { UserDataProvider } from '../../data-providers/types';
+import { getUserDataProvider } from '../../dependencies/users.dependencies';
 
 const ses = new SES({
   apiVersion: '2010-12-01',
   region: sesRegion,
 });
 
-const userRestClient = new SquidexRest<RestUser>(getAuthToken, 'users', {
-  appName,
-  baseUrl,
-});
+const userDataProvider = getUserDataProvider();
 
-/* istanbul ignore next */
 export const handler = sentryWrapper(
-  inviteHandlerFactory(sendEmailFactory(ses), userRestClient, origin, logger),
+  inviteHandlerFactory<UserDataProvider>(
+    sendEmailFactory(ses),
+    userDataProvider,
+    origin,
+    logger,
+  ),
 );

--- a/apps/crn-server/src/handlers/webhooks/fetch-by-code/handler.ts
+++ b/apps/crn-server/src/handlers/webhooks/fetch-by-code/handler.ts
@@ -1,44 +1,18 @@
 /* istanbul ignore file */
 import { algoliaSearchClientNativeFactory } from '@asap-hub/algolia';
-import {
-  InputUser,
-  RestUser,
-  SquidexGraphql,
-  SquidexRest,
-} from '@asap-hub/squidex';
 import { Handler } from 'aws-lambda/handler';
-import { algoliaApiKey, algoliaAppId, appName, baseUrl } from '../../../config';
+import { algoliaApiKey, algoliaAppId } from '../../../config';
 import Users from '../../../controllers/users';
-import { AssetSquidexDataProvider } from '../../../data-providers/assets.data-provider';
-import { UserSquidexDataProvider } from '../../../data-providers/users.data-provider';
-import { getAuthToken } from '../../../utils/auth';
 import { fetchUserByCodeHandlerFactory } from './fetch-by-code';
 import { sentryWrapper } from '../../../utils/sentry-wrapper';
-
-const squidexGraphqlClient = new SquidexGraphql(getAuthToken, {
-  appName,
-  baseUrl,
-});
-
-const userRestClient = new SquidexRest<RestUser, InputUser>(
-  getAuthToken,
-  'users',
-  {
-    appName,
-    baseUrl,
-  },
-);
-
-const userDataProvider = new UserSquidexDataProvider(
-  squidexGraphqlClient,
-  userRestClient,
-);
-
-const assetDataProvider = new AssetSquidexDataProvider(userRestClient);
+import {
+  getUserDataProvider,
+  getAssetDataProvider,
+} from '../../../dependencies/users.dependencies';
 
 export const handler: Handler = sentryWrapper(
   fetchUserByCodeHandlerFactory(
-    new Users(userDataProvider, assetDataProvider),
+    new Users(getUserDataProvider(), getAssetDataProvider()),
     algoliaSearchClientNativeFactory({ algoliaAppId, algoliaApiKey }),
   ),
 );

--- a/apps/crn-server/src/handlers/webhooks/webhook-connect-by-code.ts
+++ b/apps/crn-server/src/handlers/webhooks/webhook-connect-by-code.ts
@@ -1,39 +1,17 @@
 import { UserResponse } from '@asap-hub/model';
 import { connectByCodeHandlerFactory } from '@asap-hub/server-common';
 import { framework as lambda } from '@asap-hub/services-common';
-import {
-  InputUser,
-  RestUser,
-  SquidexGraphql,
-  SquidexRest,
-} from '@asap-hub/squidex';
 import { Handler } from 'aws-lambda';
-import { appName, auth0SharedSecret, baseUrl } from '../../config';
+import { auth0SharedSecret } from '../../config';
 import Users from '../../controllers/users';
-import { AssetSquidexDataProvider } from '../../data-providers/assets.data-provider';
-import { UserSquidexDataProvider } from '../../data-providers/users.data-provider';
-import { getAuthToken } from '../../utils/auth';
 import logger from '../../utils/logger';
 import { sentryWrapper } from '../../utils/sentry-wrapper';
+import {
+  getUserDataProvider,
+  getAssetDataProvider,
+} from '../../dependencies/users.dependencies';
 
-const squidexGraphqlClient = new SquidexGraphql(getAuthToken, {
-  appName,
-  baseUrl,
-});
-const userRestClient = new SquidexRest<RestUser, InputUser>(
-  getAuthToken,
-  'users',
-  {
-    appName,
-    baseUrl,
-  },
-);
-const userDataProvider = new UserSquidexDataProvider(
-  squidexGraphqlClient,
-  userRestClient,
-);
-const assetDataProvider = new AssetSquidexDataProvider(userRestClient);
-const users = new Users(userDataProvider, assetDataProvider);
+const users = new Users(getUserDataProvider(), getAssetDataProvider());
 const connectByCodeHandler = connectByCodeHandlerFactory<UserResponse>(
   users,
   auth0SharedSecret,

--- a/apps/crn-server/test/data-providers/contentful/users.data-provider.test.ts
+++ b/apps/crn-server/test/data-providers/contentful/users.data-provider.test.ts
@@ -648,6 +648,15 @@ describe('User data provider', () => {
         }),
       ).rejects.toThrow();
     });
+
+    test('unwraps `code` property of connections', async () => {
+      await userDataProvider.update('123', {
+        connections: [{ code: 'abc123' }],
+      });
+      expect(patchAndPublish).toHaveBeenCalledWith(entry, {
+        connections: ['abc123'],
+      });
+    });
   });
 
   describe('Create', () => {

--- a/apps/crn-server/test/fixtures/users.fixtures.ts
+++ b/apps/crn-server/test/fixtures/users.fixtures.ts
@@ -6,6 +6,7 @@ import {
   UserResponse,
   inactiveUserTag,
   UserEvent,
+  WebhookDetail,
 } from '@asap-hub/model';
 import {
   InputUser,
@@ -555,9 +556,10 @@ export const userPublishedEvent: SquidexWebhookPayload<User> = {
 export const getUserWebhookPayload = (
   id: string,
   type: UserEvent,
-): SquidexWebhookPayload<User, UserEvent> => ({
+): WebhookDetail<SquidexWebhookPayload<User, UserEvent>> => ({
   type,
   timestamp: '2021-02-15T13:11:25Z',
+  resourceId: id,
   payload: {
     $type: 'EnrichedContentEvent',
     type: 'Updated',

--- a/apps/gp2-server/src/handlers/user/invite-handler.ts
+++ b/apps/gp2-server/src/handlers/user/invite-handler.ts
@@ -1,31 +1,48 @@
+/* istanbul ignore file */
 import {
   gp2WelcomeTemplate,
   inviteHandlerFactory,
 } from '@asap-hub/server-common';
-import { gp2 as gp2Squidex, SquidexRest } from '@asap-hub/squidex';
+import {
+  gp2 as gp2Squidex,
+  SquidexRest,
+  SquidexGraphql,
+} from '@asap-hub/squidex';
 import { SES } from '@aws-sdk/client-ses';
 import { appName, baseUrl, origin, sesRegion } from '../../config';
 import { getAuthToken } from '../../utils/auth';
 import logger from '../../utils/logger';
 import { sendEmailFactory } from '../../utils/send-email';
 import { sentryWrapper } from '../../utils/sentry-wrapper';
+import {
+  UserSquidexDataProvider,
+  UserDataProvider,
+} from '../../data-providers/user.data-provider';
 
 const ses = new SES({
   apiVersion: '2010-12-01',
   region: sesRegion,
 });
 
-/* istanbul ignore next */
+const squidexGraphqlClient = new SquidexGraphql(getAuthToken, {
+  appName,
+  baseUrl,
+});
+
 const restClient = new SquidexRest<gp2Squidex.RestUser>(getAuthToken, 'users', {
   appName,
   baseUrl,
 });
 
-/* istanbul ignore next */
+const userDataProvider = new UserSquidexDataProvider(
+  squidexGraphqlClient,
+  restClient,
+);
+
 export const handler = sentryWrapper(
-  inviteHandlerFactory(
+  inviteHandlerFactory<UserDataProvider>(
     sendEmailFactory(ses),
-    restClient,
+    userDataProvider,
     origin,
     logger,
     gp2WelcomeTemplate,

--- a/packages/contentful/src/crn/types/webhook.ts
+++ b/packages/contentful/src/crn/types/webhook.ts
@@ -1,4 +1,8 @@
-export type ContentfulWebhookPayloadType = 'teams' | 'news' | 'externalAuthors';
+export type ContentfulWebhookPayloadType =
+  | 'teams'
+  | 'news'
+  | 'externalAuthors'
+  | 'users';
 
 export interface ContentfulWebhookPublishPayload<
   T extends ContentfulWebhookPayloadType = ContentfulWebhookPayloadType,

--- a/packages/server-common/src/handlers/event-bus.ts
+++ b/packages/server-common/src/handlers/event-bus.ts
@@ -1,5 +1,6 @@
-import { CalendarEvent, UserEvent } from '@asap-hub/model';
+import { CalendarEvent, UserEvent, WebhookDetail } from '@asap-hub/model';
 import { SquidexWebhookPayload, User, gp2, Calendar } from '@asap-hub/squidex';
+import { ContentfulWebhookPayload } from '@asap-hub/contentful';
 
 export type SquidexEntityEvent =
   | 'Created'
@@ -8,6 +9,9 @@ export type SquidexEntityEvent =
   | 'Unpublished'
   | 'Deleted';
 
-export type UserPayload = SquidexWebhookPayload<User | gp2.User, UserEvent>;
+export type UserPayload = WebhookDetail<
+  | SquidexWebhookPayload<User | gp2.User, UserEvent>
+  | ContentfulWebhookPayload<'users'>
+>;
 
 export type CalendarPayload = SquidexWebhookPayload<Calendar, CalendarEvent>;

--- a/packages/server-common/src/handlers/user/invite.handler.ts
+++ b/packages/server-common/src/handlers/user/invite.handler.ts
@@ -37,7 +37,7 @@ export const inviteHandlerFactory =
 
     if (user.connections?.length) {
       logger.info(
-        `Found a previous invitation code for user ${user.id}, exiting...`,
+        `Found an existing connection code for user ${user.id}, exiting...`,
       );
       return;
     }

--- a/packages/server-common/test/fixtures/users.fixtures.ts
+++ b/packages/server-common/test/fixtures/users.fixtures.ts
@@ -75,7 +75,7 @@ export const getUserWebhookPayload = (
   },
 });
 
-export const userMock = (): UserDataObject => ({
+export const getUserDataObject = (): UserDataObject => ({
   id: 'userId',
   firstName: 'Tony',
   lastName: 'Stark',

--- a/packages/server-common/test/fixtures/users.fixtures.ts
+++ b/packages/server-common/test/fixtures/users.fixtures.ts
@@ -1,4 +1,4 @@
-import { UserEvent } from '@asap-hub/model';
+import { UserEvent, UserDataObject } from '@asap-hub/model';
 import { RestUser, User, SquidexWebhookPayload } from '@asap-hub/squidex';
 
 export const patchResponse = (): RestUser => ({
@@ -73,4 +73,12 @@ export const getUserWebhookPayload = (
       labs: { iv: [] },
     },
   },
+});
+
+export const userMock = (): UserDataObject => ({
+  id: 'userId',
+  firstName: 'Tony',
+  lastName: 'Stark',
+  email: 'tony@.stark.com',
+  connections: [],
 });

--- a/packages/server-common/test/handlers/user/invite.handler.test.ts
+++ b/packages/server-common/test/handlers/user/invite.handler.test.ts
@@ -5,7 +5,7 @@ import {
   UserInviteEventBridgeEvent,
 } from '../../../src/handlers/user';
 import { crnWelcomeTemplate, SendEmail } from '../../../src/utils';
-import { userMock } from '../../fixtures/users.fixtures';
+import { getUserDataObject } from '../../fixtures/users.fixtures';
 import { loggerMock as logger } from '../../mocks/logger.mock';
 
 describe('Invite Handler', () => {
@@ -29,41 +29,41 @@ describe('Invite Handler', () => {
   test('Should throw when the user is not found', async () => {
     dataProvider.fetchById.mockResolvedValueOnce(null);
 
-    const event = getEventBridgeEventMock(userMock().id);
+    const event = getEventBridgeEventMock(getUserDataObject().id);
 
     await expect(inviteHandler(event)).rejects.toThrow(
-      `Unable to find a user with ID ${userMock().id}`,
+      `Unable to find a user with ID ${getUserDataObject().id}`,
     );
   });
 
   test('Should throw when it fails to save the user code', async () => {
     const userWithoutConnection: UserDataObject = {
-      ...userMock(),
+      ...getUserDataObject(),
       connections: [],
     };
     dataProvider.fetchById.mockResolvedValueOnce(userWithoutConnection);
     dataProvider.update.mockRejectedValueOnce(new Error('some error'));
 
-    const event = getEventBridgeEventMock(userMock().id);
+    const event = getEventBridgeEventMock(getUserDataObject().id);
 
     await expect(inviteHandler(event)).rejects.toThrow(
-      `Unable to save the code for the user with ID ${userMock().id}`,
+      `Unable to save the code for the user with ID ${getUserDataObject().id}`,
     );
   });
 
   test('Should throw when it fails to send the email but still save the new invitation code', async () => {
     const userWithoutConnection: UserDataObject = {
-      ...userMock(),
+      ...getUserDataObject(),
       connections: [],
     };
     dataProvider.fetchById.mockResolvedValueOnce(userWithoutConnection);
     dataProvider.update.mockResolvedValueOnce(null);
     sendEmailMock.mockRejectedValueOnce(new Error('some error'));
 
-    const event = getEventBridgeEventMock(userMock().id);
+    const event = getEventBridgeEventMock(getUserDataObject().id);
 
     await expect(inviteHandler(event)).rejects.toThrow(
-      `Unable to send the email for the user with ID ${userMock().id}`,
+      `Unable to send the email for the user with ID ${getUserDataObject().id}`,
     );
     expect(dataProvider.update).toBeCalledWith(userWithoutConnection.id, {
       connections: [{ code: expect.any(String) }],
@@ -73,12 +73,12 @@ describe('Invite Handler', () => {
   test('Should not send the invitation email for a user that already has the invitation code', async () => {
     const code = 'c6fdb21b-32f3-4549-ac17-d0c83dc5335b';
     const userWithConnection: UserDataObject = {
-      ...userMock(),
+      ...getUserDataObject(),
       connections: [{ code }],
     };
     dataProvider.fetchById.mockResolvedValueOnce(userWithConnection);
 
-    const event = getEventBridgeEventMock(userMock().id);
+    const event = getEventBridgeEventMock(getUserDataObject().id);
 
     await inviteHandler(event);
 
@@ -89,7 +89,7 @@ describe('Invite Handler', () => {
   test('Should not send the invitation email for a user that already has an authentication code', async () => {
     const connectionCode = 'auth0|some-other-id';
     const userWithOtherConnection: UserDataObject = {
-      ...userMock(),
+      ...getUserDataObject(),
       connections: [
         {
           code: connectionCode,
@@ -98,7 +98,7 @@ describe('Invite Handler', () => {
     };
     dataProvider.fetchById.mockResolvedValueOnce(userWithOtherConnection);
 
-    const event = getEventBridgeEventMock(userMock().id);
+    const event = getEventBridgeEventMock(getUserDataObject().id);
 
     await inviteHandler(event);
 
@@ -109,12 +109,12 @@ describe('Invite Handler', () => {
 
   test('Should find the user without an invitation code, create the invitation code and send the invitation email', async () => {
     const userWithoutConnection: UserDataObject = {
-      ...userMock(),
+      ...getUserDataObject(),
       connections: [],
     };
     dataProvider.fetchById.mockResolvedValueOnce(userWithoutConnection);
 
-    const event = getEventBridgeEventMock(userMock().id);
+    const event = getEventBridgeEventMock(getUserDataObject().id);
 
     await inviteHandler(event);
 


### PR DESCRIPTION
* Updates invite handler factory function to use a data provider instance in place of the Squidex client to allow data provider agnostic invitation pipelines.
* Updates webhook handlers to use `resourceId` for accessing entity IDs
* Updates CRN user data provider to support setting connection codes
* Updates invite handler to never send invitation if there is any connection code attached to the profile to prevent repeat invitations being sent to users when publishing profile updates