### PR TITLE
Add Contentful extension for setting a "partial" last updated date

### DIFF
--- a/.github/environment/Base
+++ b/.github/environment/Base
@@ -15,6 +15,7 @@ contentful-app-field-as-updated-at=mqvX9KU5AthRTlnIRhNNh
 contentful-app-membership-reference=Yp64pYYDuRNHdvAAAJPYa
 contentful-app-user-positions=6gJUoMACdM5WFGRz6j4pbB
 contentful-app-working-group-deliverables=2hc2UiWrW8SFhfkKMmGtk9
+contentful-app-partial-last-updated=v97H7wgmtstfxNheYWy0G
 contentful-environment=Production
 contentful-organization-id=6Hlb5Pl67A3nWMEyzxnHNZ
 crn-auth0-additional-claim-domain=https://dev.hub.asap.science

--- a/.github/workflows/on-push-app-extensions.yml
+++ b/.github/workflows/on-push-app-extensions.yml
@@ -68,6 +68,7 @@ jobs:
           - membership-reference
           - clear-on-change
           - working-group-deliverables
+          - partial-last-updated
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/packages/contentful-app-extensions/partial-last-updated/package.json
+++ b/packages/contentful-app-extensions/partial-last-updated/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@asap-hub/contentful-app-partial-last-updated",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "@contentful/app-sdk": "4.22.1",
+    "@contentful/f36-components": "4.48.0",
+    "@contentful/f36-tokens": "4.0.2",
+    "@contentful/react-apps-toolkit": "1.2.16",
+    "contentful-management": "10.39.2",
+    "emotion": "10.0.27",
+    "react": "17.0.2",
+    "react-dom": "17.0.2",
+    "react-scripts": "5.0.1"
+  },
+  "scripts": {
+    "start": "cross-env BROWSER=none react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test",
+    "test:no-watch": "react-scripts test --watchAll=false",
+    "eject": "react-scripts eject",
+    "create-app-definition": "contentful-app-scripts create-app-definition",
+    "upload": "contentful-app-scripts upload --bundle-dir ./build",
+    "upload-ci": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN"
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  },
+  "devDependencies": {
+    "@contentful/app-scripts": "1.10.2",
+    "@testing-library/jest-dom": "^5.16.5",
+    "@testing-library/react": "11.2.7",
+    "@tsconfig/create-react-app": "2.0.1",
+    "@types/jest": "29.5.3",
+    "@types/node": "18.17.3",
+    "@types/react": "17.0.64",
+    "@types/react-dom": "17.0.20",
+    "@types/testing-library__jest-dom": "5.14.9",
+    "cross-env": "7.0.3",
+    "typescript": "4.9.5"
+  },
+  "homepage": "."
+}

--- a/packages/contentful-app-extensions/partial-last-updated/public/index.html
+++ b/packages/contentful-app-extensions/partial-last-updated/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+  </body>
+</html>

--- a/packages/contentful-app-extensions/partial-last-updated/src/App.tsx
+++ b/packages/contentful-app-extensions/partial-last-updated/src/App.tsx
@@ -1,0 +1,19 @@
+import React, { useMemo } from 'react';
+import { locations } from '@contentful/app-sdk';
+import { useSDK } from '@contentful/react-apps-toolkit';
+import Field from './locations/Field';
+
+const App = () => {
+  const sdk = useSDK();
+
+  const Component = useMemo(() => {
+    if (sdk.location.is(locations.LOCATION_ENTRY_FIELD)) {
+      return Field;
+    }
+    return null;
+  }, [sdk.location]);
+
+  return Component ? <Component /> : null;
+};
+
+export default App;

--- a/packages/contentful-app-extensions/partial-last-updated/src/index.tsx
+++ b/packages/contentful-app-extensions/partial-last-updated/src/index.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { render } from 'react-dom';
+
+import { GlobalStyles } from '@contentful/f36-components';
+import { SDKProvider } from '@contentful/react-apps-toolkit';
+
+import App from './App';
+
+const root = document.getElementById('root');
+
+render(
+  <SDKProvider>
+    <GlobalStyles />
+    <App />
+  </SDKProvider>,
+  root,
+);

--- a/packages/contentful-app-extensions/partial-last-updated/src/locations/Field.tsx
+++ b/packages/contentful-app-extensions/partial-last-updated/src/locations/Field.tsx
@@ -1,0 +1,40 @@
+import React, { useRef, useEffect } from 'react';
+import { Text } from '@contentful/f36-components';
+import { FieldAppSDK } from '@contentful/app-sdk';
+import {
+  useSDK,
+  useAutoResizer,
+  useFieldValue,
+} from '@contentful/react-apps-toolkit';
+
+const Field = () => {
+  useAutoResizer();
+  const sdk = useSDK<FieldAppSDK>();
+  const [value, setValue] = useFieldValue();
+  const exclude = sdk.parameters.instance.exclude
+    .split(',')
+    .map((s: string) => s.trim());
+
+  const values: unknown[] = Object.keys(sdk.entry.fields).reduce(
+    (arr: unknown[], field: string): unknown[] => {
+      const [val] = useFieldValue(field);
+      if (!exclude.includes(field) && field !== sdk.field.id) {
+        return [...arr, val];
+      }
+      return arr;
+    },
+    [],
+  );
+
+  const firstRender = useRef(true);
+  useEffect(() => {
+    if (!firstRender.current) {
+      setValue(new Date().toISOString());
+    }
+    firstRender.current = false;
+  }, values);
+
+  return <Text>{value}</Text>;
+};
+
+export default Field;

--- a/packages/contentful-app-extensions/partial-last-updated/src/react-app-env.d.ts
+++ b/packages/contentful-app-extensions/partial-last-updated/src/react-app-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="react-scripts" />

--- a/packages/contentful-app-extensions/partial-last-updated/src/test/locations/Field.test.tsx
+++ b/packages/contentful-app-extensions/partial-last-updated/src/test/locations/Field.test.tsx
@@ -1,0 +1,108 @@
+import '@testing-library/jest-dom';
+import React, { useState } from 'react';
+import Field from '../../locations/Field';
+import { act, render, screen, waitFor } from '@testing-library/react';
+
+import {
+  useSDK,
+  useAutoResizer,
+  useFieldValue,
+} from '@contentful/react-apps-toolkit';
+
+jest.mock('@contentful/react-apps-toolkit', () => ({
+  useSDK: jest.fn(),
+  useAutoResizer: jest.fn(),
+  useFieldValue: jest.fn(),
+}));
+
+describe('Field component', () => {
+  beforeEach(() => {
+    (useSDK as jest.Mock).mockImplementation(() => ({
+      parameters: {
+        instance: {
+          exclude: 'fieldOne, fieldTwo',
+        },
+      },
+      field: {
+        id: 'thisField',
+      },
+      entry: {
+        fields: {
+          fieldOne: {},
+          fieldTwo: {},
+          fieldThree: {},
+          thisField: {},
+        },
+      },
+    }));
+
+    (useFieldValue as jest.Mock).mockImplementation((field) => {
+      if (!field) {
+        return useState('2023-04-12T16:05:00.000Z');
+      }
+      return useState(1);
+    });
+
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.resetAllMocks();
+  });
+
+  it('enables automatic resizing', async () => {
+    render(<Field />);
+    await waitFor(() => {
+      expect(useAutoResizer).toHaveBeenCalled();
+    });
+  });
+
+  it('renders the field initial value', () => {
+    render(<Field />);
+    expect(screen.getByText('2023-04-12T16:05:00.000Z')).toBeInTheDocument();
+  });
+
+  it('updates to current timestamp if a non-excluded field changes', async () => {
+    let setFieldValue = jest.fn();
+    (useFieldValue as jest.Mock).mockImplementation((field) => {
+      if (!field) {
+        return useState('2023-04-12T16:05:00.000Z');
+      }
+      if (field === 'fieldThree') {
+        const [value, _setFieldValue] = useState(1);
+        return [value, setFieldValue.mockImplementation(_setFieldValue)];
+      }
+      return useState(1);
+    });
+    render(<Field />);
+    await waitFor(() => {
+      expect(screen.getByText('2023-04-12T16:05:00.000Z')).toBeInTheDocument();
+    });
+    act(() => {
+      setFieldValue(2);
+    });
+    expect(screen.getByText(new Date().toISOString())).toBeInTheDocument();
+  });
+
+  it('does not update to current timestamp if an excluded field changes', async () => {
+    let setFieldValue = jest.fn();
+    (useFieldValue as jest.Mock).mockImplementation((field) => {
+      if (!field) {
+        return useState('2023-04-12T16:05:00.000Z');
+      }
+      if (field === 'fieldTwo') {
+        const [value, _setFieldValue] = useState(1);
+        return [value, setFieldValue.mockImplementation(_setFieldValue)];
+      }
+      return useState(1);
+    });
+    render(<Field />);
+    act(() => {
+      setFieldValue(2);
+    });
+    expect(
+      screen.queryByText(new Date().toISOString()),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/packages/contentful-app-extensions/partial-last-updated/tsconfig.json
+++ b/packages/contentful-app-extensions/partial-last-updated/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "esnext",
+
+    "allowJs": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "jsx": "react",
+    "moduleResolution": "node",
+    "noEmit": true,
+    "noFallthroughCasesInSwitch": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "strict": true,
+
+    "target": "es2015",
+    "lib": ["dom", "dom.iterable", "esnext"]
+  },
+  "include": ["src"]
+}

--- a/packages/contentful/migrations/crn/researchOutputs/20230810144400-partial-last-updated.js
+++ b/packages/contentful/migrations/crn/researchOutputs/20230810144400-partial-last-updated.js
@@ -1,0 +1,23 @@
+module.exports.description = 'Change lastUpdatedPartial field editor';
+
+module.exports.up = (migration) => {
+  const researchOutputs = migration.editContentType('researchOutputs');
+  researchOutputs.changeFieldControl(
+    'lastUpdatedPartial',
+    'app',
+    'v97H7wgmtstfxNheYWy0G',
+    {
+      exclude: 'adminNotes, publishDate',
+    },
+  );
+};
+
+module.exports.down = (migration) => {
+  const researchOutputs = migration.editContentType('researchOutputs');
+  researchOutputs.changeFieldControl(
+    'lastUpdatedPartial',
+    'builtin',
+    'datePicker',
+    {},
+  );
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -667,6 +667,33 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@asap-hub/contentful-app-partial-last-updated@workspace:packages/contentful-app-extensions/partial-last-updated":
+  version: 0.0.0-use.local
+  resolution: "@asap-hub/contentful-app-partial-last-updated@workspace:packages/contentful-app-extensions/partial-last-updated"
+  dependencies:
+    "@contentful/app-scripts": 1.10.2
+    "@contentful/app-sdk": 4.22.1
+    "@contentful/f36-components": 4.48.0
+    "@contentful/f36-tokens": 4.0.2
+    "@contentful/react-apps-toolkit": 1.2.16
+    "@testing-library/jest-dom": ^5.16.5
+    "@testing-library/react": 11.2.7
+    "@tsconfig/create-react-app": 2.0.1
+    "@types/jest": 29.5.3
+    "@types/node": 18.17.3
+    "@types/react": 17.0.64
+    "@types/react-dom": 17.0.20
+    "@types/testing-library__jest-dom": 5.14.9
+    contentful-management: 10.39.2
+    cross-env: 7.0.3
+    emotion: 10.0.27
+    react: 17.0.2
+    react-dom: 17.0.2
+    react-scripts: 5.0.1
+    typescript: 4.9.5
+  languageName: unknown
+  linkType: soft
+
 "@asap-hub/contentful-app-user-positions@workspace:packages/contentful-app-extensions/user-positions":
   version: 0.0.0-use.local
   resolution: "@asap-hub/contentful-app-user-positions@workspace:packages/contentful-app-extensions/user-positions"


### PR DESCRIPTION
This sets a date field to the current timestamp if any other field in the model changes, except an optional list of excluded fields.

Includes a migration to add the extension to the `lastUpdatedPartial` in research outputs.