### PR TITLE
CT-104 Interest groups not appearing in User page

### DIFF
--- a/apps/crn-server/src/controllers/interest-group.controller.ts
+++ b/apps/crn-server/src/controllers/interest-group.controller.ts
@@ -62,12 +62,17 @@ export default class InterestGroupController {
     options: FetchPaginationOptions,
   ): Promise<ListInterestGroupResponse> {
     const teamIds = Array.isArray(teamId) ? teamId : [teamId];
-    const { total, items } = await this.interestGroupDataProvider.fetch({
-      filter: {
-        teamId: teamIds,
-      },
-      ...options,
-    });
+    const { total, items } = teamIds.length
+      ? await this.interestGroupDataProvider.fetch({
+          filter: {
+            teamId: teamIds as [string, ...string[]],
+          },
+          ...options,
+        })
+      : {
+          total: 0,
+          items: [],
+        };
 
     return { total, items };
   }
@@ -83,7 +88,7 @@ export default class InterestGroupController {
     const { items: interestGroupsByTeams } = teamIds.length
       ? await this.interestGroupDataProvider.fetch({
           filter: {
-            teamId: teamIds,
+            teamId: teamIds as [string, ...string[]],
           },
         })
       : {

--- a/apps/crn-server/src/controllers/interest-group.controller.ts
+++ b/apps/crn-server/src/controllers/interest-group.controller.ts
@@ -80,18 +80,23 @@ export default class InterestGroupController {
     }
 
     const teamIds = user.teams.map((team) => team.id);
-    const { items: interestGroupsByTeams } =
-      await this.interestGroupDataProvider.fetch({
-        filter: {
-          teamId: teamIds,
-        },
-      });
+    const { items: interestGroupsByTeams } = teamIds.length
+      ? await this.interestGroupDataProvider.fetch({
+          filter: {
+            teamId: teamIds,
+          },
+        })
+      : {
+          items: [],
+        };
+
     const { items: interestGroupsByUser } =
       await this.interestGroupDataProvider.fetch({
         filter: {
           userId,
         },
       });
+
     const interestGroups = [...interestGroupsByTeams, ...interestGroupsByUser];
     const items = uniqBy(interestGroups, 'id');
 

--- a/apps/crn-server/src/controllers/interest-group.controller.ts
+++ b/apps/crn-server/src/controllers/interest-group.controller.ts
@@ -62,10 +62,12 @@ export default class InterestGroupController {
     options: FetchPaginationOptions,
   ): Promise<ListInterestGroupResponse> {
     const teamIds = Array.isArray(teamId) ? teamId : [teamId];
-    const { total, items } = teamIds.length
+    const { total, items } = teamIds[0]
       ? await this.interestGroupDataProvider.fetch({
           filter: {
-            teamId: teamIds as [string, ...string[]],
+            // this [teamIds[0], ...teamIds.slice(1)] is necessary
+            // because the type of teams is [string, ...string[]],
+            teamId: [teamIds[0], ...teamIds.slice(1)],
           },
           ...options,
         })
@@ -85,10 +87,12 @@ export default class InterestGroupController {
     }
 
     const teamIds = user.teams.map((team) => team.id);
-    const { items: interestGroupsByTeams } = teamIds.length
+    const { items: interestGroupsByTeams } = teamIds[0]
       ? await this.interestGroupDataProvider.fetch({
           filter: {
-            teamId: teamIds as [string, ...string[]],
+            // this [teamIds[0], ...teamIds.slice(1)] is necessary
+            // because the type of teams is [string, ...string[]],
+            teamId: [teamIds[0], ...teamIds.slice(1)],
           },
         })
       : {

--- a/apps/crn-server/test/controllers/interest-group.controller.test.ts
+++ b/apps/crn-server/test/controllers/interest-group.controller.test.ts
@@ -106,6 +106,13 @@ describe('Group controller', () => {
       });
     });
 
+    test('Should not call the data provider if teamId is empty and should return empty result', async () => {
+      const response = await interestGroupController.fetchByTeamId([], {});
+
+      expect(interestGroupDataProviderMock.fetch).not.toHaveBeenCalled();
+      expect(response).toEqual({ items: [], total: 0 });
+    });
+
     test('Should filter by multiple team IDs and add pagination parameters', async () => {
       const teamIds = [teamId, 'dc312b6e-195c-46e2-b347-58fb86715033'];
       const pagination = {
@@ -148,22 +155,23 @@ describe('Group controller', () => {
       expect(result).toEqual({ items: [getInterestGroupResponse()], total: 1 });
     });
 
-    test('Should not call the data provider to fetch based on teams if user does not belong to any team', async () => {
+    test('Should not call the data provider to fetch based on teams if user does not belong to any team and should return empty result', async () => {
       const userDataObject = getUserDataObject();
       userDataObject.teams = [];
       userDataProviderMock.fetchById.mockResolvedValueOnce(userDataObject);
       interestGroupDataProviderMock.fetch.mockResolvedValue({
-        total: 1,
-        items: [getInterestGroupDataObject()],
+        total: 0,
+        items: [],
       });
 
-      await interestGroupController.fetchByUserId(userId);
+      const response = await interestGroupController.fetchByUserId(userId);
 
       expect(userDataProviderMock.fetchById).toBeCalledWith(userId);
       expect(interestGroupDataProviderMock.fetch).toBeCalledTimes(1);
       expect(interestGroupDataProviderMock.fetch).toBeCalledWith({
         filter: { userId },
       });
+      expect(response).toEqual({ items: [], total: 0 });
     });
 
     test('Should call the data provider with correct parameters', async () => {

--- a/apps/crn-server/test/controllers/interest-group.controller.test.ts
+++ b/apps/crn-server/test/controllers/interest-group.controller.test.ts
@@ -148,6 +148,24 @@ describe('Group controller', () => {
       expect(result).toEqual({ items: [getInterestGroupResponse()], total: 1 });
     });
 
+    test('Should not call the data provider to fetch based on teams if user does not belong to any team', async () => {
+      const userDataObject = getUserDataObject();
+      userDataObject.teams = [];
+      userDataProviderMock.fetchById.mockResolvedValueOnce(userDataObject);
+      interestGroupDataProviderMock.fetch.mockResolvedValue({
+        total: 1,
+        items: [getInterestGroupDataObject()],
+      });
+
+      await interestGroupController.fetchByUserId(userId);
+
+      expect(userDataProviderMock.fetchById).toBeCalledWith(userId);
+      expect(interestGroupDataProviderMock.fetch).toBeCalledTimes(1);
+      expect(interestGroupDataProviderMock.fetch).toBeCalledWith({
+        filter: { userId },
+      });
+    });
+
     test('Should call the data provider with correct parameters', async () => {
       const userDataObject = getUserDataObject();
       userDataObject.teams = [

--- a/apps/crn-server/test/data-providers/interest-group.data-provider.test.ts
+++ b/apps/crn-server/test/data-providers/interest-group.data-provider.test.ts
@@ -180,7 +180,7 @@ describe('Group Data Provider', () => {
     });
 
     test('Should filter by multiple team IDs', async () => {
-      const teamIds = [
+      const teamIds: [string, ...string[]] = [
         'eb531b6e-195c-46e2-b347-58fb86715033',
         'dc312b6e-195c-46e2-b347-58fb86715033',
       ];
@@ -249,7 +249,7 @@ describe('Group Data Provider', () => {
 
     test('Should apply the team, user and active filters', async () => {
       const userId = 'eb531b6e-195c-46e2-b347-58fb86715033';
-      const teamIds = ['team-id-1', 'team-id-3'];
+      const teamIds: [string, ...string[]] = ['team-id-1', 'team-id-3'];
       const active = true;
 
       squidexGraphqlClientMock.request.mockResolvedValue(
@@ -275,7 +275,7 @@ describe('Group Data Provider', () => {
 
     test('Should return the deduped result', async () => {
       const userId = 'eb531b6e-195c-46e2-b347-58fb86715033';
-      const teamIds = ['team-id-1', 'team-id-3'];
+      const teamIds: [string, ...string[]] = ['team-id-1', 'team-id-3'];
 
       squidexGraphqlClientMock.request.mockResolvedValueOnce(
         getSquidexInterestGroupsGraphqlResponse(),

--- a/packages/model/src/interest-group.ts
+++ b/packages/model/src/interest-group.ts
@@ -59,7 +59,7 @@ export type InterestGroupResponse = InterestGroupDataObject;
 export type ListInterestGroupResponse = ListResponse<InterestGroupResponse>;
 
 type InterestGroupFilter = {
-  teamId?: string[];
+  teamId?: [string, ...string[]];
   userId?: string;
   active?: boolean;
 };


### PR DESCRIPTION
In prod (right side of screenshot) 

![interest-groups](https://github.com/yldio/asap-hub/assets/16595804/1ad57c8e-d2c1-4ce2-8e6e-fe0cf41f429b)

when the user does not belong to any team, the API was still returning all interest groups in this call

```
this.interestGroupDataProvider.fetch({ filter: {  teamId: teamIds } })
```

because the Squidex data provider was getting called with an empty filter here (https://github.com/yldio/asap-hub/blob/master/apps/crn-server/src/data-providers/interest-group.data-provider.ts#L63-L89) and since it was not filtering anything it returned all the interest groups which is wrong.

I've changed the controller so it does not even make a call to the data provider if the user does not belong to any team.

Although it should not happen, it seems there are 8 Grantees without teams in Prod. I've ran the following query in Squidex Prod:

```
  queryUsersContentsWithTotal(filter: "empty(data/teams/iv) and data/role/iv eq 'Grantee'") {
    total
    items {
      id
      flatData {
        onboarded
        role
      }
    }
  }
```