### PR TITLE
CT-59 Working Group Deliverables app extension

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -62,6 +62,9 @@ outputs:
   contentful-app-contributing-cohort-memberships:
     description: 'Contentful App Extension Contributing Cohort Memberships Id'
     value: ${{ steps.vars.outputs.contentful-app-contributing-cohort-memberships }}
+  contentful-app-working-group-deliverables:
+    description: 'Contentful App Extension Working Group Deliverables'
+    value: ${{ steps.vars.outputs.contentful-app-working-group-deliverables }}
   contentful-environment:
     description: 'Contentful Environment'
     value: ${{ steps.vars.outputs.contentful-environment }}

--- a/.github/environment/Base
+++ b/.github/environment/Base
@@ -15,6 +15,7 @@ contentful-app-field-as-updated-at=mqvX9KU5AthRTlnIRhNNh
 contentful-app-user-membership=1k7oc8QBS413LyX8Ed9LnA
 contentful-app-user-positions=6gJUoMACdM5WFGRz6j4pbB
 contentful-app-user-team-memberships=2iE2vFoT19Q5u4Rxpio8gz
+contentful-app-working-group-deliverables=2hc2UiWrW8SFhfkKMmGtk9
 contentful-environment=Production
 contentful-organization-id=6Hlb5Pl67A3nWMEyzxnHNZ
 crn-auth0-additional-claim-domain=https://dev.hub.asap.science

--- a/.github/workflows/on-push-app-extensions.yml
+++ b/.github/workflows/on-push-app-extensions.yml
@@ -68,6 +68,7 @@ jobs:
           - user-team-memberships
           - clear-on-change
           - contributing-cohort-memberships
+          - working-group-deliverables
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/packages/contentful-app-extensions/working-group-deliverables/package.json
+++ b/packages/contentful-app-extensions/working-group-deliverables/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "@asap-hub/contentful-app-working-group-deliverables",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "@contentful/app-sdk": "4.22.1",
+    "@contentful/f36-components": "4.48.0",
+    "@contentful/f36-tokens": "4.0.2",
+    "@contentful/field-editor-reference": "^5.9.0",
+    "@contentful/field-editor-shared": "^1.2.0",
+    "@contentful/react-apps-toolkit": "1.2.16",
+    "contentful-management": "10.39.2",
+    "emotion": "10.0.27",
+    "react": "17.0.2",
+    "react-dom": "17.0.2",
+    "react-scripts": "5.0.1"
+  },
+  "scripts": {
+    "start": "cross-env BROWSER=none react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test",
+    "test:no-watch": "react-scripts test --watchAll=false",
+    "eject": "react-scripts eject",
+    "create-app-definition": "contentful-app-scripts create-app-definition",
+    "upload": "contentful-app-scripts upload --bundle-dir ./build",
+    "upload-ci": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN"
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  },
+  "devDependencies": {
+    "@contentful/app-scripts": "1.10.2",
+    "@testing-library/jest-dom": "^5.16.5",
+    "@testing-library/react": "11.2.7",
+    "@tsconfig/create-react-app": "1.0.3",
+    "@types/jest": "29.5.3",
+    "@types/node": "18.17.0",
+    "@types/react": "17.0.62",
+    "@types/react-dom": "17.0.20",
+    "@types/testing-library__jest-dom": "5.14.8",
+    "cross-env": "7.0.3",
+    "typescript": "4.9.5"
+  },
+  "homepage": "."
+}

--- a/packages/contentful-app-extensions/working-group-deliverables/public/index.html
+++ b/packages/contentful-app-extensions/working-group-deliverables/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+  </body>
+</html>

--- a/packages/contentful-app-extensions/working-group-deliverables/src/App.tsx
+++ b/packages/contentful-app-extensions/working-group-deliverables/src/App.tsx
@@ -1,0 +1,19 @@
+import React, { useMemo } from 'react';
+import { locations } from '@contentful/app-sdk';
+import { useSDK } from '@contentful/react-apps-toolkit';
+import Field from './locations/Field';
+
+const App = () => {
+  const sdk = useSDK();
+
+  const Component = useMemo(() => {
+    if (sdk.location.is(locations.LOCATION_ENTRY_FIELD)) {
+      return Field;
+    }
+    return null;
+  }, [sdk.location]);
+
+  return Component ? <Component /> : null;
+};
+
+export default App;

--- a/packages/contentful-app-extensions/working-group-deliverables/src/index.tsx
+++ b/packages/contentful-app-extensions/working-group-deliverables/src/index.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { render } from 'react-dom';
+
+import { GlobalStyles } from '@contentful/f36-components';
+import { SDKProvider } from '@contentful/react-apps-toolkit';
+
+import App from './App';
+
+const root = document.getElementById('root');
+
+render(
+  <SDKProvider>
+    <GlobalStyles />
+    <App />
+  </SDKProvider>,
+  root,
+);

--- a/packages/contentful-app-extensions/working-group-deliverables/src/locations/Field.tsx
+++ b/packages/contentful-app-extensions/working-group-deliverables/src/locations/Field.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import {
+  MultipleEntryReferenceEditor,
+  CustomEntityCardProps,
+} from '@contentful/field-editor-reference';
+import { entityHelpers } from '@contentful/field-editor-shared';
+import {
+  EntryCard,
+  MenuItem,
+  Badge,
+  Paragraph,
+  BadgeVariant,
+} from '@contentful/f36-components';
+import { FieldExtensionSDK, Entry } from '@contentful/app-sdk';
+import { useSDK, useAutoResizer } from '@contentful/react-apps-toolkit';
+
+export const CustomCard = ({
+  entity,
+  onEdit,
+  onRemove,
+}: CustomEntityCardProps) => {
+  const entry = entity as Entry;
+  const sdk = useSDK<FieldExtensionSDK>();
+  const { fields, sys } = entity as Entry;
+  const description = fields.description?.['en-US'];
+  const deliverableStatus = fields.status?.['en-US'];
+
+  const removeEntry = async () => {
+    if (sys.publishedVersion) {
+      await sdk.space.unpublishEntry(entry);
+    }
+    await sdk.space.deleteEntry(entry);
+    if (onRemove) {
+      onRemove();
+    }
+  };
+
+  const status = entityHelpers.getEntryStatus(sys);
+
+  const badgeVariant: { [status: string]: BadgeVariant } = {
+    Complete: 'positive',
+    Incomplete: 'negative',
+    'In Progress': 'featured',
+    Pending: 'primary',
+    'Not Started': 'secondary',
+  };
+  return (
+    <EntryCard
+      contentType="Deliverable"
+      actions={[
+        <MenuItem key="remove" onClick={removeEntry}>
+          Remove
+        </MenuItem>,
+      ]}
+      status={status}
+      onClick={onEdit}
+    >
+      <>
+        <Paragraph marginBottom="none">Description: {description}</Paragraph>
+        <Paragraph marginBottom="none">
+          Deliverable status:{' '}
+          <Badge
+            variant={badgeVariant[deliverableStatus] || 'primary'}
+            style={{ width: 'fit-content' }}
+            testId={badgeVariant[deliverableStatus]}
+          >
+            {deliverableStatus}
+          </Badge>
+        </Paragraph>
+      </>
+    </EntryCard>
+  );
+};
+
+const Field = () => {
+  const sdk = useSDK<FieldExtensionSDK>();
+  useAutoResizer();
+
+  return (
+    <MultipleEntryReferenceEditor
+      isInitiallyDisabled={false}
+      hasCardEditActions={true}
+      renderCustomCard={CustomCard}
+      parameters={{
+        instance: {
+          showLinkEntityAction: false,
+          showCreateEntityAction: true,
+          bulkEditing: false,
+        },
+      }}
+      viewType="link"
+      sdk={sdk}
+      actionLabels={{
+        createNew: () => 'Add',
+      }}
+    />
+  );
+};
+
+export default Field;

--- a/packages/contentful-app-extensions/working-group-deliverables/src/react-app-env.d.ts
+++ b/packages/contentful-app-extensions/working-group-deliverables/src/react-app-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="react-scripts" />

--- a/packages/contentful-app-extensions/working-group-deliverables/src/test/locations/Field.test.tsx
+++ b/packages/contentful-app-extensions/working-group-deliverables/src/test/locations/Field.test.tsx
@@ -1,0 +1,138 @@
+import '@testing-library/jest-dom';
+import React from 'react';
+import Field, { CustomCard } from '../../locations/Field';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { FieldExtensionSDK, Entry } from '@contentful/app-sdk';
+import {
+  MultipleEntryReferenceEditor,
+  CustomEntityCardProps,
+} from '@contentful/field-editor-reference';
+import { useSDK, useAutoResizer } from '@contentful/react-apps-toolkit';
+
+jest.mock('@contentful/react-apps-toolkit', () => ({
+  useSDK: jest.fn(),
+  useAutoResizer: jest.fn(),
+}));
+
+jest.mock('@contentful/field-editor-reference', () => ({
+  MultipleEntryReferenceEditor: jest.fn(),
+  useEntity: jest.fn(),
+}));
+
+const mockBaseSdk = () => ({
+  window: {
+    startAutoResizer: jest.fn(),
+  },
+  space: {
+    unpublishEntry: jest.fn(),
+    deleteEntry: jest.fn(),
+  },
+});
+
+describe('Field component', () => {
+  let sdk: jest.Mocked<FieldExtensionSDK>;
+  let cardProps: CustomEntityCardProps;
+
+  beforeEach(() => {
+    sdk = mockBaseSdk() as unknown as jest.Mocked<FieldExtensionSDK>;
+    (useSDK as jest.Mock).mockReturnValue(sdk);
+    (MultipleEntryReferenceEditor as jest.Mock).mockImplementation(() => (
+      <p>MultipleEntryReferenceEditor</p>
+    ));
+
+    cardProps = {
+      entity: {
+        fields: {
+          description: {
+            'en-US': 'Deliverable 1',
+          },
+          status: {
+            'en-US': 'Complete',
+          },
+        },
+        sys: {
+          type: 'Entry',
+          publishedVersion: 1,
+          version: 1,
+        },
+      },
+      onEdit: jest.fn(),
+      onRemove: jest.fn(),
+    } as unknown as CustomEntityCardProps;
+  });
+
+  it('enables automatic resizing', async () => {
+    render(<Field />);
+    expect(useAutoResizer).toHaveBeenCalled();
+  });
+
+  it('passes a custom card renderer to <MultipleEntryReferenceEditor />', async () => {
+    render(<Field />);
+
+    expect(MultipleEntryReferenceEditor).toHaveBeenCalled();
+    expect(
+      (MultipleEntryReferenceEditor as jest.Mock).mock.lastCall[0]
+        .renderCustomCard,
+    ).toEqual(CustomCard);
+  });
+
+  it('renders deliverable description and status', async () => {
+    render(<CustomCard {...cardProps} />);
+    expect(screen.getByText('Description: Deliverable 1')).toBeInTheDocument();
+    expect(screen.getByText('Deliverable status:')).toBeInTheDocument();
+    expect(screen.getByText('Complete')).toBeInTheDocument();
+  });
+
+  it('calls the `onEdit` handler in contentful to open the related entity when clicked', async () => {
+    render(<CustomCard {...cardProps} />);
+
+    fireEvent.click(screen.getByText('Description: Deliverable 1'));
+    await waitFor(() => {
+      expect(cardProps.onEdit).toHaveBeenCalled();
+    });
+  });
+
+  it('renders a remove button in the card menu', async () => {
+    render(<CustomCard {...cardProps} />);
+
+    fireEvent.click(screen.getByLabelText('Actions'));
+    await waitFor(() => {
+      expect(screen.getByText('Remove')).toBeVisible();
+    });
+  });
+
+  it('unpublishes and deletes the entry when the remove button is clicked', async () => {
+    render(<CustomCard {...cardProps} />);
+
+    fireEvent.click(screen.getByLabelText('Actions'));
+    fireEvent.click(screen.getByText('Remove'));
+    await waitFor(() => {
+      expect(sdk.space.unpublishEntry).toHaveBeenCalledWith(cardProps.entity);
+      expect(sdk.space.deleteEntry).toHaveBeenCalledWith(cardProps.entity);
+      expect(cardProps.onRemove).toHaveBeenCalled();
+    });
+  });
+
+  it('does not unpublish the entry when the remove button is clicked if the entry is unpublished', async () => {
+    const props = {
+      ...cardProps,
+      entity: {
+        ...cardProps.entity,
+        sys: {
+          type: 'Entry',
+          version: 1,
+        },
+      } as Entry,
+    };
+
+    render(<CustomCard {...props} />);
+
+    fireEvent.click(screen.getByLabelText('Actions'));
+    fireEvent.click(screen.getByText('Remove'));
+    await waitFor(() => {
+      expect(sdk.space.deleteEntry).toHaveBeenCalledWith(props.entity);
+      expect(props.onRemove).toHaveBeenCalled();
+      expect(sdk.space.unpublishEntry).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/contentful-app-extensions/working-group-deliverables/tsconfig.json
+++ b/packages/contentful-app-extensions/working-group-deliverables/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "esnext",
+
+    "allowJs": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "jsx": "react",
+    "moduleResolution": "node",
+    "noEmit": true,
+    "noFallthroughCasesInSwitch": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "strict": true,
+
+    "target": "es2015",
+    "lib": ["dom", "dom.iterable", "esnext"]
+  },
+  "include": ["src"]
+}

--- a/packages/contentful/migrations/crn/workingGroups/20230724161118-change-wg-deliverables-editor.js
+++ b/packages/contentful/migrations/crn/workingGroups/20230724161118-change-wg-deliverables-editor.js
@@ -1,0 +1,21 @@
+module.exports.description = 'Change working groups deliverables editor';
+
+module.exports.up = (migration) => {
+  const workingGroups = migration.editContentType('workingGroups');
+  workingGroups.changeFieldControl(
+    'deliverables',
+    'app',
+    '2hc2UiWrW8SFhfkKMmGtk9',
+    {},
+  );
+};
+
+module.exports.down = (migration) => {
+  const workingGroups = migration.editContentType('workingGroups');
+  workingGroups.changeFieldControl(
+    'deliverables',
+    'builtin',
+    'entryLinksEditor',
+    {},
+  );
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -720,6 +720,35 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@asap-hub/contentful-app-working-group-deliverables@workspace:packages/contentful-app-extensions/working-group-deliverables":
+  version: 0.0.0-use.local
+  resolution: "@asap-hub/contentful-app-working-group-deliverables@workspace:packages/contentful-app-extensions/working-group-deliverables"
+  dependencies:
+    "@contentful/app-scripts": 1.10.2
+    "@contentful/app-sdk": 4.22.1
+    "@contentful/f36-components": 4.48.0
+    "@contentful/f36-tokens": 4.0.2
+    "@contentful/field-editor-reference": ^5.9.0
+    "@contentful/field-editor-shared": ^1.2.0
+    "@contentful/react-apps-toolkit": 1.2.16
+    "@testing-library/jest-dom": ^5.16.5
+    "@testing-library/react": 11.2.7
+    "@tsconfig/create-react-app": 1.0.3
+    "@types/jest": 29.5.3
+    "@types/node": 18.17.0
+    "@types/react": 17.0.62
+    "@types/react-dom": 17.0.20
+    "@types/testing-library__jest-dom": 5.14.8
+    contentful-management: 10.39.2
+    cross-env: 7.0.3
+    emotion: 10.0.27
+    react: 17.0.2
+    react-dom: 17.0.2
+    react-scripts: 5.0.1
+    typescript: 4.9.5
+  languageName: unknown
+  linkType: soft
+
 "@asap-hub/contentful@workspace:*, @asap-hub/contentful@workspace:packages/contentful":
   version: 0.0.0-use.local
   resolution: "@asap-hub/contentful@workspace:packages/contentful"


### PR DESCRIPTION
This PR adds an app extension to show the working group deliverable in a nicer way displaying its status and adds a migration to change the editor type of the `deliverables` field in working groups content type to this new extension.

##### Before
![Deliverables-before](https://github.com/yldio/asap-hub/assets/16595804/29d930d2-a37a-4ce0-aa29-6adcd24623a7)

##### After
![Deliverables-after](https://github.com/yldio/asap-hub/assets/16595804/e6b4a6c0-33ee-47bf-85a3-e81eed1373f3)
