### PR TITLE
fix(migration): does not throw in the fallback create

### DIFF
--- a/packages/cms-data-sync/src/utils/migration.ts
+++ b/packages/cms-data-sync/src/utils/migration.ts
@@ -70,8 +70,16 @@ export const migrateFromSquidexToContentfulFactory =
             // this is a fallback when it should have updated the entry
             // but it does not exist
             if (upsertInPlace && errorParsed && errorParsed.status === 404) {
-              const entry = await createEntry();
-              return entry;
+              try {
+                const entry = await createEntry();
+                return entry;
+              } catch (createError) {
+                logger(
+                  `(Fallback update) Error creating entry ${id}:\n${createError}`,
+                  'ERROR',
+                );
+                return null;
+              }
             }
 
             // if in create mode we could still use


### PR DESCRIPTION
There are some entries that are not present in Contentful Production, like the one that has a table `f354ec08-c7e2-48bd-9fd8-816b44ac5bc0`. So if we throw an error when we try to create an entry if it's not found in the first place, the script stops and all the other entries are not updated. So I'm wrapping the create in a try catch block.