### PR TITLE
fix: add last updated to event when it already exists

### DIFF
--- a/packages/cms-data-sync/src/events/events.data-migration.ts
+++ b/packages/cms-data-sync/src/events/events.data-migration.ts
@@ -250,6 +250,7 @@ export const migrateEvents = async () => {
         meetingMaterials,
         meetingMaterialsPermanentlyUnavailable,
         ...materialsSpeakersThumbAndMeetingLink,
+        lastUpdated: lastModified,
       };
     }
 

--- a/packages/cms-data-sync/test/events/events.data-migration.test.ts
+++ b/packages/cms-data-sync/test/events/events.data-migration.test.ts
@@ -147,6 +147,7 @@ const baseUpdatePayload = {
   videoRecording: { 'en-US': null },
   videoRecordingPermanentlyUnavailable: { 'en-US': null },
   videoRecordingUpdatedAt: { 'en-US': null },
+  lastUpdated: { 'en-US': '2023-08-01T17:00:00Z' },
 };
 
 const baseCreatePayload = {
@@ -169,7 +170,6 @@ const baseCreatePayload = {
   startDateTimeZone: { 'en-US': 'America/Sao_Paulo' },
   status: { 'en-US': 'Confirmed' },
   title: { 'en-US': 'Amazing event!!!' },
-  lastUpdated: { 'en-US': '2023-08-01T17:00:00Z' },
 };
 
 describe('Migrate events', () => {


### PR DESCRIPTION
I forgot to add `lastUpdated` to the migration when it is updating an existing event, now it only fills `lastUpdated` if it is creating an event. So this PR fixes it.