### PR TITLE
Allow `--upsert` flag to be passed into migration script

### DIFF
--- a/packages/cms-data-sync/src/index.ts
+++ b/packages/cms-data-sync/src/index.ts
@@ -3,8 +3,13 @@ import { runMigrations, models, Flag } from './run-migrations';
 
 const flags = process.argv.slice(2);
 
+const allowedFlags = [
+  '--upsert',
+  ...models.map((model: string) => `--${model}`),
+];
+
 flags.forEach((flag: string) => {
-  if (!models.some((model: string) => flag === `--${model}`)) {
+  if (!allowedFlags.includes(flag)) {
     // eslint-disable-next-line no-console
     console.error(`Unrecognised flag: ${flag}`);
     process.exit(1);


### PR DESCRIPTION
This enables upsert mode when running locally, but is prevented by the flg validation. Allow it.