### PR TITLE
Scope temporary algolia index to github run id

### DIFF
--- a/.github/workflows/reusable-crn-algolia-sync.yml
+++ b/.github/workflows/reusable-crn-algolia-sync.yml
@@ -81,7 +81,7 @@ jobs:
           ALGOLIA_APPLICATION_ID: ${{ steps.algolia-keys.outputs.algolia-app-id }}
           ALGOLIA_ADMIN_API_KEY: ${{ steps.algolia-keys.outputs.algolia-api-key }}
           ALGOLIA_INDEX: ${{ steps.setup.outputs.crn-algolia-index }}
-          ALGOLIA_INDEX_TEMP: '${{ steps.setup.outputs.crn-algolia-index }}_temp'
+          ALGOLIA_INDEX_TEMP: '${{ steps.setup.outputs.crn-algolia-index }}_${{ github.run_id }}_temp'
           # Do not copy the records if all entities are being synced
           SCOPE: ${{ inputs.entity == 'all' && '-s settings,synonyms' || '' }}
       - name: Remove the entity data (ENTITY)
@@ -90,7 +90,7 @@ jobs:
         env:
           ALGOLIA_API_KEY: ${{ steps.algolia-keys.outputs.algolia-api-key }}
           ALGOLIA_APP_ID: ${{ steps.algolia-keys.outputs.algolia-app-id }}
-          ALGOLIA_INDEX_TEMP: '${{ steps.setup.outputs.crn-algolia-index }}_temp'
+          ALGOLIA_INDEX_TEMP: '${{ steps.setup.outputs.crn-algolia-index }}_${{ github.run_id }}_temp'
           ENTITY_TYPE: ${{ (inputs.entity == 'users' && 'user') || (inputs.entity == 'research-outputs' && 'research-output') || (inputs.entity == 'external-authors' && 'external-author') || (inputs.entity == 'events' && 'event') }}
       - name: Import Research Outputs (ROs | ALL)
         if: ${{ inputs.entity == 'research-outputs' || inputs.entity == 'all'}}
@@ -98,7 +98,7 @@ jobs:
         with:
           algolia-api-key: ${{ steps.algolia-keys.outputs.algolia-api-key }}
           algolia-app-id: ${{ steps.algolia-keys.outputs.algolia-app-id }}
-          algolia-index: '${{ steps.setup.outputs.crn-algolia-index }}_temp'
+          algolia-index: '${{ steps.setup.outputs.crn-algolia-index }}_${{github.run_id}}_temp'
           app: 'crn'
           entity-type: 'research-output'
           squidex-app-name: ${{ steps.setup.outputs.crn-squidex-app-name }}
@@ -111,7 +111,7 @@ jobs:
         with:
           algolia-api-key: ${{ steps.algolia-keys.outputs.algolia-api-key }}
           algolia-app-id: ${{ steps.algolia-keys.outputs.algolia-app-id }}
-          algolia-index: '${{ steps.setup.outputs.crn-algolia-index }}_temp'
+          algolia-index: '${{ steps.setup.outputs.crn-algolia-index }}_${{github.run_id}}_temp'
           app: 'crn'
           entity-type: 'user'
           squidex-app-name: ${{ steps.setup.outputs.crn-squidex-app-name }}
@@ -124,7 +124,7 @@ jobs:
         with:
           algolia-api-key: ${{ steps.algolia-keys.outputs.algolia-api-key }}
           algolia-app-id: ${{ steps.algolia-keys.outputs.algolia-app-id }}
-          algolia-index: '${{ steps.setup.outputs.crn-algolia-index }}_temp'
+          algolia-index: '${{ steps.setup.outputs.crn-algolia-index }}_${{github.run_id}}_temp'
           app: 'crn'
           entity-type: 'external-author'
           contentful-env: ${{ inputs.contentful-environment-id }}
@@ -141,7 +141,7 @@ jobs:
         with:
           algolia-api-key: ${{ steps.algolia-keys.outputs.algolia-api-key }}
           algolia-app-id: ${{ steps.algolia-keys.outputs.algolia-app-id }}
-          algolia-index: '${{ steps.setup.outputs.crn-algolia-index }}_temp'
+          algolia-index: '${{ steps.setup.outputs.crn-algolia-index }}_${{github.run_id}}_temp'
           app: 'crn'
           entity-type: 'event'
           squidex-app-name: ${{ steps.setup.outputs.crn-squidex-app-name }}
@@ -157,7 +157,7 @@ jobs:
           ALGOLIA_API_KEY: ${{ steps.algolia-keys.outputs.algolia-api-key }}
           ALGOLIA_APP_ID: ${{ steps.algolia-keys.outputs.algolia-app-id }}
           ALGOLIA_INDEX: ${{ steps.setup.outputs.crn-algolia-index }}
-          ALGOLIA_INDEX_TEMP: '${{ steps.setup.outputs.crn-algolia-index }}_temp'
+          ALGOLIA_INDEX_TEMP: '${{ steps.setup.outputs.crn-algolia-index }}_${{ github.run_id }}_temp'
       # TODO: CRN-1329: Remove this step once the migration is complete
       - name: Copy index to a temporary index (ALL)
         run: algolia indices copy -y -w $SCOPE $ALGOLIA_INDEX-contentful $ALGOLIA_INDEX_TEMP
@@ -165,7 +165,7 @@ jobs:
           ALGOLIA_APPLICATION_ID: ${{ steps.algolia-keys.outputs.algolia-app-id }}
           ALGOLIA_ADMIN_API_KEY: ${{ steps.algolia-keys.outputs.algolia-api-key }}
           ALGOLIA_INDEX: ${{ steps.setup.outputs.crn-algolia-index }}
-          ALGOLIA_INDEX_TEMP: '${{ steps.setup.outputs.crn-algolia-index }}_temp'
+          ALGOLIA_INDEX_TEMP: '${{ steps.setup.outputs.crn-algolia-index }}_${{ github.run_id }}_temp'
           # Do not copy the records if all entities are being synced
           SCOPE: ${{ inputs.entity == 'all' && '-s settings,synonyms' || '' }}
       - name: Remove the entity data (ENTITY)
@@ -174,7 +174,7 @@ jobs:
         env:
           ALGOLIA_API_KEY: ${{ steps.algolia-keys.outputs.algolia-api-key }}
           ALGOLIA_APP_ID: ${{ steps.algolia-keys.outputs.algolia-app-id }}
-          ALGOLIA_INDEX_TEMP: '${{ steps.setup.outputs.crn-algolia-index }}_temp'
+          ALGOLIA_INDEX_TEMP: '${{ steps.setup.outputs.crn-algolia-index }}_${{ github.run_id }}_temp'
           ENTITY_TYPE: ${{ (inputs.entity == 'users' && 'user') || (inputs.entity == 'research-outputs' && 'research-output') || (inputs.entity == 'external-authors' && 'external-author') || (inputs.entity == 'events' && 'event') }}
       - name: Import Research Outputs (ROs | ALL)
         if: ${{ inputs.entity == 'research-outputs' || inputs.entity == 'all'}}
@@ -182,7 +182,7 @@ jobs:
         with:
           algolia-api-key: ${{ steps.algolia-keys.outputs.algolia-api-key }}
           algolia-app-id: ${{ steps.algolia-keys.outputs.algolia-app-id }}
-          algolia-index: '${{ steps.setup.outputs.crn-algolia-index }}_temp'
+          algolia-index: '${{ steps.setup.outputs.crn-algolia-index }}_${{github.run_id}}_temp'
           app: 'crn'
           entity-type: 'research-output'
           squidex-app-name: ${{ steps.setup.outputs.crn-squidex-app-name }}
@@ -200,7 +200,7 @@ jobs:
         with:
           algolia-api-key: ${{ steps.algolia-keys.outputs.algolia-api-key }}
           algolia-app-id: ${{ steps.algolia-keys.outputs.algolia-app-id }}
-          algolia-index: '${{ steps.setup.outputs.crn-algolia-index }}_temp'
+          algolia-index: '${{ steps.setup.outputs.crn-algolia-index }}_${{github.run_id}}_temp'
           app: 'crn'
           entity-type: 'user'
           squidex-app-name: ${{ steps.setup.outputs.crn-squidex-app-name }}
@@ -218,7 +218,7 @@ jobs:
         with:
           algolia-api-key: ${{ steps.algolia-keys.outputs.algolia-api-key }}
           algolia-app-id: ${{ steps.algolia-keys.outputs.algolia-app-id }}
-          algolia-index: '${{ steps.setup.outputs.crn-algolia-index }}_temp'
+          algolia-index: '${{ steps.setup.outputs.crn-algolia-index }}_${{github.run_id}}_temp'
           app: 'crn'
           entity-type: 'external-author'
           squidex-app-name: ${{ steps.setup.outputs.crn-squidex-app-name }}
@@ -236,7 +236,7 @@ jobs:
         with:
           algolia-api-key: ${{ steps.algolia-keys.outputs.algolia-api-key }}
           algolia-app-id: ${{ steps.algolia-keys.outputs.algolia-app-id }}
-          algolia-index: '${{ steps.setup.outputs.crn-algolia-index }}_temp'
+          algolia-index: '${{ steps.setup.outputs.crn-algolia-index }}_${{github.run_id}}_temp'
           app: 'crn'
           entity-type: 'event'
           squidex-app-name: ${{ steps.setup.outputs.crn-squidex-app-name }}
@@ -254,4 +254,4 @@ jobs:
           ALGOLIA_API_KEY: ${{ steps.algolia-keys.outputs.algolia-api-key }}
           ALGOLIA_APP_ID: ${{ steps.algolia-keys.outputs.algolia-app-id }}
           ALGOLIA_INDEX: ${{ steps.setup.outputs.crn-algolia-index }}
-          ALGOLIA_INDEX_TEMP: '${{ steps.setup.outputs.crn-algolia-index }}_temp'
+          ALGOLIA_INDEX_TEMP: '${{ steps.setup.outputs.crn-algolia-index }}_${{ github.run_id }}_temp'

--- a/.github/workflows/reusable-gp2-algolia-sync.yml
+++ b/.github/workflows/reusable-gp2-algolia-sync.yml
@@ -78,7 +78,7 @@ jobs:
           ALGOLIA_APPLICATION_ID: ${{ steps.algolia-keys.outputs.algolia-app-id }}
           ALGOLIA_ADMIN_API_KEY: ${{ steps.algolia-keys.outputs.algolia-api-key }}
           ALGOLIA_INDEX: ${{ steps.setup.outputs.gp2-algolia-index }}
-          ALGOLIA_INDEX_TEMP: '${{ steps.setup.outputs.gp2-algolia-index }}_temp'
+          ALGOLIA_INDEX_TEMP: '${{ steps.setup.outputs.gp2-algolia-index }}_${{github.run_id}}_temp'
           # Do not copy the records if all entities are being synced
           SCOPE: ${{ inputs.entity == 'all' && '-s settings,synonyms' || '' }}
       - name: Remove the entity data (ENTITY)
@@ -87,7 +87,7 @@ jobs:
         env:
           ALGOLIA_API_KEY: ${{ steps.algolia-keys.outputs.algolia-api-key }}
           ALGOLIA_APP_ID: ${{ steps.algolia-keys.outputs.algolia-app-id }}
-          ALGOLIA_INDEX_TEMP: '${{ steps.setup.outputs.gp2-algolia-index }}_temp'
+          ALGOLIA_INDEX_TEMP: '${{ steps.setup.outputs.gp2-algolia-index }}_${{github.run_id}}_temp'
           ENTITY_TYPE: ${{ (inputs.entity == 'outputs' && 'output') || (inputs.entity == 'projects' && 'project') || (inputs.entity == 'events' && 'event') || (inputs.entity == 'users' && 'user') || (inputs.entity == 'news' && 'news') }}
       - name: Import Outputs (OUTPUTS | ALL)
         if: ${{ inputs.entity == 'outputs' || inputs.entity == 'all'}}
@@ -95,7 +95,7 @@ jobs:
         with:
           algolia-api-key: ${{ steps.algolia-keys.outputs.algolia-api-key }}
           algolia-app-id: ${{ steps.algolia-keys.outputs.algolia-app-id }}
-          algolia-index: '${{ steps.setup.outputs.gp2-algolia-index }}_temp'
+          algolia-index: '${{ steps.setup.outputs.gp2-algolia-index }}_${{github.run_id}}_temp'
           app: 'gp2'
           entity-type: 'output'
           contentful-env: ${{ inputs.contentful-environment-id }}
@@ -113,7 +113,7 @@ jobs:
         with:
           algolia-api-key: ${{ steps.algolia-keys.outputs.algolia-api-key }}
           algolia-app-id: ${{ steps.algolia-keys.outputs.algolia-app-id }}
-          algolia-index: '${{ steps.setup.outputs.gp2-algolia-index }}_temp'
+          algolia-index: '${{ steps.setup.outputs.gp2-algolia-index }}_${{github.run_id}}_temp'
           app: 'gp2'
           entity-type: 'project'
           contentful-env: ${{ inputs.contentful-environment-id }}
@@ -131,7 +131,7 @@ jobs:
         with:
           algolia-api-key: ${{ steps.algolia-keys.outputs.algolia-api-key }}
           algolia-app-id: ${{ steps.algolia-keys.outputs.algolia-app-id }}
-          algolia-index: '${{ steps.setup.outputs.gp2-algolia-index }}_temp'
+          algolia-index: '${{ steps.setup.outputs.gp2-algolia-index }}_${{github.run_id}}_temp'
           app: 'gp2'
           entity-type: 'event'
           contentful-env: ${{ inputs.contentful-environment-id }}
@@ -149,7 +149,7 @@ jobs:
         with:
           algolia-api-key: ${{ steps.algolia-keys.outputs.algolia-api-key }}
           algolia-app-id: ${{ steps.algolia-keys.outputs.algolia-app-id }}
-          algolia-index: '${{ steps.setup.outputs.gp2-algolia-index }}_temp'
+          algolia-index: '${{ steps.setup.outputs.gp2-algolia-index }}_${{github.run_id}}_temp'
           app: 'gp2'
           entity-type: 'user'
           contentful-env: ${{ inputs.contentful-environment-id }}
@@ -185,4 +185,4 @@ jobs:
           ALGOLIA_API_KEY: ${{ steps.algolia-keys.outputs.algolia-api-key }}
           ALGOLIA_APP_ID: ${{ steps.algolia-keys.outputs.algolia-app-id }}
           ALGOLIA_INDEX: ${{ steps.setup.outputs.gp2-algolia-index }}
-          ALGOLIA_INDEX_TEMP: '${{ steps.setup.outputs.gp2-algolia-index }}_temp'
+          ALGOLIA_INDEX_TEMP: '${{ steps.setup.outputs.gp2-algolia-index }}_${{github.run_id}}_temp'


### PR DESCRIPTION
This should hopefully prevent simultaneous index runs from interfering with one another.