### PR TITLE
Add secondary sort on last name for team members

### DIFF
--- a/apps/crn-server/src/data-providers/contentful/team.data-provider.ts
+++ b/apps/crn-server/src/data-providers/contentful/team.data-provider.ts
@@ -23,7 +23,7 @@ import {
   addLocaleToFields,
 } from '@asap-hub/contentful';
 
-import { isTeamRole, priorities } from '../transformers';
+import { isTeamRole, sortMembers } from '../transformers';
 
 import { TeamDataProvider } from '../team.data-provider';
 
@@ -285,7 +285,7 @@ export const parseContentfulGraphQlTeams = (item: TeamItem): TeamDataObject => {
     expertiseAndResourceTags,
     tools,
     projectSummary: item.projectSummary ?? undefined,
-    members: members.sort((a, b) => priorities[a.role] - priorities[b.role]),
+    members: members.sort(sortMembers),
     labCount,
     pointOfContact: members.find(
       ({ role, alumniSinceDate, inactiveSinceDate }) =>

--- a/apps/crn-server/src/data-providers/transformers/team.ts
+++ b/apps/crn-server/src/data-providers/transformers/team.ts
@@ -115,12 +115,20 @@ export const parseGraphQLTeam = (
       ({ role, alumniSinceDate, inactiveSinceDate }) =>
         role === 'Project Manager' && !alumniSinceDate && !inactiveSinceDate,
     ),
-    members: members.sort((a, b) => priorities[a.role] - priorities[b.role]),
+    members: members.sort(sortMembers),
     projectSummary: team.flatData.projectSummary ?? undefined,
     proposalURL: team.flatData.proposal
       ? team.flatData.proposal[0]?.id
       : undefined,
   };
+};
+
+export const sortMembers = (a: TeamMember, b: TeamMember) => {
+  if (priorities[a.role] === priorities[b.role]) {
+    // sort ascending on lastName
+    return a.lastName < b.lastName ? -1 : 1;
+  }
+  return priorities[a.role] - priorities[b.role];
 };
 
 export const isTeamRole = (data: string | null): data is TeamRole =>

--- a/apps/crn-server/test/data-providers/contentful/teams.data-provider.test.ts
+++ b/apps/crn-server/test/data-providers/contentful/teams.data-provider.test.ts
@@ -551,6 +551,85 @@ describe('Teams data provider', () => {
           expect.objectContaining({ role: 'Key Personnel', id: '1' }),
         ]);
       });
+
+      test('should sort team members with the same role priority by last name', async () => {
+        const contentfulGraphQLResponse = {
+          teams: {
+            ...getContentfulGraphqlTeam(),
+            linkedFrom: {
+              teamMembershipCollection: {
+                total: 1,
+                items: [
+                  {
+                    role: 'Key Personnel',
+                    inactiveSinceDate: null,
+                    linkedFrom: {
+                      usersCollection: {
+                        total: 1,
+                        items: [
+                          {
+                            ...getContentfulGraphqlTeamMembers(),
+                            lastName: 'Baker',
+                            sys: {
+                              id: '1',
+                            },
+                          },
+                        ],
+                      },
+                    },
+                  },
+                  {
+                    role: 'Key Personnel',
+                    inactiveSinceDate: null,
+                    linkedFrom: {
+                      usersCollection: {
+                        total: 1,
+                        items: [
+                          {
+                            ...getContentfulGraphqlTeamMembers(),
+                            lastName: 'Cooper',
+                            sys: {
+                              id: '2',
+                            },
+                          },
+                        ],
+                      },
+                    },
+                  },
+                  {
+                    role: 'Key Personnel',
+                    inactiveSinceDate: null,
+                    linkedFrom: {
+                      usersCollection: {
+                        total: 1,
+                        items: [
+                          {
+                            ...getContentfulGraphqlTeamMembers(),
+                            lastName: 'Anderson',
+                            sys: {
+                              id: '3',
+                            },
+                          },
+                        ],
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        };
+
+        contentfulGraphqlClientMock.request.mockResolvedValueOnce(
+          contentfulGraphQLResponse,
+        );
+        const result = await teamDataProvider.fetchById('1');
+        expect(result?.members).toEqual([
+          expect.objectContaining({ lastName: 'Anderson' }),
+          expect.objectContaining({ lastName: 'Baker' }),
+          expect.objectContaining({ lastName: 'Cooper' }),
+        ]);
+      });
     });
 
     describe('labs', () => {


### PR DESCRIPTION
Ensure that team members who hold the same role are ordered consistently by adding a secondary sort on last name.