### PR TITLE
Don't reset addedDate on previously added research outputs

### DIFF
--- a/apps/crn-server/src/data-providers/contentful/research-output.data-provider.ts
+++ b/apps/crn-server/src/data-providers/contentful/research-output.data-provider.ts
@@ -196,10 +196,12 @@ export class ResearchOutputContentfulDataProvider
     const result = await patch(entry, update);
 
     if (updateOptions.publish) {
-      const toPublish = await patch(result, {
-        addedDate: update.lastUpdatedPartial,
-      });
-
+      let toPublish = result;
+      if (!entry.fields?.addedDate?.['en-US']) {
+        toPublish = await patch(result, {
+          addedDate: update.lastUpdatedPartial,
+        });
+      }
       const published = await toPublish.publish();
 
       const fetchOutputById = () => this.fetchOutputById(id);
@@ -439,8 +441,11 @@ const prepareInputForCreate = (input: ResearchOutputCreateDataObject) => ({
 });
 
 const prepareInputForUpdate = (input: ResearchOutputUpdateDataObject) => {
-  const { reviewRequestedById: _reviewRequestedById, ...researchOutput } =
-    input;
+  const {
+    reviewRequestedById: _reviewRequestedById,
+    addedDate: _addedDate,
+    ...researchOutput
+  } = input;
   return {
     ...prepareInput(researchOutput),
     updatedBy: getLinkEntity(input.updatedBy),

--- a/apps/crn-server/test/data-providers/contentful/research-output.data-provider.test.ts
+++ b/apps/crn-server/test/data-providers/contentful/research-output.data-provider.test.ts
@@ -1601,6 +1601,23 @@ describe('Research Outputs Data Provider', () => {
       );
     });
 
+    test('does not set addedDate to the current timestamp if editing a previously published output', async () => {
+      entry.fields.addedDate = {
+        'en-US': new Date().toISOString(),
+      };
+      await researchOutputDataProvider.update(
+        '1',
+        getResearchOutputUpdateDataObject(),
+        { publish: true },
+      );
+      expect(patch).not.toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          addedDate: expect.anything(),
+        }),
+      );
+    });
+
     test('sets `updatedBy` property to a contentful reference', async () => {
       await researchOutputDataProvider.update(
         '1',


### PR DESCRIPTION
The timestamp was being updated on all edits, but the date should represent the first time it was published.