### PR TITLE
Require published flag on research output payload

### DIFF
--- a/apps/crn-server/src/validation/research-output.validation.ts
+++ b/apps/crn-server/src/validation/research-output.validation.ts
@@ -181,6 +181,7 @@ const researchOutputPostRequestValidationSchema: JSONSchemaType<ResearchOutputPo
       'organisms',
       'environments',
       'keywords',
+      'published',
     ],
     additionalProperties: false,
   };

--- a/apps/crn-server/test/routes/research-outputs.route.test.ts
+++ b/apps/crn-server/test/routes/research-outputs.route.test.ts
@@ -675,6 +675,7 @@ describe('/research-outputs/ route', () => {
         'title',
         'sharingStatus',
         'teams',
+        'published',
       ])(
         'Should return a validation error when %s is missing',
         async (field) => {


### PR DESCRIPTION
Currently if the `published` property is not passed to the server when creating a research output then the research output is created as published irrespective of whether the user actually has permissions or not.

This is because the [validation of permissions](https://github.com/yldio/asap-hub/blob/master/packages/validation/src/permissions/research-output.ts#L61) only checks for a falsy value, so when `published` is  `undefined` it assumes at that point it is creating a draft, but then the data provider defaults the value to `true`, so the draft-like submission is created as published.

Fix by:
* adding `published` to the validation schema to ensure it is passed by the client and cannot be `undefined`
* ~default to `false` in the data provider~