### PR TITLE
Fix unit tests for dashboard announcement deadlines

### DIFF
--- a/apps/gp2-server/test/data-providers/dashboard.data-provider.test.ts
+++ b/apps/gp2-server/test/data-providers/dashboard.data-provider.test.ts
@@ -169,7 +169,7 @@ describe('Dashboard data provider', () => {
     });
 
     test('if present it parses the deadline', async () => {
-      const deadline = DateTime.fromISO('2023-09-06');
+      const deadline = DateTime.now().plus({ weeks: 1 });
       const dashboard = {
         ...getContentfulGraphqlDashboard(),
         announcementsCollection: {
@@ -195,6 +195,33 @@ describe('Dashboard data provider', () => {
       expect(dashboardDataObject.items[0]?.announcements[0]?.deadline).toEqual(
         deadline.toUTC().toString(),
       );
+    });
+
+    test('does not include announcements with deadlines in the past', async () => {
+      const deadline = DateTime.now().minus({ weeks: 1 });
+      const dashboard = {
+        ...getContentfulGraphqlDashboard(),
+        announcementsCollection: {
+          total: 1,
+          items: [
+            {
+              deadline,
+              description: 'test',
+              sys: {
+                id: '1',
+              },
+            },
+          ],
+        },
+      };
+      contentfulGraphqlClientMock.request.mockResolvedValueOnce({
+        dashboardCollection: {
+          total: 1,
+          items: [dashboard],
+        },
+      });
+      const dashboardDataObject = await dashboardDataProvider.fetch({});
+      expect(dashboardDataObject.items[0]!.announcements).toEqual([]);
     });
   });
 


### PR DESCRIPTION
The parsing for dashboard announcements removes announcements with deadlines in the past, so the test with a hard-coded deadline started failing as soon as the hard-coded date was in the past.

Replace the hard-coded date with a calculated future date, and add coverage for the case where the deadline is in the past.