### PR TITLE
Take expected timestamp before request

### DIFF
--- a/apps/crn-server/src/data-providers/contentful/research-output.data-provider.ts
+++ b/apps/crn-server/src/data-providers/contentful/research-output.data-provider.ts
@@ -192,13 +192,14 @@ export class ResearchOutputContentfulDataProvider
   ): Promise<void> {
     const environment = await this.getRestClient();
     const entry = await environment.getEntry(id);
-
-    const result = await patch(entry, prepareInputForUpdate(input));
+    const update = prepareInputForUpdate(input);
+    const result = await patch(entry, update);
 
     if (updateOptions.publish) {
       const toPublish = await patch(result, {
-        addedDate: new Date().toISOString(),
+        addedDate: update.lastUpdatedPartial,
       });
+
       const published = await toPublish.publish();
 
       const fetchOutputById = () => this.fetchOutputById(id);

--- a/apps/crn-server/test/integration/common/research-outputs.integration-test.ts
+++ b/apps/crn-server/test/integration/common/research-outputs.integration-test.ts
@@ -89,7 +89,7 @@ describe('research outputs', () => {
           },
           { researchTags },
         );
-
+        const now = new Date().toISOString();
         const response = await supertest(app)
           .post('/research-outputs')
           .send(input)
@@ -100,9 +100,7 @@ describe('research outputs', () => {
           teams: input.teams.map((id) => ({ id })),
         });
         expect(response.body.published).toEqual(false);
-        expect(response.body.created).toBeCloseInTimeTo(
-          new Date().toISOString(),
-        );
+        expect(response.body.created).toBeCloseInTimeTo(now);
         expect(response.body.addedDate).toEqual(null);
       });
 
@@ -112,7 +110,7 @@ describe('research outputs', () => {
           workingGroups: [],
           published: true,
         });
-
+        const now = new Date().toISOString();
         const response = await supertest(app)
           .post('/research-outputs')
           .send(input)
@@ -123,12 +121,8 @@ describe('research outputs', () => {
           teams: input.teams.map((id) => ({ id })),
         });
         expect(response.body.published).toEqual(true);
-        expect(response.body.created).toBeCloseInTimeTo(
-          new Date().toISOString(),
-        );
-        expect(response.body.addedDate).toBeCloseInTimeTo(
-          new Date().toISOString(),
-        );
+        expect(response.body.created).toBeCloseInTimeTo(now);
+        expect(response.body.addedDate).toBeCloseInTimeTo(now);
       });
 
       test('cannot create a published team research output as a team non-PM', async () => {
@@ -188,7 +182,7 @@ describe('research outputs', () => {
             title: `${researchOutput.title} - updated`,
           })
           .expect(200);
-
+        const now = new Date().toISOString();
         await retryable(async () => {
           const response = await supertest(app)
             .get(`/research-outputs/${researchOutputId}`)
@@ -197,13 +191,12 @@ describe('research outputs', () => {
           expect(response.body.title).toEqual(
             `${researchOutput.title} - updated`,
           );
-          expect(response.body.lastUpdatedPartial).toBeCloseInTimeTo(
-            new Date().toISOString(),
-          );
+          expect(response.body.lastUpdatedPartial).toBeCloseInTimeTo(now);
         });
       });
 
       test('can update a draft research output to request a review', async () => {
+        const now = new Date().toISOString();
         const response = await supertest(app)
           .put(`/research-outputs/${researchOutputId}`)
           .send({ ...researchOutput, reviewRequestedById: loggedInUser.id })
@@ -216,9 +209,7 @@ describe('research outputs', () => {
         expect(response.body.reviewRequestedBy.lastName).toEqual(
           loggedInUser.lastName,
         );
-        expect(response.body.lastUpdatedPartial).toBeCloseInTimeTo(
-          new Date().toISOString(),
-        );
+        expect(response.body.lastUpdatedPartial).toBeCloseInTimeTo(now);
       });
 
       // regression test for cache behaviour when updating published content  in contentful
@@ -271,6 +262,7 @@ describe('research outputs', () => {
         });
 
         test('can publish a draft output by updating with `published: true`', async () => {
+          const now = new Date().toISOString();
           await supertest(app)
             .put(`/research-outputs/${publishOutputId}`)
             .send({
@@ -285,9 +277,7 @@ describe('research outputs', () => {
               .expect(200);
 
             expect(response.body.published).toEqual(true);
-            expect(response.body.addedDate).toBeCloseInTimeTo(
-              new Date().toISOString(),
-            );
+            expect(response.body.addedDate).toBeCloseInTimeTo(now);
           });
         });
 
@@ -399,7 +389,7 @@ describe('research outputs', () => {
           },
           { researchTags },
         );
-
+        const now = new Date().toISOString();
         const response = await supertest(app)
           .post('/research-outputs')
           .send(input)
@@ -409,9 +399,7 @@ describe('research outputs', () => {
           teams: input.teams.map((id) => ({ id })),
         });
         expect(response.body.published).toEqual(false);
-        expect(response.body.created).toBeCloseInTimeTo(
-          new Date().toISOString(),
-        );
+        expect(response.body.created).toBeCloseInTimeTo(now);
         expect(response.body.addedDate).toEqual(null);
       });
 
@@ -450,7 +438,7 @@ describe('research outputs', () => {
           },
           { researchTags },
         );
-
+        const now = new Date().toISOString();
         const response = await supertest(app)
           .post('/research-outputs')
           .send(input)
@@ -460,12 +448,8 @@ describe('research outputs', () => {
           teams: input.teams.map((id) => ({ id })),
         });
         expect(response.body.published).toEqual(true);
-        expect(response.body.created).toBeCloseInTimeTo(
-          new Date().toISOString(),
-        );
-        expect(response.body.addedDate).toBeCloseInTimeTo(
-          new Date().toISOString(),
-        );
+        expect(response.body.created).toBeCloseInTimeTo(now);
+        expect(response.body.addedDate).toBeCloseInTimeTo(now);
       });
     });
 


### PR DESCRIPTION
Refactor the integration tests for setting created and updated timestamps to set the expectation as the date before the request is made. This means that if there are long waits for the request to resolve (due to contentful rate limiting) then the expected timestamp should still be within the expected bounds.