### PR TITLE
CRN-1489 Fix related events not appearing in WG research outputs

### DIFF
--- a/apps/crn-frontend/src/network/working-groups/WorkingGroupOutput.tsx
+++ b/apps/crn-frontend/src/network/working-groups/WorkingGroupOutput.tsx
@@ -30,6 +30,7 @@ import {
   useLabSuggestions,
   usePostResearchOutput,
   usePutResearchOutput,
+  useRelatedEventsSuggestions,
   useRelatedResearchSuggestions,
   useResearchTags,
   useTeamSuggestions,
@@ -87,6 +88,7 @@ const WorkingGroupOutput: React.FC<WorkingGroupOutputProps> = ({
   const getRelatedResearchSuggestions = useRelatedResearchSuggestions(
     researchOutputData?.id,
   );
+  const getRelatedEventSuggestions = useRelatedEventsSuggestions();
   const researchTags = useResearchTags();
 
   const published = researchOutputData ? !!researchOutputData.published : false;
@@ -148,6 +150,7 @@ const WorkingGroupOutput: React.FC<WorkingGroupOutputProps> = ({
             }
             getTeamSuggestions={getTeamSuggestions}
             getRelatedResearchSuggestions={getRelatedResearchSuggestions}
+            getRelatedEventSuggestions={getRelatedEventSuggestions}
             researchTags={researchTags}
             serverValidationErrors={errors}
             clearServerValidationError={(instancePath: string) =>

--- a/apps/storybook/src/ResearchOutputRelatedEventsCard.stories.tsx
+++ b/apps/storybook/src/ResearchOutputRelatedEventsCard.stories.tsx
@@ -31,5 +31,6 @@ export const Normal = () => (
     }
     isSaving={false}
     relatedEvents={[]}
+    onChangeRelatedEvents={() => null}
   />
 );

--- a/packages/react-components/src/organisms/ResearchOutputRelatedEventsCard.tsx
+++ b/packages/react-components/src/organisms/ResearchOutputRelatedEventsCard.tsx
@@ -16,10 +16,10 @@ type ResearchOutputRelatedEventsCardProps = {
   readonly relatedEvents: ComponentPropsWithRef<
     typeof LabeledMultiSelect<ResearchOutputRelatedEventsOption>
   >['values'];
-  readonly getRelatedEventSuggestions?: ComponentPropsWithRef<
+  readonly getRelatedEventSuggestions: ComponentPropsWithRef<
     typeof LabeledMultiSelect<ResearchOutputRelatedEventsOption>
   >['loadOptions'];
-  readonly onChangeRelatedEvents?: ComponentPropsWithRef<
+  readonly onChangeRelatedEvents: ComponentPropsWithRef<
     typeof LabeledMultiSelect<ResearchOutputRelatedEventsOption>
   >['onChange'];
 

--- a/packages/react-components/src/organisms/__tests__/ResearchOutputRelatedEventsCard.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/ResearchOutputRelatedEventsCard.test.tsx
@@ -11,6 +11,8 @@ const props: ComponentProps<typeof ResearchOutputRelatedEventsCard> = {
   relatedEvents: [],
   isSaving: false,
   isEditMode: false,
+  getRelatedEventSuggestions: jest.fn(),
+  onChangeRelatedEvents: jest.fn(),
 };
 
 it('renders the related events card', async () => {

--- a/packages/react-components/src/templates/ResearchOutputForm.tsx
+++ b/packages/react-components/src/templates/ResearchOutputForm.tsx
@@ -69,7 +69,7 @@ type ResearchOutputFormProps = Pick<
         typeof ResearchOutputRelatedResearchCard
       >['getRelatedResearchSuggestions']
     >;
-    getRelatedEventSuggestions?: NonNullable<
+    getRelatedEventSuggestions: NonNullable<
       ComponentProps<
         typeof ResearchOutputRelatedEventsCard
       >['getRelatedEventSuggestions']
@@ -162,7 +162,7 @@ const ResearchOutputForm: React.FC<ResearchOutputFormProps> = ({
   getTeamSuggestions = noop,
   getAuthorSuggestions = noop,
   getRelatedResearchSuggestions = noop,
-  getRelatedEventSuggestions = noop,
+  getRelatedEventSuggestions,
   researchTags,
   serverValidationErrors,
   clearServerValidationError,

--- a/packages/react-components/src/templates/__tests__/ResearchOutputForm.test.tsx
+++ b/packages/react-components/src/templates/__tests__/ResearchOutputForm.test.tsx
@@ -48,6 +48,8 @@ const props: ComponentProps<typeof ResearchOutputForm> = {
     canPublishResearchOutput: true,
     canShareResearchOutput: true,
   },
+  getRelatedResearchSuggestions: jest.fn(),
+  getRelatedEventSuggestions: jest.fn(),
 };
 
 jest.setTimeout(60000);


### PR DESCRIPTION
This PR fixes this bug: There isn’t any event suggestion when we try to add a related event in a Working Group research output, so we can’t add a related event.

<img width="1434" alt="Screenshot 2023-09-04 at 13 07 44" src="https://github.com/yldio/asap-hub/assets/16595804/064bb139-c1f0-4124-b232-c8515022fcc5">

In order to fix it, it was added `getRelatedEventSuggestions` to `WorkingGroupOutput` so events appear on the search and can be added as related events.

I've also changed some types so it would give a Typescript error if we don't pass `getRelatedEventSuggestions` to `WorkingGroupOutput`.