### PR TITLE
CT-33 Event custom validation

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -41,6 +41,9 @@ outputs:
   contentful-app-event-additional-materials:
     description: 'Contentful App Extension Event Additional Materials Id'
     value: ${{ steps.vars.outputs.contentful-app-event-additional-materials }}
+  contentful-app-event-custom-validation:
+    description: 'Contentful App Extension Event Custom Validation'
+    value: ${{ steps.vars.outputs.contentful-app-event-custom-validation }}
   contentful-app-event-speakers-title:
     description: 'Contentful App Extension Event Speakers Title Id'
     value: ${{ steps.vars.outputs.contentful-app-event-speakers-title }}

--- a/.github/environment/Base
+++ b/.github/environment/Base
@@ -8,6 +8,7 @@ contentful-app-clear-on-change=6en82KYFrsxlAIPqypMdOp
 contentful-app-date-field-as-first-published-at=6AEbdOZc7KICbwW6KszNlp
 contentful-app-disabled-fields=2finDNk15g5UtOq4DaLNxv
 contentful-app-event-additional-materials=3TfrYX8zVOgFtKxro89UVA
+contentful-app-event-custom-validation=2nWYJi9yK7A6WKwm9eezb
 contentful-app-event-speakers-gp2=3dyTFkiCqTbARDWBzY4HB
 contentful-app-event-speakers-title=6ZkXISzhv1b7jjgyaK2piv
 contentful-app-field-as-updated-at=mqvX9KU5AthRTlnIRhNNh

--- a/.github/workflows/on-push-app-extensions.yml
+++ b/.github/workflows/on-push-app-extensions.yml
@@ -60,6 +60,7 @@ jobs:
           - date-field-as-first-published-at
           - disabled-fields
           - event-additional-materials
+          - event-custom-validation
           - event-speakers-title
           - event-speakers-gp2
           - field-as-updated-at

--- a/packages/contentful-app-extensions/event-custom-validation/package.json
+++ b/packages/contentful-app-extensions/event-custom-validation/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@asap-hub/contentful-app-event-custom-validation",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "@contentful/app-sdk": "4.22.1",
+    "@contentful/f36-components": "4.48.0",
+    "@contentful/f36-tokens": "4.0.2",
+    "@contentful/react-apps-toolkit": "1.2.16",
+    "@contentful/rich-text-react-renderer": "^15.16.4",
+    "contentful-management": "10.39.2",
+    "emotion": "10.0.27",
+    "react": "17.0.2",
+    "react-dom": "17.0.2",
+    "react-scripts": "5.0.1"
+  },
+  "scripts": {
+    "start": "cross-env BROWSER=none react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test",
+    "test:no-watch": "react-scripts test --watchAll=false",
+    "eject": "react-scripts eject",
+    "create-app-definition": "contentful-app-scripts create-app-definition",
+    "upload": "contentful-app-scripts upload --bundle-dir ./build",
+    "upload-ci": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN"
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  },
+  "devDependencies": {
+    "@contentful/app-scripts": "1.10.2",
+    "@testing-library/jest-dom": "^5.16.5",
+    "@testing-library/react": "11.2.7",
+    "@tsconfig/create-react-app": "1.0.3",
+    "@types/jest": "29.5.3",
+    "@types/node": "18.17.1",
+    "@types/react": "17.0.62",
+    "@types/react-dom": "17.0.20",
+    "@types/testing-library__jest-dom": "5.14.9",
+    "cross-env": "7.0.3",
+    "typescript": "4.9.5"
+  },
+  "homepage": "."
+}

--- a/packages/contentful-app-extensions/event-custom-validation/public/index.html
+++ b/packages/contentful-app-extensions/event-custom-validation/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+  </body>
+</html>

--- a/packages/contentful-app-extensions/event-custom-validation/src/App.tsx
+++ b/packages/contentful-app-extensions/event-custom-validation/src/App.tsx
@@ -1,0 +1,19 @@
+import React, { useMemo } from 'react';
+import { locations } from '@contentful/app-sdk';
+import { useSDK } from '@contentful/react-apps-toolkit';
+import Field from './locations/Field';
+
+const App = () => {
+  const sdk = useSDK();
+
+  const Component = useMemo(() => {
+    if (sdk.location.is(locations.LOCATION_ENTRY_FIELD)) {
+      return Field;
+    }
+    return null;
+  }, [sdk.location]);
+
+  return Component ? <Component /> : null;
+};
+
+export default App;

--- a/packages/contentful-app-extensions/event-custom-validation/src/index.tsx
+++ b/packages/contentful-app-extensions/event-custom-validation/src/index.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { render } from 'react-dom';
+
+import { GlobalStyles } from '@contentful/f36-components';
+import { SDKProvider } from '@contentful/react-apps-toolkit';
+
+import App from './App';
+
+const root = document.getElementById('root');
+
+render(
+  <SDKProvider>
+    <GlobalStyles />
+    <App />
+  </SDKProvider>,
+  root,
+);

--- a/packages/contentful-app-extensions/event-custom-validation/src/locations/Field.tsx
+++ b/packages/contentful-app-extensions/event-custom-validation/src/locations/Field.tsx
@@ -1,0 +1,188 @@
+import { Entry, FieldAppSDK, Link } from '@contentful/app-sdk';
+import { Note, Stack } from '@contentful/f36-components';
+import { useSDK, useAutoResizer } from '@contentful/react-apps-toolkit';
+import React, { useEffect, useState } from 'react';
+import { getEntry, onEntryChanged } from '../utils';
+
+export const VALID_ENTRY_MESSAGE = 'Entry is valid';
+export const DUPLICATE_SPEAKERS_MESSAGE =
+  'Duplicates with same team and speaker are not allowed';
+export const EXTERNAL_AUTHOR_WITH_TEAM_MESSAGE =
+  'Selecting team for speaker is not allowed when user is external author';
+export const EMPTY_SPEAKER_MESSAGE =
+  'You must select team or user or both for speaker';
+
+const hasDuplicates = (array: string[]) => {
+  const uniqueItems = new Set(array);
+  return uniqueItems.size !== array.length;
+};
+
+const Field = () => {
+  useAutoResizer();
+
+  const sdk = useSDK<FieldAppSDK>();
+
+  const [errors, setErrors] = useState<string[]>([]);
+  const [warnings, setWarnings] = useState<string[]>([]);
+
+  const getValidations = async () => {
+    const entry = getEntry(sdk);
+
+    if (!entry.fields.speakers || !entry.fields.speakers.length) {
+      return {
+        hasDuplicateSpeakers: false,
+        hasSpeakersWithoutTeamAndUser: false,
+        hasExternalAuthorAndTeam: false,
+      };
+    }
+
+    const speakerMembershipIds = entry.fields.speakers.map(
+      (e: Entry) => e.sys.id,
+    );
+
+    const entries = await sdk.cma.entry.getMany({
+      query: {
+        'sys.id[in]': speakerMembershipIds,
+      },
+    });
+
+    const speakerIds = entries.items.map((item) => {
+      const team = item.fields?.team?.['en-US'];
+      const user = item.fields?.user?.['en-US'];
+
+      return user || team ? `${team?.sys?.id}-${user?.sys?.id}` : null;
+    });
+
+    const filteredSpeakerIds = speakerIds.filter((x) => x !== null) as string[];
+
+    const hasExternalAuthorAndTeamArr = await Promise.all(
+      entries.items.map(async (item) => {
+        const team = item.fields?.team?.['en-US'];
+        const user = item.fields?.user?.['en-US'];
+
+        if (!user) return false;
+
+        const userEntry = await sdk.cma.entry.get({
+          entryId: user.sys.id,
+        });
+
+        return Boolean(
+          userEntry.sys.contentType.sys.id === 'externalAuthors' && team,
+        );
+      }),
+    );
+
+    const hasExternalAuthorAndTeam = hasExternalAuthorAndTeamArr.some(
+      (v) => !!v,
+    );
+
+    const userAssociatedWithWrongTeam = await Promise.all(
+      entries.items.map(async (item) => {
+        const team = item.fields?.team?.['en-US'];
+        const user = item.fields?.user?.['en-US'];
+
+        if (!user) return null;
+
+        const userEntry = await sdk.cma.entry.get({
+          entryId: user.sys.id,
+        });
+
+        if (userEntry.sys.contentType.sys.id === 'externalAuthors') return null;
+
+        const userTeamMembershipIds = userEntry.fields.teams?.['en-US'].map(
+          (t: Link<'Entry'>) => t.sys.id,
+        );
+
+        const teamEntry = await sdk.cma.entry.get({
+          entryId: team.sys.id,
+        });
+
+        const teamMembership = await sdk.cma.entry.getMany({
+          query: {
+            'sys.id[in]': userTeamMembershipIds,
+          },
+        });
+
+        const teamIds = (teamMembership.items || []).map(
+          (membership) => membership.fields.team['en-US']?.sys?.id,
+        );
+
+        if (!teamIds.includes(team.sys.id)) {
+          return `User ${userEntry.fields.firstName['en-US']} ${userEntry.fields.lastName['en-US']} does not belong to team ${teamEntry.fields.displayName['en-US']}.`;
+        }
+
+        return null;
+      }),
+    );
+
+    return {
+      hasDuplicateSpeakers: hasDuplicates(filteredSpeakerIds),
+      hasSpeakersWithoutTeamAndUser:
+        speakerIds.length > filteredSpeakerIds.length,
+      hasExternalAuthorAndTeam,
+      userAssociatedWithWrongTeam: userAssociatedWithWrongTeam.filter(
+        (x) => x !== null,
+      ) as string[],
+    };
+  };
+  useEffect(
+    () =>
+      onEntryChanged(sdk, async () => {
+        const newErrors: string[] = [];
+        const newWarnings: string[] = [];
+
+        const {
+          hasDuplicateSpeakers,
+          hasExternalAuthorAndTeam,
+          hasSpeakersWithoutTeamAndUser,
+          userAssociatedWithWrongTeam,
+        } = await getValidations();
+
+        if (hasDuplicateSpeakers) {
+          newErrors.push(DUPLICATE_SPEAKERS_MESSAGE);
+        }
+
+        if (hasExternalAuthorAndTeam) {
+          newErrors.push(EXTERNAL_AUTHOR_WITH_TEAM_MESSAGE);
+        }
+
+        if (hasSpeakersWithoutTeamAndUser) {
+          newErrors.push(EMPTY_SPEAKER_MESSAGE);
+        }
+
+        if (userAssociatedWithWrongTeam?.length) {
+          userAssociatedWithWrongTeam.forEach((message) => {
+            newWarnings.push(message);
+          });
+        }
+
+        setErrors(newErrors);
+        setWarnings(newWarnings);
+        sdk.field.setValue(newErrors.length === 0 ? 'true' : 'false');
+      }),
+    [sdk],
+  );
+
+  return (
+    <Stack flexDirection="column" alignItems="flex-start">
+      {errors.length === 0 && (
+        <Note variant="positive">{VALID_ENTRY_MESSAGE}</Note>
+      )}
+
+      {errors.map((error, index) => (
+        <Note key={index} variant="negative">
+          {error}
+        </Note>
+      ))}
+      {warnings.length > 0
+        ? warnings.map((warning, index) => (
+            <Note key={index} variant="warning">
+              {warning}
+            </Note>
+          ))
+        : null}
+    </Stack>
+  );
+};
+
+export default Field;

--- a/packages/contentful-app-extensions/event-custom-validation/src/react-app-env.d.ts
+++ b/packages/contentful-app-extensions/event-custom-validation/src/react-app-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="react-scripts" />

--- a/packages/contentful-app-extensions/event-custom-validation/src/test/locations/Field.test.tsx
+++ b/packages/contentful-app-extensions/event-custom-validation/src/test/locations/Field.test.tsx
@@ -1,0 +1,368 @@
+import { FieldExtensionSDK } from '@contentful/app-sdk';
+import { useSDK, useAutoResizer } from '@contentful/react-apps-toolkit';
+import '@testing-library/jest-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+
+import Field, {
+  VALID_ENTRY_MESSAGE,
+  DUPLICATE_SPEAKERS_MESSAGE,
+  EMPTY_SPEAKER_MESSAGE,
+  EXTERNAL_AUTHOR_WITH_TEAM_MESSAGE,
+} from '../../locations/Field';
+
+jest.mock('@contentful/react-apps-toolkit', () => ({
+  useSDK: jest.fn(),
+  useAutoResizer: jest.fn(),
+}));
+
+const speakerFields = {
+  team: {
+    'en-US': {
+      sys: {
+        id: 'team-1',
+      },
+    },
+  },
+  user: {
+    'en-US': {
+      sys: {
+        id: 'user-1',
+      },
+    },
+  },
+};
+
+const unsubscribeFn = () => {};
+const mockBaseSdk = () => ({
+  field: {
+    setValue: jest.fn(),
+  },
+  entry: {
+    getSys: jest.fn(),
+    getMetadata: jest.fn(),
+    fields: {
+      speakers: {
+        id: 'speakers',
+        onValueChanged: jest.fn(() => unsubscribeFn),
+        getValue: jest.fn(() => [
+          {
+            sys: {
+              type: 'Link',
+              linkType: 'Entry',
+              id: 'speaker-link-1',
+            },
+          },
+        ]),
+      },
+    },
+    onMetadataChanged: jest.fn(() => unsubscribeFn),
+    onSysChanged: jest.fn((cb) => {
+      cb(() => ({
+        id: '456',
+        space: {
+          sys: {
+            id: '123',
+          },
+        },
+        firstPublishedAt: '2023-04-14T18:00:00.000Z',
+      }));
+      return jest.fn(() => unsubscribeFn);
+    }),
+  },
+  cma: {
+    entry: {
+      getMany: jest.fn(() =>
+        Promise.resolve({
+          items: [
+            {
+              fields: speakerFields,
+            },
+          ],
+        }),
+      ),
+      get: jest.fn(() =>
+        Promise.resolve({
+          sys: {
+            contentType: {
+              sys: {
+                id: 'users',
+              },
+            },
+          },
+          fields: {
+            teams: {
+              'en-US': [{ sys: { id: 'team-1' } }],
+            },
+          },
+        }),
+      ),
+    },
+  },
+});
+
+describe('Field component', () => {
+  let sdk: jest.Mocked<FieldExtensionSDK>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    sdk = mockBaseSdk() as unknown as jest.Mocked<FieldExtensionSDK>;
+    (useSDK as jest.Mock).mockReturnValue(sdk);
+  });
+
+  it('enables automatic resizing', async () => {
+    render(<Field />);
+    await waitFor(() => {
+      expect(useAutoResizer).toHaveBeenCalled();
+    });
+  });
+
+  it('displays message that entry is valid when there are no validation errors', async () => {
+    render(<Field />);
+    await waitFor(() => {
+      expect(screen.getByText(VALID_ENTRY_MESSAGE)).toBeInTheDocument();
+      expect(screen.queryByText(DUPLICATE_SPEAKERS_MESSAGE)).toBeNull();
+      expect(screen.queryByText(EXTERNAL_AUTHOR_WITH_TEAM_MESSAGE)).toBeNull();
+      expect(screen.queryByText(EMPTY_SPEAKER_MESSAGE)).toBeNull();
+    });
+  });
+
+  it('displays error message when there is a speaker without user or team', async () => {
+    const testSdk = {
+      ...mockBaseSdk(),
+      cma: {
+        entry: {
+          getMany: jest.fn(() =>
+            Promise.resolve({
+              items: [
+                {
+                  fields: {
+                    team: null,
+                    user: null,
+                  },
+                },
+              ],
+            }),
+          ),
+        },
+      },
+    } as unknown as jest.Mocked<FieldExtensionSDK>;
+    (useSDK as jest.Mock).mockReturnValue(testSdk);
+
+    render(<Field />);
+    await waitFor(() => {
+      expect(screen.getByText(EMPTY_SPEAKER_MESSAGE)).toBeInTheDocument();
+      expect(screen.queryByText(VALID_ENTRY_MESSAGE)).toBeNull();
+    });
+  });
+
+  it('displays error message when there are duplicated speakers', async () => {
+    const baseSdk = mockBaseSdk();
+    const testSdk = {
+      ...baseSdk,
+      cma: {
+        entry: {
+          ...baseSdk.cma.entry,
+          getMany: jest.fn(() =>
+            Promise.resolve({
+              items: [
+                {
+                  fields: speakerFields,
+                },
+                {
+                  fields: speakerFields,
+                },
+              ],
+            }),
+          ),
+        },
+      },
+    } as unknown as jest.Mocked<FieldExtensionSDK>;
+    (useSDK as jest.Mock).mockReturnValue(testSdk);
+
+    render(<Field />);
+    await waitFor(() => {
+      expect(screen.getByText(DUPLICATE_SPEAKERS_MESSAGE)).toBeInTheDocument();
+      expect(screen.queryByText(VALID_ENTRY_MESSAGE)).toBeNull();
+    });
+  });
+
+  it('displays error message when there are external authors associated to a team', async () => {
+    const baseSdk = mockBaseSdk();
+    const testSdk = {
+      ...baseSdk,
+      cma: {
+        entry: {
+          getMany: jest.fn(() =>
+            Promise.resolve({
+              items: [
+                {
+                  fields: speakerFields,
+                },
+              ],
+            }),
+          ),
+          get: jest.fn(() =>
+            Promise.resolve({
+              sys: {
+                contentType: {
+                  sys: {
+                    id: 'externalAuthors',
+                  },
+                },
+              },
+            }),
+          ),
+        },
+      },
+    } as unknown as jest.Mocked<FieldExtensionSDK>;
+    (useSDK as jest.Mock).mockReturnValue(testSdk);
+
+    render(<Field />);
+    await waitFor(() => {
+      expect(
+        screen.getByText(EXTERNAL_AUTHOR_WITH_TEAM_MESSAGE),
+      ).toBeInTheDocument();
+      expect(screen.queryByText(VALID_ENTRY_MESSAGE)).toBeNull();
+    });
+  });
+
+  it('displays more than one validation message error at a time', async () => {
+    const baseSdk = mockBaseSdk();
+    const testSdk = {
+      ...baseSdk,
+      cma: {
+        entry: {
+          getMany: jest.fn(() =>
+            Promise.resolve({
+              items: [
+                {
+                  fields: speakerFields,
+                },
+                {
+                  fields: {
+                    team: null,
+                    user: null,
+                  },
+                },
+              ],
+            }),
+          ),
+          get: jest.fn(() =>
+            Promise.resolve({
+              sys: {
+                contentType: {
+                  sys: {
+                    id: 'externalAuthors',
+                  },
+                },
+              },
+            }),
+          ),
+        },
+      },
+    } as unknown as jest.Mocked<FieldExtensionSDK>;
+    (useSDK as jest.Mock).mockReturnValue(testSdk);
+
+    render(<Field />);
+    await waitFor(() => {
+      expect(
+        screen.getByText(EXTERNAL_AUTHOR_WITH_TEAM_MESSAGE),
+      ).toBeInTheDocument();
+      expect(screen.getByText(EMPTY_SPEAKER_MESSAGE)).toBeInTheDocument();
+      expect(screen.queryByText(VALID_ENTRY_MESSAGE)).toBeNull();
+    });
+  });
+
+  it('displays warning message when there is an user associated with a team that he/she does not belong', async () => {
+    const baseSdk = mockBaseSdk();
+    const testSdk = {
+      ...baseSdk,
+      cma: {
+        entry: {
+          getMany: jest.fn((param) => {
+            if (param.query['sys.id[in]'][0] === 'speaker-link-1') {
+              return Promise.resolve({
+                items: [
+                  {
+                    fields: speakerFields,
+                  },
+                ],
+              });
+            }
+
+            if (param.query['sys.id[in]'][0] === 'team-membership-1') {
+              return Promise.resolve({
+                items: [
+                  {
+                    fields: {
+                      team: {
+                        sys: {
+                          id: 'team-2',
+                        },
+                      },
+                    },
+                  },
+                ],
+              });
+            }
+          }),
+          get: jest.fn((param) => {
+            if (param.entryId === 'user-1') {
+              return Promise.resolve({
+                sys: {
+                  contentType: {
+                    sys: {
+                      id: 'users',
+                    },
+                  },
+                },
+                fields: {
+                  firstName: {
+                    'en-US': 'John',
+                  },
+                  lastName: {
+                    'en-US': 'Doe',
+                  },
+                  teams: {
+                    'en-US': [{ sys: { id: 'team-membership-1' } }],
+                  },
+                },
+              });
+            }
+
+            if (param.entryId === 'team-1') {
+              return Promise.resolve({
+                fields: {
+                  displayName: {
+                    'en-US': 'Team One',
+                  },
+                },
+              });
+            }
+
+            if (param.entryId === 'team-2') {
+              return Promise.resolve({
+                fields: {
+                  displayName: {
+                    'en-US': 'Team Two',
+                  },
+                },
+              });
+            }
+          }),
+        },
+      },
+    } as unknown as jest.Mocked<FieldExtensionSDK>;
+    (useSDK as jest.Mock).mockReturnValue(testSdk);
+
+    render(<Field />);
+    await waitFor(() => {
+      expect(screen.getByText(VALID_ENTRY_MESSAGE)).toBeInTheDocument();
+      expect(
+        screen.getByText('User John Doe does not belong to team Team One.'),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/contentful-app-extensions/event-custom-validation/src/test/locations/Field.test.tsx
+++ b/packages/contentful-app-extensions/event-custom-validation/src/test/locations/Field.test.tsx
@@ -122,6 +122,7 @@ describe('Field component', () => {
     render(<Field />);
     await waitFor(() => {
       expect(screen.getByText(VALID_ENTRY_MESSAGE)).toBeInTheDocument();
+      expect(sdk.field.setValue).not.toHaveBeenCalledWith();
       expect(screen.queryByText(DUPLICATE_SPEAKERS_MESSAGE)).toBeNull();
       expect(screen.queryByText(EXTERNAL_AUTHOR_WITH_TEAM_MESSAGE)).toBeNull();
       expect(screen.queryByText(EMPTY_SPEAKER_MESSAGE)).toBeNull();
@@ -153,6 +154,7 @@ describe('Field component', () => {
     render(<Field />);
     await waitFor(() => {
       expect(screen.getByText(EMPTY_SPEAKER_MESSAGE)).toBeInTheDocument();
+      expect(testSdk.field.setValue).toHaveBeenCalledWith('false');
       expect(screen.queryByText(VALID_ENTRY_MESSAGE)).toBeNull();
     });
   });
@@ -184,6 +186,7 @@ describe('Field component', () => {
     render(<Field />);
     await waitFor(() => {
       expect(screen.getByText(DUPLICATE_SPEAKERS_MESSAGE)).toBeInTheDocument();
+      expect(testSdk.field.setValue).toHaveBeenCalledWith('false');
       expect(screen.queryByText(VALID_ENTRY_MESSAGE)).toBeNull();
     });
   });
@@ -224,6 +227,7 @@ describe('Field component', () => {
       expect(
         screen.getByText(EXTERNAL_AUTHOR_WITH_TEAM_MESSAGE),
       ).toBeInTheDocument();
+      expect(testSdk.field.setValue).toHaveBeenCalledWith('false');
       expect(screen.queryByText(VALID_ENTRY_MESSAGE)).toBeNull();
     });
   });
@@ -270,6 +274,7 @@ describe('Field component', () => {
       expect(
         screen.getByText(EXTERNAL_AUTHOR_WITH_TEAM_MESSAGE),
       ).toBeInTheDocument();
+      expect(testSdk.field.setValue).toHaveBeenCalledWith('false');
       expect(screen.getByText(EMPTY_SPEAKER_MESSAGE)).toBeInTheDocument();
       expect(screen.queryByText(VALID_ENTRY_MESSAGE)).toBeNull();
     });
@@ -360,6 +365,7 @@ describe('Field component', () => {
     render(<Field />);
     await waitFor(() => {
       expect(screen.getByText(VALID_ENTRY_MESSAGE)).toBeInTheDocument();
+      expect(testSdk.field.setValue).toHaveBeenCalledWith('true');
       expect(
         screen.getByText('User John Doe does not belong to team Team One.'),
       ).toBeInTheDocument();

--- a/packages/contentful-app-extensions/event-custom-validation/src/utils.ts
+++ b/packages/contentful-app-extensions/event-custom-validation/src/utils.ts
@@ -1,0 +1,37 @@
+import { EditorAppSDK, FieldAppSDK, SidebarAppSDK } from '@contentful/app-sdk';
+import { EntryProps } from 'contentful-management';
+
+type SDK = FieldAppSDK | SidebarAppSDK | EditorAppSDK;
+
+export function getEntry(sdk: SDK): EntryProps {
+  return {
+    // @ts-expect-error type
+    sys: sdk.entry.getSys(),
+    fields: Object.fromEntries(
+      Object.values(sdk.entry.fields).map((field) => [
+        field.id,
+        field.getValue(),
+      ]),
+    ),
+    metadata: sdk.entry.getMetadata(),
+  };
+}
+
+export function onEntryChanged(sdk: SDK, callback: () => void): () => void {
+  const triggerCallback = () => callback();
+
+  const subscriptions: (() => void)[] = [];
+
+  subscriptions.push(sdk.entry.onSysChanged(triggerCallback));
+  /* eslint-disable no-restricted-syntax */
+
+  for (const field of Object.values(sdk.entry.fields)) {
+    subscriptions.push(field.onValueChanged(triggerCallback));
+  }
+  subscriptions.push(sdk.entry.onMetadataChanged(triggerCallback));
+
+  return () => {
+    subscriptions.forEach((unsubscribe) => unsubscribe());
+  };
+  /* eslint-enable no-restricted-syntax */
+}

--- a/packages/contentful-app-extensions/event-custom-validation/tsconfig.json
+++ b/packages/contentful-app-extensions/event-custom-validation/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "esnext",
+
+    "allowJs": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "jsx": "react",
+    "moduleResolution": "node",
+    "noEmit": true,
+    "noFallthroughCasesInSwitch": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "strict": true,
+
+    "target": "es2015",
+    "lib": ["dom", "dom.iterable", "esnext"]
+  },
+  "include": ["src"]
+}

--- a/packages/contentful/migrations/crn/events/20230728134529-add-validation-field.js
+++ b/packages/contentful/migrations/crn/events/20230728134529-add-validation-field.js
@@ -1,0 +1,31 @@
+module.exports.description = 'Add speakers validation field';
+
+module.exports.up = (migration) => {
+  const events = migration.editContentType('events');
+
+  events
+    .createField('validation')
+    .name('Validation')
+    .type('Symbol')
+    .localized(false)
+    .required(true)
+    .validations([
+      {
+        in: ['true'],
+      },
+    ])
+    .defaultValue({
+      'en-US': 'true',
+    })
+    .disabled(false)
+    .omitted(true);
+
+  events.moveField('validation').afterField('speakers');
+
+  events.changeFieldControl('validation', 'app', '2nWYJi9yK7A6WKwm9eezb', {});
+};
+
+module.exports.down = (migration) => {
+  const events = migration.editContentType('events');
+  events.deleteField('validation');
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -524,6 +524,34 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@asap-hub/contentful-app-event-custom-validation@workspace:packages/contentful-app-extensions/event-custom-validation":
+  version: 0.0.0-use.local
+  resolution: "@asap-hub/contentful-app-event-custom-validation@workspace:packages/contentful-app-extensions/event-custom-validation"
+  dependencies:
+    "@contentful/app-scripts": 1.10.2
+    "@contentful/app-sdk": 4.22.1
+    "@contentful/f36-components": 4.48.0
+    "@contentful/f36-tokens": 4.0.2
+    "@contentful/react-apps-toolkit": 1.2.16
+    "@contentful/rich-text-react-renderer": ^15.16.4
+    "@testing-library/jest-dom": ^5.16.5
+    "@testing-library/react": 11.2.7
+    "@tsconfig/create-react-app": 1.0.3
+    "@types/jest": 29.5.3
+    "@types/node": 18.17.1
+    "@types/react": 17.0.62
+    "@types/react-dom": 17.0.20
+    "@types/testing-library__jest-dom": 5.14.9
+    contentful-management: 10.39.2
+    cross-env: 7.0.3
+    emotion: 10.0.27
+    react: 17.0.2
+    react-dom: 17.0.2
+    react-scripts: 5.0.1
+    typescript: 4.9.5
+  languageName: unknown
+  linkType: soft
+
 "@asap-hub/contentful-app-event-speakers-gp2@workspace:packages/contentful-app-extensions/event-speakers-gp2":
   version: 0.0.0-use.local
   resolution: "@asap-hub/contentful-app-event-speakers-gp2@workspace:packages/contentful-app-extensions/event-speakers-gp2"


### PR DESCRIPTION
This PR adds an extension to add custom validation to `events` following this model https://github.com/contentful/apps/tree/master/examples/custom-validation as suggested by contentful support (read this thread https://contentful-community.slack.com/archives/CBR24P3T4/p1688145410897879?thread_ts=1687960592.599549&cid=CBR24P3T4).

The validations are listed here in this ticket https://asaphub.atlassian.net/browse/CT-33 similar of what we have in squidex, only 3 of them (requirements 1, 2, 4 of the ticket) make the entry unpublishable. Below there is the code of the script we use to do these validations in Squidex:

![Screenshot 2023-07-28 at 14 25 19](https://github.com/yldio/asap-hub/assets/16595804/4b8bdc03-db11-4d85-a520-c0951a0e3dfb)

This requirement

> When a CMS user updates an event and they create a speaker and select a team and a user that is not part of that team then that user should not be displayed.

does not make the entry unpublishable in Squidex, so I made it behave the same way in Contentful. And this is covered in the response parser of the data providers
- squidex: https://github.com/yldio/asap-hub/blob/master/apps/crn-server/src/data-providers/transformers/event.ts#L121:L135
- contentful: https://github.com/yldio/asap-hub/blob/CT-33-create-custom-validation-for-events/apps/crn-server/src/data-providers/contentful/event.data-provider.ts#L332:L346

But I also left a warning in Contentful when this happens:
![Screenshot 2023-07-28 at 14 30 31](https://github.com/yldio/asap-hub/assets/16595804/2a7fb2cf-9824-4071-a08e-4ffa256aea1d)

--- 

#### Example of an error that makes the error unpublishable
![Screenshot 2023-07-28 at 14 19 06](https://github.com/yldio/asap-hub/assets/16595804/f511a112-4e62-4d05-98e2-0b8e4542db9c)
