### PR TITLE
Add Github Actions setup output for user teams app

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -44,6 +44,9 @@ outputs:
   contentful-app-user-positions:
     description: 'Contentful App Extension User Positions Id'
     value: ${{ steps.vars.outputs.contentful-app-user-positions }}
+  contentful-app-user-team-memberships:
+    description: 'Contentful App Extension User Team Memberships Id'
+    value: ${{ steps.vars.outputs.contentful-app-user-team-memberships }}
   contentful-environment:
     description: 'Contentful Environment'
     value: ${{ steps.vars.outputs.contentful-environment }}


### PR DESCRIPTION
This was missed in the previous refactor of Contentful App deployments.