### PR TITLE
Don't publish draft research outputs when running an upsert migration

### DIFF
--- a/packages/cms-data-sync/src/utils/migration.ts
+++ b/packages/cms-data-sync/src/utils/migration.ts
@@ -57,7 +57,10 @@ export const migrateFromSquidexToContentfulFactory =
 
           n += 1;
           logger(`Updated entry with id ${id}. (${n}/${data.length})`, 'INFO');
-          return updatedEntry;
+          if (item.status === 'PUBLISHED') {
+            return updatedEntry;
+          }
+          return null;
         };
 
         try {


### PR DESCRIPTION
If you run a migration of research outputs with upsert enabled then all pre-migrated outputs are published, including drafts which should not be published.

To fix check that the status of the Squidex record is published in the same way as when creating new records.