### PR TITLE
Add in-memory cache for Contentful API client

### DIFF
--- a/packages/contentful/src/client.ts
+++ b/packages/contentful/src/client.ts
@@ -2,6 +2,8 @@ import { createClient as createCDAClient } from 'contentful';
 import { createClient, Environment } from 'contentful-management';
 import { GraphQLClient } from 'graphql-request';
 
+const cache = new Map<string, Environment>();
+
 export type CreateClientParams = {
   space: string;
   accessToken: string;
@@ -32,11 +34,18 @@ export const getRestClient = async ({
   accessToken,
   environment: environmentId,
 }: CreateClientParams): Promise<Environment> => {
+  const key = `${accessToken}-${spaceId}-${environmentId}`;
+  const cached = cache.get(key);
+  if (cached) {
+    return cached;
+  }
   const client = createClient({
     accessToken,
   });
   const space = await client.getSpace(spaceId);
-  return space.getEnvironment(environmentId);
+  const environment = await space.getEnvironment(environmentId);
+  cache.set(key, environment);
+  return environment;
 };
 
 export const getCDAClient = ({

--- a/packages/contentful/test/client.test.ts
+++ b/packages/contentful/test/client.test.ts
@@ -26,6 +26,7 @@ describe('graphQL and Rest clients', () => {
       mockContentfulManagement.createClient.mockReturnValue({
         getSpace: getSpaceFn,
       } as any as jest.Mocked<contentfulManagement.PlainClientAPI>);
+      getEnvironment.mockImplementation(async () => ({}));
     });
 
     it('should create a client', async () => {
@@ -44,6 +45,51 @@ describe('graphQL and Rest clients', () => {
       });
       expect(getSpaceFn).toHaveBeenCalledWith(spaceId);
       expect(getEnvironment).toHaveBeenCalledWith(environmentId);
+    });
+
+    it('returns the same client instance if called with the same credentials', async () => {
+      const accessToken = 'token';
+      const spaceId = 'space-id';
+      const environmentId = 'env-id-0';
+
+      const client1 = await getRestClient({
+        space: spaceId,
+        accessToken,
+        environment: environmentId,
+      });
+
+      const client2 = await getRestClient({
+        space: spaceId,
+        accessToken,
+        environment: environmentId,
+      });
+
+      expect(contentfulManagement.createClient).toBeCalledTimes(1);
+      expect(getSpaceFn).toHaveBeenCalledTimes(1);
+      expect(getEnvironment).toHaveBeenCalledTimes(1);
+      expect(client1).toBe(client2);
+    });
+
+    it('returns different client instances if called with different credentials', async () => {
+      const accessToken = 'token';
+      const spaceId = 'space-id';
+
+      const client1 = await getRestClient({
+        space: spaceId,
+        accessToken,
+        environment: 'env-id-1',
+      });
+
+      const client2 = await getRestClient({
+        space: spaceId,
+        accessToken,
+        environment: 'env-id-2',
+      });
+
+      expect(contentfulManagement.createClient).toBeCalledTimes(2);
+      expect(getSpaceFn).toHaveBeenCalledTimes(2);
+      expect(getEnvironment).toHaveBeenCalledTimes(2);
+      expect(client1).not.toBe(client2);
     });
   });
 


### PR DESCRIPTION
Rather than creating a new client for every request that uses the Contentful Management API, maintain an in-memory cache of environment instances per accesskey/space/env tuple so that the same client instance is re-used across multiple requests within the same process.

This will reduce the number of requests made to Contentful by 2 per POST/PUT, and so should reduce the risk of hitting API rate limits.