### PR TITLE
Don't strip non-empty top-level text nodes

### DIFF
--- a/packages/cms-data-sync/test/utils/rich-text.test.ts
+++ b/packages/cms-data-sync/test/utils/rich-text.test.ts
@@ -341,6 +341,87 @@ describe('convertHtmlToContentfulFormat', () => {
       },
     ]);
   });
+
+  it('handles multiple spans nested inside divs', () => {
+    const html = '<div><span>Some</span><span> text</span></div>';
+    expect(convertHtmlToContentfulFormat(html).document.content).toEqual([
+      {
+        content: [
+          {
+            data: {},
+            marks: [],
+            nodeType: 'text',
+            value: 'Some',
+          },
+          {
+            data: {},
+            marks: [],
+            nodeType: 'text',
+            value: ' text',
+          },
+        ],
+        data: {},
+        nodeType: 'paragraph',
+      },
+    ]);
+  });
+
+  it('handles multiple spans nested inside divs with a list in between', () => {
+    const html = `<div>
+    <span>Some</span><span> text</span>
+    <ol><li>List</li></ol>
+    <span>More</span><span> text</span>
+    </div>`;
+    expect(convertHtmlToContentfulFormat(html).document.content).toEqual([
+      {
+        content: [
+          {
+            data: {},
+            marks: [],
+            nodeType: 'text',
+            value: 'Some',
+          },
+          {
+            data: {},
+            marks: [],
+            nodeType: 'text',
+            value: ' text',
+          },
+        ],
+        data: {},
+        nodeType: 'paragraph',
+      },
+      {
+        content: [
+          {
+            content: expect.arrayContaining([]),
+            data: {},
+            nodeType: 'list-item',
+          },
+        ],
+        data: {},
+        nodeType: 'ordered-list',
+      },
+      {
+        content: [
+          {
+            data: {},
+            marks: [],
+            nodeType: 'text',
+            value: 'More',
+          },
+          {
+            data: {},
+            marks: [],
+            nodeType: 'text',
+            value: ' text',
+          },
+        ],
+        data: {},
+        nodeType: 'paragraph',
+      },
+    ]);
+  });
 });
 
 describe('createDocumentIfNeeded', () => {


### PR DESCRIPTION
the migration was removing all text nodes that were at the top level of the rich text structure, irrespective of whether they contained text. This resulted in the loss of text data from the description fields of research outputs.

Instead, where there are top-level text nodes that contain text, wrap them into a paragraph node and preserve the content.