### PR TITLE
Contentful: Add migration to events and users to use new app extensions

### DIFF
--- a/packages/contentful/migrations/crn/events/20230511122400-event-speaker-controls.js
+++ b/packages/contentful/migrations/crn/events/20230511122400-event-speaker-controls.js
@@ -1,0 +1,34 @@
+module.exports.description = 'Create events content model';
+
+module.exports.up = (migration) => {
+  const events = migration.editContentType('events');
+
+  events.changeFieldControl('speakers', 'app', '6ZkXISzhv1b7jjgyaK2piv', {});
+
+  const eventSpeakers = migration.editContentType('eventSpeakers');
+
+  eventSpeakers.displayField('team');
+
+  eventSpeakers.deleteField('title');
+};
+
+module.exports.down = (migration) => {
+  const eventSpeakers = migration.editContentType('eventSpeakers');
+
+  eventSpeakers
+    .createField('title')
+    .name('Title')
+    .type('Symbol')
+    .localized(false)
+    .required(false)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+
+  eventSpeakers.changeFieldControl(
+    'title',
+    'app',
+    '6ZkXISzhv1b7jjgyaK2piv',
+    {},
+  );
+};

--- a/packages/contentful/migrations/crn/users/20230511122800-user-team-control.js
+++ b/packages/contentful/migrations/crn/users/20230511122800-user-team-control.js
@@ -1,0 +1,17 @@
+module.exports.description = 'Create events content model';
+
+module.exports.up = (migration) => {
+  const users = migration.editContentType('users');
+
+  users.changeFieldControl('teams', 'app', '2iE2vFoT19Q5u4Rxpio8gz', {});
+};
+
+module.exports.down = (migration) => {
+  const users = migration.editContentType('users');
+
+  users.changeFieldControl('teams', 'builtin', 'entryCardsEditor', {
+    bulkEditing: false,
+    showLinkEntityAction: false,
+    showCreateEntityAction: true,
+  });
+};

--- a/packages/contentful/src/crn/autogenerated-gql/graphql.ts
+++ b/packages/contentful/src/crn/autogenerated-gql/graphql.ts
@@ -522,7 +522,6 @@ export type EventSpeakers = Entry & {
   linkedFrom?: Maybe<EventSpeakersLinkingCollections>;
   sys: Sys;
   team?: Maybe<Teams>;
-  title?: Maybe<Scalars['String']>;
   user?: Maybe<EventSpeakersUser>;
 };
 
@@ -535,11 +534,6 @@ export type EventSpeakersLinkedFromArgs = {
 export type EventSpeakersTeamArgs = {
   locale?: InputMaybe<Scalars['String']>;
   preview?: InputMaybe<Scalars['Boolean']>;
-};
-
-/** [See type definition](https://app.contentful.com/spaces/5v6w5j61tndm/content_types/eventSpeakers) */
-export type EventSpeakersTitleArgs = {
-  locale?: InputMaybe<Scalars['String']>;
 };
 
 /** [See type definition](https://app.contentful.com/spaces/5v6w5j61tndm/content_types/eventSpeakers) */
@@ -562,13 +556,6 @@ export type EventSpeakersFilter = {
   sys?: InputMaybe<SysFilter>;
   team?: InputMaybe<CfTeamsNestedFilter>;
   team_exists?: InputMaybe<Scalars['Boolean']>;
-  title?: InputMaybe<Scalars['String']>;
-  title_contains?: InputMaybe<Scalars['String']>;
-  title_exists?: InputMaybe<Scalars['Boolean']>;
-  title_in?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-  title_not?: InputMaybe<Scalars['String']>;
-  title_not_contains?: InputMaybe<Scalars['String']>;
-  title_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
   user_exists?: InputMaybe<Scalars['Boolean']>;
 };
 
@@ -600,8 +587,6 @@ export enum EventSpeakersOrder {
   SysPublishedAtDesc = 'sys_publishedAt_DESC',
   SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
   SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
-  TitleAsc = 'title_ASC',
-  TitleDesc = 'title_DESC',
 }
 
 export type EventSpeakersUser = ExternalAuthors | Users;
@@ -3147,13 +3132,6 @@ export type CfEventSpeakersNestedFilter = {
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
   sys?: InputMaybe<SysFilter>;
   team_exists?: InputMaybe<Scalars['Boolean']>;
-  title?: InputMaybe<Scalars['String']>;
-  title_contains?: InputMaybe<Scalars['String']>;
-  title_exists?: InputMaybe<Scalars['Boolean']>;
-  title_in?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-  title_not?: InputMaybe<Scalars['String']>;
-  title_not_contains?: InputMaybe<Scalars['String']>;
-  title_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
   user_exists?: InputMaybe<Scalars['Boolean']>;
 };
 

--- a/packages/contentful/src/crn/schema/autogenerated-schema.graphql
+++ b/packages/contentful/src/crn/schema/autogenerated-schema.graphql
@@ -349,7 +349,6 @@ type EventSpeakers implements Entry {
   linkedFrom(allowedLocales: [String]): EventSpeakersLinkingCollections
   sys: Sys!
   team(locale: String, preview: Boolean): Teams
-  title(locale: String): String
   user(locale: String, preview: Boolean): EventSpeakersUser
 }
 
@@ -367,13 +366,6 @@ input EventSpeakersFilter {
   sys: SysFilter
   team: cfTeamsNestedFilter
   team_exists: Boolean
-  title: String
-  title_contains: String
-  title_exists: Boolean
-  title_in: [String]
-  title_not: String
-  title_not_contains: String
-  title_not_in: [String]
   user_exists: Boolean
 }
 
@@ -391,8 +383,6 @@ enum EventSpeakersOrder {
   sys_publishedAt_DESC
   sys_publishedVersion_ASC
   sys_publishedVersion_DESC
-  title_ASC
-  title_DESC
 }
 
 union EventSpeakersUser = ExternalAuthors | Users
@@ -1985,13 +1975,6 @@ input cfEventSpeakersNestedFilter {
   contentfulMetadata: ContentfulMetadataFilter
   sys: SysFilter
   team_exists: Boolean
-  title: String
-  title_contains: String
-  title_exists: Boolean
-  title_in: [String]
-  title_not: String
-  title_not_contains: String
-  title_not_in: [String]
   user_exists: Boolean
 }
 


### PR DESCRIPTION
Modifies the field controls on the events->speakers and users->teams fields to use the newly created app extensions for showing second-order linked entities.