### PR TITLE
Handle null entries in event speakers collection

### DIFF
--- a/apps/crn-server/src/data-providers/contentful/event.data-provider.ts
+++ b/apps/crn-server/src/data-providers/contentful/event.data-provider.ts
@@ -424,7 +424,10 @@ export const parseGraphQLEvent = (item: EventItem): EventDataObject => {
         title: wg.title || '',
       }))[0] || undefined;
 
-  const speakersItems = (speakersCollection?.items as SpeakerItem[]) ?? [];
+  const speakersItems =
+    speakersCollection?.items.filter(
+      (x: SpeakerItem | null): x is SpeakerItem => x !== null,
+    ) ?? [];
   return {
     id,
     title: title!,

--- a/apps/crn-server/test/data-providers/contentful/event.data-provider.test.ts
+++ b/apps/crn-server/test/data-providers/contentful/event.data-provider.test.ts
@@ -442,6 +442,33 @@ describe('Events Contentful Data Provider', () => {
     });
 
     describe('Event speakers', () => {
+      test('Should remove null speakers from the list', async () => {
+        const contentfulGraphQLResponse = getContentfulGraphqlEvent();
+        contentfulGraphQLResponse.speakersCollection!.items = [
+          null,
+          ...contentfulGraphQLResponse.speakersCollection!.items,
+        ];
+
+        contentfulGraphqlClientMock.request.mockResolvedValueOnce({
+          events: contentfulGraphQLResponse,
+        });
+
+        const result = await eventDataProvider.fetchById(eventId);
+        expect(result!.speakers.length).toEqual(1);
+        const speakerResult = result!.speakers[0]! as EventSpeakerTeam;
+        expect(speakerResult.team.displayName).toEqual('The team three');
+      });
+      test('Should default speakers to an empty array', async () => {
+        const contentfulGraphQLResponse = getContentfulGraphqlEvent();
+        contentfulGraphQLResponse.speakersCollection = null;
+
+        contentfulGraphqlClientMock.request.mockResolvedValueOnce({
+          events: contentfulGraphQLResponse,
+        });
+
+        const result = await eventDataProvider.fetchById(eventId);
+        expect(result!.speakers).toEqual([]);
+      });
       test('Should return team inactiveSince as undefined when it comes as null from graphql response', async () => {
         const contentfulGraphQLResponse = getContentfulGraphqlEvent();
         contentfulGraphQLResponse.speakersCollection!.items![0]!.team!.inactiveSince! =


### PR DESCRIPTION
The code was previously written to assume null entries in event speakers was an impossible scenario, but it is not and so the case needs to be handled.

Filter null entries from the speakers array and remove the type coercion to the non-nullable type.