### PR TITLE
fixes user orphaned working groups

### DIFF
--- a/apps/gp2-server/src/data-providers/contentful/user.data-provider.ts
+++ b/apps/gp2-server/src/data-providers/contentful/user.data-provider.ts
@@ -415,29 +415,35 @@ const parseWorkingGroups = (
     >['linkedFrom']
   >['workingGroupMembershipCollection'],
 ): gp2Model.UserDataObject['workingGroups'] =>
-  workingGroupItems?.items.map((wg) => {
-    const linkedWorkingGroup =
-      wg?.linkedFrom?.workingGroupsCollection?.items[0];
+  workingGroupItems?.items
+    ?.filter(
+      (workingGroup) =>
+        workingGroup?.linkedFrom?.workingGroupsCollection?.items &&
+        workingGroup.linkedFrom.workingGroupsCollection.items.length > 0,
+    )
+    .map((workingGroup) => {
+      const linkedWorkingGroup =
+        workingGroup?.linkedFrom?.workingGroupsCollection?.items[0];
 
-    const id = linkedWorkingGroup?.sys.id;
-    if (!id) {
-      throw new Error('Working Group not defined.');
-    }
-    return {
-      id,
-      title: linkedWorkingGroup.title || '',
-      members:
-        linkedWorkingGroup.membersCollection?.items.map((member) => {
-          const user = member?.user;
-          const role = member?.role;
+      const workingGroupId = linkedWorkingGroup?.sys.id;
+      if (!workingGroupId) {
+        throw new Error('Working Group not defined.');
+      }
+      return {
+        id: workingGroupId,
+        title: linkedWorkingGroup.title || '',
+        members:
+          linkedWorkingGroup.membersCollection?.items.map((member) => {
+            const user = member?.user;
+            const role = member?.role;
 
-          if (!(role && user && gp2Model.isWorkingGroupMemberRole(role))) {
-            throw new Error('Invalid working group members');
-          }
-          return { role, userId: user.sys.id };
-        }) || [],
-    };
-  }) || [];
+            if (!(role && user && gp2Model.isWorkingGroupMemberRole(role))) {
+              throw new Error('Invalid working group members');
+            }
+            return { role, userId: user.sys.id };
+          }) || [],
+      };
+    }) || [];
 
 const parsePositions = (
   positions: NonNullable<

--- a/apps/gp2-server/test/data-providers/contentful/user.data-provider.test.ts
+++ b/apps/gp2-server/test/data-providers/contentful/user.data-provider.test.ts
@@ -744,7 +744,49 @@ describe('User data provider', () => {
       });
       test('Should return empty array if working group has not been defined', async () => {
         const mockResponse = getContentfulGraphqlUser({
-          linkedFrom: { workingGroupMembershipCollection: null },
+          linkedFrom: { workingGroupMembershipCollection: {} },
+        });
+        contentfulGraphqlClientMock.request.mockResolvedValueOnce({
+          users: mockResponse,
+        });
+
+        const result = await userDataProvider.fetchById('user-id');
+        expect(result?.workingGroups).toEqual([]);
+      });
+      test('Should return empty array if no working group collection items', async () => {
+        const mockResponse = getContentfulGraphqlUser({
+          linkedFrom: {
+            workingGroupMembershipCollection: { items: [] },
+          },
+        });
+        contentfulGraphqlClientMock.request.mockResolvedValueOnce({
+          users: mockResponse,
+        });
+
+        const result = await userDataProvider.fetchById('user-id');
+        expect(result?.workingGroups).toEqual([]);
+      });
+      test('Should return empty array if no linked working group', async () => {
+        const mockResponse = getContentfulGraphqlUser({
+          linkedFrom: {
+            workingGroupMembershipCollection: {
+              items: [
+                {
+                  user: {
+                    sys: {
+                      id: '42',
+                    },
+                  },
+                  role: 'Co-Lead',
+                  linkedFrom: {
+                    workingGroupsCollection: {
+                      items: [],
+                    },
+                  },
+                },
+              ],
+            },
+          },
         });
         contentfulGraphqlClientMock.request.mockResolvedValueOnce({
           users: mockResponse,


### PR DESCRIPTION
- FIxes error when fetching user related to an orphaned working group

Steps to reproduce:

- Associate user to working group
- Delete working group
- Try to load the user details