### PR TITLE
Remove coverage collection from squidex integration tests

### DIFF
--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -75,7 +75,7 @@ jobs:
           total: ${{ strategy.job-total }}
   report-coverage:
     runs-on: ubuntu-latest
-    needs: [unit, integration-squidex, integration-contentful]
+    needs: [unit, integration-contentful]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/download-artifact@v3
@@ -93,6 +93,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   integration-squidex:
+    if: ${{ inputs.environment-name=='Branch' }}
     permissions:
       packages: read
     runs-on: ubuntu-latest
@@ -123,20 +124,13 @@ jobs:
           SQUIDEX_BASE_URL: ${{ steps.setup.outputs.squidex-base-url }}
       - name: Run integration tests
         timeout-minutes: 20
-        run: yarn test:integration:squidex --coverage --forceExit
+        run: yarn test:integration:squidex --forceExit
         env:
           APP: crn
           SQUIDEX_APP_NAME: ${{ steps.setup.outputs.crn-squidex-app-name }}-${{ github.run_id }}
           SQUIDEX_CLIENT_ID: ${{ steps.setup.outputs.crn-squidex-ci-client-id }}
           SQUIDEX_CLIENT_SECRET: ${{ secrets.CRN_SQUIDEX_CI_CLIENT_SECRET }}
           SQUIDEX_BASE_URL: ${{ steps.setup.outputs.squidex-base-url }}
-      - name: move coverage
-        shell: bash
-        run: mv coverage/coverage-final.json coverage/integration-squidex.json
-      - uses: actions/upload-artifact@v3
-        with:
-          name: coverage-artifacts
-          path: coverage/
       - name: Delete app
         shell: bash
         if: always()


### PR DESCRIPTION
These can't run on master for reasons, so collecting coverage is preventing master from successfully reporting coverage.

Only run contentful integraiton tests on master so coverage can be collected successfully on all builds.