### PR TITLE
Ensure uniqueness of channel ids when subscribing to google calendars

### DIFF
--- a/apps/crn-server/src/data-providers/contentful/calendar.data-provider.ts
+++ b/apps/crn-server/src/data-providers/contentful/calendar.data-provider.ts
@@ -155,7 +155,8 @@ export class CalendarContentfulDataProvider implements CalendarDataProvider {
     const calendar = await environment.getEntry(id);
     const previousGoogleApiMetadata = calendar.fields.googleApiMetadata;
 
-    const { resourceId, expirationDate, syncToken, ...otherFields } = update;
+    const { resourceId, channelId, expirationDate, syncToken, ...otherFields } =
+      update;
 
     updateEntryFields(calendar, otherFields);
 
@@ -175,6 +176,7 @@ export class CalendarContentfulDataProvider implements CalendarDataProvider {
                   calendar.fields.googleCalendarId['en-US'],
               }
             : {}),
+          ...(channelId ? { channelId } : {}),
           ...(syncToken ? { syncToken } : {}),
           ...(expirationDate ? { expirationDate } : {}),
         },
@@ -209,6 +211,7 @@ export const parseGraphQlCalendarToDataObject = (
     id: item.sys.id,
     version: item.sys.publishedVersion ?? 1,
     resourceId: item.googleApiMetadata?.resourceId ?? undefined,
+    channelId: item.googleApiMetadata?.channelId ?? undefined,
     expirationDate: item.googleApiMetadata?.expirationDate ?? undefined,
     syncToken: item.googleApiMetadata?.syncToken ?? undefined,
     workingGroups,

--- a/apps/gp2-server/src/data-providers/calendar.data-provider.ts
+++ b/apps/gp2-server/src/data-providers/calendar.data-provider.ts
@@ -113,7 +113,8 @@ export class CalendarContentfulDataProvider
     const calendar = await environment.getEntry(id);
     const previousGoogleApiMetadata = calendar.fields.googleApiMetadata;
 
-    const { resourceId, expirationDate, syncToken, ...otherFields } = update;
+    const { resourceId, channelId, expirationDate, syncToken, ...otherFields } =
+      update;
 
     const calendarWithUpdatedFields = updateEntryFields(calendar, otherFields);
 
@@ -133,6 +134,7 @@ export class CalendarContentfulDataProvider
                   calendar.fields.googleCalendarId['en-US'],
               }
             : {}),
+          ...(channelId ? { channelId } : {}),
           ...(syncToken ? { syncToken } : {}),
           ...(expirationDate ? { expirationDate } : {}),
         },
@@ -150,6 +152,7 @@ export const parseGraphQlCalendarToDataObject = (
   id: item.sys.id,
   version: item.sys.publishedVersion ?? 1,
   resourceId: item.googleApiMetadata?.resourceId,
+  channelId: item.googleApiMetadata?.channelId,
   expirationDate: item.googleApiMetadata?.expirationDate,
   syncToken: item.googleApiMetadata?.syncToken,
   ...parseContentfulGraphqlCalendarPartialToDataObject(item),

--- a/packages/model/src/calendar-common.ts
+++ b/packages/model/src/calendar-common.ts
@@ -58,6 +58,7 @@ export interface BasicCalendar {
   name: string;
   syncToken?: string | null;
   resourceId?: string | null;
+  channelId?: string | null;
   expirationDate?: number | null;
   version: number;
 }
@@ -73,5 +74,6 @@ export type CalendarUpdateDataObject = Partial<CalendarCreateDataObject>;
 
 export interface CalendarUpdateRequest {
   resourceId?: string | null;
+  channelId?: string | null;
   expirationDate?: number | null;
 }

--- a/packages/server-common/src/handlers/calendar/calendar-handler-factory.contentful.ts
+++ b/packages/server-common/src/handlers/calendar/calendar-handler-factory.contentful.ts
@@ -27,6 +27,7 @@ type CalendarSkeleton = {
     googleApiMetadata: EntryFieldTypes.Object<{
       associatedGoogleCalendarId?: string | null;
       resourceId?: string | null;
+      channelId?: string | null;
     }>;
   };
 };
@@ -94,11 +95,13 @@ export const calendarCreatedContentfulHandlerFactory =
       try {
         await unsubscribe(
           googleApiMetadata.resourceId as string,
-          getCalendarSubscriptionId(calendarId),
+          (googleApiMetadata.channelId ||
+            getCalendarSubscriptionId(calendarId)) as string,
         );
 
         await calendarDataProvider.update(calendarId, {
           resourceId: null,
+          channelId: null,
         });
       } catch (error) {
         logger.error(error, 'Error during unsubscribing from the calendar');
@@ -119,13 +122,17 @@ export const calendarCreatedContentfulHandlerFactory =
       !googleApiMetadata?.resourceId
     ) {
       try {
+        const channelId = `${getCalendarSubscriptionId(
+          calendarId,
+        )}_${Date.now()}`;
         const { resourceId, expiration } = await subscribe(
           webhookEventGoogleCalendarId,
-          getCalendarSubscriptionId(calendarId),
+          channelId,
         );
 
         await calendarDataProvider.update(calendarId, {
           resourceId,
+          channelId,
           expirationDate: expiration,
         });
       } catch (error) {

--- a/packages/server-common/src/handlers/calendar/resubscribe-handler.ts
+++ b/packages/server-common/src/handlers/calendar/resubscribe-handler.ts
@@ -33,7 +33,10 @@ export const resubscribeCalendarsHandlerFactory =
       calendars.map(async (calendar) => {
         if (calendar.resourceId) {
           try {
-            await unsubscribe(calendar.resourceId, getCalendarId(calendar.id));
+            await unsubscribe(
+              calendar.resourceId,
+              calendar.channelId || getCalendarId(calendar.id),
+            );
             await calendarDataProvider.update(calendar.id, {
               resourceId: null,
             });
@@ -43,13 +46,15 @@ export const resubscribeCalendarsHandlerFactory =
         }
 
         try {
+          const channelId = `${getCalendarId(calendar.id)}_${Date.now()}`;
           const { expiration, resourceId } = await subscribe(
             calendar.googleCalendarId,
-            getCalendarId(calendar.id),
+            channelId,
           );
 
           await calendarDataProvider.update(calendar.id, {
             resourceId,
+            channelId,
             expirationDate: expiration,
           });
           logger.info(`Successfully resubscribed the calendar '${calendar.id}`);

--- a/packages/server-common/src/handlers/webhooks/events-updated.handler.ts
+++ b/packages/server-common/src/handlers/webhooks/events-updated.handler.ts
@@ -10,20 +10,20 @@ export const webhookEventUpdatedHandlerFactory = (
   { googleApiToken }: { googleApiToken: string },
 ): lambda.Handler => {
   const getCalendar = async (resourceId: string) => {
+    let calendars;
     try {
-      const calendars = await calendarDataProvider.fetch({
+      calendars = await calendarDataProvider.fetch({
         resourceId,
       });
-
-      if (!calendars.items[0]) {
-        throw new Error('Failed to fetch calendar by resource ID.');
-      }
-      const [calendar] = calendars.items;
-      return calendar;
     } catch (error) {
       logger.error(error, 'Error fetching calendar');
       throw Boom.badGateway();
     }
+    if (!calendars.items[0]) {
+      throw Boom.notFound();
+    }
+    const [calendar] = calendars.items;
+    return calendar;
   };
   return lambda.http(async (request) => {
     logger.debug(JSON.stringify(request, null, 2), 'Request');

--- a/packages/server-common/test/handlers/calendar/calendar-handler-factory.contentful.test.ts
+++ b/packages/server-common/test/handlers/calendar/calendar-handler-factory.contentful.test.ts
@@ -7,6 +7,7 @@ import { calendarCreatedContentfulHandlerFactory } from '../../../src/handlers/c
 import { Alerts } from '../../../src/utils/alerts';
 import { calendarDataProviderMock } from '../../mocks/calendar-data-provider.mock';
 import { loggerMock as logger } from '../../mocks/logger.mock';
+import { expectChannelId } from './utils';
 import {
   getCalendarContentfulEvent,
   getCalendarFromDeliveryApi,
@@ -180,8 +181,12 @@ describe('Calendar handler', () => {
 
     expect(res).toBe('OK');
     expect(unsubscribe).not.toHaveBeenCalled();
-    expect(subscribe).toHaveBeenCalledWith('calendar-1', 'calendar-1');
+    expect(subscribe).toHaveBeenCalledWith(
+      'calendar-1',
+      expectChannelId('calendar-1'),
+    );
     expect(calendarDataProviderMock.update).toHaveBeenCalledWith('calendar-1', {
+      channelId: expectChannelId('calendar-1'),
       expirationDate: expiration,
       resourceId,
     });
@@ -237,15 +242,22 @@ describe('Calendar handler', () => {
     expect(calendarDataProviderMock.update).toHaveBeenNthCalledWith(
       1,
       'calendar-1',
-      { resourceId: null },
+      { resourceId: null, channelId: null },
     );
 
-    expect(subscribe).toHaveBeenCalledWith('google-calendar-2', 'calendar-1');
+    expect(subscribe).toHaveBeenCalledWith(
+      'google-calendar-2',
+      expectChannelId('calendar-1'),
+    );
 
     expect(calendarDataProviderMock.update).toHaveBeenNthCalledWith(
       2,
       'calendar-1',
-      { resourceId, expirationDate: expiration },
+      {
+        channelId: expectChannelId('calendar-1'),
+        resourceId,
+        expirationDate: expiration,
+      },
     );
   });
 
@@ -276,18 +288,22 @@ describe('Calendar handler', () => {
     expect(calendarDataProviderMock.update).toHaveBeenNthCalledWith(
       1,
       'calendar-1',
-      { resourceId: null },
+      { resourceId: null, channelId: null },
     );
 
     expect(subscribe).toHaveBeenCalledWith(
       'google-calendar-2',
-      'cms:calendar-1',
+      expectChannelId('cms:calendar-1'),
     );
 
     expect(calendarDataProviderMock.update).toHaveBeenNthCalledWith(
       2,
       'calendar-1',
-      { resourceId, expirationDate: expiration },
+      {
+        channelId: expectChannelId('cms:calendar-1'),
+        resourceId,
+        expirationDate: expiration,
+      },
     );
   });
 
@@ -317,6 +333,7 @@ describe('Calendar handler', () => {
     expect(unsubscribe).toHaveBeenCalledWith('resource-id-1', 'calendar-1');
     expect(calendarDataProviderMock.update).toHaveBeenCalledWith('calendar-1', {
       resourceId: null,
+      channelId: null,
     });
 
     expect(subscribe).not.toHaveBeenCalled();
@@ -347,9 +364,13 @@ describe('Calendar handler', () => {
     expect(res).toBe('OK');
     expect(unsubscribe).not.toHaveBeenCalled();
 
-    expect(subscribe).toHaveBeenCalledWith('google-calendar-2', 'calendar-1');
+    expect(subscribe).toHaveBeenCalledWith(
+      'google-calendar-2',
+      expectChannelId('calendar-1'),
+    );
 
     expect(calendarDataProviderMock.update).toHaveBeenCalledWith('calendar-1', {
+      channelId: expectChannelId('calendar-1'),
       resourceId,
       expirationDate: expiration,
     });

--- a/packages/server-common/test/handlers/calendar/resubscribe-calendars.test.ts
+++ b/packages/server-common/test/handlers/calendar/resubscribe-calendars.test.ts
@@ -11,6 +11,7 @@ import {
 } from '../../helpers/events';
 import { calendarDataProviderMock } from '../../mocks/calendar-data-provider.mock';
 import { loggerMock as logger } from '../../mocks/logger.mock';
+import { expectChannelId } from './utils';
 
 describe('Resubscribe calendar handler', () => {
   const unsubscribeMock: jest.MockedFunction<UnsubscribeFromEventChanges> =
@@ -102,11 +103,11 @@ describe('Resubscribe calendar handler', () => {
     );
     expect(subscribeMock).toHaveBeenCalledWith(
       calendarDataObject1.googleCalendarId,
-      calendarDataObject1.id,
+      expectChannelId(calendarDataObject1.id),
     );
     expect(subscribeMock).toHaveBeenCalledWith(
       calendarDataObject2.googleCalendarId,
-      calendarDataObject2.id,
+      expectChannelId(calendarDataObject2.id),
     );
   });
 
@@ -138,11 +139,11 @@ describe('Resubscribe calendar handler', () => {
     );
     expect(subscribeMock).toHaveBeenCalledWith(
       calendarDataObject1.googleCalendarId,
-      `cms:${calendarDataObject1.id}`,
+      expectChannelId(`cms:${calendarDataObject1.id}`),
     );
     expect(subscribeMock).toHaveBeenCalledWith(
       calendarDataObject2.googleCalendarId,
-      `cms:${calendarDataObject2.id}`,
+      expectChannelId(`cms:${calendarDataObject2.id}`),
     );
   });
 
@@ -169,11 +170,11 @@ describe('Resubscribe calendar handler', () => {
     expect(subscribeMock).toHaveBeenCalledTimes(2);
     expect(subscribeMock).toHaveBeenCalledWith(
       calendarDataObject1.googleCalendarId,
-      calendarDataObject1.id,
+      expectChannelId(calendarDataObject1.id),
     );
     expect(subscribeMock).toHaveBeenCalledWith(
       calendarDataObject2.googleCalendarId,
-      calendarDataObject2.id,
+      expectChannelId(calendarDataObject2.id),
     );
   });
 
@@ -199,6 +200,7 @@ describe('Resubscribe calendar handler', () => {
     expect(calendarDataProviderMock.update).toHaveBeenCalledWith(
       getCalendarDataObject().id,
       {
+        channelId: expectChannelId(getCalendarDataObject().id),
         resourceId,
         expirationDate: expiration,
       },
@@ -227,6 +229,7 @@ describe('Resubscribe calendar handler', () => {
     expect(calendarDataProviderMock.update).toHaveBeenCalledWith(
       getCalendarDataObject().id,
       {
+        channelId: expectChannelId(getCalendarDataObject().id),
         resourceId,
         expirationDate: expiration,
       },
@@ -256,6 +259,7 @@ describe('Resubscribe calendar handler', () => {
     expect(calendarDataProviderMock.update).toHaveBeenCalledWith(
       getCalendarDataObject().id,
       {
+        channelId: expectChannelId(getCalendarDataObject().id),
         resourceId,
         expirationDate: expiration,
       },
@@ -282,6 +286,7 @@ describe('Resubscribe calendar handler', () => {
     expect(calendarDataProviderMock.update).toHaveBeenCalledWith(
       getCalendarDataObject().id,
       {
+        channelId: expectChannelId(getCalendarDataObject().id),
         resourceId,
         expirationDate: expiration,
       },

--- a/packages/server-common/test/handlers/calendar/utils.ts
+++ b/packages/server-common/test/handlers/calendar/utils.ts
@@ -1,0 +1,4 @@
+export const expectChannelId = (id: string) =>
+  // starting with specific id
+  // and ending with timestamp
+  expect.stringMatching(new RegExp(`^${id}_\\d+`));

--- a/packages/server-common/test/handlers/webhooks/events-updated.handler.test.ts
+++ b/packages/server-common/test/handlers/webhooks/events-updated.handler.test.ts
@@ -106,7 +106,7 @@ describe('Event Webhook', () => {
     expect(res.statusCode).toStrictEqual(502);
   });
 
-  test('Should return 502 when fails to find the calendar by resourceId', async () => {
+  test('Should return 404 when fails to find the calendar by resourceId', async () => {
     calendarDataProviderMock.fetch.mockResolvedValueOnce({
       items: [],
       total: 0,
@@ -116,7 +116,7 @@ describe('Event Webhook', () => {
       getApiGatewayEvent(googlePayload),
     )) as APIGatewayProxyResult;
 
-    expect(res.statusCode).toStrictEqual(502);
+    expect(res.statusCode).toStrictEqual(404);
   });
 
   test('Should return 200 and save nextSyncToken to squidex when it receives one from google', async () => {


### PR DESCRIPTION
It is not possible to create multiple subscriptions with the same channel id, but the resource id returned when creating a subscription is required to unsubscribe.

This means that if the resource id is removed from the record in the CMS, then a new subscription cannot be created because the channel id is non unique, but the previous subscription cannot be removed.

Ensure that new subscriptions can always be created by adding a timestamp onto the channel id to ensure uniqueness. Also store the generated channel id when subscribing so that it can be used if needed to unsubscribe in future.