### PR TITLE
Delete events in series in integration test setup

### DIFF
--- a/apps/crn-server/test/integration/fixtures/contentful.ts
+++ b/apps/crn-server/test/integration/fixtures/contentful.ts
@@ -389,12 +389,12 @@ export class ContentfulFixture implements Fixture {
       content_type: 'events',
     });
 
-    events.forEach(async (entry) => {
+    for (const entry of events) {
       if (entry.isPublished()) {
         await entry.unpublish();
       }
       await entry.delete();
-    });
+    }
   }
 }
 


### PR DESCRIPTION
Doing these in parallel results in 429 errors when running against an environment with a large volume of events. Do thm in series so that it doesn't fail with a 429.