### PR TITLE
Changed display mode of the Pill component to flex

### DIFF
--- a/packages/react-components/src/atoms/Pill.tsx
+++ b/packages/react-components/src/atoms/Pill.tsx
@@ -6,7 +6,8 @@ import { lineHeight, perRem } from '../pixels';
 
 const borderWidth = 1;
 const styles = css({
-  display: 'inline-block',
+  display: 'flex',
+  alignItems: 'center',
   boxSizing: 'border-box',
   height: lineHeight,
   margin: `${12 / perRem}em 0`,


### PR DESCRIPTION
There was a bug with the text inside the Pill component. It wasn't centered.
This fix centers the text inside the pill component