### PR TITLE
CT-99 fix number of allowed embedded media in events

### DIFF
--- a/packages/contentful/migrations/crn/events/20230821125117-change-rich-text-validation-numbers.js
+++ b/packages/contentful/migrations/crn/events/20230821125117-change-rich-text-validation-numbers.js
@@ -1,0 +1,415 @@
+module.exports.description = 'Change rich text validation';
+
+module.exports.up = (migration) => {
+  const richTextValidations = [
+    {
+      enabledMarks: [
+        'bold',
+        'italic',
+        'underline',
+        'code',
+        'superscript',
+        'subscript',
+      ],
+      message:
+        'Only bold, italic, underline, code, superscript, and subscript marks are allowed',
+    },
+    {
+      enabledNodeTypes: [
+        'heading-1',
+        'heading-2',
+        'heading-3',
+        'heading-4',
+        'heading-5',
+        'heading-6',
+        'ordered-list',
+        'unordered-list',
+        'hr',
+        'blockquote',
+        'embedded-entry-block',
+        'embedded-asset-block',
+        'table',
+        'hyperlink',
+        'entry-hyperlink',
+        'asset-hyperlink',
+        'embedded-entry-inline',
+      ],
+
+      message:
+        'Only heading 1, heading 2, heading 3, heading 4, heading 5, heading 6, ordered list, unordered list, horizontal rule, quote, block entry, asset, table, link to Url, link to entry, link to asset, and inline entry nodes are allowed',
+    },
+    {
+      nodes: {
+        'asset-hyperlink': [
+          {
+            size: {
+              min: null,
+              max: 15,
+            },
+
+            message: null,
+          },
+        ],
+
+        'embedded-asset-block': [
+          {
+            size: {
+              min: null,
+              max: 15,
+            },
+
+            message: null,
+          },
+        ],
+
+        'embedded-entry-block': [
+          {
+            linkContentType: ['media'],
+            message: null,
+          },
+          {
+            size: {
+              min: null,
+              max: 15,
+            },
+
+            message: null,
+          },
+        ],
+
+        'embedded-entry-inline': [
+          {
+            linkContentType: ['media'],
+            message: null,
+          },
+          {
+            size: {
+              min: null,
+              max: 15,
+            },
+
+            message: null,
+          },
+        ],
+
+        'entry-hyperlink': [
+          {
+            linkContentType: ['media'],
+            message: null,
+          },
+          {
+            size: {
+              min: null,
+              max: 15,
+            },
+
+            message: null,
+          },
+        ],
+      },
+    },
+  ];
+
+  const events = migration.editContentType('events');
+
+  events.editField('presentation').validations(richTextValidations);
+
+  events.editField('notes').validations(richTextValidations);
+
+  events.editField('videoRecording').validations(richTextValidations);
+};
+
+module.exports.down = (migration) => {
+  // back to how it was in 20230404114001-create-events-content-model.js
+  const events = migration.editContentType('events');
+  events.editField('presentation').validations([
+    {
+      enabledMarks: [
+        'bold',
+        'italic',
+        'underline',
+        'code',
+        'superscript',
+        'subscript',
+      ],
+      message:
+        'Only bold, italic, underline, code, superscript, and subscript marks are allowed',
+    },
+    {
+      enabledNodeTypes: [
+        'heading-1',
+        'heading-2',
+        'heading-3',
+        'heading-4',
+        'heading-5',
+        'heading-6',
+        'ordered-list',
+        'unordered-list',
+        'hr',
+        'blockquote',
+        'embedded-entry-block',
+        'embedded-asset-block',
+        'table',
+        'hyperlink',
+        'entry-hyperlink',
+        'asset-hyperlink',
+        'embedded-entry-inline',
+      ],
+
+      message:
+        'Only heading 1, heading 2, heading 3, heading 4, heading 5, heading 6, ordered list, unordered list, horizontal rule, quote, block entry, asset, table, link to Url, link to entry, link to asset, and inline entry nodes are allowed',
+    },
+    {
+      nodes: {
+        'asset-hyperlink': [
+          {
+            size: {
+              min: null,
+              max: 10,
+            },
+
+            message: null,
+          },
+        ],
+
+        'embedded-asset-block': [
+          {
+            size: {
+              min: null,
+              max: 10,
+            },
+
+            message: null,
+          },
+        ],
+
+        'embedded-entry-block': [
+          {
+            size: {
+              min: null,
+              max: 10,
+            },
+
+            message: null,
+          },
+        ],
+
+        'embedded-entry-inline': [
+          {
+            size: {
+              min: null,
+              max: 10,
+            },
+
+            message: null,
+          },
+        ],
+
+        'entry-hyperlink': [
+          {
+            size: {
+              min: null,
+              max: 10,
+            },
+
+            message: null,
+          },
+        ],
+      },
+    },
+  ]);
+
+  events.editField('notes').validations([
+    {
+      enabledMarks: [
+        'bold',
+        'italic',
+        'underline',
+        'code',
+        'superscript',
+        'subscript',
+      ],
+      message:
+        'Only bold, italic, underline, code, superscript, and subscript marks are allowed',
+    },
+    {
+      enabledNodeTypes: [
+        'heading-1',
+        'heading-2',
+        'heading-3',
+        'heading-4',
+        'heading-5',
+        'heading-6',
+        'ordered-list',
+        'unordered-list',
+        'hr',
+        'blockquote',
+        'embedded-entry-block',
+        'embedded-asset-block',
+        'table',
+        'hyperlink',
+        'entry-hyperlink',
+        'asset-hyperlink',
+        'embedded-entry-inline',
+      ],
+
+      message:
+        'Only heading 1, heading 2, heading 3, heading 4, heading 5, heading 6, ordered list, unordered list, horizontal rule, quote, block entry, asset, table, link to Url, link to entry, link to asset, and inline entry nodes are allowed',
+    },
+    {
+      nodes: {
+        'asset-hyperlink': [
+          {
+            size: {
+              min: null,
+              max: 7,
+            },
+
+            message: null,
+          },
+        ],
+
+        'embedded-asset-block': [
+          {
+            size: {
+              min: null,
+              max: 8,
+            },
+
+            message: null,
+          },
+        ],
+
+        'embedded-entry-block': [
+          {
+            size: {
+              min: null,
+              max: 10,
+            },
+
+            message: null,
+          },
+        ],
+
+        'embedded-entry-inline': [
+          {
+            size: {
+              min: null,
+              max: 6,
+            },
+
+            message: null,
+          },
+        ],
+
+        'entry-hyperlink': [
+          {
+            size: {
+              min: null,
+              max: 10,
+            },
+
+            message: null,
+          },
+        ],
+      },
+    },
+  ]);
+
+  events.editField('videoRecording').validations([
+    {
+      enabledMarks: [
+        'bold',
+        'italic',
+        'underline',
+        'code',
+        'superscript',
+        'subscript',
+      ],
+      message:
+        'Only bold, italic, underline, code, superscript, and subscript marks are allowed',
+    },
+    {
+      enabledNodeTypes: [
+        'heading-1',
+        'heading-2',
+        'heading-3',
+        'heading-4',
+        'heading-5',
+        'heading-6',
+        'ordered-list',
+        'unordered-list',
+        'hr',
+        'blockquote',
+        'embedded-entry-block',
+        'embedded-asset-block',
+        'table',
+        'hyperlink',
+        'entry-hyperlink',
+        'asset-hyperlink',
+        'embedded-entry-inline',
+      ],
+
+      message:
+        'Only heading 1, heading 2, heading 3, heading 4, heading 5, heading 6, ordered list, unordered list, horizontal rule, quote, block entry, asset, table, link to Url, link to entry, link to asset, and inline entry nodes are allowed',
+    },
+    {
+      nodes: {
+        'asset-hyperlink': [
+          {
+            size: {
+              min: null,
+              max: 10,
+            },
+
+            message: null,
+          },
+        ],
+
+        'embedded-asset-block': [
+          {
+            size: {
+              min: null,
+              max: 10,
+            },
+
+            message: null,
+          },
+        ],
+
+        'embedded-entry-block': [
+          {
+            size: {
+              min: null,
+              max: 10,
+            },
+
+            message: null,
+          },
+        ],
+
+        'embedded-entry-inline': [
+          {
+            size: {
+              min: null,
+              max: 10,
+            },
+
+            message: null,
+          },
+        ],
+
+        'entry-hyperlink': [
+          {
+            size: {
+              min: null,
+              max: 10,
+            },
+
+            message: null,
+          },
+        ],
+      },
+    },
+  ]);
+};


### PR DESCRIPTION
Some events can't be published in Contentful because they have more presentations/images than we current allow. So this PR changes the rich text fields validations to support 15 embedded entries/assets in each field. Also, it adds a filter to let the user select only entries from content-type `media` in the embedded entries.


<img width="1434" alt="Screenshot 2023-08-21 at 13 53 08" src="https://github.com/yldio/asap-hub/assets/16595804/7abfa82d-8f11-4ee7-a248-5bd2c1e7336f">


<img width="1433" alt="Screenshot 2023-08-21 at 13 52 31" src="https://github.com/yldio/asap-hub/assets/16595804/1bccdfd3-1db0-4ac3-8b04-bfe66de902e3">
