### PR TITLE
Increase timeout for reminders tests

### DIFF
--- a/apps/crn-server/test/integration/common/reminders.integration-test.ts
+++ b/apps/crn-server/test/integration/common/reminders.integration-test.ts
@@ -27,7 +27,7 @@ jest.mock('../../../src/config', () => ({
   logLevel: 'silent',
 }));
 
-jest.setTimeout(120000);
+jest.setTimeout(240000);
 
 const fixtures = FixtureFactory(process.env.INTEGRATION_TEST_CMS);
 


### PR DESCRIPTION
These tests do a large amount of setup work, deleting all pre-existing events, so the first test in the suite often causes a timeout.

Increase the timeout to allow more time for setup when Contentful is rate limited.