### PR TITLE
CT-41 - Add app to set title field on a team membership model

### DIFF
--- a/packages/cms-data-sync/src/users/users.data-migration.ts
+++ b/packages/cms-data-sync/src/users/users.data-migration.ts
@@ -88,6 +88,9 @@ export const migrateUsers = async () => {
               fields: addLocaleToFields({
                 role: team.role,
                 inactiveSinceDate: team.inactiveSinceDate,
+                title: `${team.id[0].flatData.displayName}${
+                  team.inactiveSinceDate ? ' (inactive)' : ''
+                }`,
                 team: {
                   sys: {
                     type: 'Link',

--- a/packages/cms-data-sync/test/users/users.data-migration.test.ts
+++ b/packages/cms-data-sync/test/users/users.data-migration.test.ts
@@ -297,7 +297,14 @@ describe('Migrate users', () => {
             {
               role: 'Project Manager',
               inactiveSinceDate: '2021-12-23T12:00:00.000Z',
-              id: [{ id: 'team-1' }],
+              id: [
+                {
+                  id: 'team-1',
+                  flatData: {
+                    displayName: 'Team 1',
+                  },
+                },
+              ],
             },
           ],
         }),
@@ -309,6 +316,7 @@ describe('Migrate users', () => {
 
       expect(contentfulEnv.createEntry).toHaveBeenCalledWith('teamMembership', {
         fields: {
+          title: { 'en-US': 'Team 1 (inactive)' },
           role: { 'en-US': 'Project Manager' },
           inactiveSinceDate: { 'en-US': '2021-12-23T12:00:00.000Z' },
           team: {

--- a/packages/contentful-app-extensions/user-team-memberships/package.json
+++ b/packages/contentful-app-extensions/user-team-memberships/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@asap-hub/contentful-app-user-team-memberships",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "@contentful/app-sdk": "4.17.0",
+    "@contentful/f36-components": "4.34.1",
+    "@contentful/f36-tokens": "4.0.1",
+    "@contentful/react-apps-toolkit": "1.2.15",
+    "contentful-management": "10.32.0",
+    "emotion": "10.0.27",
+    "react": "17.0.2",
+    "react-dom": "17.0.2",
+    "react-scripts": "5.0.1"
+  },
+  "scripts": {
+    "start": "cross-env BROWSER=none react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test",
+    "test:no-watch": "react-scripts test --watchAll=false",
+    "eject": "react-scripts eject",
+    "create-app-definition": "contentful-app-scripts create-app-definition",
+    "upload": "contentful-app-scripts upload --bundle-dir ./build",
+    "upload-ci": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN"
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  },
+  "devDependencies": {
+    "@contentful/app-scripts": "1.7.13",
+    "@testing-library/jest-dom": "^5.16.5",
+    "@testing-library/react": "11.2.7",
+    "@tsconfig/create-react-app": "1.0.3",
+    "@types/jest": "^29.4.0",
+    "@types/node": "18.15.11",
+    "@types/react": "17.0.58",
+    "@types/react-dom": "17.0.19",
+    "@types/testing-library__jest-dom": "5.14.5",
+    "cross-env": "7.0.3",
+    "typescript": "4.9.5"
+  },
+  "homepage": "."
+}

--- a/packages/contentful-app-extensions/user-team-memberships/public/index.html
+++ b/packages/contentful-app-extensions/user-team-memberships/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+  </body>
+</html>

--- a/packages/contentful-app-extensions/user-team-memberships/src/App.tsx
+++ b/packages/contentful-app-extensions/user-team-memberships/src/App.tsx
@@ -1,0 +1,19 @@
+import React, { useMemo } from 'react';
+import { locations } from '@contentful/app-sdk';
+import { useSDK } from '@contentful/react-apps-toolkit';
+import Field from './locations/Field';
+
+const App = () => {
+  const sdk = useSDK();
+
+  const Component = useMemo(() => {
+    if (sdk.location.is(locations.LOCATION_ENTRY_FIELD)) {
+      return Field;
+    }
+    return null;
+  }, [sdk.location]);
+
+  return Component ? <Component /> : null;
+};
+
+export default App;

--- a/packages/contentful-app-extensions/user-team-memberships/src/index.tsx
+++ b/packages/contentful-app-extensions/user-team-memberships/src/index.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { render } from 'react-dom';
+
+import { GlobalStyles } from '@contentful/f36-components';
+import { SDKProvider } from '@contentful/react-apps-toolkit';
+
+import App from './App';
+
+const root = document.getElementById('root');
+
+render(
+  <SDKProvider>
+    <GlobalStyles />
+    <App />
+  </SDKProvider>,
+  root,
+);

--- a/packages/contentful-app-extensions/user-team-memberships/src/locations/Field.tsx
+++ b/packages/contentful-app-extensions/user-team-memberships/src/locations/Field.tsx
@@ -1,0 +1,40 @@
+import React, { useEffect, useState } from 'react';
+import { Paragraph } from '@contentful/f36-components';
+import { FieldExtensionSDK, Link } from '@contentful/app-sdk';
+import {
+  useSDK,
+  useFieldValue,
+  useAutoResizer,
+} from '@contentful/react-apps-toolkit';
+
+const Field = () => {
+  const sdk = useSDK<FieldExtensionSDK>();
+  useAutoResizer();
+
+  const [title, setTitle] = useFieldValue<string>('title');
+  const [team] = useFieldValue<Link>('team');
+  const [inactiveSince] = useFieldValue<string>('inactiveSinceDate');
+  const [teamName, setTeamName] = useState();
+
+  const updateTeamName = async (id: string) => {
+    const teamEntry = await sdk.space.getEntry(id);
+    setTeamName(teamEntry.fields.displayName['en-US']);
+  };
+
+  useEffect(() => {
+    const id = team?.sys?.id;
+    if (id) {
+      updateTeamName(id);
+    }
+  }, [team]);
+
+  useEffect(() => {
+    if (teamName) {
+      setTitle(`${teamName}${inactiveSince ? ' (inactive)' : ''}`);
+    }
+  }, [teamName, inactiveSince]);
+
+  return <Paragraph>{title}</Paragraph>;
+};
+
+export default Field;

--- a/packages/contentful-app-extensions/user-team-memberships/src/react-app-env.d.ts
+++ b/packages/contentful-app-extensions/user-team-memberships/src/react-app-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="react-scripts" />

--- a/packages/contentful-app-extensions/user-team-memberships/src/test/locations/Field.test.tsx
+++ b/packages/contentful-app-extensions/user-team-memberships/src/test/locations/Field.test.tsx
@@ -1,0 +1,108 @@
+import '@testing-library/jest-dom';
+import React, { useState } from 'react';
+import Field from '../../locations/Field';
+import { render, screen, waitFor } from '@testing-library/react';
+import { FieldExtensionSDK } from '@contentful/app-sdk';
+import {
+  useSDK,
+  useAutoResizer,
+  useFieldValue,
+} from '@contentful/react-apps-toolkit';
+
+jest.mock('@contentful/react-apps-toolkit', () => ({
+  useSDK: jest.fn(),
+  useAutoResizer: jest.fn(),
+  useFieldValue: jest.fn(),
+}));
+
+const mockBaseSdk = () => ({
+  space: {
+    getEntry: jest.fn().mockImplementation((entryId) => {
+      if (entryId === 'team-id') {
+        return Promise.resolve({
+          fields: {
+            displayName: {
+              'en-US': 'Team A',
+            },
+          },
+        });
+      }
+    }),
+  },
+});
+
+const setTitle = jest.fn();
+const mockUseFieldValue = (field: string) => {
+  if (field === 'team') {
+    return [{ sys: { id: 'team-id' } }];
+  }
+  if (field === 'title') {
+    const [title, _setTitle] = useState(null);
+    return [title, setTitle.mockImplementation(_setTitle)];
+  }
+  return [null];
+};
+
+describe('Field component', () => {
+  let sdk: jest.Mocked<FieldExtensionSDK>;
+
+  beforeEach(() => {
+    sdk = mockBaseSdk() as unknown as jest.Mocked<FieldExtensionSDK>;
+    (useSDK as jest.Mock).mockReturnValue(sdk);
+    (useFieldValue as jest.Mock).mockImplementation(mockUseFieldValue);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('enables automatic resizing', async () => {
+    render(<Field />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Team A')).toBeInTheDocument();
+      expect(useAutoResizer).toHaveBeenCalled();
+    });
+  });
+
+  it('sets the title with the team name', async () => {
+    render(<Field />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Team A')).toBeInTheDocument();
+      // make sure that the title is not set with `null` on first render
+      expect(setTitle).toHaveBeenCalledTimes(1);
+      expect(setTitle).toHaveBeenCalledWith('Team A');
+    });
+  });
+
+  it('sets the title with an inactive marker if inactiveDate is set', async () => {
+    (useFieldValue as jest.Mock).mockImplementation((field) => {
+      if (field === 'inactiveSinceDate') {
+        return ['2020-01-01T12:00:00.000Z'];
+      }
+      return mockUseFieldValue(field);
+    });
+
+    render(<Field />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Team A (inactive)')).toBeInTheDocument();
+      expect(setTitle).toHaveBeenCalledWith('Team A (inactive)');
+    });
+  });
+
+  it('does nothing if team is not defined', async () => {
+    (useFieldValue as jest.Mock).mockImplementation((field) => {
+      if (field === 'team') {
+        return [null];
+      }
+      return mockUseFieldValue(field);
+    });
+
+    render(<Field />);
+
+    expect(sdk.space.getEntry).not.toHaveBeenCalled();
+    expect(setTitle).not.toHaveBeenCalled();
+  });
+});

--- a/packages/contentful-app-extensions/user-team-memberships/tsconfig.json
+++ b/packages/contentful-app-extensions/user-team-memberships/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+
+    "allowJs": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "jsx": "react",
+    "moduleResolution": "node",
+    "noEmit": true,
+    "noFallthroughCasesInSwitch": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "strict": true,
+
+    "target": "es2015",
+    "lib": ["dom", "dom.iterable", "esnext"]
+  },
+  "include": ["src"]
+}

--- a/packages/contentful/migrations/crn/teamMembership/20230503102954-add-title-field.js
+++ b/packages/contentful/migrations/crn/teamMembership/20230503102954-add-title-field.js
@@ -1,0 +1,29 @@
+module.exports.description = 'Add title to team membership';
+
+module.exports.up = (migration) => {
+  const teamMembership = migration
+    .editContentType('teamMembership')
+    .displayField('title');
+
+  teamMembership
+    .createField('title')
+    .name('Title')
+    .type('Symbol')
+    .localized(false)
+    .required(false)
+    .validations([])
+    .disabled(false)
+    .omitted(true);
+
+  teamMembership.changeFieldControl(
+    'title',
+    'app',
+    '2FMHOHfQOOTcOJlTrn4rne',
+    {},
+  );
+};
+
+module.exports.down = (migration) => {
+  const teamMembership = migration.editContentType('teamMembership');
+  teamMembership.deleteField('title');
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -513,6 +513,33 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@asap-hub/contentful-app-user-team-memberships@workspace:packages/contentful-app-extensions/user-team-memberships":
+  version: 0.0.0-use.local
+  resolution: "@asap-hub/contentful-app-user-team-memberships@workspace:packages/contentful-app-extensions/user-team-memberships"
+  dependencies:
+    "@contentful/app-scripts": 1.7.13
+    "@contentful/app-sdk": 4.17.0
+    "@contentful/f36-components": 4.34.1
+    "@contentful/f36-tokens": 4.0.1
+    "@contentful/react-apps-toolkit": 1.2.15
+    "@testing-library/jest-dom": ^5.16.5
+    "@testing-library/react": 11.2.7
+    "@tsconfig/create-react-app": 1.0.3
+    "@types/jest": ^29.4.0
+    "@types/node": 18.15.11
+    "@types/react": 17.0.58
+    "@types/react-dom": 17.0.19
+    "@types/testing-library__jest-dom": 5.14.5
+    contentful-management: 10.32.0
+    cross-env: 7.0.3
+    emotion: 10.0.27
+    react: 17.0.2
+    react-dom: 17.0.2
+    react-scripts: 5.0.1
+    typescript: 4.9.5
+  languageName: unknown
+  linkType: soft
+
 "@asap-hub/contentful@workspace:*, @asap-hub/contentful@workspace:packages/contentful":
   version: 0.0.0-use.local
   resolution: "@asap-hub/contentful@workspace:packages/contentful"


### PR DESCRIPTION
* Sets the title field with the linked team name and an inactive flag so it shows correctly on user models.
* Sets the title field when migrating records from Squidex.
<img width="733" alt="Screenshot 2023-05-03 at 14 48 14" src="https://user-images.githubusercontent.com/117398/235935214-8059b134-ef89-4c94-b4b9-47e89ec878f9.png">
