### PR TITLE
Fix migration of nested lists in rich text

### DIFF
--- a/packages/cms-data-sync/test/utils/rich-text.test.ts
+++ b/packages/cms-data-sync/test/utils/rich-text.test.ts
@@ -366,6 +366,39 @@ describe('convertHtmlToContentfulFormat', () => {
     ]);
   });
 
+  it('does not split list items with <sup> tags into separate paragraphs', () => {
+    const html = '<ul><li>On the 1<sup>st</sup> January</li></ul>';
+
+    expect(convertHtmlToContentfulFormat(html).document.content).toEqual([
+      {
+        content: [
+          {
+            content: [
+              {
+                content: [
+                  { data: {}, value: 'On the 1', marks: [], nodeType: 'text' },
+                  {
+                    data: {},
+                    value: 'st',
+                    marks: [{ type: 'superscript' }],
+                    nodeType: 'text',
+                  },
+                  { data: {}, value: ' January', marks: [], nodeType: 'text' },
+                ],
+                data: {},
+                nodeType: 'paragraph',
+              },
+            ],
+            data: {},
+            nodeType: 'list-item',
+          },
+        ],
+        data: {},
+        nodeType: 'unordered-list',
+      },
+    ]);
+  });
+
   it('handles multiple spans nested inside divs with a list in between', () => {
     const html = `<div>
     <span>Some</span><span> text</span>
@@ -419,6 +452,134 @@ describe('convertHtmlToContentfulFormat', () => {
         ],
         data: {},
         nodeType: 'paragraph',
+      },
+    ]);
+  });
+
+  it('handles nested lists with sibling list items', () => {
+    const html = `<div>
+      <ul>
+        <li>List item 1</li>
+        <li>List item 2</li>
+        <ul>
+          <li>Sublist item</li>
+        </ul>
+      </ul>
+    </div>`;
+    expect(convertHtmlToContentfulFormat(html).document.content).toEqual([
+      {
+        content: [
+          {
+            content: [
+              {
+                content: [
+                  {
+                    data: {},
+                    marks: [],
+                    nodeType: 'text',
+                    value: 'List item 1',
+                  },
+                ],
+                data: {},
+                nodeType: 'paragraph',
+              },
+            ],
+            data: {},
+            nodeType: 'list-item',
+          },
+          {
+            content: [
+              {
+                content: [
+                  {
+                    data: {},
+                    marks: [],
+                    nodeType: 'text',
+                    value: 'List item 2',
+                  },
+                ],
+                data: {},
+                nodeType: 'paragraph',
+              },
+              {
+                content: [
+                  {
+                    content: [
+                      {
+                        content: [
+                          {
+                            data: {},
+                            marks: [],
+                            nodeType: 'text',
+                            value: 'Sublist item',
+                          },
+                        ],
+                        data: {},
+                        nodeType: 'paragraph',
+                      },
+                    ],
+                    data: {},
+                    nodeType: 'list-item',
+                  },
+                ],
+                data: {},
+                nodeType: 'unordered-list',
+              },
+            ],
+            data: {},
+            nodeType: 'list-item',
+          },
+        ],
+        data: {},
+        nodeType: 'unordered-list',
+      },
+    ]);
+  });
+
+  it('handles nested lists without sibling list items', () => {
+    const html = `<div>
+      <ul>
+        <ul>
+          <li>Sublist item</li>
+        </ul>
+      </ul>
+    </div>`;
+    expect(convertHtmlToContentfulFormat(html).document.content).toEqual([
+      {
+        content: [
+          {
+            content: [
+              {
+                content: [
+                  {
+                    content: [
+                      {
+                        content: [
+                          {
+                            data: {},
+                            marks: [],
+                            nodeType: 'text',
+                            value: 'Sublist item',
+                          },
+                        ],
+                        data: {},
+                        nodeType: 'paragraph',
+                      },
+                    ],
+                    data: {},
+                    nodeType: 'list-item',
+                  },
+                ],
+                data: {},
+                nodeType: 'unordered-list',
+              },
+            ],
+            data: {},
+            nodeType: 'list-item',
+          },
+        ],
+        data: {},
+        nodeType: 'unordered-list',
       },
     ]);
   });


### PR DESCRIPTION
* If an unordered list is nested directly inside another list, without an intermediate list item then `parseHtml` drops the inner list as it is technically invalid html.
* Add a step to the migration to find any unordered list elements that are direct descendants of another list, and wrap them inside the previous list item if it exists, or wrap in their own list item if no previous item exists.
* Add `li` to th list of ignored tags for wrapping in `<p>` tags so that list items containing other tags - such as `<sup>` do not get incorrectly split into multiple paragraphs.
* Add a step to remove any empty text nodes as these were removed as a side-effect of the paragraph wrapping, so were causing tests to fail.