### PR TITLE
Re-deploy contentful apps if deployment script/config changes

### DIFF
--- a/.github/workflows/on-push-app-extensions.yml
+++ b/.github/workflows/on-push-app-extensions.yml
@@ -25,6 +25,9 @@ jobs:
         with:
           PATTERNS: |
             packages/contentful-app-extensions/**/*.+(ts|tsx)
+          FILES: |
+            .github/workflows/on-push-app-extensions.yml
+            .github/environment/Base
       - id: diff
         run: |
           echo "::set-output name=diff::${{ env.GIT_DIFF }}"


### PR DESCRIPTION
Currently the contentful apps are only deployed if the source code for the app changes, but if the deployment workflows are changed thn they also need to re-deploy.