### PR TITLE
Add feature flag headers to remaining api calls

### DIFF
--- a/apps/crn-frontend/src/dashboard/api.ts
+++ b/apps/crn-frontend/src/dashboard/api.ts
@@ -10,7 +10,11 @@ export const getDashboard = async (
   authorization: string,
 ): Promise<DashboardResponse> => {
   const resp = await fetch(`${API_BASE_URL}/dashboard`, {
-    headers: { authorization, ...createSentryHeaders() },
+    headers: {
+      authorization,
+      ...createSentryHeaders(),
+      ...createFeatureFlagHeaders(),
+    },
   });
   if (!resp.ok) {
     throw new Error(

--- a/apps/crn-frontend/src/guides/api.ts
+++ b/apps/crn-frontend/src/guides/api.ts
@@ -1,5 +1,8 @@
 import { ListGuideResponse } from '@asap-hub/model';
-import { createSentryHeaders } from '@asap-hub/frontend-utils';
+import {
+  createSentryHeaders,
+  createFeatureFlagHeaders,
+} from '@asap-hub/frontend-utils';
 import { API_BASE_URL } from '../config';
 
 export const getGuides = async (
@@ -9,6 +12,7 @@ export const getGuides = async (
     headers: {
       authorization,
       ...createSentryHeaders(),
+      ...createFeatureFlagHeaders(),
     },
   });
   if (!resp.ok) {

--- a/apps/crn-frontend/src/network/teams/api.ts
+++ b/apps/crn-frontend/src/network/teams/api.ts
@@ -91,6 +91,7 @@ export const createResearchOutput = async (
       authorization,
       'content-type': 'application/json',
       ...createSentryHeaders(),
+      ...createFeatureFlagHeaders(),
     },
     body: JSON.stringify(researchOutput),
   });
@@ -122,6 +123,7 @@ export const updateTeamResearchOutput = async (
         authorization,
         'content-type': 'application/json',
         ...createSentryHeaders(),
+        ...createFeatureFlagHeaders(),
       },
       body: JSON.stringify(researchOutput),
     },
@@ -149,6 +151,7 @@ export const getLabs = async (
       authorization,
       'content-type': 'application/json',
       ...createSentryHeaders(),
+      ...createFeatureFlagHeaders(),
     },
   });
   if (!resp.ok) {

--- a/apps/crn-frontend/src/network/teams/groups/api.ts
+++ b/apps/crn-frontend/src/network/teams/groups/api.ts
@@ -1,5 +1,8 @@
 import { ListGroupResponse } from '@asap-hub/model';
-import { createSentryHeaders } from '@asap-hub/frontend-utils';
+import {
+  createSentryHeaders,
+  createFeatureFlagHeaders,
+} from '@asap-hub/frontend-utils';
 
 import { API_BASE_URL } from '../../../config';
 
@@ -8,7 +11,11 @@ export const getTeamGroups = async (
   authorization: string,
 ): Promise<ListGroupResponse | undefined> => {
   const resp = await fetch(`${API_BASE_URL}/teams/${id}/groups`, {
-    headers: { authorization, ...createSentryHeaders() },
+    headers: {
+      authorization,
+      ...createSentryHeaders(),
+      ...createFeatureFlagHeaders(),
+    },
   });
   if (!resp.ok) {
     if (resp.status === 404) {

--- a/apps/crn-frontend/src/network/users/api.ts
+++ b/apps/crn-frontend/src/network/users/api.ts
@@ -111,6 +111,7 @@ export const patchUser = async (
       authorization,
       'content-type': 'application/json',
       ...createSentryHeaders(),
+      ...createFeatureFlagHeaders(),
     },
     body: JSON.stringify(patch),
   });
@@ -133,6 +134,7 @@ export const postUserAvatar = async (
       authorization,
       'content-type': 'application/json',
       ...createSentryHeaders(),
+      ...createFeatureFlagHeaders(),
     },
     body: JSON.stringify(post),
   });

--- a/apps/crn-frontend/src/network/working-groups/api.ts
+++ b/apps/crn-frontend/src/network/working-groups/api.ts
@@ -17,7 +17,11 @@ export const getWorkingGroups = async (
   const resp = await fetch(
     createListApiUrl('working-groups', options).toString(),
     {
-      headers: { authorization, ...createSentryHeaders() },
+      headers: {
+        authorization,
+        ...createSentryHeaders(),
+        ...createFeatureFlagHeaders(),
+      },
     },
   );
 

--- a/apps/crn-frontend/src/shared-research/api.ts
+++ b/apps/crn-frontend/src/shared-research/api.ts
@@ -1,6 +1,10 @@
 import qs from 'qs';
 import { AlgoliaSearchClient } from '@asap-hub/algolia';
-import { createSentryHeaders, GetListOptions } from '@asap-hub/frontend-utils';
+import {
+  createSentryHeaders,
+  createFeatureFlagHeaders,
+  GetListOptions,
+} from '@asap-hub/frontend-utils';
 import {
   ResearchOutputDocumentType,
   ResearchOutputResponse,
@@ -33,7 +37,11 @@ export const getResearchOutput = async (
   authorization: string,
 ): Promise<ResearchOutputResponse | undefined> => {
   const resp = await fetch(`${API_BASE_URL}/research-outputs/${id}`, {
-    headers: { authorization, ...createSentryHeaders() },
+    headers: {
+      authorization,
+      ...createSentryHeaders(),
+      ...createFeatureFlagHeaders(),
+    },
   });
   if (!resp.ok) {
     if (resp.status === 404) {
@@ -149,7 +157,11 @@ export const getResearchTags = async (
   const query = qs.stringify(options);
 
   const resp = await fetch(`${API_BASE_URL}/research-tags?${query}`, {
-    headers: { authorization, ...createSentryHeaders() },
+    headers: {
+      authorization,
+      ...createSentryHeaders(),
+      ...createFeatureFlagHeaders(),
+    },
   });
 
   if (!resp.ok) {


### PR DESCRIPTION
Add the feature flag cookies to all API calls where it wasn't previously there, so all data can be written to and loaded from Contentful.