### PR TITLE
Allow apostrophes in email addresses

### DIFF
--- a/packages/contentful/migrations/crn/users/20230814130100-email-validation.js
+++ b/packages/contentful/migrations/crn/users/20230814130100-email-validation.js
@@ -1,0 +1,41 @@
+module.exports.description = 'Change email validation';
+
+module.exports.up = (migration) => {
+  const users = migration.editContentType('users');
+  users.editField('email').validations([
+    {
+      regexp: {
+        pattern: "^\\w[\\w.\\-+']*@([\\w-]+\\.)+[\\w-]+$",
+        flags: null,
+      },
+    },
+  ]);
+  users.editField('contactEmail').validations([
+    {
+      regexp: {
+        pattern: "^\\w[\\w.\\-+']*@([\\w-]+\\.)+[\\w-]+$",
+        flags: null,
+      },
+    },
+  ]);
+};
+
+module.exports.down = (migration) => {
+  const users = migration.editContentType('users');
+  users.editField('email').validations([
+    {
+      regexp: {
+        pattern: '^\\w[\\w.\\-+]*@([\\w-]+\\.)+[\\w-]+$',
+        flags: null,
+      },
+    },
+  ]);
+  users.editField('contactEmail').validations([
+    {
+      regexp: {
+        pattern: '^\\w[\\w.\\-+]*@([\\w-]+\\.)+[\\w-]+$',
+        flags: null,
+      },
+    },
+  ]);
+};


### PR DESCRIPTION
There are users in prod squidex who cannot currently be migrated on account of their email addresses containing an apostrophe. Make sure this is allowed in Contentful.