### PR TITLE
Fix markdown link instructions

### DIFF
--- a/packages/react-components/src/organisms/ResearchOutputFormSharingCard.tsx
+++ b/packages/react-components/src/organisms/ResearchOutputFormSharingCard.tsx
@@ -196,7 +196,7 @@ const ResearchOutputFormSharingCard: React.FC<
         value={descriptionMD}
         info={
           <Markdown
-            value={`**Markup Language**\n\n**Bold:** \\*\\*your text\\*\\*\n\n**Italic:** \\*your text\\*\n\n**H1:** \\# Your Text\n\n**H2:** \\#\\# Your Text\n\n**H3:** \\#\\#\\# Your Text\n\n**Hyperlink:** (your text)[https://example.com]\n\n**New Paragraph:** To create a line break, you will need to press the enter button twice.
+            value={`**Markup Language**\n\n**Bold:** \\*\\*your text\\*\\*\n\n**Italic:** \\*your text\\*\n\n**H1:** \\# Your Text\n\n**H2:** \\#\\# Your Text\n\n**H3:** \\#\\#\\# Your Text\n\n**Hyperlink:** [your text](https://example.com)\n\n**New Paragraph:** To create a line break, you will need to press the enter button twice.
         `}
           ></Markdown>
         }


### PR DESCRIPTION
The round and square brackets were the wrong way round in the markdown instructions.