### PR TITLE
Copy settings when running partial algolia sync

### DIFF
--- a/.github/workflows/reusable-crn-algolia-sync.yml
+++ b/.github/workflows/reusable-crn-algolia-sync.yml
@@ -83,7 +83,7 @@ jobs:
           ALGOLIA_INDEX: ${{ steps.setup.outputs.crn-algolia-index }}
           ALGOLIA_INDEX_TEMP: '${{ steps.setup.outputs.crn-algolia-index }}_temp'
           # Do not copy the records if all entities are being synced
-          SCOPE: ${{ inputs.entity == 'all' && '-s settings,synonyms' || '-s synonyms' }}
+          SCOPE: ${{ inputs.entity == 'all' && '-s settings,synonyms' || '' }}
       - name: Remove the entity data (ENTITY)
         if: ${{ inputs.entity != 'all'}}
         run: yarn algolia:remove-records -a $ALGOLIA_APP_ID -k $ALGOLIA_API_KEY -n $ALGOLIA_INDEX_TEMP -e $ENTITY_TYPE
@@ -167,7 +167,7 @@ jobs:
           ALGOLIA_INDEX: ${{ steps.setup.outputs.crn-algolia-index }}
           ALGOLIA_INDEX_TEMP: '${{ steps.setup.outputs.crn-algolia-index }}_temp'
           # Do not copy the records if all entities are being synced
-          SCOPE: ${{ inputs.entity == 'all' && '-s settings,synonyms' || '-s synonyms' }}
+          SCOPE: ${{ inputs.entity == 'all' && '-s settings,synonyms' || '' }}
       - name: Remove the entity data (ENTITY)
         if: ${{ inputs.entity != 'all'}}
         run: yarn algolia:remove-records -a $ALGOLIA_APP_ID -k $ALGOLIA_API_KEY -n $ALGOLIA_INDEX_TEMP -e $ENTITY_TYPE


### PR DESCRIPTION
Removing the settings from the scope of the partial algolia sync was causing the settings on the index to be completely removed when the temporary index was restored (because the temporary index was created with empty settings).

When creating the temporary index for partial indexing runs, do not limit the scope to only synonyms, and allow all data to be copied, and the settings therefore to be preserved when restoring back to the main index.