### PR TITLE
Handle errors in algolia search requests

### DIFF
--- a/apps/crn-frontend/src/events/api.ts
+++ b/apps/crn-frontend/src/events/api.ts
@@ -21,16 +21,20 @@ export const getEvents = async (
 ): Promise<ListEventResponse> => {
   const filters = getEventFilters({ before, after }, constraint);
 
-  const result = await algoliaClient.search(
-    ['event'],
-    searchQuery,
-    {
-      filters,
-      page: currentPage ?? undefined,
-      hitsPerPage: pageSize ?? undefined,
-    },
-    !!before,
-  );
+  const result = await algoliaClient
+    .search(
+      ['event'],
+      searchQuery,
+      {
+        filters,
+        page: currentPage ?? undefined,
+        hitsPerPage: pageSize ?? undefined,
+      },
+      !!before,
+    )
+    .catch((error: Error) => {
+      throw new Error(`Could not search: ${error.message}`);
+    });
 
   return {
     items: result.hits,

--- a/apps/crn-frontend/src/network/users/api.ts
+++ b/apps/crn-frontend/src/network/users/api.ts
@@ -63,11 +63,15 @@ export const getUsers = async (
       ? `(${tagFilters}) AND (${roleFilters})`
       : tagFilters || roleFilters;
 
-  const result = await algoliaClient.search(['user'], searchQuery, {
-    filters: algoliaFilters.length > 0 ? algoliaFilters : undefined,
-    page: currentPage ?? undefined,
-    hitsPerPage: pageSize ?? undefined,
-  });
+  const result = await algoliaClient
+    .search(['user'], searchQuery, {
+      filters: algoliaFilters.length > 0 ? algoliaFilters : undefined,
+      page: currentPage ?? undefined,
+      hitsPerPage: pageSize ?? undefined,
+    })
+    .catch((error: Error) => {
+      throw new Error(`Could not search: ${error.message}`);
+    });
 
   return {
     items: result.hits,


### PR DESCRIPTION
If algolia returns an error while searching then it gets stuck in a continuous loop of retrying the request. This is particularly bad when the error is a 429 response for making too many requests.

Instead of getting stuck in a continuous loop of retrying failed searches throw an error and display a failure message.