### PR TITLE
CT-101 Fix rich text displaying only one iframe

### DIFF
--- a/apps/crn-server/test/fixtures/events.fixtures.ts
+++ b/apps/crn-server/test/fixtures/events.fixtures.ts
@@ -396,9 +396,9 @@ export const getContentfulEventDataObject = (): EventDataObject => ({
   interestGroup: undefined,
   workingGroup: undefined,
   notes: '<p>These are the notes from the meeting</p>',
-  presentation: '<p><iframe src="https://example.com"/></p>',
+  presentation: '<p><iframe src="https://example.com"></iframe></p>',
   videoRecording:
-    '<p><iframe src="https://player.vimeo.com/video/493052720"/></p>',
+    '<p><iframe src="https://player.vimeo.com/video/493052720"></iframe></p>',
   thumbnail: 'https://example.com',
 });
 

--- a/apps/gp2-server/test/fixtures/event.fixtures.ts
+++ b/apps/gp2-server/test/fixtures/event.fixtures.ts
@@ -296,9 +296,9 @@ export const getEventSpeakerUser = (): gp2Model.EventSpeakerUser => ({
 export const getContentfulEventDataObject = (): gp2Model.EventDataObject => ({
   ...getEventDataObject(),
   notes: '<p>These are the notes from the meeting</p>',
-  presentation: '<p><iframe src="https://example.com"/></p>',
+  presentation: '<p><iframe src="https://example.com"></iframe></p>',
   videoRecording:
-    '<p><iframe src="https://player.vimeo.com/video/493052720"/></p>',
+    '<p><iframe src="https://player.vimeo.com/video/493052720"></iframe></p>',
   thumbnail: 'https://example.com',
   calendar: {
     ...getEventDataObject().calendar,

--- a/packages/contentful/src/utils/parse-rich-text.ts
+++ b/packages/contentful/src/utils/parse-rich-text.ts
@@ -63,7 +63,7 @@ export const parseRichText = (rtf: RichTextFromQuery) => {
 
         if (entryById && entryById[entryId]) {
           const { url } = entryById[entryId];
-          return `<iframe src="${url}"/>`;
+          return `<iframe src="${url}"></iframe>`;
         }
         throw new Error(
           `Entry with id ${entryId} does not exist in contentful`,
@@ -80,10 +80,10 @@ export const parseRichText = (rtf: RichTextFromQuery) => {
 
           switch (contentType) {
             case 'application/pdf':
-              return `<iframe src="${url}"${dimensions}>`;
+              return `<iframe src="${url}"${dimensions}></iframe>`;
 
             case 'video/mp4':
-              return `<iframe src="${url}"${dimensions} allowFullScreen>`;
+              return `<iframe src="${url}"${dimensions} allowFullScreen></iframe>`;
 
             default:
               return `<img src="${url}"${dimensions} alt=${

--- a/packages/contentful/test/utils/parse-rich-text.test.ts
+++ b/packages/contentful/test/utils/parse-rich-text.test.ts
@@ -51,7 +51,7 @@ describe('parseRichText', () => {
         },
       };
       expect(parseRichText(rtf)).toEqual(
-        `<p>Here it will appear an image</p><iframe src=\"https://images.ctfassets.net/envId/image1/file-1.pdf\" width=\"200\" height=\"300\"><p>below there&#39;s a cat</p><iframe src=\"https://images.ctfassets.net/envId/image2/file-2.pdf\"><p> </p>`,
+        `<p>Here it will appear an image</p><iframe src=\"https://images.ctfassets.net/envId/image1/file-1.pdf\" width=\"200\" height=\"300\"></iframe><p>below there&#39;s a cat</p><iframe src=\"https://images.ctfassets.net/envId/image2/file-2.pdf\"></iframe><p> </p>`,
       );
     });
 
@@ -81,7 +81,7 @@ describe('parseRichText', () => {
         },
       };
       expect(parseRichText(rtf)).toEqual(
-        `<p>Here it will appear an image</p><iframe src=\"https://images.ctfassets.net/envId/image1/video-1.mp4\" width=\"200\" height=\"300\" allowFullScreen><p>below there&#39;s a cat</p><iframe src=\"https://images.ctfassets.net/envId/image2/video-2.mp4\" allowFullScreen><p> </p>`,
+        `<p>Here it will appear an image</p><iframe src=\"https://images.ctfassets.net/envId/image1/video-1.mp4\" width=\"200\" height=\"300\" allowFullScreen></iframe><p>below there&#39;s a cat</p><iframe src=\"https://images.ctfassets.net/envId/image2/video-2.mp4\" allowFullScreen></iframe><p> </p>`,
       );
     });
 
@@ -133,7 +133,7 @@ describe('parseRichText', () => {
         links: linksWithEntries,
       };
       expect(parseRichText(rtf)).toEqual(
-        `<p>A nice pdf</p><iframe src=\"http://drive.com/document\"/><p>A good video</p><iframe src=\"http://vimeo.com/video\"/><p> </p>`,
+        `<p>A nice pdf</p><iframe src=\"http://drive.com/document\"></iframe><p>A good video</p><iframe src=\"http://vimeo.com/video\"></iframe><p> </p>`,
       );
     });
 

--- a/packages/react-components/src/organisms/__tests__/RichText.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/RichText.test.tsx
@@ -19,6 +19,18 @@ it('renders <iframe>', () => {
   expect(getByTitle('Some Frame')).toBeInTheDocument();
 });
 
+it('renders more than one <iframe>', () => {
+  const { getByTitle } = render(
+    <RichText
+      text={
+        '<iframe title="First Frame"></iframe><p>Next iframe</p><iframe title="Second Frame" ></iframe>'
+      }
+    />,
+  );
+  expect(getByTitle('First Frame')).toBeInTheDocument();
+  expect(getByTitle('Second Frame')).toBeInTheDocument();
+});
+
 it('renders <a> as a link', () => {
   const { getByText } = render(
     <RichText text={'<a href="https://localhost/">anchor</a>'} />,


### PR DESCRIPTION
The problem with more than one `iframe` not appearing in the frontend is that the way the iframe was being generated given the contentful document was wrong. It shouldn't have a self closing tag so it should always have `</iframe>` at the end.

![Screenshot 2023-08-23 at 08 28 35 (2)](https://github.com/yldio/asap-hub/assets/16595804/b5fd7bfa-0cf5-48ba-98f6-e1f50c935f9d)
