### PR TITLE
Remove empty `section` tags from rich text at migration

### DIFF
--- a/packages/cms-data-sync/src/utils/rich-text.ts
+++ b/packages/cms-data-sync/src/utils/rich-text.ts
@@ -35,6 +35,20 @@ export const removeStylingTagsWrappingImgTags = (html: string): string =>
     '$3',
   );
 
+const removeUnsupportedTags = (html: string): string => {
+  const $ = cheerio.load(html);
+  const tags = ['section'];
+  tags.forEach((tag) => {
+    $(tag).each((_, element) => {
+      if ($(element).text().trim() === '') {
+        $(element).remove();
+      }
+    });
+  });
+
+  return $('body').html() ?? html;
+};
+
 export const wrapIframeWithPTag = (html: string): string => {
   const $ = cheerio.load(html);
   const iframe = $('iframe');
@@ -236,6 +250,7 @@ export const convertHtmlToContentfulFormat = (html: string) => {
   // can just remove them here
   let processedHtml;
   processedHtml = html.replace(/<[\\/]{0,1}(div)[^><]*>/g, '');
+  processedHtml = removeUnsupportedTags(processedHtml);
   processedHtml = removeSinglePTag(processedHtml);
   processedHtml = removeStylingTagsWrappingIFrameTags(processedHtml);
   processedHtml = removeStylingTagsWrappingImgTags(processedHtml);

--- a/packages/cms-data-sync/test/utils/rich-text.test.ts
+++ b/packages/cms-data-sync/test/utils/rich-text.test.ts
@@ -583,6 +583,28 @@ describe('convertHtmlToContentfulFormat', () => {
       },
     ]);
   });
+
+  it('removes empty section tags from content', () => {
+    const html = `<div>
+      <section>
+      </section>
+      <p>Content</p>
+    </div>`;
+    expect(convertHtmlToContentfulFormat(html).document.content).toEqual([
+      {
+        content: [
+          {
+            value: 'Content',
+            marks: [],
+            data: {},
+            nodeType: 'text',
+          },
+        ],
+        data: {},
+        nodeType: 'paragraph',
+      },
+    ]);
+  });
 });
 
 describe('createDocumentIfNeeded', () => {


### PR DESCRIPTION
These are not supported in the parser, and so cause an error. Remove empty ones to prevent the error.

Note: the only section tags that currently exist in prod data are empty, so the non-empty case does not currently need to be considered.