### PR TITLE
refactor: working group update type

### DIFF
--- a/apps/crn-server/test/data-providers/working-groups.data-provider.test.ts
+++ b/apps/crn-server/test/data-providers/working-groups.data-provider.test.ts
@@ -480,16 +480,20 @@ describe('Working Group Data Provider', () => {
 
   describe('update method', () => {
     it('calls `patch` method on squidex rest client', async () => {
-      await workingGroupDataProvider.update('123', { title: 'New title' });
+      await workingGroupDataProvider.update('123', {
+        deliverables: [
+          {
+            description: '<p>Deliverable one</p>',
+            status: 'Complete',
+          },
+        ],
+      });
 
       expect(workingGroupRestClient.patch).toHaveBeenCalled();
     });
 
     it('maps arguments to `{ iv: <arg> }` pattern expected by Squidex API', async () => {
       await workingGroupDataProvider.update('123', {
-        title: 'New title',
-        description: '<p>Description</p>',
-        complete: true,
         deliverables: [
           {
             description: '<p>Deliverable one</p>',
@@ -500,22 +504,9 @@ describe('Working Group Data Provider', () => {
             status: 'Incomplete',
           },
         ],
-        shortText: '',
-        calendars: ['123'],
-        leaders: [
-          {
-            user: ['456'],
-            role: '',
-            workstreamRole: '',
-          },
-        ],
-        members: ['456'],
       });
 
       expect(workingGroupRestClient.patch).toHaveBeenCalledWith('123', {
-        title: { iv: 'New title' },
-        description: { iv: '<p>Description</p>' },
-        complete: { iv: true },
         deliverables: {
           iv: [
             {
@@ -528,18 +519,6 @@ describe('Working Group Data Provider', () => {
             },
           ],
         },
-        shortText: { iv: '' },
-        calendars: { iv: ['123'] },
-        leaders: {
-          iv: [
-            {
-              user: ['456'],
-              role: '',
-              workstreamRole: '',
-            },
-          ],
-        },
-        members: { iv: ['456'] },
       });
     });
   });

--- a/packages/model/src/working-group.ts
+++ b/packages/model/src/working-group.ts
@@ -77,16 +77,9 @@ export type WorkingGroupDataObject = {
   readonly lastModifiedDate: string;
 };
 
-export type WorkingGroupUpdateDataObject = Partial<
-  Omit<WorkingGroupDataObject, 'leaders' | 'members' | 'calendars'> & {
-    calendars: string[];
-    leaders: {
-      user: string[];
-      role: string;
-      workstreamRole: string;
-    }[];
-    members: string[];
-  }
+export type WorkingGroupUpdateDataObject = Pick<
+  WorkingGroupDataObject,
+  'deliverables'
 >;
 
 export type WorkingGroupListDataObject = ListResponse<WorkingGroupDataObject>;


### PR DESCRIPTION
The update method on Working Group Data Provider was added here https://github.com/yldio/asap-hub/pull/2703/files. The idea was to update `deliverables` and this is the only use case for update so far.

Since we are implementing Contentful's data providers now, I think it would be better to enforce the properties that can be updated in the data provider. If we update other things like calendar, leaders or members it would be necessary to check if this calendar/user exists and create a link to update the entry, it's not a "plain" payload like passing ids. So since there isn't a use case where these properties are updated, I believe we could remove then from `WorkingGroupUpdateDataObject`.