### PR TITLE
Fix bugs with event speaker title Contentful extension

### DIFF
--- a/packages/contentful-app-extensions/event-speakers-title/src/locations/Field.tsx
+++ b/packages/contentful-app-extensions/event-speakers-title/src/locations/Field.tsx
@@ -32,13 +32,21 @@ const Field = () => {
     const userId = sdk.entry.fields.user.getValue()?.sys?.id;
     if (userId) {
       const user = await sdk.space.getEntry(userId);
-      setUserName(user.fields.name['en-US']);
+      if (user.fields.name) {
+        setUserName(user.fields.name['en-US']);
+      } else {
+        setUserName(
+          `${user.fields.firstName['en-US']} ${user.fields.lastName['en-US']}`,
+        );
+      }
     }
   });
 
   useEffect(() => {
     const titleValue = getTitle(teamName, userName);
-    sdk.field.setValue(titleValue);
+    if (titleValue) {
+      sdk.field.setValue(titleValue);
+    }
     setTitle(titleValue);
   }, [teamName, userName, sdk.field]);
 

--- a/packages/contentful-app-extensions/event-speakers-title/src/test/locations/Field.test.tsx
+++ b/packages/contentful-app-extensions/event-speakers-title/src/test/locations/Field.test.tsx
@@ -1,12 +1,14 @@
 import '@testing-library/jest-dom';
-import React from 'react';
+import React, { useState } from 'react';
 import Field from '../../locations/Field';
 import { render, screen, waitFor } from '@testing-library/react';
 
-import { useSDK } from '@contentful/react-apps-toolkit';
+import { useSDK, useFieldValue } from '@contentful/react-apps-toolkit';
 
 jest.mock('@contentful/react-apps-toolkit', () => ({
   useSDK: jest.fn(),
+  useAutoResizer: jest.fn(),
+  useFieldValue: jest.fn(),
 }));
 
 type IdMap = {
@@ -14,14 +16,7 @@ type IdMap = {
   team: string | null;
 };
 
-const mockBaseSdk = ({ user, team }: IdMap) => ({
-  window: {
-    startAutoResizer: jest.fn(),
-  },
-  field: {
-    getValue: jest.fn(),
-    setValue: jest.fn(),
-  },
+const mockBaseSdk = () => ({
   space: {
     getEntry: jest.fn().mockImplementation((entryId) => {
       if (entryId === 'team-id') {
@@ -59,65 +54,90 @@ const mockBaseSdk = ({ user, team }: IdMap) => ({
       return Promise.resolve(null);
     }),
   },
-  entry: {
-    onSysChanged: jest.fn((cb) => {
-      cb(jest.fn());
-      return jest.fn();
-    }),
-    fields: {
-      team: {
-        getValue: jest.fn(() => (team ? { sys: { id: team } } : null)),
-      },
-      user: {
-        getValue: jest.fn(() => (user ? { sys: { id: user } } : null)),
-      },
-    },
-  },
 });
+
+const setTitle = jest.fn();
+const mockUseFieldValue =
+  ({ team, user }: IdMap) =>
+  (field: string) => {
+    if (field === 'team') {
+      return team ? [{ sys: { id: team } }] : [undefined];
+    }
+    if (field === 'user') {
+      return user ? [{ sys: { id: user } }] : [undefined];
+    }
+    if (field === 'title') {
+      const [title, _setTitle] = useState(null);
+      return [title, setTitle.mockImplementation(_setTitle)];
+    }
+    return [null];
+  };
 
 describe('Field component', () => {
   it('sets title based on team name and user name', async () => {
-    const mockSDK = mockBaseSdk({ user: 'user-id', team: 'team-id' });
+    const mockSDK = mockBaseSdk();
     (useSDK as jest.Mock).mockReturnValue(mockSDK);
+    (useFieldValue as jest.Mock).mockImplementation(
+      mockUseFieldValue({ user: 'user-id', team: 'team-id' }),
+    );
     render(<Field />);
     await waitFor(() => {
-      expect(mockSDK.field.setValue).toHaveBeenCalledWith('Team A - Hub User');
+      expect(setTitle).toHaveBeenCalledWith('Team A - Hub User');
     });
     expect(screen.getByText('Team A - Hub User')).toBeInTheDocument();
   });
 
   it('sets title based on team name and external author name', async () => {
-    const mockSDK = mockBaseSdk({
-      user: 'external-author-id',
-      team: 'team-id',
-    });
+    const mockSDK = mockBaseSdk();
     (useSDK as jest.Mock).mockReturnValue(mockSDK);
+    (useFieldValue as jest.Mock).mockImplementation(
+      mockUseFieldValue({
+        user: 'external-author-id',
+        team: 'team-id',
+      }),
+    );
     render(<Field />);
     await waitFor(() => {
-      expect(mockSDK.field.setValue).toHaveBeenCalledWith(
-        'Team A - External Author',
-      );
+      expect(setTitle).toHaveBeenCalledWith('Team A - External Author');
     });
     expect(screen.getByText('Team A - External Author')).toBeInTheDocument();
   });
 
   it('sets title based on team name only', async () => {
-    const mockSDK = mockBaseSdk({ user: null, team: 'team-id' });
+    const mockSDK = mockBaseSdk();
     (useSDK as jest.Mock).mockReturnValue(mockSDK);
+    (useFieldValue as jest.Mock).mockImplementation(
+      mockUseFieldValue({ user: null, team: 'team-id' }),
+    );
     render(<Field />);
     await waitFor(() => {
-      expect(mockSDK.field.setValue).toHaveBeenCalledWith('Team A');
+      expect(setTitle).toHaveBeenCalledWith('Team A');
     });
     expect(screen.getByText('Team A')).toBeInTheDocument();
   });
 
   it('sets title based on user name only', async () => {
-    const mockSDK = mockBaseSdk({ user: 'user-id', team: null });
+    const mockSDK = mockBaseSdk();
     (useSDK as jest.Mock).mockReturnValue(mockSDK);
+    (useFieldValue as jest.Mock).mockImplementation(
+      mockUseFieldValue({ user: 'user-id', team: null }),
+    );
     render(<Field />);
     await waitFor(() => {
-      expect(mockSDK.field.setValue).toHaveBeenCalledWith('Hub User');
+      expect(setTitle).toHaveBeenCalledWith('Hub User');
     });
     expect(screen.getByText('Hub User')).toBeInTheDocument();
+  });
+
+  it('sets title to empty string if team and user are removed', async () => {
+    const mockSDK = mockBaseSdk();
+    (useSDK as jest.Mock).mockReturnValue(mockSDK);
+    (useFieldValue as jest.Mock).mockImplementation(
+      mockUseFieldValue({ user: null, team: null }),
+    );
+    render(<Field />);
+    await waitFor(() => {
+      expect(setTitle).toHaveBeenCalledWith('');
+    });
   });
 });


### PR DESCRIPTION
* The properties of an external author model and a user model differ, so when loading a user model need to use `${firstName} ${lastName}` and not `name`.
* Fix issue where the title would change to an empty value and back when opening the page.
* Add coverage for each type of linked user as well as a case where no user or no team is selected.