### PR TITLE
Use Content Delivery API for polling Contentful

### DIFF
--- a/apps/crn-server/src/handlers/webhooks/webhook-contentful.ts
+++ b/apps/crn-server/src/handlers/webhooks/webhook-contentful.ts
@@ -5,7 +5,7 @@ import { APIGatewayEvent, Handler } from 'aws-lambda';
 import 'source-map-support/register';
 import {
   contentfulEnvId,
-  contentfulPreviewAccessToken,
+  contentfulAccessToken,
   contentfulSpaceId,
   contentfulWebhookAuthenticationToken,
   eventBus,
@@ -23,7 +23,7 @@ export const contentfulWebhookFactory = (
     {
       eventBus,
       eventSource,
-      previewAccessToken: contentfulPreviewAccessToken,
+      accessToken: contentfulAccessToken,
       environment: contentfulEnvId,
       space: contentfulSpaceId,
     },

--- a/apps/crn-server/test/handlers/webhooks/webhook-contentful.test.ts
+++ b/apps/crn-server/test/handlers/webhooks/webhook-contentful.test.ts
@@ -17,7 +17,7 @@ import { getApiGatewayEvent } from '../../helpers/events';
 
 jest.mock('@asap-hub/contentful', () => ({
   ...jest.requireActual('@asap-hub/contentful'),
-  getCPAClient: () => ({
+  getCDAClient: () => ({
     getEntry: jest.fn().mockResolvedValue({
       sys: {
         id: '1',

--- a/apps/gp2-server/src/handlers/webhooks/contentful.ts
+++ b/apps/gp2-server/src/handlers/webhooks/contentful.ts
@@ -5,7 +5,7 @@ import { APIGatewayEvent, Handler } from 'aws-lambda';
 import 'source-map-support/register';
 import {
   contentfulEnvId,
-  contentfulPreviewAccessToken,
+  contentfulAccessToken,
   contentfulSpaceId,
   contentfulWebhookAuthenticationToken,
   eventBus,
@@ -23,7 +23,7 @@ export const contentfulWebhookFactory = (
     {
       eventBus,
       eventSource,
-      previewAccessToken: contentfulPreviewAccessToken,
+      accessToken: contentfulAccessToken,
       environment: contentfulEnvId,
       space: contentfulSpaceId,
     },

--- a/apps/gp2-server/test/handlers/webhooks/contentful.test.ts
+++ b/apps/gp2-server/test/handlers/webhooks/contentful.test.ts
@@ -5,14 +5,18 @@ import {
 import { WebhookDetail, WebhookDetailType } from '@asap-hub/model';
 import { EventBridge } from '@aws-sdk/client-eventbridge';
 import { APIGatewayProxyResult } from 'aws-lambda';
-import { eventBus, eventSource } from '../../../src/config';
+import {
+  eventBus,
+  eventSource,
+  contentfulWebhookAuthenticationToken,
+} from '../../../src/config';
 import { contentfulWebhookFactory } from '../../../src/handlers/webhooks/contentful';
 import { getNewsPublishContentfulWebhookPayload } from '../../fixtures/news.fixtures';
 import { getApiGatewayEvent } from '../../helpers/events';
 
 jest.mock('@asap-hub/contentful', () => ({
   ...jest.requireActual('@asap-hub/contentful'),
-  getCPAClient: () => ({
+  getCDAClient: () => ({
     getEntry: jest.fn().mockResolvedValue({
       sys: {
         id: '1',
@@ -27,8 +31,6 @@ describe('Contentful event webhook', () => {
   const evenBridgeMock = {
     putEvents: jest.fn(),
   } as unknown as jest.Mocked<EventBridge>;
-  const contentfulWebhookAuthenticationToken =
-    'contentful-webhook-authentication-token';
   const handler = contentfulWebhookFactory(evenBridgeMock);
 
   beforeEach(jest.resetAllMocks);

--- a/packages/server-common/src/handlers/webhooks/contentful.handler.ts
+++ b/packages/server-common/src/handlers/webhooks/contentful.handler.ts
@@ -1,6 +1,6 @@
 import {
   ContentfulWebhookPayload,
-  getCPAClient,
+  getCDAClient,
   pollContentfulDeliveryApi,
 } from '@asap-hub/contentful';
 import { WebhookDetail, WebhookDetailType } from '@asap-hub/model';
@@ -40,7 +40,7 @@ type Config = {
   eventSource: string;
   space: string;
   environment: string;
-  previewAccessToken: string;
+  accessToken: string;
 };
 export const contentfulHandlerFactory =
   (
@@ -61,16 +61,15 @@ export const contentfulHandlerFactory =
     if (!detail.sys.revision) {
       throw new Error('Invalid payload');
     }
-
     const entryVersion = detail.sys.revision;
-    const cpaClient = getCPAClient({
-      previewAccessToken: config.previewAccessToken,
+    const cdaClient = getCDAClient({
+      accessToken: config.accessToken,
       space: config.space,
       environment: config.environment,
     });
     const fetchEntryById = async () => {
       try {
-        const entry = await cpaClient.getEntry(detail.resourceId);
+        const entry = await cdaClient.getEntry(detail.resourceId);
         return entry;
       } catch (error) {
         if (

--- a/packages/server-common/test/handlers/webhooks/contentful.handler.test.ts
+++ b/packages/server-common/test/handlers/webhooks/contentful.handler.test.ts
@@ -20,7 +20,7 @@ const mockGetEntry: jest.MockedFunction<
 
 jest.mock('@asap-hub/contentful', () => ({
   ...jest.requireActual('@asap-hub/contentful'),
-  getCPAClient: () => ({
+  getCDAClient: () => ({
     getEntry: mockGetEntry,
   }),
   pollContentfulDeliveryApi: jest.fn(),


### PR DESCRIPTION
The caching rules for the Content Delivery API and Content Preview API are different, so a record returning as being up to date against the CPA does not guarantee that a subsequent GraphQL request will return fresh data.

Using the Content Delivery API, which seems to use the same caching rules as GraphQL, ensures that the record is up to date before emitting to EventBridge.

### Notes:

This was tested/validated using the following method:
* Run serverless locally, with the contentful webhook pointed at it via ngrok
* Run a script to update a value in a contentful record to the current ISO8601 date string every second. It was not possible to reproduce with relatively low frequency manual updates.
* Add a graphql query to the webhook handler to fetch that record _after_ the polling is complete, and log out an error when that value as fetched from graphql is less than the value on the webhook payload

Then when running with the preview API there were many errors logged, and with the delivery API it never happened.
