### PR TITLE
Increase default test timeout

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -64,5 +64,6 @@ module.exports = {
     ...packagePaths,
     ...lintConfigs,
   ],
+  testTimeout: 10000,
   testRegex: '^$', // root project does not have tests itself
 };


### PR DESCRIPTION
We occasionally get test timeouts in React component tests with the default 5000ms timeout, to which the "solution" is generally to simply brute force the test by restarting.

Increase timeout to 10000ms to allow these to run reliably.