### PR TITLE
Allow `--all` flag on migrations

### DIFF
--- a/packages/cms-data-sync/src/index.ts
+++ b/packages/cms-data-sync/src/index.ts
@@ -5,6 +5,7 @@ const flags = process.argv.slice(2);
 
 const allowedFlags = [
   '--upsert',
+  '--all',
   ...models.map((model: string) => `--${model}`),
 ];
 


### PR DESCRIPTION
This was missed, so throws an error when you try to migrate all models.