### PR TITLE
Remove the current output from suggestions for related research

### DIFF
--- a/apps/crn-frontend/src/__tests__/shared-research.test.ts
+++ b/apps/crn-frontend/src/__tests__/shared-research.test.ts
@@ -1,7 +1,19 @@
+import { AlgoliaSearchClient } from '@asap-hub/algolia';
 import { OutputDocumentTypeParameter } from '@asap-hub/routing';
 import { ResearchOutputDocumentType } from '@asap-hub/model';
+import { useAlgolia } from '../hooks/algolia';
+import {
+  paramOutputDocumentTypeToResearchOutputDocumentType,
+  useRelatedResearchSuggestions,
+} from '../shared-research';
 
-import { paramOutputDocumentTypeToResearchOutputDocumentType } from '../shared-research';
+const mockAlgoliaClient = {
+  search: jest.fn(),
+};
+
+jest.mock('../hooks/algolia', () => ({
+  useAlgolia: jest.fn(),
+}));
 
 it.each<{
   param: Parameters<
@@ -24,4 +36,74 @@ it.each<{
   expect(paramOutputDocumentTypeToResearchOutputDocumentType(param)).toEqual(
     outputType,
   );
+});
+
+describe('useRelatedResearchSuggestions', () => {
+  beforeEach(() => {
+    const mockUseAlgolia = useAlgolia as jest.MockedFunction<typeof useAlgolia>;
+    mockUseAlgolia.mockReturnValue({
+      client: mockAlgoliaClient as unknown as AlgoliaSearchClient<'crn'>,
+    });
+    mockAlgoliaClient.search.mockResolvedValue({
+      hits: [
+        {
+          id: 'output-1',
+          title: 'Title 1',
+          type: 'Type',
+          documentType: 'Document Type',
+        },
+        {
+          id: 'output-2',
+          title: 'Title 2',
+          type: 'Type',
+          documentType: 'Document Type',
+        },
+      ],
+    });
+  });
+
+  it('performs an algolia search for research outputs', async () => {
+    const getSuggestions = useRelatedResearchSuggestions();
+    await getSuggestions('');
+
+    expect(mockAlgoliaClient.search).toHaveBeenCalledWith(
+      ['research-output'],
+      '',
+      expect.anything(),
+    );
+  });
+
+  it('maps algolia search result to { label, value, type, documentType }', async () => {
+    const getSuggestions = useRelatedResearchSuggestions();
+    const result = await getSuggestions('');
+
+    expect(result).toEqual([
+      {
+        value: 'output-1',
+        label: 'Title 1',
+        type: 'Type',
+        documentType: 'Document Type',
+      },
+      {
+        value: 'output-2',
+        label: 'Title 2',
+        type: 'Type',
+        documentType: 'Document Type',
+      },
+    ]);
+  });
+
+  it('removes the current id from the results if provided', async () => {
+    const getSuggestions = useRelatedResearchSuggestions('output-1');
+    const result = await getSuggestions('');
+
+    expect(result).toEqual([
+      {
+        value: 'output-2',
+        label: 'Title 2',
+        type: 'Type',
+        documentType: 'Document Type',
+      },
+    ]);
+  });
 });

--- a/apps/crn-frontend/src/network/teams/TeamOutput.tsx
+++ b/apps/crn-frontend/src/network/teams/TeamOutput.tsx
@@ -89,7 +89,9 @@ const TeamOutput: React.FC<TeamOutputProps> = ({
   const getLabSuggestions = useLabSuggestions();
   const getAuthorSuggestions = useAuthorSuggestions();
   const getTeamSuggestions = useTeamSuggestions();
-  const getRelatedResearchSuggestions = useRelatedResearchSuggestions();
+  const getRelatedResearchSuggestions = useRelatedResearchSuggestions(
+    researchOutputData?.id,
+  );
   const getRelatedEventSuggestions = useRelatedEventsSuggestions();
   const researchTags = useResearchTags();
 

--- a/apps/crn-frontend/src/network/working-groups/WorkingGroupOutput.tsx
+++ b/apps/crn-frontend/src/network/working-groups/WorkingGroupOutput.tsx
@@ -80,7 +80,9 @@ const WorkingGroupOutput: React.FC<WorkingGroupOutputProps> = ({
   const getLabSuggestions = useLabSuggestions();
   const getAuthorSuggestions = useAuthorSuggestions();
   const getTeamSuggestions = useTeamSuggestions();
-  const getRelatedResearchSuggestions = useRelatedResearchSuggestions();
+  const getRelatedResearchSuggestions = useRelatedResearchSuggestions(
+    researchOutputData?.id,
+  );
   const researchTags = useResearchTags();
 
   const published = researchOutputData ? !!researchOutputData.published : false;

--- a/apps/crn-frontend/src/shared-research.ts
+++ b/apps/crn-frontend/src/shared-research.ts
@@ -80,7 +80,7 @@ export const useLabSuggestions = () => {
     );
 };
 
-export const useRelatedResearchSuggestions = () => {
+export const useRelatedResearchSuggestions = (currentId?: string) => {
   const algoliaClient = useAlgolia();
   return (searchQuery: string) =>
     getResearchOutputs(algoliaClient.client, {
@@ -88,14 +88,18 @@ export const useRelatedResearchSuggestions = () => {
       filters: new Set(),
       currentPage: null,
       pageSize: null,
-    }).then(({ hits }) =>
-      hits.map(({ id, title, type, documentType }) => ({
-        label: title,
-        value: id,
-        type,
-        documentType,
-      })),
-    );
+    })
+      .then(({ hits }) =>
+        hits.map(({ id, title, type, documentType }) => ({
+          label: title,
+          value: id,
+          type,
+          documentType,
+        })),
+      )
+      .then((hits) =>
+        currentId ? hits.filter(({ value }) => value !== currentId) : hits,
+      );
 };
 
 export const useRelatedEventsSuggestions = () => {


### PR DESCRIPTION
When editing a research output, don't suggest the output that is being edited as an option for related research.