### PR TITLE
CT-108 Add (hidden:false) to algolia event queries

### DIFF
--- a/apps/crn-frontend/src/dashboard/Body.tsx
+++ b/apps/crn-frontend/src/dashboard/Body.tsx
@@ -25,7 +25,7 @@ const Body: FC<BodyProps> = ({ date, user, ...props }) => {
       past: true,
       pageSize,
       currentPage: 0,
-      constraint: { notStatus: 'Cancelled' },
+      constraint: { notStatus: 'Cancelled', hidden: 'false' },
     }),
     user,
   );

--- a/apps/crn-frontend/src/events/EventList.tsx
+++ b/apps/crn-frontend/src/events/EventList.tsx
@@ -49,6 +49,7 @@ const EventList: React.FC<EventListProps> = ({
       searchQuery,
       currentPage,
       pageSize,
+      constraint: { hidden: 'false' },
     }),
   );
 
@@ -58,6 +59,7 @@ const EventList: React.FC<EventListProps> = ({
       searchQuery,
       currentPage,
       pageSize,
+      constraint: { hidden: 'false' },
     }),
   );
   usePrefetchCalendars();

--- a/apps/crn-frontend/src/events/__tests__/api.test.ts
+++ b/apps/crn-frontend/src/events/__tests__/api.test.ts
@@ -86,7 +86,7 @@ describe('getEvents', () => {
       algoliaSearchClient,
       getEventListOptions(new Date('2021-01-01T12:00:00'), {
         past: true,
-        constraint: { notStatus: 'Cancelled' },
+        constraint: { notStatus: 'Cancelled', hidden: 'false' },
       }),
     );
 
@@ -94,7 +94,8 @@ describe('getEvents', () => {
       ['event'],
       '',
       {
-        filters: '(endDateTimestamp < 1609498800) AND (NOT status:Cancelled)',
+        filters:
+          '(endDateTimestamp < 1609498800) AND (NOT status:Cancelled AND hidden:false)',
         hitsPerPage: 10,
         page: 0,
       },
@@ -125,14 +126,14 @@ describe('getEvents', () => {
 
     await getEvents(algoliaSearchClient, {
       ...getEventListOptions(new Date('2021-01-01T12:00:00'), { past: false }),
-      constraint: { userId: 'user-1' },
+      constraint: { userId: 'user-1', hidden: 'false' },
     });
     expect(search).toBeCalledWith(
       ['event'],
       '',
       {
         filters:
-          '(endDateTimestamp > 1609498800) AND (speakers.user.id: "user-1")',
+          '(endDateTimestamp > 1609498800) AND (speakers.user.id: "user-1" AND hidden:false)',
         hitsPerPage: 10,
         page: 0,
       },
@@ -145,14 +146,14 @@ describe('getEvents', () => {
 
     await getEvents(algoliaSearchClient, {
       ...getEventListOptions(new Date('2021-01-01T12:00:00Z'), { past: true }),
-      constraint: { userId: 'user-1' },
+      constraint: { userId: 'user-1', hidden: 'false' },
     });
     expect(search).toBeCalledWith(
       ['event'],
       '',
       {
         filters:
-          '(endDateTimestamp < 1609498800) AND (speakers.user.id: "user-1")',
+          '(endDateTimestamp < 1609498800) AND (speakers.user.id: "user-1" AND hidden:false)',
         hitsPerPage: 10,
         page: 0,
       },
@@ -165,14 +166,14 @@ describe('getEvents', () => {
 
     await getEvents(algoliaSearchClient, {
       ...getEventListOptions(new Date('2021-01-01T12:00:00'), { past: false }),
-      constraint: { teamId: 'team-1' },
+      constraint: { teamId: 'team-1', hidden: 'false' },
     });
     expect(search).toBeCalledWith(
       ['event'],
       '',
       {
         filters:
-          '(endDateTimestamp > 1609498800) AND (speakers.team.id: "team-1")',
+          '(endDateTimestamp > 1609498800) AND (speakers.team.id: "team-1" AND hidden:false)',
         hitsPerPage: 10,
         page: 0,
       },
@@ -217,14 +218,14 @@ describe('getEvents', () => {
 
     await getEvents(algoliaSearchClient, {
       ...getEventListOptions(new Date('2021-01-01T12:00:00'), { past: false }),
-      constraint: { interestGroupId: 'group-5' },
+      constraint: { interestGroupId: 'group-5', hidden: 'false' },
     });
     expect(search).toBeCalledWith(
       ['event'],
       '',
       {
         filters:
-          '(endDateTimestamp > 1609498800) AND (interestGroup.id: "group-5")',
+          '(endDateTimestamp > 1609498800) AND (interestGroup.id: "group-5" AND hidden:false)',
         hitsPerPage: 10,
         page: 0,
       },
@@ -237,14 +238,14 @@ describe('getEvents', () => {
 
     await getEvents(algoliaSearchClient, {
       ...getEventListOptions(new Date('2021-01-01T12:00:00'), { past: false }),
-      constraint: { workingGroupId: 'wg-1' },
+      constraint: { workingGroupId: 'wg-1', hidden: 'false' },
     });
     expect(search).toBeCalledWith(
       ['event'],
       '',
       {
         filters:
-          '(endDateTimestamp > 1609498800) AND (workingGroup.id: "wg-1")',
+          '(endDateTimestamp > 1609498800) AND (workingGroup.id: "wg-1" AND hidden:false)',
         hitsPerPage: 10,
         page: 0,
       },
@@ -263,14 +264,14 @@ describe('getSquidexUrl', () => {
   };
 
   it('returns the user or team url', () => {
-    options.constraint = { teamId: 'team-1' };
+    options.constraint = { teamId: 'team-1', hidden: 'false' };
     expect(getSquidexUrl(options).toString()).toEqual(
       'http://api/events?take=10&skip=10',
     );
   });
 
   it('returns the interest group url if the constraint contains interest group id', () => {
-    options.constraint = { interestGroupId: 'group-1' };
+    options.constraint = { interestGroupId: 'group-1', hidden: 'false' };
     expect(getSquidexUrl(options).toString()).toEqual(
       'http://api/interest-groups/group-1/events?take=10&skip=10',
     );

--- a/apps/crn-frontend/src/events/state.ts
+++ b/apps/crn-frontend/src/events/state.ts
@@ -118,7 +118,12 @@ export const useEvents = (options: GetEventListOptions, user?: User | null) => {
   const { client } = useAlgolia();
 
   if (events === undefined) {
-    throw getEvents(client, options).then(setEvents).catch(setEvents);
+    throw getEvents(client, {
+      ...options,
+      constraint: { ...options.constraint, hidden: 'false' },
+    })
+      .then(setEvents)
+      .catch(setEvents);
   }
 
   if (events instanceof Error) {

--- a/apps/crn-frontend/src/network/__tests__/EventsEmbedList.test.tsx
+++ b/apps/crn-frontend/src/network/__tests__/EventsEmbedList.test.tsx
@@ -92,9 +92,9 @@ const userPath = (userId: string) =>
 const teamPath = (teamId: string) =>
   network({}).teams({}).team({ teamId }).upcoming({}).$;
 it.each`
-  description                     | constraint            | getPath     | refreshState        | after                         | before
-  ${'upcoming events by userId '} | ${{ userId: '1013' }} | ${userPath} | ${refreshUserState} | ${'2021-12-28T13:00:00.000Z'} | ${undefined}
-  ${'upcoming events by teamId '} | ${{ teamId: '1009' }} | ${teamPath} | ${refreshTeamState} | ${'2021-12-28T13:00:00.000Z'} | ${undefined}
+  description                     | constraint                             | getPath     | refreshState        | after                         | before
+  ${'upcoming events by userId '} | ${{ userId: '1013', hidden: 'false' }} | ${userPath} | ${refreshUserState} | ${'2021-12-28T13:00:00.000Z'} | ${undefined}
+  ${'upcoming events by teamId '} | ${{ teamId: '1009', hidden: 'false' }} | ${teamPath} | ${refreshTeamState} | ${'2021-12-28T13:00:00.000Z'} | ${undefined}
 `(
   'renders a list of $description',
   async ({ constraint, getPath, after, before }) => {
@@ -127,7 +127,7 @@ it.each`
 
 describe('EventsEmbed with no upcoming events', () => {
   it('shows the component for no upcoming events', async () => {
-    const constraint = { teamId: '1010' };
+    const constraint = { teamId: '1010', hidden: 'false' };
     const pathName = teamPath(constraint.teamId);
     const isPast = false;
 
@@ -143,7 +143,7 @@ describe('EventsEmbed with no upcoming events', () => {
   });
 
   it('shows the component for no past events', async () => {
-    const constraint = { teamId: '1010' };
+    const constraint = { teamId: '1010', hidden: 'false' };
     const pathName = teamPath(constraint.teamId);
     const isPast = true;
 
@@ -159,7 +159,7 @@ describe('EventsEmbed with no upcoming events', () => {
   });
 
   it('shows empty state when no noEventsComponent is passed', async () => {
-    const constraint = { teamId: '1010' };
+    const constraint = { teamId: '1010', hidden: 'false' };
     const pathName = teamPath(constraint.teamId);
     const isPast = false;
 

--- a/apps/crn-frontend/src/network/interest-groups/InterestGroupProfile.tsx
+++ b/apps/crn-frontend/src/network/interest-groups/InterestGroupProfile.tsx
@@ -44,6 +44,7 @@ const InterestGroupProfile: FC<InterestGroupProfileProps> = ({
 
   const [upcomingEvents, pastEvents] = useUpcomingAndPastEvents(currentTime, {
     interestGroupId,
+    hidden: 'false',
   });
 
   if (interestGroup) {
@@ -85,7 +86,7 @@ const InterestGroupProfile: FC<InterestGroupProfileProps> = ({
           )}
           currentTime={currentTime}
           displayName={interestGroup.name}
-          eventConstraint={{ interestGroupId }}
+          eventConstraint={{ interestGroupId, hidden: 'false' }}
           isActive={interestGroup.active}
           paths={paths}
           type="interest group"

--- a/apps/crn-frontend/src/network/teams/TeamProfile.tsx
+++ b/apps/crn-frontend/src/network/teams/TeamProfile.tsx
@@ -88,6 +88,7 @@ const TeamProfile: FC<TeamProfileProps> = ({ currentTime }) => {
   ]);
   const [upcomingEvents, pastEvents] = useUpcomingAndPastEvents(currentTime, {
     teamId,
+    hidden: 'false',
   });
 
   const { pageSize } = usePaginationParams();
@@ -165,7 +166,7 @@ const TeamProfile: FC<TeamProfileProps> = ({ currentTime }) => {
               )}
               currentTime={currentTime}
               displayName={team.displayName}
-              eventConstraint={{ teamId }}
+              eventConstraint={{ teamId, hidden: 'false' }}
               isActive={!team?.inactiveSince}
               Outputs={
                 <Outputs

--- a/apps/crn-frontend/src/network/teams/__tests__/TeamProfile.test.tsx
+++ b/apps/crn-frontend/src/network/teams/__tests__/TeamProfile.test.tsx
@@ -430,6 +430,7 @@ it.each`
     searchQuery: '',
     constraint: {
       teamId: 't0',
+      hidden: 'false',
     },
   });
 });

--- a/apps/crn-frontend/src/network/users/UserProfile.tsx
+++ b/apps/crn-frontend/src/network/users/UserProfile.tsx
@@ -74,7 +74,7 @@ const UserProfile: FC<UserProfileProps> = ({ currentTime }) => {
     getEventListOptions(currentTime, {
       past: false,
       pageSize,
-      constraint: { userId },
+      constraint: { userId, hidden: 'false' },
     }),
     currentUser,
   );
@@ -83,7 +83,7 @@ const UserProfile: FC<UserProfileProps> = ({ currentTime }) => {
     getEventListOptions(currentTime, {
       past: true,
       pageSize,
-      constraint: { userId },
+      constraint: { userId, hidden: 'false' },
     }),
     currentUser,
   );
@@ -155,7 +155,7 @@ const UserProfile: FC<UserProfileProps> = ({ currentTime }) => {
                   <Route path={path + tabRoutes.upcoming.template}>
                     <Frame title="Upcoming Events">
                       <EventsList
-                        constraint={{ userId: user?.id }}
+                        constraint={{ userId: user?.id, hidden: 'false' }}
                         currentTime={currentTime}
                         past={false}
                         noEventsComponent={
@@ -171,7 +171,7 @@ const UserProfile: FC<UserProfileProps> = ({ currentTime }) => {
                     <Frame title="Past Events">
                       <EventsList
                         past
-                        constraint={{ userId: user?.id }}
+                        constraint={{ userId: user?.id, hidden: 'false' }}
                         currentTime={currentTime}
                         noEventsComponent={
                           <NoEvents

--- a/apps/crn-frontend/src/network/users/__tests__/UserProfile.test.tsx
+++ b/apps/crn-frontend/src/network/users/__tests__/UserProfile.test.tsx
@@ -464,6 +464,7 @@ it('navigates to the upcoming events tab', async () => {
     searchQuery: '',
     constraint: {
       userId: userResponse.id,
+      hidden: 'false',
     },
   });
 });
@@ -492,6 +493,7 @@ it('navigates to the past events tab', async () => {
     searchQuery: '',
     constraint: {
       userId: userResponse.id,
+      hidden: 'false',
     },
   });
 });

--- a/apps/crn-frontend/src/network/working-groups/WorkingGroupProfile.tsx
+++ b/apps/crn-frontend/src/network/working-groups/WorkingGroupProfile.tsx
@@ -88,7 +88,7 @@ const WorkingGroupProfile: FC<WorkingGroupProfileProps> = ({ currentTime }) => {
 
   const [upcomingEventsResult, pastEventsResult] = useUpcomingAndPastEvents(
     currentTime,
-    { workingGroupId },
+    { workingGroupId, hidden: 'false' },
   );
   const { pageSize } = usePaginationParams();
 
@@ -181,7 +181,7 @@ const WorkingGroupProfile: FC<WorkingGroupProfileProps> = ({ currentTime }) => {
               }
               currentTime={currentTime}
               displayName={workingGroup.title}
-              eventConstraint={{ workingGroupId }}
+              eventConstraint={{ workingGroupId, hidden: 'false' }}
               isActive={!workingGroup.complete}
               Outputs={
                 <Outputs

--- a/packages/algolia/schema/crn/algolia-reverse-timestamp-schema.json
+++ b/packages/algolia/schema/crn/algolia-reverse-timestamp-schema.json
@@ -15,7 +15,8 @@
     "status",
     "interestGroup.id",
     "workingGroup.id",
-    "workingGroups.id"
+    "workingGroups.id",
+    "hidden"
   ],
   "attributesToIndex": [
     "displayName",

--- a/packages/algolia/schema/crn/algolia-schema.json
+++ b/packages/algolia/schema/crn/algolia-schema.json
@@ -59,7 +59,8 @@
     "status",
     "interestGroup.id",
     "workingGroup.id",
-    "workingGroups.id"
+    "workingGroups.id",
+    "hidden"
   ],
   "attributesToSnippet": null,
   "attributesToHighlight": null,

--- a/packages/algolia/src/filters.ts
+++ b/packages/algolia/src/filters.ts
@@ -22,6 +22,7 @@ const getFilter = (filters: string[], constraint?: EventConstraint) => {
     constraint?.workingGroupId &&
       `workingGroup.id: "${constraint.workingGroupId}"`,
     constraint?.notStatus && `NOT status:${constraint.notStatus}`,
+    constraint?.hidden && `hidden:${constraint.hidden}`,
   ]
     .filter(Boolean)
     .join(' AND ');

--- a/packages/model/src/event.ts
+++ b/packages/model/src/event.ts
@@ -77,6 +77,7 @@ export type EventConstraint = {
   userId?: string;
   teamId?: string;
   notStatus?: string;
+  hidden: string;
 };
 
 export type EventCreateDataObject = Pick<


### PR DESCRIPTION
In order to show only not hidden events, the attribute `hidden` was added to algolia `attributesForFaceting` and `hidden: 'false'` was added to all event queries we do in FE as it was added as required in `EventConstraint`.