### PR TITLE
GP2HUB-92 bugfix: Events not being created when calendar is added

### DIFF
--- a/packages/server-common/src/utils/type-narrowing.ts
+++ b/packages/server-common/src/utils/type-narrowing.ts
@@ -1,0 +1,6 @@
+/* istanbul ignore file */
+import { EventController, gp2 } from '@asap-hub/model';
+
+export const isCRNEventController = (
+  controller: EventController | gp2.EventController,
+): controller is EventController => 'tags' in controller.create;


### PR DESCRIPTION
An error was happening during sync google events due to a field that is present in CRN events but not present in GP2 events.


Log in AWS: https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/%2Faws%2Flambda%2Fgp2-hub-3690-eventsUpdated/log-events/2023%2F09%2F13%2F[%24LATEST]f7949a7fcf76436ba97bf7cac4b356f6?start=PT72H

<img width="1426" alt="Screenshot 2023-09-14 at 09 37 35" src="https://github.com/yldio/asap-hub/assets/16595804/8cd3702e-5cc7-4df8-af74-d30e5446c73d">

Somehow typescript didn't catch this. So I'm using type narrowing now to ensure tags won't be sent to GP2 events. 

--- 

After the changes in this PR, I've manually added a calendar to both CRN and GP2 and checked that the events are syncing properly

CRN: [https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/%2Faws%2Flambda%2Fasap-hub-3697-gcalEventsUpdatedContentful/log-events/2023%2F09%2F15%2F[%24LATEST]56e402e041e347d7bdd705b02c77a191?start=PT3H](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/%2Faws%2Flambda%2Fasap-hub-3697-gcalEventsUpdatedContentful/log-events/2023%2F09%2F15%2F%5B%24LATEST%5D56e402e041e347d7bdd705b02c77a191?start=PT3H)

GP2: [https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/%2Faws%2Flambda%2Fgp2-hub-3697-eventsUpdated/log-events/2023%2F09%2F15%2F[%24LATEST]4a332d31edef4fbb855df2262ae2720d?start=PT3H](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/%2Faws%2Flambda%2Fgp2-hub-3697-eventsUpdated/log-events/2023%2F09%2F15%2F%5B%24LATEST%5D4a332d31edef4fbb855df2262ae2720d?start=PT3H)