### PR TITLE
CT-85 Remove extra new line at the end of usage notes

### DIFF
--- a/packages/cms-data-sync/src/utils/rich-text.ts
+++ b/packages/cms-data-sync/src/utils/rich-text.ts
@@ -174,5 +174,7 @@ export function richTextToMarkdown(text = ''): string {
   });
 
   const { contents } = processor.processSync(text);
-  return contents as string;
+  const markdownText = contents as string;
+
+  return markdownText.replace(/\n$/, '');
 }

--- a/packages/cms-data-sync/test/research-outputs/research-outputs.data-migration.test.ts
+++ b/packages/cms-data-sync/test/research-outputs/research-outputs.data-migration.test.ts
@@ -384,9 +384,7 @@ describe('Migrate research outputs', () => {
       {
         fields: expect.objectContaining({
           usageNotes: {
-            'en-US': expect.stringContaining(
-              'Some content with em and strong tags.',
-            ),
+            'en-US': 'Some content with em and strong tags.',
           },
         }),
       },

--- a/packages/react-components/src/utils/__tests__/parsing.test.ts
+++ b/packages/react-components/src/utils/__tests__/parsing.test.ts
@@ -3,7 +3,7 @@ import { richTextToMarkdown } from '../parsing';
 describe('richTextToMarkdown', () => {
   it('handles basic text', () => {
     const result = richTextToMarkdown('text');
-    expect(result).toBe(`text\n`);
+    expect(result).toBe('text');
   });
 
   it('handles formatted text', () => {
@@ -13,7 +13,6 @@ describe('richTextToMarkdown', () => {
 
 **dasdasd**
 
-## dasdsad
-`);
+## dasdsad`);
   });
 });

--- a/packages/react-components/src/utils/parsing.tsx
+++ b/packages/react-components/src/utils/parsing.tsx
@@ -178,5 +178,7 @@ export function richTextToMarkdown(text = '', poorText = false): string {
   });
 
   const { contents } = processor.processSync(text);
-  return contents as string;
+  const markdownText = contents as string;
+
+  return markdownText.replace(/\n$/, '');
 }


### PR DESCRIPTION
Ticket: https://asaphub.atlassian.net/browse/CT-85

It seems that `remarkStringify` adds a new line at the end of the string. I'm removing it so the `usageNotes` look the same after the research output migration. I'm also removing this new line from the `richTextToMarkdown` used in the front end to show the descriptions in md.