### PR TITLE
Optimise integration tests in CI to avoid rate limiting

### DIFF
--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -139,6 +139,7 @@ jobs:
 
   integration-contentful:
     if: ${{ inputs.environment-name=='Branch' }}
+    concurrency: integration-contentful
     permissions:
       packages: read
     runs-on: ubuntu-latest

--- a/apps/crn-server/test/integration/common/reminders.integration-test.ts
+++ b/apps/crn-server/test/integration/common/reminders.integration-test.ts
@@ -44,7 +44,7 @@ describe('Reminders', () => {
 
   beforeAll(async () => {
     await fixtures.clearAllPreviousEvents();
-    jest.useFakeTimers({ doNotFake: ['setTimeout'] });
+    jest.useFakeTimers({ doNotFake: ['setTimeout', 'clearTimeout'] });
     team = await fixtures.createTeam(getTeamFixture());
     loggedInUser = await fixtures.createUser(
       getUserFixture({
@@ -126,7 +126,7 @@ describe('Reminders', () => {
         eventHappeningNow.id,
         endedEventWithLoggedInUserSpeaker.id,
       ]);
-    }, 300000);
+    });
   });
 
   describe('Event Happening Today Reminder', () => {

--- a/apps/crn-server/test/integration/fixtures/contentful.ts
+++ b/apps/crn-server/test/integration/fixtures/contentful.ts
@@ -232,6 +232,10 @@ export class ContentfulFixture implements Fixture {
   }
 
   async teardown() {
+    // no need to teardown in CI because we'll delete the environment anyway
+    if (process.env.CI) {
+      return;
+    }
     const environment = await this.getEnvironment();
     while (this.apiAdapter.created.length) {
       const id = this.apiAdapter.created.pop();

--- a/apps/crn-server/test/integration/fixtures/squidex.ts
+++ b/apps/crn-server/test/integration/fixtures/squidex.ts
@@ -177,6 +177,10 @@ export class SquidexFixture implements Fixture {
   }
 
   async teardown() {
+    // no need to teardown in CI because we'll delete the environment anyway
+    if (process.env.CI) {
+      return;
+    }
     return this.teardownHelper();
   }
 


### PR DESCRIPTION
* Add a concurrency group to contentful tests to limit to a single run in progress
* Don't bother tearing down data created in the test run in CI where the environment is deleted anyway
* Don't mock `clearTimeout` because we don't rely on it in tests, but it _might_ interfere with the working of `async-retry`
* Reduce absurdly long timeout to only be _very_ long