### PR TITLE
Enable run migration for single entity in on-demand-cms-sync

### DIFF
--- a/.github/workflows/on-demand-cms-sync.yml
+++ b/.github/workflows/on-demand-cms-sync.yml
@@ -18,6 +18,26 @@ on:
         required: true
         type: string
         description: Choose which Squidex app to sync from
+      entity:
+        required: false
+        type: choice
+        description: Choose which entity to sync
+        default: all
+        options:
+          - teams
+          - teamProposals
+          - externalAuthors
+          - calendars
+          - labs
+          - users
+          - events
+          - interestGroups
+          - workingGroups
+          - tutorials
+          - discover
+          - researchTags
+          - researchOutputs
+          - all
 
 jobs:
   sync_cms_data:
@@ -42,7 +62,7 @@ jobs:
         run: |
           yarn build:babel
           yarn build:typecheck
-          yarn workspace @asap-hub/cms-data-sync migrate
+          yarn workspace @asap-hub/cms-data-sync migrate --${{ inputs.entity }}
         env:
           CONTENTFUL_MANAGEMENT_ACCESS_TOKEN: ${{ secrets.CONTENTFUL_MANAGEMENT_TOKEN }}
           CONTENTFUL_SPACE_ID: ${{ steps.setup.outputs.crn-contentful-space-id }}

--- a/packages/cms-data-sync/src/run-migrations.ts
+++ b/packages/cms-data-sync/src/run-migrations.ts
@@ -48,7 +48,9 @@ export const runMigrations = async (flags: Flag[] = []) => {
   });
 
   const hasFlag = (flag: ModelName): boolean =>
-    flags.length === 0 || flags.includes(`--${flag}`);
+    flags.length === 0 ||
+    flags.includes(`--${flag}`) ||
+    flags.includes('--all');
 
   const contentfulSpace = await contentfulClient.getSpace(CONTENTFUL_SPACE_ID!);
 

--- a/packages/cms-data-sync/test/run-migrations.test.ts
+++ b/packages/cms-data-sync/test/run-migrations.test.ts
@@ -210,6 +210,27 @@ describe('Migrations', () => {
     console.log = consoleLogRef;
   });
 
+  it('runs all migrations if flag with value `all` is passed', async () => {
+    spaceMock.getWebhooks.mockResolvedValue({
+      items: [],
+    } as unknown as Collection<WebHooks, WebhookProps>);
+
+    await runMigrations('--all');
+
+    expect(migrateTeams).toHaveBeenCalled();
+    expect(migrateExternalAuthors).toHaveBeenCalled();
+    expect(migrateCalendars).toHaveBeenCalled();
+    expect(migrateLabs).toHaveBeenCalled();
+    expect(migrateUsers).toHaveBeenCalled();
+    expect(migrateInterestGroups).toHaveBeenCalled();
+    expect(migrateWorkingGroups).toHaveBeenCalled();
+    expect(migrateTutorials).toHaveBeenCalled();
+    expect(migrateDiscover).toHaveBeenCalled();
+    expect(migrateResearchTags).toHaveBeenCalled();
+    expect(migrateResearchOutputs).toHaveBeenCalled();
+    expect(migrateTeamProposals).toHaveBeenCalled();
+  });
+
   it('runs only a subset of migrations if flags are passed', async () => {
     spaceMock.getWebhooks.mockResolvedValue({
       items: [],


### PR DESCRIPTION
This PR makes it possible to select a single entity to run the migration in `on-demand-cms-sync` action

![Screenshot 2023-08-08 at 08 00 47](https://github.com/yldio/asap-hub/assets/16595804/1c2b246c-5baf-4cef-b8a5-5979fb5aae49)

Example of a run where only external authors have been migrated https://github.com/yldio/asap-hub/actions/runs/5796062135/job/15708866982#step:6:431