### PR TITLE
Output the currently used environments in Contentful

### DIFF
--- a/.github/actions/contentful-create-environment/action.yml
+++ b/.github/actions/contentful-create-environment/action.yml
@@ -32,7 +32,8 @@ runs:
                             --header "Authorization: Bearer ${CONTENTFUL_MANAGEMENT_ACCESS_TOKEN}" \
                             https://api.contentful.com/spaces/${CONTENTFUL_SPACE_ID}/environments \
                             | jq '.total' -r)
-
+                            
+        echo "Currently using $ENVIRONMENTS environments"
         if [[ "$ENVIRONMENTS" == "$MAX_CONTENTFUL_ENVIRONMENTS" ]]; then
           echo "Max Contentful environments reached. Cannot create more."
           exit 1;


### PR DESCRIPTION
To debug some odd failures where it reports using more environments than we seem to actually be using.