### PR TITLE
Increase timeout for contentful user invitation handler

### DIFF
--- a/apps/crn-server/serverless.ts
+++ b/apps/crn-server/serverless.ts
@@ -462,6 +462,7 @@ const serverlessConfig: AWS = {
       },
     },
     inviteUserContentful: {
+      timeout: 120,
       handler: './src/handlers/user/invite-handler.handler',
       events: [
         {


### PR DESCRIPTION
This was missed when the 30 second sleep was added to the handler, and so with a default timeout of 16 seconds always times out.

Increase the timeout to match the squidex invitation handler.