### PR TITLE
CT-116 Adding missing help texts to Contentful

### DIFF
--- a/packages/contentful/migrations/crn/events/20230905123502-add-help-text.js
+++ b/packages/contentful/migrations/crn/events/20230905123502-add-help-text.js
@@ -1,0 +1,52 @@
+module.exports.description = 'Add help texts copied from Squidex';
+
+module.exports.up = (migration) => {
+  const events = migration.editContentType('events');
+
+  events.changeFieldControl(
+    'presentationPermanentlyUnavailable',
+    'builtin',
+    'boolean',
+    {
+      helpText:
+        "This box is automatically ticked if no output is added after 14 days from the event's end date.",
+      trueLabel: 'Yes',
+      falseLabel: 'No',
+    },
+  );
+
+  events.changeFieldControl('startDate', 'app', '2finDNk15g5UtOq4DaLNxv', {
+    helpText: 'if you want to edit this, go to google cal',
+  });
+
+  events.changeFieldControl('endDate', 'app', '2finDNk15g5UtOq4DaLNxv', {
+    helpText: 'if you want to edit this, go to google cal',
+  });
+
+  events.changeFieldControl('description', 'app', '2finDNk15g5UtOq4DaLNxv', {
+    helpText: 'if you want to edit this, go to google cal',
+  });
+
+  events.changeFieldControl('title', 'app', '2finDNk15g5UtOq4DaLNxv', {
+    helpText: 'if you want to edit this, go to google cal',
+  });
+};
+
+module.exports.down = (migration) => {
+  const events = migration.editContentType('events');
+
+  events.changeFieldControl(
+    'presentationPermanentlyUnavailable',
+    'builtin',
+    'boolean',
+    {},
+  );
+
+  events.changeFieldControl('startDate', 'app', '2finDNk15g5UtOq4DaLNxv', {});
+
+  events.changeFieldControl('endDate', 'app', '2finDNk15g5UtOq4DaLNxv', {});
+
+  events.changeFieldControl('description', 'app', '2finDNk15g5UtOq4DaLNxv', {});
+
+  events.changeFieldControl('title', 'app', '2finDNk15g5UtOq4DaLNxv', {});
+};

--- a/packages/contentful/migrations/crn/externalAuthors/20230905124643-add-help-text.js
+++ b/packages/contentful/migrations/crn/externalAuthors/20230905124643-add-help-text.js
@@ -1,0 +1,14 @@
+module.exports.description = 'Add help texts copied from Squidex';
+
+module.exports.up = (migration) => {
+  const externalAuthors = migration.editContentType('externalAuthors');
+
+  externalAuthors.changeFieldControl('orcid', 'builtin', 'singleLine', {
+    helpText: 'ORCIDs cannot be repeated on the Hub',
+  });
+};
+
+module.exports.down = (migration) => {
+  const externalAuthors = migration.editContentType('externalAuthors');
+  externalAuthors.changeFieldControl('orcid', 'builtin', 'singleLine', {});
+};

--- a/packages/contentful/migrations/crn/interestGroups/20230905125029-add-help-text.js
+++ b/packages/contentful/migrations/crn/interestGroups/20230905125029-add-help-text.js
@@ -1,0 +1,20 @@
+module.exports.description = 'Add help texts copied from Squidex';
+
+module.exports.up = (migration) => {
+  const interestGroups = migration.editContentType('interestGroups');
+
+  interestGroups.changeFieldControl('active', 'builtin', 'boolean', {
+    helpText:
+      'Active groups have Subscribe buttons and Calendar and Upcoming Events tabs',
+    trueLabel: 'Yes',
+    falseLabel: 'No',
+  });
+};
+
+module.exports.down = (migration) => {
+  const interestGroups = migration.editContentType('interestGroups');
+  interestGroups.changeFieldControl('active', 'builtin', 'boolean', {
+    trueLabel: 'Yes',
+    falseLabel: 'No',
+  });
+};

--- a/packages/contentful/migrations/crn/researchOutputs/20230905135647-add-help-text.js
+++ b/packages/contentful/migrations/crn/researchOutputs/20230905135647-add-help-text.js
@@ -1,0 +1,79 @@
+module.exports.description = 'Add help texts copied from Squidex';
+
+module.exports.up = (migration) => {
+  const researchOutputs = migration.editContentType('researchOutputs');
+
+  researchOutputs.changeFieldControl(
+    'lastUpdatedPartial',
+    'app',
+    'v97H7wgmtstfxNheYWy0G',
+    {
+      exclude: 'adminNotes, publishDate',
+      helpText: 'Does not include changes to Publish Date and Admin notes',
+    },
+  );
+
+  researchOutputs.changeFieldControl('asapFunded', 'builtin', 'dropdown', {
+    helpText: '"Not sure" will not be shown on the Hub',
+  });
+
+  researchOutputs.changeFieldControl(
+    'usedInAPublication',
+    'builtin',
+    'dropdown',
+    {
+      helpText: '"Not sure" will not be shown on the Hub',
+    },
+  );
+
+  researchOutputs.changeFieldControl('publishDate', 'builtin', 'datePicker', {
+    ampm: '24',
+    format: 'timeZ',
+    helpText:
+      'Date of publishing (outside the Hub). Only applies to outputs that have been published.',
+  });
+
+  researchOutputs.changeFieldControl(
+    'labCatalogNumber',
+    'builtin',
+    'singleLine',
+    {
+      helpText:
+        'If this is a hyperlink, please start with "http://" or "https://"',
+    },
+  );
+};
+
+module.exports.down = (migration) => {
+  const researchOutputs = migration.editContentType('researchOutputs');
+
+  researchOutputs.changeFieldControl(
+    'lastUpdatedPartial',
+    'app',
+    'v97H7wgmtstfxNheYWy0G',
+    {
+      exclude: 'adminNotes, publishDate',
+    },
+  );
+
+  researchOutputs.changeFieldControl('asapFunded', 'builtin', 'dropdown', {});
+
+  researchOutputs.changeFieldControl(
+    'usedInAPublication',
+    'builtin',
+    'dropdown',
+    {},
+  );
+
+  researchOutputs.changeFieldControl('publishDate', 'builtin', 'datePicker', {
+    ampm: '24',
+    format: 'timeZ',
+  });
+
+  researchOutputs.changeFieldControl(
+    'labCatalogNumber',
+    'builtin',
+    'singleLine',
+    {},
+  );
+};

--- a/packages/contentful/migrations/crn/users/20230905115618-add-help-text.js
+++ b/packages/contentful/migrations/crn/users/20230905115618-add-help-text.js
@@ -1,0 +1,51 @@
+module.exports.description = 'Add help texts copied from Squidex';
+
+module.exports.up = (migration) => {
+  const users = migration.editContentType('users');
+
+  users.changeFieldControl('biography', 'builtin', 'multipleLine', {
+    helpText: 'This data shows up in the second tab',
+  });
+
+  users.changeFieldControl('adminNotes', 'builtin', 'multipleLine', {
+    helpText:
+      "This is ASAP internal content and it's not being shown on the Hub",
+  });
+
+  users.changeFieldControl('onboarded', 'builtin', 'boolean', {
+    helpText:
+      'Use this to allow the user to see the full Hub and skip profile completion',
+    trueLabel: 'Yes',
+    falseLabel: 'No',
+  });
+
+  users.changeFieldControl('teams', 'app', 'Yp64pYYDuRNHdvAAAJPYa', {
+    helpText:
+      'Mandatory for grantees. They cannot publish profile without a team.',
+    entityName: 'team',
+    showUserEmail: false,
+  });
+
+  users.changeFieldControl('labs', 'builtin', 'entryLinksEditor', {
+    helpText:
+      'Mandatory for grantees. They cannot publish profile without a lab.',
+    bulkEditing: false,
+    showLinkEntityAction: true,
+    showCreateEntityAction: true,
+  });
+};
+
+module.exports.down = (migration) => {
+  const users = migration.editContentType('users');
+
+  users.changeFieldControl('biography', 'builtin', 'multipleLine', {});
+
+  users.changeFieldControl('adminNotes', 'builtin', 'multipleLine', {});
+
+  users.changeFieldControl('onboarded', 'builtin', 'boolean', {});
+
+  users.changeFieldControl('teams', 'app', 'Yp64pYYDuRNHdvAAAJPYa', {
+    entityName: 'team',
+  });
+  users.changeFieldControl('labs', 'builtin', 'entryLinksEditor', {});
+};


### PR DESCRIPTION
This PR adds all missing "hints" from Squidex to Contentful.

<img width="1435" alt="Screenshot 2023-09-06 at 06 21 16" src="https://github.com/yldio/asap-hub/assets/16595804/879d85dc-7cfe-40d1-be8e-fff95c2e5979">


<img width="1440" alt="Screenshot 2023-09-06 at 06 22 38" src="https://github.com/yldio/asap-hub/assets/16595804/ea678e5a-8ecc-4f98-bb17-996e20e07980">

Some of these hints were inside the section which we don't have in Contentful, so I've added some section hints directly to the field helpText.

