### PR TITLE
Add flags to make migrations optional

### DIFF
--- a/packages/cms-data-sync/src/index.ts
+++ b/packages/cms-data-sync/src/index.ts
@@ -1,6 +1,14 @@
 /* istanbul ignore file */
-import { runMigrations } from './run-migrations';
+import { runMigrations, models, Flag } from './run-migrations';
 
 const flags = process.argv.slice(2);
 
-runMigrations(flags);
+flags.forEach((flag: string) => {
+  if (!models.some((model: string) => flag === `--${model}`)) {
+    // eslint-disable-next-line no-console
+    console.error(`Unrecognised flag: ${flag}`);
+    process.exit(1);
+  }
+});
+
+runMigrations(flags as Flag[]);

--- a/packages/cms-data-sync/src/index.ts
+++ b/packages/cms-data-sync/src/index.ts
@@ -1,4 +1,6 @@
 /* istanbul ignore file */
 import { runMigrations } from './run-migrations';
 
-runMigrations();
+const flags = process.argv.slice(2);
+
+runMigrations(flags);

--- a/packages/cms-data-sync/src/run-migrations.ts
+++ b/packages/cms-data-sync/src/run-migrations.ts
@@ -12,7 +12,23 @@ import { migrateTutorials } from './tutorials/tutorials.data-migration';
 import { logger } from './utils';
 import { contentfulRateLimiter } from './contentful-rate-limiter';
 
-export const runMigrations = async (flags: string[] = []) => {
+export const models = [
+  'teams',
+  'externalAuthors',
+  'calendars',
+  'labs',
+  'users',
+  'events',
+  'interestGroups',
+  'workingGroups',
+  'tutorials',
+];
+
+type ModelName = (typeof models)[number];
+
+export type Flag = `--${ModelName}`;
+
+export const runMigrations = async (flags: Flag[] = []) => {
   const {
     CONTENTFUL_MANAGEMENT_ACCESS_TOKEN,
     CONTENTFUL_SPACE_ID,
@@ -23,10 +39,8 @@ export const runMigrations = async (flags: string[] = []) => {
     accessToken: CONTENTFUL_MANAGEMENT_ACCESS_TOKEN!,
   });
 
-  const hasFlag = (flag: string): boolean =>
-    flags.length === 0 ||
-    flags.includes('--all') ||
-    flags.includes(`--${flag}`);
+  const hasFlag = (flag: ModelName): boolean =>
+    flags.length === 0 || flags.includes(`--${flag}`);
 
   const contentfulSpace = await contentfulClient.getSpace(CONTENTFUL_SPACE_ID!);
 

--- a/packages/cms-data-sync/src/run-migrations.ts
+++ b/packages/cms-data-sync/src/run-migrations.ts
@@ -12,7 +12,7 @@ import { migrateTutorials } from './tutorials/tutorials.data-migration';
 import { logger } from './utils';
 import { contentfulRateLimiter } from './contentful-rate-limiter';
 
-export const runMigrations = async () => {
+export const runMigrations = async (flags: string[] = []) => {
   const {
     CONTENTFUL_MANAGEMENT_ACCESS_TOKEN,
     CONTENTFUL_SPACE_ID,
@@ -22,6 +22,11 @@ export const runMigrations = async () => {
   const contentfulClient = createClient({
     accessToken: CONTENTFUL_MANAGEMENT_ACCESS_TOKEN!,
   });
+
+  const hasFlag = (flag: string): boolean =>
+    flags.length === 0 ||
+    flags.includes('--all') ||
+    flags.includes(`--${flag}`);
 
   const contentfulSpace = await contentfulClient.getSpace(CONTENTFUL_SPACE_ID!);
 
@@ -58,24 +63,24 @@ export const runMigrations = async () => {
 
   let error;
   try {
-    await migrateTeams();
-    await migrateExternalAuthors();
-    await migrateCalendars();
-    await migrateLabs();
+    if (hasFlag('teams')) await migrateTeams();
+    if (hasFlag('externalAuthors')) await migrateExternalAuthors();
+    if (hasFlag('calendars')) await migrateCalendars();
+    if (hasFlag('labs')) await migrateLabs();
 
     // needs: teams, labs
-    await migrateUsers();
+    if (hasFlag('users')) await migrateUsers();
 
     // needs: teams, users, external authors, calendars
-    await migrateEvents();
+    if (hasFlag('events')) await migrateEvents();
 
     // needs: teams, users, calendars
-    await migrateInterestGroups();
+    if (hasFlag('interestGroups')) await migrateInterestGroups();
 
     // needs: users, calendars
-    await migrateWorkingGroups();
+    if (hasFlag('workingGroups')) await migrateWorkingGroups();
 
-    await migrateTutorials();
+    if (hasFlag('tutorials')) await migrateTutorials();
   } catch (err) {
     error = err;
     logger('Error migrating data', 'ERROR');

--- a/packages/cms-data-sync/test/run-migrations.test.ts
+++ b/packages/cms-data-sync/test/run-migrations.test.ts
@@ -161,6 +161,23 @@ describe('Migrations', () => {
     console.log = consoleLogRef;
   });
 
+  it('runs only a subset of migrations if flags are passed', async () => {
+    spaceMock.getWebhooks.mockResolvedValue({
+      items: [],
+    } as unknown as Collection<WebHooks, WebhookProps>);
+
+    await runMigrations('--teams');
+
+    expect(migrateTeams).toHaveBeenCalled();
+    expect(migrateExternalAuthors).not.toHaveBeenCalled();
+    expect(migrateCalendars).not.toHaveBeenCalled();
+    expect(migrateLabs).not.toHaveBeenCalled();
+    expect(migrateUsers).not.toHaveBeenCalled();
+    expect(migrateInterestGroups).not.toHaveBeenCalled();
+    expect(migrateWorkingGroups).not.toHaveBeenCalled();
+    expect(migrateTutorials).not.toHaveBeenCalled();
+  });
+
   it('deactivates webhook and activates it again after running the migrations', async () => {
     const mockedTestEnvSetter = jest.fn();
     const testEnvWebhook = {


### PR DESCRIPTION
Most of the time when working on a migration you are only interested in migrating the one entity type that you're working on. This provides a quick way to selectively migrate only one model type without having to comment out lots of code.

Omitting any flags defaults to migrating everything.

Example:

```
yarn workspace @asap-hub/cms-data-sync migrate --teams
```

```
yarn workspace @asap-hub/cms-data-sync migrate --teams --users
```