### PR TITLE
fix(migration): convert eventLink to null when it is an empty string

### DIFF
--- a/packages/cms-data-sync/src/events/events.data-migration.ts
+++ b/packages/cms-data-sync/src/events/events.data-migration.ts
@@ -208,6 +208,7 @@ export const migrateEvents = async () => {
       meetingMaterials,
       meetingMaterialsPermanentlyUnavailable,
       calendar,
+      eventLink,
     } = squidexFlatData;
 
     const materialsSpeakersThumbAndMeetingLink = {
@@ -224,9 +225,12 @@ export const migrateEvents = async () => {
         contentfulEnvironment,
         presentation,
       ),
-      // it throws an error if meetingLink is ''
-      // because it's not a valid url
-      meetingLink: meetingLink?.trim() === '' ? null : meetingLink?.trim(),
+      // it throws an error if meetingLink or eventLink
+      // is '' because it's not a valid url
+      meetingLink:
+        meetingLink?.trim() === '' || !meetingLink ? null : meetingLink?.trim(),
+      eventLink:
+        eventLink?.trim() === '' || !eventLink ? null : eventLink?.trim(),
     };
 
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion


### PR DESCRIPTION
This event with id `c7e6413e-ece9-4d08-92a5-a04f95b6bfb1` could not be published during the migration

![Screenshot 2023-09-01 at 11 03 51](https://github.com/yldio/asap-hub/assets/16595804/5efeb253-181a-419a-94a7-a7f443b5e385)

because the `eventLink` is an empty string and it gives a validation error on Contentful's side

![Screenshot 2023-09-01 at 11 04 05](https://github.com/yldio/asap-hub/assets/16595804/abe26a04-0b5d-40aa-bb90-f5334fda1c4f)

so this PR transforms `eventLink` that are empty strings to `null`.

