### PR TITLE
CT-89 Fix issues with RO description migration

### DIFF
--- a/packages/cms-data-sync/src/utils/rich-text.ts
+++ b/packages/cms-data-sync/src/utils/rich-text.ts
@@ -172,14 +172,8 @@ export const convertHtmlToContentfulFormat = (html: string) => {
   processedHtml = removeSinglePTag(processedHtml);
   processedHtml = removeStylingTagsWrappingIFrameTags(processedHtml);
   processedHtml = removeStylingTagsWrappingImgTags(processedHtml);
-  console.log('before wrapIframeWithPTag', processedHtml);
-
   processedHtml = wrapIframeWithPTag(processedHtml);
-  console.log('\n\n');
-  console.log('before wrapPlainTextWithPTag', processedHtml);
   processedHtml = wrapPlainTextWithPTag(processedHtml);
-  console.log('after wrapPlainTextWithPTag', processedHtml);
-  console.log('\n\n');
 
   logger(`HTML pre-parsed:\n${html}`, 'DEBUG');
   logger(`HTML post-parsed:\n${processedHtml}`, 'DEBUG');

--- a/packages/cms-data-sync/src/utils/rich-text.ts
+++ b/packages/cms-data-sync/src/utils/rich-text.ts
@@ -61,7 +61,7 @@ export const wrapPlainTextWithPTag = (html: string): string => {
 
   $('*:not(p)')
     .contents()
-    .filter((_, cheerio) => {
+    .filter((_, element) => {
       const filterTags = (parent: cheerio.ParentNode | null) => {
         // we don't want to wrap by p those tags below
         if (
@@ -82,19 +82,17 @@ export const wrapPlainTextWithPTag = (html: string): string => {
             'b',
             'em',
             'i',
-          ].includes(
-            (cheerio.parent as cheerio.ParentNode & { name: string }).name,
-          );
+          ].includes((parent as cheerio.ParentNode & { name: string }).name);
         }
 
         return true;
       };
 
       return Boolean(
-        cheerio.nodeType === 3 &&
-          filterTags(cheerio?.parent) &&
-          cheerio.nodeValue &&
-          cheerio.nodeValue.trim().length > 0,
+        element.nodeType === 3 &&
+          filterTags(element?.parent) &&
+          element.nodeValue &&
+          element.nodeValue.trim().length > 0,
       );
     })
     .wrap('<p></p>');

--- a/packages/cms-data-sync/src/utils/rich-text.ts
+++ b/packages/cms-data-sync/src/utils/rich-text.ts
@@ -41,60 +41,68 @@ export const wrapIframeWithPTag = (html: string): string => {
   return output ?? html;
 };
 
-export const removeClosingPTagWithoutOpening = (html: string): string => {
+export const removeSinglePTag = (html: string): string => {
   const openingTag = '<p>';
   const closingTag = '</p>';
 
-  if (!html.startsWith(openingTag) && html.endsWith(closingTag)) {
-    return html.substring(0, html.length - closingTag.length);
+  if (html.endsWith(closingTag)) {
+    const lastIndexOpeningTag = html.lastIndexOf(openingTag);
+
+    if (lastIndexOpeningTag == -1) {
+      return html.substring(0, html.length - closingTag.length);
+    }
   }
 
-  if (html.startsWith(openingTag) && !html.endsWith(closingTag)) {
-    return html.substring(openingTag.length, html.length);
+  if (html.startsWith(openingTag)) {
+    const lastIndexClosingTag = html.lastIndexOf(closingTag);
+
+    if (lastIndexClosingTag == -1) {
+      return html.substring(openingTag.length, html.length);
+    }
   }
 
   return html;
 };
 
+type ParentNode = cheerio.ParentNode & { name?: string };
 export const wrapPlainTextWithPTag = (html: string): string => {
   const $ = cheerio.load(html);
 
+  const excludedTags = [
+    'sup',
+    'sub',
+    'a',
+    'h1',
+    'h2',
+    'h3',
+    'h4',
+    'h5',
+    'h6',
+    'strong',
+    'b',
+    'em',
+    'i',
+  ];
+
+  const filterTags = (parent: ParentNode | null) => {
+    // we don't want to wrap by p those tags below
+    if (parent && parent?.name) {
+      return !excludedTags.includes(parent.name);
+    }
+
+    return true;
+  };
+
   $('*:not(p)')
     .contents()
-    .filter((_, element) => {
-      const filterTags = (parent: cheerio.ParentNode | null) => {
-        // we don't want to wrap by p those tags below
-        if (
-          parent &&
-          (parent as cheerio.ParentNode & { name?: string })?.name
-        ) {
-          return ![
-            'sup',
-            'sub',
-            'a',
-            'h1',
-            'h2',
-            'h3',
-            'h4',
-            'h5',
-            'h6',
-            'strong',
-            'b',
-            'em',
-            'i',
-          ].includes((parent as cheerio.ParentNode & { name: string }).name);
-        }
-
-        return true;
-      };
-
-      return Boolean(
+    .filter((_, element) =>
+      Boolean(
         element.nodeType === 3 &&
           filterTags(element?.parent) &&
           element.nodeValue &&
           element.nodeValue.trim().length > 0,
-      );
-    })
+      ),
+    )
     .wrap('<p></p>');
 
   return $('body').html() ?? html;
@@ -167,11 +175,17 @@ export const convertHtmlToContentfulFormat = (html: string) => {
   // can just remove them here
   let processedHtml;
   processedHtml = html.replace(/<[\\/]{0,1}(div)[^><]*>/g, '');
-  processedHtml = removeClosingPTagWithoutOpening(processedHtml);
+  processedHtml = removeSinglePTag(processedHtml);
   processedHtml = removeStylingTagsWrappingIFrameTags(processedHtml);
   processedHtml = removeStylingTagsWrappingImgTags(processedHtml);
+  console.log('before wrapIframeWithPTag', processedHtml);
+
   processedHtml = wrapIframeWithPTag(processedHtml);
+  console.log('\n\n');
+  console.log('before wrapPlainTextWithPTag', processedHtml);
   processedHtml = wrapPlainTextWithPTag(processedHtml);
+  console.log('after wrapPlainTextWithPTag', processedHtml);
+  console.log('\n\n');
 
   logger(`HTML pre-parsed:\n${html}`, 'DEBUG');
   logger(`HTML post-parsed:\n${processedHtml}`, 'DEBUG');

--- a/packages/cms-data-sync/src/utils/rich-text.ts
+++ b/packages/cms-data-sync/src/utils/rich-text.ts
@@ -84,21 +84,15 @@ export const wrapPlainTextWithPTag = (html: string): string => {
     'i',
   ];
 
-  const filterTags = (parent: ParentNode | null) => {
-    // we don't want to wrap by p those tags below
-    if (parent && parent?.name) {
-      return !excludedTags.includes(parent.name);
-    }
-
-    return true;
-  };
+  const filterTags = (parent: ParentNode | null) =>
+    parent && parent?.name && !excludedTags.includes(parent.name);
 
   $('*:not(p)')
     .contents()
     .filter((_, element) =>
       Boolean(
-        element.nodeType === 3 &&
-          filterTags(element?.parent) &&
+        filterTags(element?.parent) &&
+          element.nodeType === 3 &&
           element.nodeValue &&
           element.nodeValue.trim().length > 0,
       ),

--- a/packages/cms-data-sync/src/utils/rich-text.ts
+++ b/packages/cms-data-sync/src/utils/rich-text.ts
@@ -48,7 +48,7 @@ export const removeSinglePTag = (html: string): string => {
   if (html.endsWith(closingTag)) {
     const lastIndexOpeningTag = html.lastIndexOf(openingTag);
 
-    if (lastIndexOpeningTag == -1) {
+    if (lastIndexOpeningTag === -1) {
       return html.substring(0, html.length - closingTag.length);
     }
   }
@@ -56,7 +56,7 @@ export const removeSinglePTag = (html: string): string => {
   if (html.startsWith(openingTag)) {
     const lastIndexClosingTag = html.lastIndexOf(closingTag);
 
-    if (lastIndexClosingTag == -1) {
+    if (lastIndexClosingTag === -1) {
       return html.substring(openingTag.length, html.length);
     }
   }

--- a/packages/cms-data-sync/test/utils/rich-text.test.ts
+++ b/packages/cms-data-sync/test/utils/rich-text.test.ts
@@ -6,7 +6,7 @@ import {
   removeStylingTagsWrappingImgTags,
   wrapIframeWithPTag,
   wrapPlainTextWithPTag,
-  removeClosingPTagWithoutOpening,
+  removeSinglePTag,
 } from '../../src/utils';
 import { createInlineAssets, createMediaEntries } from '../../src/utils';
 
@@ -369,11 +369,6 @@ describe('createDocumentIfNeeded', () => {
           nodeType: 'paragraph',
         },
         {
-          content: [{ data: {}, marks: [], nodeType: 'text', value: '' }],
-          data: {},
-          nodeType: 'paragraph',
-        },
-        {
           content: [],
           data: {
             target: {
@@ -580,19 +575,19 @@ describe('wrapPlainTextWithPTag', () => {
   });
 });
 
-describe('removeClosingPTagWithoutOpening', () => {
+describe('removeSinglePTag', () => {
   test('removes single closing </p>', () => {
     const html = 'Text</p>';
-    expect(removeClosingPTagWithoutOpening(html)).toEqual('Text');
+    expect(removeSinglePTag(html)).toEqual('Text');
   });
 
   test('removes single opening <p>', () => {
     const html = '<p>Text';
-    expect(removeClosingPTagWithoutOpening(html)).toEqual('Text');
+    expect(removeSinglePTag(html)).toEqual('Text');
   });
 
   test('does not remove closing </p> if there is a opening <p>', () => {
     const html = '<p>Text</p>';
-    expect(removeClosingPTagWithoutOpening(html)).toEqual('<p>Text</p>');
+    expect(removeSinglePTag(html)).toEqual('<p>Text</p>');
   });
 });

--- a/packages/cms-data-sync/test/utils/rich-text.test.ts
+++ b/packages/cms-data-sync/test/utils/rich-text.test.ts
@@ -5,6 +5,8 @@ import {
   removeStylingTagsWrappingIFrameTags,
   removeStylingTagsWrappingImgTags,
   wrapIframeWithPTag,
+  wrapPlainTextWithPTag,
+  removeClosingPTagWithoutOpening,
 } from '../../src/utils';
 import { createInlineAssets, createMediaEntries } from '../../src/utils';
 
@@ -82,12 +84,6 @@ describe('convertHtmlToContentfulFormat', () => {
                         data: {},
                         marks: [],
                         nodeType: 'text',
-                        value: '',
-                      },
-                      {
-                        data: {},
-                        marks: [],
-                        nodeType: 'text',
                         value: 'item 1',
                       },
                     ],
@@ -102,12 +98,6 @@ describe('convertHtmlToContentfulFormat', () => {
                   {
                     data: {},
                     content: [
-                      {
-                        data: {},
-                        marks: [],
-                        nodeType: 'text',
-                        value: '',
-                      },
                       {
                         data: {},
                         marks: [],
@@ -379,6 +369,11 @@ describe('createDocumentIfNeeded', () => {
           nodeType: 'paragraph',
         },
         {
+          content: [{ data: {}, marks: [], nodeType: 'text', value: '' }],
+          data: {},
+          nodeType: 'paragraph',
+        },
+        {
           content: [],
           data: {
             target: {
@@ -537,5 +532,67 @@ describe('wrapIframeWithPTag', () => {
     expect(wrapIframeWithPTag(html)).toEqual(
       '<p>Presenter 1<br><iframe src="video"></iframe></p>',
     );
+  });
+});
+
+describe('wrapPlainTextWithPTag', () => {
+  test('works when text does not have any p tag', () => {
+    const input = 'Hello';
+    const expectedOutput = '<p>Hello</p>';
+    expect(wrapPlainTextWithPTag(input)).toEqual(expectedOutput);
+  });
+
+  test('works when there is a paragraph with p tag and one without it', () => {
+    const input =
+      '<p>SNCAflox delta neo mouse line; first coding exon is flanked by loxP sites.</p>Full name: B6(Cg)-Sncatm1.1Vlb/J mie';
+    const expectedOutput =
+      '<p>SNCAflox delta neo mouse line; first coding exon is flanked by loxP sites.</p><p>Full name: B6(Cg)-Sncatm1.1Vlb/J mie</p>';
+    expect(wrapPlainTextWithPTag(input)).toEqual(expectedOutput);
+  });
+
+  test.each`
+    tag
+    ${`sup`}
+    ${`sub`}
+    ${`a`}
+    ${`strong`}
+    ${`b`}
+    ${`em`}
+    ${`i`}
+  `('does not wrap $tag by p', ({ tag }) => {
+    const input = `<p>this is <${tag}>any text</${tag}></p>`;
+    const expectedOutput = `<p>this is <${tag}>any text</${tag}></p>`;
+    expect(wrapPlainTextWithPTag(input)).toEqual(expectedOutput);
+  });
+
+  test.each`
+    tag
+    ${`h1`}
+    ${`h2`}
+    ${`h3`}
+    ${`h4`}
+    ${`h5`}
+    ${`h6`}
+  `('does not wrap inner text of $tag by p', ({ tag }) => {
+    const input = `<${tag}>heading</${tag}>`;
+    const expectedOutput = `<${tag}>heading</${tag}>`;
+    expect(wrapPlainTextWithPTag(input)).toEqual(expectedOutput);
+  });
+});
+
+describe('removeClosingPTagWithoutOpening', () => {
+  test('removes single closing </p>', () => {
+    const html = 'Text</p>';
+    expect(removeClosingPTagWithoutOpening(html)).toEqual('Text');
+  });
+
+  test('removes single opening <p>', () => {
+    const html = '<p>Text';
+    expect(removeClosingPTagWithoutOpening(html)).toEqual('Text');
+  });
+
+  test('does not remove closing </p> if there is a opening <p>', () => {
+    const html = '<p>Text</p>';
+    expect(removeClosingPTagWithoutOpening(html)).toEqual('<p>Text</p>');
   });
 });


### PR DESCRIPTION
This PR fixes two issues with missing description or part of description:

1. When there's a closing </p> but not opening
Example
```
 "description": "Alpha synuclein preformed fibrils (PFF) can spread in prion-like manner both in in vitro neuronal cultures as well as in vivo when injected into the mouse brain and gut, forming pSer129-a-syn-posiitive LB-like inclusions. We developed a method where PFF are injected into the muscularis layer of the pylorus and duodenum, mimicking the spread of pathologic a-syn observed in PD.</p>",
```
found in `100f57e3-6846-464c-8b77-01c0080a35ac` (https://cloud.squidex.io/app/asap-hub/content/research-outputs/100f57e3-6846-464c-8b77-01c0080a35ac?tab=inspect)

2. When there's text not wrapped by <p>
Example
```
<p>SNCAflox delta neo mouse line; first coding exon is flanked by loxP sites.</p>\nFull name: B6(Cg)-Sncatm1.1Vlb/J mie
```

found in `21e4414a-f2c8-4324-a3f3-3b6b46554c71` (https://cloud.squidex.io/app/asap-hub/content/research-outputs/21e4414a-f2c8-4324-a3f3-3b6b46554c71?tab=inspect)

Note about this one: After passing through `parseHtml` from `contentful-html-rich-text-converter` that converts to contentful document we get this node

```
node value {
  data: {},
  marks: [],
  value: '\nFull name: B6(Cg)-Sncatm1.1Vlb/J mie',
  nodeType: 'text'
}
```

that is removed here https://github.com/yldio/asap-hub/blob/master/packages/cms-data-sync/src/utils/rich-text.ts#L109.

but without this line above we get this error:

![Screenshot 2023-08-14 at 09 03 51](https://github.com/yldio/asap-hub/assets/16595804/ce0fcef3-2a7c-47d6-a8a8-c2c65d8412af)
 
because it should have a nodeType `paragraph` instead of `text`. So the solution was to wrap by <p> **before** converting to contentful document in `parseHtml` from `contentful-html-rich-text-converter`.
