### PR TITLE
Map empty string values in user profile to null

### DIFF
--- a/apps/crn-server/src/data-providers/contentful/user.data-provider.ts
+++ b/apps/crn-server/src/data-providers/contentful/user.data-provider.ts
@@ -217,6 +217,9 @@ const cleanUser = (userToUpdate: UserUpdateDataObject) =>
         connections: connections.map(({ code }) => code),
       };
     }
+    if (typeof value === 'string') {
+      return { ...acc, [key]: value.trim() === '' ? null : value };
+    }
     return { ...acc, [key]: value };
   }, {} as { [key: string]: unknown });
 

--- a/apps/crn-server/test/data-providers/contentful/users.data-provider.test.ts
+++ b/apps/crn-server/test/data-providers/contentful/users.data-provider.test.ts
@@ -673,6 +673,18 @@ describe('User data provider', () => {
         },
       });
     });
+    test('converts empty string values to `null`', async () => {
+      await userDataProvider.update('123', {
+        firstName: '  ',
+        degree: '',
+        onboarded: false,
+      });
+      expect(patchAndPublish).toHaveBeenCalledWith(entry, {
+        firstName: null,
+        degree: null,
+        onboarded: false,
+      });
+    });
 
     test('checks version of published data and polls until they match', async () => {
       contentfulGraphqlClientMock.request.mockResolvedValueOnce({


### PR DESCRIPTION
Passing an empty string for a non-required field with pattern or "allowed values" validators throws an error. In particular when onboarding a new user, the "Degree" field is marked as optional on the frontend, but not selecting a value causes an error because `""` is not one of the allowed values in Contentful.

Map any empty string values to `null` in the data provider to prevent the validator throwing an error.