### PR TITLE
CT-17 Working Groups webhook

### DIFF
--- a/apps/crn-server/serverless.ts
+++ b/apps/crn-server/serverless.ts
@@ -889,7 +889,7 @@ const serverlessConfig: AWS = {
         SENTRY_DSN: sentryDsnHandlers,
       },
     },
-    updateWorkingGroupDeliverables: {
+    updateSquidexWorkingGroupDeliverables: {
       handler:
         './src/handlers/working-group/update-deliverables-handler.handler',
       events: [
@@ -905,6 +905,26 @@ const serverlessConfig: AWS = {
       ],
       environment: {
         SENTRY_DSN: sentryDsnHandlers,
+        IS_CONTENTFUL_ENABLED_V2: 'false',
+      },
+    },
+    updateContentfulWorkingGroupDeliverables: {
+      handler:
+        './src/handlers/working-group/update-deliverables-handler.handler',
+      events: [
+        {
+          eventBridge: {
+            eventBus: 'asap-events-${self:provider.stage}',
+            pattern: {
+              source: [eventBusSourceContentful],
+              'detail-type': ['WorkingGroupsPublished'],
+            },
+          },
+        },
+      ],
+      environment: {
+        SENTRY_DSN: sentryDsnHandlers,
+        IS_CONTENTFUL_ENABLED_V2: 'true',
       },
     },
     squidexWebhook: {

--- a/apps/crn-server/src/dependencies/working-groups.dependencies.ts
+++ b/apps/crn-server/src/dependencies/working-groups.dependencies.ts
@@ -1,0 +1,54 @@
+import { getGraphQLClient as getContentfulGraphQLClient } from '@asap-hub/contentful';
+import {
+  RestWorkingGroup,
+  SquidexGraphql,
+  SquidexRest,
+} from '@asap-hub/squidex';
+import {
+  appName,
+  baseUrl,
+  contentfulAccessToken,
+  contentfulEnvId,
+  contentfulSpaceId,
+  isContentfulEnabledV2,
+} from '../config';
+import { WorkingGroupContentfulDataProvider } from '../data-providers/contentful/working-groups.data-provider';
+import { WorkingGroupSquidexDataProvider } from '../data-providers/working-groups.data-provider';
+
+import { WorkingGroupDataProvider } from '../data-providers/types';
+import { getAuthToken } from '../utils/auth';
+import { getContentfulRestClientFactory } from './clients.dependencies';
+
+export const getWorkingGroupDataProvider = (): WorkingGroupDataProvider => {
+  if (isContentfulEnabledV2) {
+    const contentfulGraphQLClient = getContentfulGraphQLClient({
+      space: contentfulSpaceId,
+      accessToken: contentfulAccessToken,
+      environment: contentfulEnvId,
+    });
+
+    return new WorkingGroupContentfulDataProvider(
+      contentfulGraphQLClient,
+      getContentfulRestClientFactory,
+    );
+  }
+
+  const squidexGraphqlClient = new SquidexGraphql(getAuthToken, {
+    appName,
+    baseUrl,
+  });
+
+  const squidexRestClient = new SquidexRest<RestWorkingGroup>(
+    getAuthToken,
+    'working-groups',
+    {
+      appName,
+      baseUrl,
+    },
+  );
+
+  return new WorkingGroupSquidexDataProvider(
+    squidexGraphqlClient,
+    squidexRestClient,
+  );
+};

--- a/apps/crn-server/src/handlers/event-bus.ts
+++ b/apps/crn-server/src/handlers/event-bus.ts
@@ -61,10 +61,16 @@ export type ResearchOutputPayload = SquidexWebhookPayload<
   ResearchOutputEvent
 >;
 
-export type WorkingGroupPayload = SquidexWebhookPayload<
-  WorkingGroup,
-  WorkingGroupEvent
+export type WorkingGroupSquidexPayload = WebhookDetail<
+  SquidexWebhookPayload<WorkingGroup, WorkingGroupEvent>
 >;
+
+export type WorkingGroupContentfulPayload = WebhookDetail<
+  ContentfulWebhookPayload<'workingGroups'>
+>;
+export type WorkingGroupPayload =
+  | WorkingGroupSquidexPayload
+  | WorkingGroupContentfulPayload;
 
 export type TeamPayload = SquidexWebhookPayload<Team, TeamEvent>;
 

--- a/apps/crn-server/test/dependencies/working-groups.dependencies.test.ts
+++ b/apps/crn-server/test/dependencies/working-groups.dependencies.test.ts
@@ -1,0 +1,41 @@
+describe('Working Groups Dependencies', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  it('Should resolve Working Group Squidex Data Provider when the Contentful feature flag is off', async () => {
+    process.env.IS_CONTENTFUL_ENABLED_V2 = 'false';
+
+    const { WorkingGroupSquidexDataProvider } = await import(
+      '../../src/data-providers/working-groups.data-provider'
+    );
+    const getWorkingGroupDataProviderModule = await import(
+      '../../src/dependencies/working-groups.dependencies'
+    );
+    const WorkingGroupDataProvider =
+      getWorkingGroupDataProviderModule.getWorkingGroupDataProvider();
+
+    expect(WorkingGroupDataProvider).toBeInstanceOf(
+      WorkingGroupSquidexDataProvider,
+    );
+  });
+
+  it('Should resolve Working Group Contentful Data Provider when the Contentful feature flag is on', async () => {
+    process.env.IS_CONTENTFUL_ENABLED_V2 = 'true';
+    const { WorkingGroupContentfulDataProvider } = await import(
+      '../../src/data-providers/contentful/working-groups.data-provider'
+    );
+    const getWorkingGroupDataProviderModule = await import(
+      '../../src/dependencies/working-groups.dependencies'
+    );
+    const WorkingGroupDataProvider =
+      getWorkingGroupDataProviderModule.getWorkingGroupDataProvider();
+
+    expect(WorkingGroupDataProvider).toBeInstanceOf(
+      WorkingGroupContentfulDataProvider,
+    );
+  });
+});
+
+// necessary to avoid " cannot be compiled under '--isolatedModules' because it is considered a global script file"
+export {};

--- a/apps/crn-server/test/fixtures/working-groups.fixtures.ts
+++ b/apps/crn-server/test/fixtures/working-groups.fixtures.ts
@@ -1,8 +1,10 @@
 import {
   FetchWorkingGroupsQuery as ContentfulFetchWorkingGroupsQuery,
   FetchWorkingGroupByIdQuery as ContentfulFetchWorkingGroupByIdQuery,
+  ContentfulWebhookPayload,
 } from '@asap-hub/contentful';
 import {
+  WebhookDetail,
   WorkingGroupDataObject,
   WorkingGroupEvent,
   WorkingGroupListDataObject,
@@ -124,10 +126,11 @@ export const getSquidexGraphqlWorkingGroup = (): NonNullable<
   },
 });
 
-export const getWorkingGroupEventPayload = (
+export const getWorkingGroupSquidexEventPayload = (
   id: string,
   data: Partial<WorkingGroup>,
 ): WorkingGroupPayload => ({
+  resourceId: id,
   type: 'WorkingGroupsUpdated',
   timestamp: '2021-01-01T00:00:00.000Z',
   payload: {
@@ -152,13 +155,146 @@ export const getWorkingGroupEventPayload = (
   },
 });
 
-export const getWorkingGroupEvent = (
+export const getWorkingGroupSquidexEvent = (
   data = {},
 ): EventBridgeEvent<WorkingGroupEvent, WorkingGroupPayload> =>
   createEventBridgeEventMock(
-    getWorkingGroupEventPayload('123', data),
+    getWorkingGroupSquidexEventPayload('123', data),
     'WorkingGroupsUpdated',
     '123',
+  );
+
+export const getWorkingGroupContentfulWebhookDetail = (
+  id: string,
+): WebhookDetail<ContentfulWebhookPayload<'workingGroups'>> => ({
+  resourceId: id,
+  metadata: {
+    tags: [],
+  },
+  sys: {
+    type: 'Entry',
+    id: 'fc496d00-053f-44fd-9bac-68dd9d959848',
+    space: {
+      sys: {
+        type: 'Link',
+        linkType: 'Space',
+        id: '5v6w5j61tndm',
+      },
+    },
+    environment: {
+      sys: {
+        id: 'crn-3046',
+        type: 'Link',
+        linkType: 'Environment',
+      },
+    },
+    contentType: {
+      sys: {
+        type: 'Link',
+        linkType: 'ContentType',
+        id: 'workingGroups',
+      },
+    },
+    createdBy: {
+      sys: {
+        type: 'Link',
+        linkType: 'User',
+        id: '2SHvngTJ24kxZGAPDJ8J1y',
+      },
+    },
+    updatedBy: {
+      sys: {
+        type: 'Link',
+        linkType: 'User',
+        id: '2SHvngTJ24kxZGAPDJ8J1y',
+      },
+    },
+    revision: 14,
+    createdAt: '2023-05-17T13:39:03.250Z',
+    updatedAt: '2023-05-18T16:17:36.425Z',
+  },
+  fields: {
+    title: {
+      'en-US': 'WG-1',
+    },
+    complete: {
+      'en-US': false,
+    },
+    description: {
+      'en-US': {
+        data: {},
+        content: [
+          {
+            data: {},
+            content: [
+              {
+                data: {},
+                marks: [],
+                value: 'A nice working group!',
+                nodeType: 'text',
+              },
+            ],
+            nodeType: 'paragraph',
+          },
+        ],
+        nodeType: 'document',
+      },
+    },
+    shortText: {
+      'en-US': 'WG',
+    },
+    calendars: {
+      'en-US': {
+        sys: {
+          type: 'Link',
+          linkType: 'Entry',
+          id: '605f89c4-a2f7-4e78-9e12-0f83ff32c4b3',
+        },
+      },
+    },
+    deliverables: {
+      'en-US': [
+        {
+          sys: {
+            type: 'Link',
+            linkType: 'Entry',
+            id: '4mrJ1Cxkr3utqIE7OUx3pU',
+          },
+        },
+        {
+          sys: {
+            type: 'Link',
+            linkType: 'Entry',
+            id: '6o83rchawGuC54cCsoZODf',
+          },
+        },
+      ],
+    },
+    members: {
+      'en-US': [
+        {
+          sys: {
+            type: 'Link',
+            linkType: 'Entry',
+            id: '3Rsu13aXSheyBphmOnwEBq',
+          },
+        },
+      ],
+    },
+  },
+});
+
+export const getWorkingGroupContentfulEvent = (
+  id: string = 'wg-1',
+  eventType: WorkingGroupEvent = 'WorkingGroupsPublished',
+): EventBridgeEvent<
+  WorkingGroupEvent,
+  WebhookDetail<ContentfulWebhookPayload<'workingGroups'>>
+> =>
+  createEventBridgeEventMock(
+    getWorkingGroupContentfulWebhookDetail(id),
+    eventType,
+    id,
   );
 
 export const getContentfulGraphql = (props = {}) => {

--- a/packages/contentful/src/crn/types/webhook.ts
+++ b/packages/contentful/src/crn/types/webhook.ts
@@ -5,7 +5,8 @@ export type ContentfulWebhookPayloadType =
   | 'users'
   | 'calendars'
   | 'events'
-  | 'interestGroups';
+  | 'interestGroups'
+  | 'workingGroups';
 
 export interface ContentfulWebhookPublishPayload<
   T extends ContentfulWebhookPayloadType = ContentfulWebhookPayloadType,


### PR DESCRIPTION
This PR updates the handler `update-deliverables-handler` so it is able to process events from squidex and contentful and update the deliverables from working groups.

Testing:
- Create a working group in Contentful with 
  - complete equals false
  - a deliverable with status `Pending`
  - a deliverable with status `In progress`
- Publish this working group entry
- Change the complete to true and publish the entry again
- Check that the deliverables are now with status `Not started` and `Incomplete` respectively 