### PR TITLE
Add testing of app extensions to main PR pipeline

### DIFF
--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -32,6 +32,18 @@ jobs:
       - name: Check
         run: |
           yarn ${{ matrix.script }}
+  extensions:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/yldio/asap-hub/node-python-sq:f93db8bae8be7528565c2510dbc8e3eece97983d
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Run contentful app extension tests
+        run: yarn workspaces foreach --include "*/contentful-app-*" -v run test:no-watch
   unit:
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
It's currently possible to push failing tests for app extensions which don't get detected until they hit master.