### PR TITLE
Add wrapping `<p/>` around rich text fields populated with plain text

### DIFF
--- a/packages/cms-data-sync/src/utils/rich-text.ts
+++ b/packages/cms-data-sync/src/utils/rich-text.ts
@@ -41,6 +41,14 @@ export const wrapIframeWithPTag = (html: string): string => {
   return output ?? html;
 };
 
+export const wrapPlainTextWithPTag = (html: string): string => {
+  const $ = cheerio.load(html);
+  if ($('body').children().length === 0 && $('body').text()) {
+    return `<p>${html}</p>`;
+  }
+  return html;
+};
+
 export const clearParsedHtmlOutput = (htmlDocument: Document) => ({
   ...htmlDocument,
   content: htmlDocument?.content
@@ -111,6 +119,7 @@ export const convertHtmlToContentfulFormat = (html: string) => {
   processedHtml = removeStylingTagsWrappingIFrameTags(processedHtml);
   processedHtml = removeStylingTagsWrappingImgTags(processedHtml);
   processedHtml = wrapIframeWithPTag(processedHtml);
+  processedHtml = wrapPlainTextWithPTag(processedHtml);
 
   // processedHtml = addPTagsToIframeTagNotWrappedByAnything(processedHtml);
   logger(`HTML pre-parsed:\n${html}`, 'DEBUG');

--- a/packages/cms-data-sync/src/utils/rich-text.ts
+++ b/packages/cms-data-sync/src/utils/rich-text.ts
@@ -121,7 +121,6 @@ export const convertHtmlToContentfulFormat = (html: string) => {
   processedHtml = wrapIframeWithPTag(processedHtml);
   processedHtml = wrapPlainTextWithPTag(processedHtml);
 
-  // processedHtml = addPTagsToIframeTagNotWrappedByAnything(processedHtml);
   logger(`HTML pre-parsed:\n${html}`, 'DEBUG');
   logger(`HTML post-parsed:\n${processedHtml}`, 'DEBUG');
 

--- a/packages/cms-data-sync/test/utils/rich-text.test.ts
+++ b/packages/cms-data-sync/test/utils/rich-text.test.ts
@@ -37,6 +37,32 @@ describe('convertHtmlToContentfulFormat', () => {
       inlineIFramesBodies: [],
     });
   });
+  it('wraps plain text in a paragraph element', () => {
+    const html = 'Hello world';
+
+    expect(convertHtmlToContentfulFormat(html)).toEqual({
+      document: {
+        content: [
+          {
+            content: [
+              {
+                data: {},
+                marks: [],
+                value: 'Hello world',
+                nodeType: 'text',
+              },
+            ],
+            data: {},
+            nodeType: 'paragraph',
+          },
+        ],
+        data: {},
+        nodeType: 'document',
+      },
+      inlineAssetBodies: [],
+      inlineIFramesBodies: [],
+    });
+  });
 
   it('converts html with list to contentful expected rich text format properly', () => {
     const html = '<ul><li>item 1</li><li>item 2</li></ul>';


### PR DESCRIPTION
Some description fields on research outputs in Squidex return content as plain text strings rather than rich text html. This causes them to migrate as empty because the parser removes top-level `text` nodes.

When a rich text field contains no html tags then wrap the text with a single `<p/>` before parsing so that the top level node is a `paragraph` as expected.