### PR TITLE
CT-50 Team tool update

### DIFF
--- a/apps/crn-server/src/data-providers/contentful/teams.data-provider.ts
+++ b/apps/crn-server/src/data-providers/contentful/teams.data-provider.ts
@@ -123,14 +123,21 @@ export class TeamContentfulDataProvider implements TeamDataProvider {
 
     const team = await environment.getEntry(id);
 
-    const tools = publishedTools.map((tool) => ({
+    const previousToolsLinks = team.fields.tools
+      ? team.fields.tools['en-US']
+      : [];
+
+    const newToolsLinks = publishedTools.map((tool) => ({
       sys: {
         type: 'Link',
         linkType: 'Entry',
         id: tool.sys.id,
       },
     }));
-    await patchAndPublish(team, { tools });
+
+    await patchAndPublish(team, {
+      tools: [...previousToolsLinks, ...newToolsLinks],
+    });
   }
 
   async create(input: TeamCreateDataObject): Promise<string> {


### PR DESCRIPTION
The purpose of this ticket initially was to clear tools that were unlinked to Teams, but I've noticed that there was a bug in the team data provider update method: when we add a new tool and the field is populated already we shouldn't unlink the existing ones, we should add it to the list of tools linked to the Team, at least this is what happens in squidex.
So in the end, we don't need to clear the unlined tools because there shouldn't be tools unlinked. So this PR only fixes the behavior of adding the new tool to the existing tools link array.