### PR TITLE
Don't add draft research outputs to algolia

### DIFF
--- a/apps/crn-server/src/handlers/research-output/algolia-index-research-output-handler.ts
+++ b/apps/crn-server/src/handlers/research-output/algolia-index-research-output-handler.ts
@@ -24,6 +24,12 @@ export const indexResearchOutputHandler =
         const researchOutput = await researchOutputController.fetchById(id);
         logger.debug(`Fetched research-output ${researchOutput.id}`);
 
+        if (!researchOutput.published) {
+          await algoliaClient.remove(id);
+          logger.debug(`Removed research-output ${researchOutput.id}`);
+          return researchOutput;
+        }
+
         await algoliaClient.save({
           data: researchOutput,
           type: 'research-output',

--- a/apps/crn-server/test/handlers/research-output/algolia-index-research-output-handler.test.ts
+++ b/apps/crn-server/test/handlers/research-output/algolia-index-research-output-handler.test.ts
@@ -145,7 +145,7 @@ describe('Research Output index handler', () => {
     });
   });
 
-  test('Should fetch the research-output and remove the record in Algolia when research-output is unpublished', async () => {
+  test('Should fetch the research-output and remove the record in Algolia when research-output is deleted', async () => {
     const event = unpublishedEvent('ro-1234');
 
     researchOutputControllerMock.fetchById.mockRejectedValue(Boom.notFound());
@@ -157,6 +157,69 @@ describe('Research Output index handler', () => {
     expect(algoliaSearchClientMock.remove).toHaveBeenCalledWith(
       event.detail.resourceId,
     );
+  });
+
+  test('Should fetch the research-output and remove the record in Algolia when research-output is unpublished', async () => {
+    const event = unpublishedEvent('ro-1234');
+    const researchOutputResponse = getResearchOutputResponse();
+
+    researchOutputControllerMock.fetchById.mockResolvedValueOnce({
+      ...researchOutputResponse,
+      relatedResearch: [],
+      published: false,
+    });
+
+    await indexHandler(event);
+
+    expect(algoliaSearchClientMock.save).not.toHaveBeenCalled();
+    expect(algoliaSearchClientMock.remove).toHaveBeenCalledTimes(1);
+    expect(algoliaSearchClientMock.remove).toHaveBeenCalledWith(
+      event.detail.resourceId,
+    );
+  });
+
+  test('Should reindex the related research when research-output is unpublished', async () => {
+    const event = unpublishedEvent('ro-1234');
+    const researchOutputResponse = getResearchOutputResponse();
+    const relatedResearchOutputResponse = getResearchOutputResponse();
+    relatedResearchOutputResponse.id = 'ro-1235';
+    relatedResearchOutputResponse.title = 'Related research output';
+
+    researchOutputControllerMock.fetchById.mockResolvedValueOnce({
+      ...researchOutputResponse,
+      relatedResearch: [
+        {
+          id: relatedResearchOutputResponse.id,
+          title: relatedResearchOutputResponse.title,
+          type: 'Published',
+          isOwnRelatedResearchLink: true,
+          teams: [
+            {
+              id: 'team-1234',
+              displayName: 'Team 1',
+            },
+          ],
+          workingGroups: [],
+          documentType: 'Grant Document',
+        },
+      ],
+      published: false,
+    });
+    researchOutputControllerMock.fetchById.mockResolvedValueOnce(
+      relatedResearchOutputResponse,
+    );
+
+    await indexHandler(event);
+
+    expect(algoliaSearchClientMock.remove).toHaveBeenCalledTimes(1);
+    expect(algoliaSearchClientMock.remove).toHaveBeenCalledWith(
+      event.detail.resourceId,
+    );
+    expect(algoliaSearchClientMock.save).toHaveBeenCalledTimes(1);
+    expect(algoliaSearchClientMock.save).toHaveBeenCalledWith({
+      data: expect.objectContaining({ id: 'ro-1235' }),
+      type: 'research-output',
+    });
   });
 
   test('Should fetch the research-output and remove the record in Algolia when research-output is deleted', async () => {


### PR DESCRIPTION
The code previously assumed that if a research output was unpublished then fetching the output would result in a "Not Found" error, but since the concept of draft outputs was introduced this is no longer the case, and the unpublish case needs to be handled separately from the deleted/not found case.

If a research output is not published then remove it from the algolia index.