### PR TITLE
Include Contentful apps in typescript build list

### DIFF
--- a/packages/contentful-app-extensions/clear-on-change/tsconfig.json
+++ b/packages/contentful-app-extensions/clear-on-change/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "composite": true,
     "module": "esnext",
 
     "allowJs": true,

--- a/packages/contentful-app-extensions/disabled-fields/tsconfig.json
+++ b/packages/contentful-app-extensions/disabled-fields/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "composite": true,
     "module": "esnext",
 
     "allowJs": true,

--- a/packages/contentful-app-extensions/event-additional-materials/tsconfig.json
+++ b/packages/contentful-app-extensions/event-additional-materials/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "composite": true,
     "module": "esnext",
 
     "allowJs": true,

--- a/packages/contentful-app-extensions/event-speakers-title/tsconfig.json
+++ b/packages/contentful-app-extensions/event-speakers-title/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "composite": true,
     "module": "esnext",
 
     "allowJs": true,

--- a/packages/contentful-app-extensions/field-as-updated-at/tsconfig.json
+++ b/packages/contentful-app-extensions/field-as-updated-at/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "composite": true,
     "module": "esnext",
 
     "allowJs": true,

--- a/packages/contentful-app-extensions/user-positions/tsconfig.json
+++ b/packages/contentful-app-extensions/user-positions/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "composite": true,
     "module": "esnext",
 
     "allowJs": true,

--- a/packages/contentful-app-extensions/user-team-memberships/tsconfig.json
+++ b/packages/contentful-app-extensions/user-team-memberships/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "composite": true,
     "module": "esnext",
 
     "allowJs": true,

--- a/scripts/get-composite-ts-projects.js
+++ b/scripts/get-composite-ts-projects.js
@@ -20,15 +20,18 @@ const {
 const rootDir = resolve(__dirname, '..');
 const packagesDir = resolve(rootDir, 'packages');
 const appsDir = resolve(rootDir, 'apps');
+const contentfulAppsDir = resolve(
+  rootDir,
+  'packages/contentful-app-extensions',
+);
 
 const compositeProjectPaths = [];
 const configErrors = [];
 
-[packagesDir, appsDir].forEach((parentDir) => {
+[packagesDir, appsDir, contentfulAppsDir].forEach((parentDir) => {
   const projects = readdirSync(parentDir);
   projects.forEach((projectDir) => {
     const dir = resolve(parentDir, projectDir);
-
     let dependencies;
     let devDependencies;
     // read package.json
@@ -46,7 +49,6 @@ const configErrors = [];
       // non-TypeScript project, pretend it doesn't exist
       return;
     }
-
     // read tsconfig.json
     const { error, config } = readConfigFile(tsconfigPath, tsSys.readFile);
     if (error) {


### PR DESCRIPTION
Contentful apps are now listed in the workspaces to be type checked in the [Definitions](https://github.com/yldio/asap-hub/actions/runs/5289058234/jobs/9571560053) build step.