### PR TITLE
Generalise nested list fix to ordered lists as well

### DIFF
--- a/packages/cms-data-sync/src/utils/rich-text.ts
+++ b/packages/cms-data-sync/src/utils/rich-text.ts
@@ -88,7 +88,7 @@ export const removeSinglePTag = (html: string): string => {
 const wrapNestedLists = (html: string): string => {
   const $ = cheerio.load(html);
 
-  $('ul > ul').each((_, element) => {
+  $('ul > ul, ol > ol, ol > ul, ul > ol').each((_, element) => {
     const previous = $(element).prev();
     if (previous && previous.length && previous[0].name === 'li') {
       $(element).appendTo(previous);

--- a/packages/cms-data-sync/test/utils/rich-text.test.ts
+++ b/packages/cms-data-sync/test/utils/rich-text.test.ts
@@ -456,7 +456,7 @@ describe('convertHtmlToContentfulFormat', () => {
     ]);
   });
 
-  it('handles nested lists with sibling list items', () => {
+  it('handles nested unordered lists with sibling list items', () => {
     const html = `<div>
       <ul>
         <li>List item 1</li>
@@ -536,7 +536,87 @@ describe('convertHtmlToContentfulFormat', () => {
     ]);
   });
 
-  it('handles nested lists without sibling list items', () => {
+  it('handles nested ordered lists with sibling list items', () => {
+    const html = `<div>
+      <ol>
+        <li>List item 1</li>
+        <li>List item 2</li>
+        <ol>
+          <li>Sublist item</li>
+        </ol>
+      </ol>
+    </div>`;
+    expect(convertHtmlToContentfulFormat(html).document.content).toEqual([
+      {
+        content: [
+          {
+            content: [
+              {
+                content: [
+                  {
+                    data: {},
+                    marks: [],
+                    nodeType: 'text',
+                    value: 'List item 1',
+                  },
+                ],
+                data: {},
+                nodeType: 'paragraph',
+              },
+            ],
+            data: {},
+            nodeType: 'list-item',
+          },
+          {
+            content: [
+              {
+                content: [
+                  {
+                    data: {},
+                    marks: [],
+                    nodeType: 'text',
+                    value: 'List item 2',
+                  },
+                ],
+                data: {},
+                nodeType: 'paragraph',
+              },
+              {
+                content: [
+                  {
+                    content: [
+                      {
+                        content: [
+                          {
+                            data: {},
+                            marks: [],
+                            nodeType: 'text',
+                            value: 'Sublist item',
+                          },
+                        ],
+                        data: {},
+                        nodeType: 'paragraph',
+                      },
+                    ],
+                    data: {},
+                    nodeType: 'list-item',
+                  },
+                ],
+                data: {},
+                nodeType: 'ordered-list',
+              },
+            ],
+            data: {},
+            nodeType: 'list-item',
+          },
+        ],
+        data: {},
+        nodeType: 'ordered-list',
+      },
+    ]);
+  });
+
+  it('handles nested unordered lists without sibling list items', () => {
     const html = `<div>
       <ul>
         <ul>
@@ -580,6 +660,53 @@ describe('convertHtmlToContentfulFormat', () => {
         ],
         data: {},
         nodeType: 'unordered-list',
+      },
+    ]);
+  });
+  it('handles nested ordered lists without sibling list items', () => {
+    const html = `<div>
+      <ol>
+        <ol>
+          <li>Sublist item</li>
+        </ol>
+      </ol>
+    </div>`;
+    expect(convertHtmlToContentfulFormat(html).document.content).toEqual([
+      {
+        content: [
+          {
+            content: [
+              {
+                content: [
+                  {
+                    content: [
+                      {
+                        content: [
+                          {
+                            data: {},
+                            marks: [],
+                            nodeType: 'text',
+                            value: 'Sublist item',
+                          },
+                        ],
+                        data: {},
+                        nodeType: 'paragraph',
+                      },
+                    ],
+                    data: {},
+                    nodeType: 'list-item',
+                  },
+                ],
+                data: {},
+                nodeType: 'ordered-list',
+              },
+            ],
+            data: {},
+            nodeType: 'list-item',
+          },
+        ],
+        data: {},
+        nodeType: 'ordered-list',
       },
     ]);
   });


### PR DESCRIPTION
The previous fix only applied to unordered lists nested inside one another. Include ordered lists as well.