### PR TITLE
feat: CT-38 Enable ORCID sync for Contentful

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -32,6 +32,9 @@ outputs:
   contentful-app-disabled-fields:
     description: 'Contentful App Extension Disabled Fields Id'
     value: ${{ steps.vars.outputs.contentful-app-disabled-fields }}
+  contentful-app-clear-on-change:
+    description: 'Contentful App Extension Clear Field On Change'
+    value: ${{ steps.vars.outputs.contentful-app-clear-on-change }}
   contentful-app-event-additional-materials:
     description: 'Contentful App Extension Event Additional Materials Id'
     value: ${{ steps.vars.outputs.contentful-app-event-additional-materials }}

--- a/.github/environment/Base
+++ b/.github/environment/Base
@@ -5,6 +5,7 @@ cache-prefix-definitions=definitions-ouput
 cache-prefix-frontend=frontend-output
 cache-prefix-transpile=transpile-output
 contentful-app-disabled-fields=2finDNk15g5UtOq4DaLNxv
+contentful-app-clear-on-change=6qDxRPM72qYTWfP4d6Sn0C
 contentful-app-event-additional-materials=3TfrYX8zVOgFtKxro89UVA
 contentful-app-event-speakers-title=6ZkXISzhv1b7jjgyaK2piv
 contentful-app-field-as-updated-at=mqvX9KU5AthRTlnIRhNNh

--- a/.github/workflows/on-push-app-extensions.yml
+++ b/.github/workflows/on-push-app-extensions.yml
@@ -65,6 +65,7 @@ jobs:
           - field-as-updated-at
           - user-positions
           - user-team-memberships
+          - clear-on-change
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/apps/crn-server/serverless.ts
+++ b/apps/crn-server/serverless.ts
@@ -848,7 +848,7 @@ const serverlessConfig: AWS = {
         IS_CONTENTFUL_ENABLED_V2: 'false',
       },
     },
-    cronjobSyncContentful: {
+    cronjobSyncOrcidContentful: {
       handler: './src/handlers/webhooks/cronjob-sync-orcid.handler',
       events: [
         {

--- a/apps/crn-server/serverless.ts
+++ b/apps/crn-server/serverless.ts
@@ -836,7 +836,7 @@ const serverlessConfig: AWS = {
           contentfulWebhookAuthenticationToken,
       },
     },
-    cronjobSyncOrcid: {
+    cronjobSyncOrcidSquidex: {
       handler: './src/handlers/webhooks/cronjob-sync-orcid.handler',
       events: [
         {
@@ -845,6 +845,19 @@ const serverlessConfig: AWS = {
       ],
       environment: {
         SENTRY_DSN: sentryDsnHandlers,
+        IS_CONTENTFUL_ENABLED_V2: 'false',
+      },
+    },
+    cronjobSyncContentful: {
+      handler: './src/handlers/webhooks/cronjob-sync-orcid.handler',
+      events: [
+        {
+          schedule: 'rate(1 hour)', // run every hour
+        },
+      ],
+      environment: {
+        SENTRY_DSN: sentryDsnHandlers,
+        IS_CONTENTFUL_ENABLED_V2: 'true',
       },
     },
   },

--- a/apps/crn-server/serverless.ts
+++ b/apps/crn-server/serverless.ts
@@ -352,7 +352,7 @@ const serverlessConfig: AWS = {
         SENTRY_DSN: sentryDsnHandlers,
       },
     },
-    syncUserOrcid: {
+    syncUserOrcidSquidex: {
       handler: './src/handlers/user/sync-orcid-handler.handler',
       events: [
         {
@@ -370,6 +370,28 @@ const serverlessConfig: AWS = {
       ],
       environment: {
         SENTRY_DSN: sentryDsnHandlers,
+        IS_CONTENTFUL_ENABLED_V2: 'false',
+      },
+    },
+    syncUserOrcidContentful: {
+      handler: './src/handlers/user/sync-orcid-handler.handler',
+      events: [
+        {
+          eventBridge: {
+            eventBus: 'asap-events-${self:provider.stage}',
+            pattern: {
+              source: [eventBusSourceContentful],
+              'detail-type': ['UsersPublished'],
+            },
+            retryPolicy: {
+              maximumRetryAttempts: 2,
+            },
+          },
+        },
+      ],
+      environment: {
+        SENTRY_DSN: sentryDsnHandlers,
+        IS_CONTENTFUL_ENABLED_V2: 'true',
       },
     },
     inviteUserSquidex: {

--- a/apps/crn-server/src/handlers/event-bus.ts
+++ b/apps/crn-server/src/handlers/event-bus.ts
@@ -6,6 +6,7 @@ import {
   LabEvent,
   ResearchOutputEvent,
   TeamEvent,
+  UserEvent,
   WebhookDetail,
   WorkingGroupEvent,
 } from '@asap-hub/model';
@@ -17,6 +18,7 @@ import {
   ResearchOutput,
   SquidexWebhookPayload,
   Team,
+  User,
   WorkingGroup,
 } from '@asap-hub/squidex';
 
@@ -48,3 +50,12 @@ export type WorkingGroupPayload = SquidexWebhookPayload<
 >;
 
 export type TeamPayload = SquidexWebhookPayload<Team, TeamEvent>;
+
+export type UserSquidexPayload = WebhookDetail<
+  SquidexWebhookPayload<User, UserEvent>
+>;
+export type UserContentfulPayload = WebhookDetail<
+  ContentfulWebhookPayload<'users'>
+>;
+
+export type UserPayload = UserSquidexPayload | UserContentfulPayload;

--- a/apps/crn-server/src/handlers/user/sync-orcid-handler.ts
+++ b/apps/crn-server/src/handlers/user/sync-orcid-handler.ts
@@ -1,4 +1,3 @@
-import { DateTime } from 'luxon';
 import { UserEvent } from '@asap-hub/model';
 import { EventBridgeHandler } from '@asap-hub/server-common';
 import Users, { UserController } from '../../controllers/users';

--- a/apps/crn-server/src/handlers/user/sync-orcid-handler.ts
+++ b/apps/crn-server/src/handlers/user/sync-orcid-handler.ts
@@ -19,15 +19,10 @@ export const syncOrcidUserHandler =
 
     const userResponse = await users.fetchById(resourceId);
 
-    // skip if orcidLastSyncDate is less than 24 hours ago
-    if (
-      !userResponse.orcid ||
-      (userResponse.orcidLastSyncDate &&
-        DateTime.fromISO(userResponse.orcidLastSyncDate) >
-          DateTime.now().minus({ hours: 24 }))
-    ) {
+    // skip if orcid is missing or orcidLastSyncDate is given
+    if (!userResponse.orcid || userResponse.orcidLastSyncDate) {
       logger.debug(
-        `Skipping sync for user ${resourceId} as orcidLastSyncDate is less than 24 hours ago`,
+        `Skipping sync for user ${resourceId} because orcid is missing or it has already been synced`,
       );
       return;
     }

--- a/apps/crn-server/src/handlers/webhooks/cronjob-sync-orcid.ts
+++ b/apps/crn-server/src/handlers/webhooks/cronjob-sync-orcid.ts
@@ -19,7 +19,7 @@ const rawHandler = async (): Promise<lambda.Response> => {
     .toISO();
 
   const { items: outdatedUsers } = await userDataProvider.fetch({
-    take: 100,
+    take: 50,
     filter: {
       orcid: '-',
       orcidLastSyncDate,

--- a/apps/crn-server/src/handlers/webhooks/cronjob-sync-orcid.ts
+++ b/apps/crn-server/src/handlers/webhooks/cronjob-sync-orcid.ts
@@ -1,38 +1,17 @@
 import { framework as lambda } from '@asap-hub/services-common';
-import {
-  InputUser,
-  RestUser,
-  SquidexGraphql,
-  SquidexRest,
-} from '@asap-hub/squidex';
 import pThrottle from 'p-throttle';
 import { DateTime } from 'luxon';
 import { UserDataObject, UserResponse } from '@asap-hub/model';
-import { appName, baseUrl } from '../../config';
 import Users from '../../controllers/users';
-import { AssetSquidexDataProvider } from '../../data-providers/assets.data-provider';
-import { UserSquidexDataProvider } from '../../data-providers/users.data-provider';
-import { getAuthToken } from '../../utils/auth';
 import { sentryWrapper } from '../../utils/sentry-wrapper';
+import {
+  getAssetDataProvider,
+  getUserDataProvider,
+} from '../../dependencies/users.dependencies';
 
 const rawHandler = async (): Promise<lambda.Response> => {
-  const squidexGraphqlClient = new SquidexGraphql(getAuthToken, {
-    appName,
-    baseUrl,
-  });
-  const userRestClient = new SquidexRest<RestUser, InputUser>(
-    getAuthToken,
-    'users',
-    {
-      appName,
-      baseUrl,
-    },
-  );
-  const userDataProvider = new UserSquidexDataProvider(
-    squidexGraphqlClient,
-    userRestClient,
-  );
-  const assetDataProvider = new AssetSquidexDataProvider(userRestClient);
+  const userDataProvider = getUserDataProvider();
+  const assetDataProvider = getAssetDataProvider();
   const users = new Users(userDataProvider, assetDataProvider);
   const orcidLastSyncDate = DateTime.now()
     .set({ hour: 0, minute: 0 })

--- a/apps/crn-server/test/fixtures/users.fixtures.ts
+++ b/apps/crn-server/test/fixtures/users.fixtures.ts
@@ -14,6 +14,7 @@ import {
   User,
   SquidexWebhookPayload,
 } from '@asap-hub/squidex';
+import { EventBridgeEvent } from 'aws-lambda';
 import {
   FetchUserQuery,
   FetchUsersQuery,
@@ -609,7 +610,13 @@ export const getUserWebhookPayload = (
   },
 });
 
-export const getUserEvent = (id: string, eventType: UserEvent) =>
+export const getUserEvent = (
+  id: string,
+  eventType: UserEvent,
+): EventBridgeEvent<
+  UserEvent,
+  WebhookDetail<SquidexWebhookPayload<User, UserEvent>>
+> =>
   createEventBridgeEventMock(
     getUserWebhookPayload(id, eventType),
     eventType,

--- a/packages/contentful-app-extensions/README.md
+++ b/packages/contentful-app-extensions/README.md
@@ -3,3 +3,7 @@
 Each folder in this package contains an independent react app. Although they live in the monorepo, internal workspaces packages are not used by the apps.
 
 Reference: https://www.contentful.com/developers/docs/extensibility/app-framework/tutorial/
+
+**Adding new app**
+
+Reference: https://www.notion.so/Contentful-App-Extensions-d216b4c9ec9b4652b2f779ce532007b5

--- a/packages/contentful-app-extensions/clear-on-change/package.json
+++ b/packages/contentful-app-extensions/clear-on-change/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@asap-hub/contentful-app-clear-on-change",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "@contentful/app-sdk": "4.17.0",
+    "@contentful/f36-components": "4.34.1",
+    "@contentful/f36-tokens": "4.0.1",
+    "@contentful/react-apps-toolkit": "1.2.15",
+    "@contentful/rich-text-html-renderer": "16.0.3",
+    "contentful-management": "10.32.0",
+    "emotion": "10.0.27",
+    "react": "17.0.2",
+    "react-dom": "17.0.2",
+    "react-scripts": "5.0.1"
+  },
+  "scripts": {
+    "start": "cross-env BROWSER=none react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test",
+    "test:no-watch": "react-scripts test --watchAll=false",
+    "eject": "react-scripts eject",
+    "create-app-definition": "contentful-app-scripts create-app-definition",
+    "upload": "contentful-app-scripts upload --bundle-dir ./build",
+    "upload-ci": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN"
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  },
+  "devDependencies": {
+    "@contentful/app-scripts": "1.7.13",
+    "@testing-library/jest-dom": "^5.16.5",
+    "@testing-library/react": "11.2.7",
+    "@tsconfig/create-react-app": "1.0.3",
+    "@types/jest": "^29.4.0",
+    "@types/node": "18.15.11",
+    "@types/react": "17.0.58",
+    "@types/react-dom": "17.0.19",
+    "@types/testing-library__jest-dom": "5.14.5",
+    "cross-env": "7.0.3",
+    "typescript": "4.9.5"
+  },
+  "homepage": "."
+}

--- a/packages/contentful-app-extensions/clear-on-change/public/index.html
+++ b/packages/contentful-app-extensions/clear-on-change/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+  </body>
+</html>

--- a/packages/contentful-app-extensions/clear-on-change/src/App.tsx
+++ b/packages/contentful-app-extensions/clear-on-change/src/App.tsx
@@ -1,0 +1,19 @@
+import React, { useMemo } from 'react';
+import { locations } from '@contentful/app-sdk';
+import { useSDK } from '@contentful/react-apps-toolkit';
+import Field from './locations/Field';
+
+const App = () => {
+  const sdk = useSDK();
+
+  const Component = useMemo(() => {
+    if (sdk.location.is(locations.LOCATION_ENTRY_FIELD)) {
+      return Field;
+    }
+    return null;
+  }, [sdk.location]);
+
+  return Component ? <Component /> : null;
+};
+
+export default App;

--- a/packages/contentful-app-extensions/clear-on-change/src/index.tsx
+++ b/packages/contentful-app-extensions/clear-on-change/src/index.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { render } from 'react-dom';
+
+import { GlobalStyles } from '@contentful/f36-components';
+import { SDKProvider } from '@contentful/react-apps-toolkit';
+
+import App from './App';
+
+const root = document.getElementById('root');
+
+render(
+  <SDKProvider>
+    <GlobalStyles />
+    <App />
+  </SDKProvider>,
+  root,
+);

--- a/packages/contentful-app-extensions/clear-on-change/src/locations/Field.tsx
+++ b/packages/contentful-app-extensions/clear-on-change/src/locations/Field.tsx
@@ -13,7 +13,6 @@ const Field = () => {
 
   useEffect(() => {
     if (!firstUpdate.current) {
-      console.log('clearing');
       setCurrentFieldValue(null);
     } else {
       firstUpdate.current = false;

--- a/packages/contentful-app-extensions/clear-on-change/src/locations/Field.tsx
+++ b/packages/contentful-app-extensions/clear-on-change/src/locations/Field.tsx
@@ -1,0 +1,26 @@
+import React, { useEffect, useRef } from 'react';
+import { Paragraph } from '@contentful/f36-components';
+import { FieldExtensionSDK } from '@contentful/app-sdk';
+import { useSDK, useFieldValue } from '@contentful/react-apps-toolkit';
+
+const Field = () => {
+  const sdk = useSDK<FieldExtensionSDK>();
+
+  const { observedField } = sdk.parameters.instance;
+  const [observedFieldValue] = useFieldValue(observedField);
+  const [currentFieldValue, setCurrentFieldValue] = useFieldValue();
+  const firstUpdate = useRef(true);
+
+  useEffect(() => {
+    if (!firstUpdate.current) {
+      console.log('clearing');
+      setCurrentFieldValue(null);
+    } else {
+      firstUpdate.current = false;
+    }
+  }, [observedFieldValue]);
+
+  return <Paragraph>{currentFieldValue}</Paragraph>;
+};
+
+export default Field;

--- a/packages/contentful-app-extensions/clear-on-change/src/react-app-env.d.ts
+++ b/packages/contentful-app-extensions/clear-on-change/src/react-app-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="react-scripts" />

--- a/packages/contentful-app-extensions/clear-on-change/src/test/locations/Field.test.tsx
+++ b/packages/contentful-app-extensions/clear-on-change/src/test/locations/Field.test.tsx
@@ -1,0 +1,70 @@
+import '@testing-library/jest-dom';
+import React from 'react';
+import Field from '../../locations/Field';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { useSDK, useFieldValue } from '@contentful/react-apps-toolkit';
+
+jest.mock('@contentful/react-apps-toolkit', () => ({
+  useSDK: jest.fn(),
+  useFieldValue: jest.fn(),
+}));
+
+describe('Field component', () => {
+  beforeEach(() => {
+    (useSDK as jest.Mock).mockImplementation(() => ({
+      parameters: {
+        instance: {
+          observedField: 'orcid',
+        },
+      },
+    }));
+  });
+
+  it('Displays the field value', () => {
+    (useFieldValue as jest.Mock).mockImplementation((field) =>
+      field === 'orcid'
+        ? // always return the same ORCID
+          ['0000-0003-0974-0307']
+        : ['test-field-value', jest.fn()],
+    );
+
+    render(<Field />);
+
+    expect(screen.getByText('test-field-value')).toBeInTheDocument();
+  });
+
+  it('Does not clear the field value when observed field remains the same', () => {
+    const setCurrentFieldValueMock = jest.fn();
+    (useFieldValue as jest.Mock).mockImplementation((field) =>
+      field === 'orcid'
+        ? // always return the same ORCID
+          ['0000-0003-0974-0307']
+        : ['2023-04-12T16:05:00.000Z', setCurrentFieldValueMock],
+    );
+
+    const { rerender } = render(<Field />);
+    rerender(<Field />);
+
+    expect(setCurrentFieldValueMock).not.toHaveBeenCalledWith(null);
+  });
+
+  it('Clears the field value when observed field changes', () => {
+    const mockOrcid = jest
+      .fn()
+      .mockReturnValueOnce('0000-0000-0000-0000')
+      .mockReturnValueOnce('0000-0003-0974-0307');
+    const setCurrentFieldValueMock = jest.fn();
+    (useFieldValue as jest.Mock).mockImplementation((field) =>
+      field === 'orcid'
+        ? // return a different ORCID on each call
+          [mockOrcid()]
+        : ['2023-04-12T16:05:00.000Z', setCurrentFieldValueMock],
+    );
+
+    const { rerender } = render(<Field />);
+    rerender(<Field />);
+
+    expect(setCurrentFieldValueMock).toHaveBeenCalledWith(null);
+  });
+});

--- a/packages/contentful-app-extensions/clear-on-change/tsconfig.json
+++ b/packages/contentful-app-extensions/clear-on-change/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+
+    "allowJs": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "jsx": "react",
+    "moduleResolution": "node",
+    "noEmit": true,
+    "noFallthroughCasesInSwitch": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "strict": true,
+
+    "target": "es2015",
+    "lib": ["dom", "dom.iterable", "esnext"]
+  },
+  "include": ["src"]
+}

--- a/packages/squidex/schema/crn/schemas/users.json
+++ b/packages/squidex/schema/crn/schemas/users.json
@@ -9,7 +9,7 @@
     },
     "scripts": {
       "create": "if(JSON.stringify(ctx.data.teams.iv).indexOf('ASAP Staff') > 0  && ctx.data.role.iv !== 'Staff') {\n    reject('Only Staff can be given this team role. Change ASAP Hub Role to \"Staff\".')\n}",
-      "update": "if(JSON.stringify(ctx.data.teams.iv).indexOf('ASAP Staff') > 0  && ctx.data.role.iv !== 'Staff') {\n    reject('Only Staff can be given this team role. Change ASAP Hub Role to \"Staff\".')\n}\n\nconst becameAlumni = ctx.data.alumniSinceDate.iv && (ctx.oldData.alumniSinceDate.iv !== ctx.data.alumniSinceDate.iv);\nlet anyTeamChanged = false;\n\nctx.data.teams.iv = ctx.data.teams.iv.map((team) => {\n    if (becameAlumni && !team.inactiveSinceDate) {\n        team.inactiveSinceDate = new Date().toISOString();\n        anyTeamChanged = true;\n    }\n    return team;\n});\n\nif (anyTeamChanged) {\n    replace();\n}"
+      "update": "if(JSON.stringify(ctx.data.teams.iv).indexOf('ASAP Staff') > 0  && ctx.data.role.iv !== 'Staff') {\n    reject('Only Staff can be given this team role. Change ASAP Hub Role to \"Staff\".')\n}\n\nconst becameAlumni = ctx.data.alumniSinceDate.iv && (ctx.oldData.alumniSinceDate.iv !== ctx.data.alumniSinceDate.iv);\nlet anyTeamChanged = false;\n\nctx.data.teams.iv = ctx.data.teams.iv.map((team) => {\n    if (becameAlumni && !team.inactiveSinceDate) {\n        team.inactiveSinceDate = new Date().toISOString();\n        anyTeamChanged = true;\n    }\n    return team;\n});\n\nif (anyTeamChanged) {\n    replace();\n}\n\nif (ctx.data.orcid.iv !== ctx.oldData.orcid.iv) {\n    ctx.data.orcidLastSyncDate.iv = null;\n    replace()\n}"
     },
     "fieldsInReferences": ["firstName", "lastName", "orcid"],
     "fieldsInLists": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -404,6 +404,34 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@asap-hub/contentful-app-clear-on-change@workspace:packages/contentful-app-extensions/clear-on-change":
+  version: 0.0.0-use.local
+  resolution: "@asap-hub/contentful-app-clear-on-change@workspace:packages/contentful-app-extensions/clear-on-change"
+  dependencies:
+    "@contentful/app-scripts": 1.7.13
+    "@contentful/app-sdk": 4.17.0
+    "@contentful/f36-components": 4.34.1
+    "@contentful/f36-tokens": 4.0.1
+    "@contentful/react-apps-toolkit": 1.2.15
+    "@contentful/rich-text-html-renderer": 16.0.3
+    "@testing-library/jest-dom": ^5.16.5
+    "@testing-library/react": 11.2.7
+    "@tsconfig/create-react-app": 1.0.3
+    "@types/jest": ^29.4.0
+    "@types/node": 18.15.11
+    "@types/react": 17.0.58
+    "@types/react-dom": 17.0.19
+    "@types/testing-library__jest-dom": 5.14.5
+    contentful-management: 10.32.0
+    cross-env: 7.0.3
+    emotion: 10.0.27
+    react: 17.0.2
+    react-dom: 17.0.2
+    react-scripts: 5.0.1
+    typescript: 4.9.5
+  languageName: unknown
+  linkType: soft
+
 "@asap-hub/contentful-app-disabled-fields@workspace:packages/contentful-app-extensions/disabled-fields":
   version: 0.0.0-use.local
   resolution: "@asap-hub/contentful-app-disabled-fields@workspace:packages/contentful-app-extensions/disabled-fields"


### PR DESCRIPTION
### Changes
- refactor sync orcid handler
- add contentful handler to serverless
- adds a clear-on-change Contentful app which resets a field based on a change to another field. 
--> In our case we reset the orcidLastSyncDate when the orcid field is modified, which is how we tell our webhook to sync it.

### OOS
What is missing here is the migration to alter the orcidLastSyncDate to use the extension but that will be done through a follow-up PR, it's testable within this PR though as it can be manually cleared to trigger the sync
