### PR TITLE
Migration/update entries

### DIFF
--- a/.github/workflows/on-demand-cms-sync.yml
+++ b/.github/workflows/on-demand-cms-sync.yml
@@ -38,8 +38,8 @@ on:
           - researchTags
           - researchOutputs
           - all
-      is-update-mode-enabled:
-        description: 'Is update mode enabled'
+      upsert-in-place:
+        description: 'Upsert entry in place'
         required: false
         type: boolean
         default: false
@@ -76,7 +76,7 @@ jobs:
           CRN_SQUIDEX_CLIENT_ID: ${{ steps.setup.outputs.crn-squidex-ci-client-id }}
           CRN_SQUIDEX_CLIENT_SECRET: ${{ secrets.CRN_SQUIDEX_CI_CLIENT_SECRET }}
           SQUIDEX_BASE_URL: ${{ steps.setup.outputs.squidex-base-url }}
-          IS_UPDATE_MODE_ENABLED: ${{ inputs.is-update-mode-enabled}}
+          UPSERT_IN_PLACE: ${{ inputs.upsert-in-place}}
 
   notify_failure:
     runs-on: ubuntu-latest

--- a/.github/workflows/on-demand-cms-sync.yml
+++ b/.github/workflows/on-demand-cms-sync.yml
@@ -38,6 +38,11 @@ on:
           - researchTags
           - researchOutputs
           - all
+      is-update-mode-enabled:
+        description: 'Is update mode enabled'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   sync_cms_data:
@@ -71,6 +76,7 @@ jobs:
           CRN_SQUIDEX_CLIENT_ID: ${{ steps.setup.outputs.crn-squidex-ci-client-id }}
           CRN_SQUIDEX_CLIENT_SECRET: ${{ secrets.CRN_SQUIDEX_CI_CLIENT_SECRET }}
           SQUIDEX_BASE_URL: ${{ steps.setup.outputs.squidex-base-url }}
+          IS_UPDATE_MODE_ENABLED: ${{ inputs.is-update-mode-enabled}}
 
   notify_failure:
     runs-on: ubuntu-latest

--- a/packages/cms-data-sync/src/utils/migration.ts
+++ b/packages/cms-data-sync/src/utils/migration.ts
@@ -3,7 +3,7 @@ import { Environment, Entry } from 'contentful-management';
 import { clearContentfulEntries, publishContentfulEntries } from './entries';
 import { logger as loggerFunc } from './logs';
 import { contentfulRateLimiter } from '../contentful-rate-limiter';
-import { isUpdateModeEnabled } from './setup';
+import { upsertInPlace } from './setup';
 
 export const migrateFromSquidexToContentfulFactory =
   (contentfulEnvironment: Environment, logger: typeof loggerFunc) =>
@@ -20,7 +20,7 @@ export const migrateFromSquidexToContentfulFactory =
   ) => {
     const data = await fetchData();
 
-    if (clearPreviousEntries && !isUpdateModeEnabled) {
+    if (clearPreviousEntries && !upsertInPlace) {
       await clearContentfulEntries(contentfulEnvironment, contentTypeId);
     }
     let n = 0;
@@ -60,7 +60,7 @@ export const migrateFromSquidexToContentfulFactory =
         };
 
         try {
-          return updateEntry || isUpdateModeEnabled
+          return updateEntry || upsertInPlace
             ? await updateExistingEntry()
             : await createEntry();
         } catch (err) {
@@ -69,7 +69,7 @@ export const migrateFromSquidexToContentfulFactory =
               const errorParsed = JSON.parse(err?.message);
               // this is a fallback when it should have updated the entry
               // but it does not exist
-              if (isUpdateModeEnabled && errorParsed.status === 404) {
+              if (upsertInPlace && errorParsed.status === 404) {
                 const entry = await createEntry();
                 return entry;
               }

--- a/packages/cms-data-sync/src/utils/migration.ts
+++ b/packages/cms-data-sync/src/utils/migration.ts
@@ -67,12 +67,16 @@ export const migrateFromSquidexToContentfulFactory =
             : await createEntry();
         } catch (err) {
           if (err instanceof Error) {
-            const errorParsed = JSON.parse(err.message);
-            // this is a fallback when it should have updated the entry
-            // but it does not exist
-            if (shouldUpdateEntry && errorParsed.status === 404) {
-              const entry = await createEntry();
-              return entry;
+            try {
+              const errorParsed = JSON.parse(err?.message);
+              // this is a fallback when it should have updated the entry
+              // but it does not exist
+              if (shouldUpdateEntry && errorParsed.status === 404) {
+                const entry = await createEntry();
+                return entry;
+              }
+            } catch (e) {
+              throw err;
             }
           }
 

--- a/packages/cms-data-sync/src/utils/migration.ts
+++ b/packages/cms-data-sync/src/utils/migration.ts
@@ -59,10 +59,8 @@ export const migrateFromSquidexToContentfulFactory =
           return updatedEntry;
         };
 
-        const shouldUpdateEntry = updateEntry || isUpdateModeEnabled;
-
         try {
-          return shouldUpdateEntry
+          return updateEntry || isUpdateModeEnabled
             ? await updateExistingEntry()
             : await createEntry();
         } catch (err) {
@@ -71,7 +69,7 @@ export const migrateFromSquidexToContentfulFactory =
               const errorParsed = JSON.parse(err?.message);
               // this is a fallback when it should have updated the entry
               // but it does not exist
-              if (shouldUpdateEntry && errorParsed.status === 404) {
+              if (isUpdateModeEnabled && errorParsed.status === 404) {
                 const entry = await createEntry();
                 return entry;
               }

--- a/packages/cms-data-sync/src/utils/migration.ts
+++ b/packages/cms-data-sync/src/utils/migration.ts
@@ -60,6 +60,9 @@ export const migrateFromSquidexToContentfulFactory =
         };
 
         const shouldUpdateEntry = updateEntry || isUpdateModeEnabled;
+        console.log('updateEntry', updateEntry);
+        console.log('isUpdateModeEnabled', isUpdateModeEnabled);
+        console.log('shouldUpdateEntry', shouldUpdateEntry);
 
         try {
           return shouldUpdateEntry

--- a/packages/cms-data-sync/src/utils/migration.ts
+++ b/packages/cms-data-sync/src/utils/migration.ts
@@ -60,9 +60,6 @@ export const migrateFromSquidexToContentfulFactory =
         };
 
         const shouldUpdateEntry = updateEntry || isUpdateModeEnabled;
-        console.log('updateEntry', updateEntry);
-        console.log('isUpdateModeEnabled', isUpdateModeEnabled);
-        console.log('shouldUpdateEntry', shouldUpdateEntry);
 
         try {
           return shouldUpdateEntry

--- a/packages/cms-data-sync/src/utils/setup.ts
+++ b/packages/cms-data-sync/src/utils/setup.ts
@@ -18,6 +18,10 @@ import { rateLimiter } from './rate-limiter';
 export const isVerbose = () =>
   process.env.VERBOSE_DATA_SYNC && process.env.VERBOSE_DATA_SYNC === 'true';
 
+export const isUpdateModeEnabled =
+  process.env.IS_UPDATE_MODE_ENABLED &&
+  process.env.IS_UPDATE_MODE_ENABLED === 'true';
+
 class ApiAdapter extends RestAdapter {
   async makeRequest<R>(options: MakeRequestOptions): Promise<R> {
     await rateLimiter.removeTokens(1);

--- a/packages/cms-data-sync/src/utils/setup.ts
+++ b/packages/cms-data-sync/src/utils/setup.ts
@@ -19,7 +19,8 @@ export const isVerbose = () =>
   process.env.VERBOSE_DATA_SYNC && process.env.VERBOSE_DATA_SYNC === 'true';
 
 export const upsertInPlace =
-  process.env.UPSERT_IN_PLACE && process.env.UPSERT_IN_PLACE === 'true';
+  (process.env.UPSERT_IN_PLACE && process.env.UPSERT_IN_PLACE === 'true') ||
+  process.argv.includes('--upsert');
 
 class ApiAdapter extends RestAdapter {
   async makeRequest<R>(options: MakeRequestOptions): Promise<R> {

--- a/packages/cms-data-sync/src/utils/setup.ts
+++ b/packages/cms-data-sync/src/utils/setup.ts
@@ -18,9 +18,8 @@ import { rateLimiter } from './rate-limiter';
 export const isVerbose = () =>
   process.env.VERBOSE_DATA_SYNC && process.env.VERBOSE_DATA_SYNC === 'true';
 
-export const isUpdateModeEnabled =
-  process.env.IS_UPDATE_MODE_ENABLED &&
-  process.env.IS_UPDATE_MODE_ENABLED === 'true';
+export const upsertInPlace =
+  process.env.UPSERT_IN_PLACE && process.env.UPSERT_IN_PLACE === 'true';
 
 class ApiAdapter extends RestAdapter {
   async makeRequest<R>(options: MakeRequestOptions): Promise<R> {

--- a/packages/cms-data-sync/test/events/events.data-migration.test.ts
+++ b/packages/cms-data-sync/test/events/events.data-migration.test.ts
@@ -334,8 +334,13 @@ describe('Migrate events', () => {
     squidexGraphqlClientMock.request.mockResolvedValueOnce(
       getEventSquidexResponse(),
     );
-    jest
-      .spyOn(contentfulEnv, 'getEntry')
+
+    when(contentfulEnv.getEntry)
+      .calledWith('external-user-1')
+      .mockRejectedValue(new Error('{"status":404}'));
+
+    when(contentfulEnv.getEntry)
+      .calledWith('null')
       .mockRejectedValue(new Error('{"status":404}'));
 
     const entry = getEntry({});
@@ -346,7 +351,8 @@ describe('Migrate events', () => {
 
     await migrateEvents();
 
-    expect(console.log).toHaveBeenCalledWith(
+    expect(console.log).toHaveBeenNthCalledWith(
+      2,
       '\x1b[31m',
       '[ERROR] Either user external-user-1 or team null do not exist in contentful. Please review event with id event-1',
     );

--- a/packages/cms-data-sync/test/events/events.data-migration.test.ts
+++ b/packages/cms-data-sync/test/events/events.data-migration.test.ts
@@ -212,6 +212,10 @@ describe('Migrate events', () => {
     jest.spyOn(contentfulEnv, 'createEntry').mockResolvedValue(getEntry({}));
 
     jest.spyOn(eventEntry, 'publish').mockResolvedValue(getEntry({}));
+
+    const entry = getEntry({});
+    entry.update = jest.fn();
+    jest.spyOn(contentfulEnv, 'getEntry').mockResolvedValue(entry);
   });
 
   afterEach(() => {
@@ -267,6 +271,12 @@ describe('Migrate events', () => {
       .calledWith('old-speaker')
       .mockResolvedValueOnce(previousSpeakerMock);
 
+    const entry = getEntry({});
+    entry.update = jest.fn();
+    when(contentfulEnv.getEntry)
+      .calledWith('event-1')
+      .mockResolvedValueOnce(entry);
+
     await migrateEvents();
 
     expect(previousSpeakerMock.unpublish).toHaveBeenCalled();
@@ -304,7 +314,13 @@ describe('Migrate events', () => {
 
     when(contentfulEnv.getEntry)
       .calledWith('old-speaker')
-      .mockRejectedValueOnce(new Error());
+      .mockRejectedValueOnce(new Error('{"status":500}'));
+
+    const entry = getEntry({});
+    entry.update = jest.fn();
+    when(contentfulEnv.getEntry)
+      .calledWith('event-1')
+      .mockResolvedValueOnce(entry);
 
     await migrateEvents();
 
@@ -320,7 +336,13 @@ describe('Migrate events', () => {
     );
     jest
       .spyOn(contentfulEnv, 'getEntry')
-      .mockRejectedValue(new Error('not-found'));
+      .mockRejectedValue(new Error('{"status":404}'));
+
+    const entry = getEntry({});
+    entry.update = jest.fn();
+    when(contentfulEnv.getEntry)
+      .calledWith('event-1')
+      .mockResolvedValueOnce(entry);
 
     await migrateEvents();
 
@@ -534,7 +556,13 @@ describe('Migrate events', () => {
 
     when(contentfulEnv.getEntry)
       .calledWith('calendar-1')
-      .mockRejectedValueOnce(new Error('not-found'));
+      .mockRejectedValueOnce(new Error('{"status":404}'));
+
+    const entry = getEntry({});
+    entry.update = jest.fn();
+    when(contentfulEnv.getEntry)
+      .calledWith('event-1')
+      .mockResolvedValueOnce(entry);
 
     jest
       .spyOn(contentfulEnv, 'getEntries')

--- a/packages/cms-data-sync/test/news/news.data-migration.test.ts
+++ b/packages/cms-data-sync/test/news/news.data-migration.test.ts
@@ -243,7 +243,7 @@ describe('Migrate news', () => {
       const convertHtmlToContentfulFormatMock =
         convertHtmlToContentfulFormat as jest.Mock;
       convertHtmlToContentfulFormatMock.mockImplementationOnce(() => {
-        throw new Error();
+        throw new Error('{"status":500}');
       });
 
       jest
@@ -291,7 +291,7 @@ describe('Migrate news', () => {
       jest
         .spyOn(contenfulEnv, 'createEntryWithId')
         .mockImplementationOnce(() => {
-          throw new Error();
+          throw new Error('{"status":500}');
         })
         .mockImplementationOnce(() => Promise.resolve(newsEntry));
 
@@ -314,7 +314,7 @@ describe('Migrate news', () => {
         publishContentfulEntries as jest.Mock;
 
       jest.spyOn(contenfulEnv, 'createEntryWithId').mockImplementation(() => {
-        throw new Error();
+        throw new Error('{"status":500}');
       });
 
       await migrateNews();

--- a/packages/cms-data-sync/test/pages/pages.data-migration.test.ts
+++ b/packages/cms-data-sync/test/pages/pages.data-migration.test.ts
@@ -135,7 +135,9 @@ describe('Migrate Pages', () => {
     squidexGraphqlClientMock.request.mockResolvedValueOnce(
       pagesSquidexGraphqlResponse,
     );
-    contentfulEnv.createEntryWithId.mockRejectedValueOnce(new Error('Error'));
+    contentfulEnv.createEntryWithId.mockRejectedValueOnce(
+      new Error('{"status":500}'),
+    );
     contentfulEnv.createEntryWithId.mockResolvedValueOnce(entry);
 
     await migratePages();

--- a/packages/cms-data-sync/test/utils/migration.test.ts
+++ b/packages/cms-data-sync/test/utils/migration.test.ts
@@ -158,6 +158,21 @@ describe('Migration from Squidex to Contentful', () => {
       );
     });
 
+    test('Throw error if get entry does not work for an unexpected reason (not 404 status)', async () => {
+      fetchData.mockResolvedValueOnce([squidexRecord]);
+      parseData.mockResolvedValueOnce({
+        ...item,
+        updateEntry: true,
+      });
+      contentfulEnvironmentMock.getEntry.mockRejectedValueOnce(
+        new Error('unexpected'),
+      );
+
+      await expect(
+        migrateFromSquidexToContentful('entity', fetchData, parseData, true),
+      ).rejects.toThrowError('unexpected');
+    });
+
     test('Should use a fallback parser if the item fails to create with the first attempt and error is different than 404', async () => {
       fetchData.mockResolvedValueOnce([squidexRecord]);
       parseData.mockResolvedValueOnce(item);


### PR DESCRIPTION
This PR adds an "update mode" to the on-demand migration action which is disabled as default.

![Screenshot 2023-08-08 at 13 23 26](https://github.com/yldio/asap-hub/assets/16595804/eee7bb73-337e-497d-a8d2-a355bad2c3f7)

When enabled (checkbox checked) it will first try to update the entry but if it gives an error because the entry is not found it will create the entry. Also, it prevents from deleting all entries at the beginning of the script.

Example of a run: https://github.com/yldio/asap-hub/actions/runs/5799477437/job/15719558065