### PR TITLE
Don't index events with `hidden: true` into algolia

### DIFF
--- a/apps/crn-server/src/handlers/event/algolia-index-event-handler.ts
+++ b/apps/crn-server/src/handlers/event/algolia-index-event-handler.ts
@@ -1,7 +1,7 @@
 import { AlgoliaClient, algoliaSearchClientFactory } from '@asap-hub/algolia';
 import { EventController, EventEvent } from '@asap-hub/model';
 import { EventBridgeHandler } from '@asap-hub/server-common';
-import { isBoom } from '@hapi/boom';
+import { notFound, isBoom } from '@hapi/boom';
 import { EventBridgeEvent } from 'aws-lambda';
 import { algoliaApiKey, algoliaAppId, algoliaIndex } from '../../config';
 import Event from '../../controllers/event.controller';
@@ -22,7 +22,9 @@ export const indexEventHandler =
       const crnEvent = await eventController.fetchById(event.detail.resourceId);
 
       logger.debug(`Fetched event ${crnEvent.id}`);
-
+      if (crnEvent.hidden) {
+        throw notFound();
+      }
       await algoliaClient.save({
         data: crnEvent,
         type: 'event',

--- a/apps/crn-server/src/handlers/event/algolia-index-external-author-events-handler.ts
+++ b/apps/crn-server/src/handlers/event/algolia-index-external-author-events-handler.ts
@@ -47,10 +47,12 @@ export const indexExternalAuthorEventsHandler =
       );
 
       await algoliaClient.saveMany(
-        foundEvents.items.map((data) => ({
-          data,
-          type: 'event',
-        })),
+        foundEvents.items
+          .filter((e) => !e.hidden)
+          .map((data) => ({
+            data,
+            type: 'event',
+          })),
       );
 
       logger.info(`Updated ${foundEvents.items.length} events.`);

--- a/apps/crn-server/src/handlers/event/algolia-index-group-events-handler.ts
+++ b/apps/crn-server/src/handlers/event/algolia-index-group-events-handler.ts
@@ -47,10 +47,12 @@ export const indexGroupEventsHandler =
       );
 
       await algoliaClient.saveMany(
-        foundEvents.items.map((data) => ({
-          data,
-          type: 'event',
-        })),
+        foundEvents.items
+          .filter((e) => !e.hidden)
+          .map((data) => ({
+            data,
+            type: 'event',
+          })),
       );
 
       logger.info(`Updated ${foundEvents.items.length} events.`);

--- a/apps/crn-server/src/handlers/event/algolia-index-team-events-handler.ts
+++ b/apps/crn-server/src/handlers/event/algolia-index-team-events-handler.ts
@@ -47,10 +47,12 @@ export const indexTeamEventsHandler =
       );
 
       await algoliaClient.saveMany(
-        foundEvents.items.map((data) => ({
-          data,
-          type: 'event',
-        })),
+        foundEvents.items
+          .filter((e) => !e.hidden)
+          .map((data) => ({
+            data,
+            type: 'event',
+          })),
       );
 
       logger.info(`Updated ${foundEvents.items.length} events.`);

--- a/apps/crn-server/src/handlers/event/algolia-index-user-events-handler.ts
+++ b/apps/crn-server/src/handlers/event/algolia-index-user-events-handler.ts
@@ -45,10 +45,12 @@ export const indexUserEventsHandler =
       );
 
       await algoliaClient.saveMany(
-        foundEvents.items.map((data) => ({
-          data,
-          type: 'event',
-        })),
+        foundEvents.items
+          .filter((e) => !e.hidden)
+          .map((data) => ({
+            data,
+            type: 'event',
+          })),
       );
 
       logger.info(`Updated ${foundEvents.items.length} events.`);

--- a/apps/crn-server/test/handlers/event/algolia-index-event-handler.test.ts
+++ b/apps/crn-server/test/handlers/event/algolia-index-event-handler.test.ts
@@ -95,6 +95,18 @@ describe('Event index handler', () => {
     );
   });
 
+  test('Should fetch the event and remove the record in Algolia when event is hidden', async () => {
+    const event = updateEvent();
+    const eventResponse = { ...getEventResponse(), hidden: true };
+    eventControllerMock.fetchById.mockResolvedValueOnce(eventResponse);
+
+    await indexHandler(event);
+
+    expect(algoliaSearchClientMock.remove).toHaveBeenCalledWith(
+      event.detail.resourceId,
+    );
+  });
+
   test('Should throw an error and do not trigger algolia when the event request fails with another error code', async () => {
     eventControllerMock.fetchById.mockRejectedValue(Boom.badData());
 

--- a/apps/crn-server/test/handlers/event/algolia-index-group-events-handler.test.ts
+++ b/apps/crn-server/test/handlers/event/algolia-index-group-events-handler.test.ts
@@ -3,7 +3,10 @@ import Boom from '@hapi/boom';
 import { EventBridgeEvent } from 'aws-lambda';
 import { InterestGroupPayload } from '../../../src/handlers/event-bus';
 import { indexGroupEventsHandler } from '../../../src/handlers/event/algolia-index-group-events-handler';
-import { getListEventResponse } from '../../fixtures/events.fixtures';
+import {
+  getListEventResponse,
+  getEventDataObject,
+} from '../../fixtures/events.fixtures';
 import { getInterestGroupEvent } from '../../fixtures/interest-groups.fixtures';
 import { toPayload } from '../../helpers/algolia';
 import { getAlgoliaSearchClientMock } from '../../mocks/algolia-client.mock';
@@ -48,6 +51,38 @@ describe('Index Events on Group event handler', () => {
     await expect(
       indexHandler(getInterestGroupEvent('group-id', 'GroupsUpdated')),
     ).rejects.toThrow(algoliaError);
+  });
+
+  test('Should not index hidden events', async () => {
+    eventControllerMock.fetch.mockResolvedValueOnce({
+      total: 3,
+      items: [
+        {
+          ...getEventDataObject(),
+          id: 'event-1',
+          hidden: true,
+        },
+        {
+          ...getEventDataObject(),
+          id: 'event-2',
+          hidden: false,
+        },
+        {
+          ...getEventDataObject(),
+          id: 'event-3',
+          hidden: true,
+        },
+      ],
+    });
+
+    await indexHandler(getInterestGroupEvent('group-id', 'GroupsPublished'));
+
+    expect(algoliaSearchClientMock.saveMany).toHaveBeenCalledWith([
+      {
+        type: 'event',
+        data: { ...getEventDataObject(), id: 'event-2', hidden: false },
+      },
+    ]);
   });
 
   test.each(possibleEvents)(

--- a/apps/crn-server/test/handlers/event/algolia-index-user-events-handler.test.ts
+++ b/apps/crn-server/test/handlers/event/algolia-index-user-events-handler.test.ts
@@ -3,7 +3,10 @@ import { UserPayload } from '@asap-hub/server-common';
 import Boom from '@hapi/boom';
 import { EventBridgeEvent } from 'aws-lambda';
 import { indexUserEventsHandler } from '../../../src/handlers/event/algolia-index-user-events-handler';
-import { getListEventResponse } from '../../fixtures/events.fixtures';
+import {
+  getListEventResponse,
+  getEventDataObject,
+} from '../../fixtures/events.fixtures';
 import { getUserEvent } from '../../fixtures/users.fixtures';
 import { toPayload } from '../../helpers/algolia';
 import { getAlgoliaSearchClientMock } from '../../mocks/algolia-client.mock';
@@ -45,6 +48,38 @@ describe('Index Events on User event handler', () => {
     await expect(
       indexHandler(getUserEvent('user-id', 'UsersUpdated')),
     ).rejects.toThrow(algoliaError);
+  });
+
+  test('Should not index hidden events', async () => {
+    eventControllerMock.fetch.mockResolvedValueOnce({
+      total: 3,
+      items: [
+        {
+          ...getEventDataObject(),
+          id: 'event-1',
+          hidden: true,
+        },
+        {
+          ...getEventDataObject(),
+          id: 'event-2',
+          hidden: false,
+        },
+        {
+          ...getEventDataObject(),
+          id: 'event-3',
+          hidden: true,
+        },
+      ],
+    });
+
+    await indexHandler(getUserEvent('user-id', 'UsersCreated'));
+
+    expect(algoliaSearchClientMock.saveMany).toHaveBeenCalledWith([
+      {
+        type: 'event',
+        data: { ...getEventDataObject(), id: 'event-2', hidden: false },
+      },
+    ]);
   });
 
   test.each(possibleEvents)(


### PR DESCRIPTION
If an event is hidden then it needs to not be indexed into Algolia, so filter out events with `hidden: true` when indexing events based on related entities.

Also remove any events which have the `hidden` property set to `true` from the Algolia index.