### PR TITLE
refactor: sync all calendar github action

### DIFF
--- a/.github/workflows/on-demand-calendar-sync.yml
+++ b/.github/workflows/on-demand-calendar-sync.yml
@@ -43,6 +43,7 @@ jobs:
           CONTENTFUL_MANAGEMENT_ACCESS_TOKEN: ${{ secrets.CONTENTFUL_MANAGEMENT_TOKEN }}
           CONTENTFUL_SPACE_ID: ${{ steps.setup.outputs.crn-contentful-space-id }}
           CONTENTFUL_ENV_ID: ${{ inputs.contentful-env }}
+          IS_CONTENTFUL_ENABLED_V2: true
 
   notify_failure:
     runs-on: ubuntu-latest

--- a/apps/crn-server/src/handlers/calendar/resubscribe-handler.ts
+++ b/apps/crn-server/src/handlers/calendar/resubscribe-handler.ts
@@ -15,6 +15,7 @@ import {
 import { getCalendarDataProvider } from '../../dependencies/calendars.dependencies';
 import logger from '../../utils/logger';
 import { sentryWrapper } from '../../utils/sentry-wrapper';
+import { getCalendarSubscriptionId } from '../../utils/get-calendar-subscription-id';
 
 /* istanbul ignore next */
 const getJWTCredentials = getJWTCredentialsFactory({
@@ -24,7 +25,7 @@ const getJWTCredentials = getJWTCredentialsFactory({
 
 /* istanbul ignore next */
 const getCalendarId = (id: string): string =>
-  isContentfulEnabledV2 ? `contentful__${id}` : id;
+  isContentfulEnabledV2 ? getCalendarSubscriptionId(id) : id;
 
 export const handler = sentryWrapper(
   resubscribeCalendarsHandlerFactory(

--- a/apps/crn-server/src/handlers/calendar/subscribe-handler.ts
+++ b/apps/crn-server/src/handlers/calendar/subscribe-handler.ts
@@ -22,6 +22,7 @@ import {
 import { getCalendarDataProvider } from '../../dependencies/calendars.dependencies';
 import logger from '../../utils/logger';
 import { sentryWrapper } from '../../utils/sentry-wrapper';
+import { getCalendarSubscriptionId } from '../../utils/get-calendar-subscription-id';
 
 /* istanbul ignore next */
 const getJWTCredentialsAWS = getJWTCredentialsFactory({
@@ -49,6 +50,7 @@ export const webhookHandler = isContentfulEnabledV2
         space: contentfulSpaceId,
         accessToken: contentfulAccessToken,
       },
+      getCalendarSubscriptionId,
     )
   : calendarCreatedSquidexHandlerFactory(
       subscribeToEventChangesFactory(getJWTCredentialsAWS, logger, {

--- a/apps/crn-server/src/utils/get-calendar-subscription-id.ts
+++ b/apps/crn-server/src/utils/get-calendar-subscription-id.ts
@@ -1,0 +1,4 @@
+import { contentfulEnvId } from '../config';
+
+export const getCalendarSubscriptionId = (id: string): string =>
+  `contentful__${contentfulEnvId}__${id}`;

--- a/apps/crn-server/test/utils/get-calendar-subscription-id.test.ts
+++ b/apps/crn-server/test/utils/get-calendar-subscription-id.test.ts
@@ -1,0 +1,14 @@
+describe('getCalendarSubscriptionId', () => {
+  test('Should return provided id prefixed with contentful__{env}__', async () => {
+    process.env.CONTENTFUL_ENV_ID = 'test-env';
+
+    const { getCalendarSubscriptionId } = await import(
+      '../../src/utils/get-calendar-subscription-id'
+    );
+    expect(getCalendarSubscriptionId('123')).toEqual(
+      `contentful__test-env__123`,
+    );
+  });
+});
+
+export {};

--- a/packages/server-common/src/handlers/calendar/calendar-handler-factory.contentful.ts
+++ b/packages/server-common/src/handlers/calendar/calendar-handler-factory.contentful.ts
@@ -31,6 +31,8 @@ type CalendarSkeleton = {
   };
 };
 
+const defaultGetCalendarId = (id: string): string => id;
+
 export const calendarCreatedContentfulHandlerFactory =
   (
     subscribe: SubscribeToEventChanges,
@@ -39,6 +41,7 @@ export const calendarCreatedContentfulHandlerFactory =
     alerts: Alerts,
     logger: Logger,
     contentfulDeliveryApiConfig: ContentfulDeliveryApiConfig,
+    getCalendarSubscriptionIdFunction?: (id: string) => string,
   ) =>
   async (
     event: EventBridgeEvent<CalendarEvent, CalendarContentfulPayload>,
@@ -54,6 +57,8 @@ export const calendarCreatedContentfulHandlerFactory =
 
     const webhookEventVersion = sys.revision;
     const webhookEventGoogleCalendarId = fields.googleCalendarId['en-US'];
+    const getCalendarSubscriptionId =
+      getCalendarSubscriptionIdFunction || defaultGetCalendarId;
 
     logger.info(
       `Received a '${eventType}' event for the calendar ${calendarId}`,
@@ -89,7 +94,7 @@ export const calendarCreatedContentfulHandlerFactory =
       try {
         await unsubscribe(
           googleApiMetadata.resourceId as string,
-          `contentful__${calendarId}`,
+          getCalendarSubscriptionId(calendarId),
         );
 
         await calendarDataProvider.update(calendarId, {
@@ -115,7 +120,7 @@ export const calendarCreatedContentfulHandlerFactory =
       try {
         const { resourceId, expiration } = await subscribe(
           webhookEventGoogleCalendarId,
-          `contentful__${calendarId}`,
+          getCalendarSubscriptionId(calendarId),
         );
 
         await calendarDataProvider.update(calendarId, {

--- a/packages/server-common/test/handlers/calendar/resubscribe-calendars.test.ts
+++ b/packages/server-common/test/handlers/calendar/resubscribe-calendars.test.ts
@@ -128,7 +128,7 @@ describe('Resubscribe calendar handler', () => {
     subscribeMock.mockResolvedValue({ resourceId, expiration });
 
     await invokeHandlerWithIdFunction();
-    console.log(unsubscribeMock.mock.calls);
+
     expect(unsubscribeMock).toHaveBeenCalledWith(
       calendarDataObject1.resourceId,
       `cms:${calendarDataObject1.id}`,


### PR DESCRIPTION
This PR includes

- refactor calendar subscription id to include contentful environment name. This is to prevent getting 'not unique id error' when subscribing to events.

- fix action environment to have contentful enabled so the script to uses contentful calendar data provider

- refactor sync-all action to update `googlemetadata.associatedGoogleCalendarId` and retain previous data to trigger calendar change handler

