### PR TITLE
GP2HUB-96 Add thumbnail to news

### DIFF
--- a/apps/gp2-server/src/data-providers/news.data-provider.ts
+++ b/apps/gp2-server/src/data-providers/news.data-provider.ts
@@ -57,6 +57,7 @@ export const parseGraphQlNews = (item: NewsItem): gp2Model.NewsDataObject => ({
   id: item.sys.id ?? '',
   title: item.title ?? '',
   shortText: item.shortText ?? '',
+  thumbnail: item.thumbnail?.url ?? undefined,
   link: item.link ?? undefined,
   linkText: item.linkText ?? undefined,
   created: item.publishDate,

--- a/apps/gp2-server/test/fixtures/news.fixtures.ts
+++ b/apps/gp2-server/test/fixtures/news.fixtures.ts
@@ -12,6 +12,9 @@ export const getContentfulGraphqlNews = (): NonNullable<
 > => ({
   title: 'a news item',
   shortText: 'the short text of the news',
+  thumbnail: {
+    url: 'http://image.com/assets/thumbnail-uuid1',
+  },
   link: 'http://example.com/a-link',
   linkText: 'some link text',
   sys: {
@@ -34,6 +37,7 @@ export const getNewsDataObject = (): gp2Model.NewsDataObject => ({
   id: '42',
   title: 'a news item',
   shortText: 'the short text of the news',
+  thumbnail: 'http://image.com/assets/thumbnail-uuid1',
   created: '2021-12-28T00:00:00.000Z',
   link: 'http://example.com/a-link',
   linkText: 'some link text',

--- a/packages/contentful/migrations/gp2/news/20230925091407-add-thumbnail-field.js
+++ b/packages/contentful/migrations/gp2/news/20230925091407-add-thumbnail-field.js
@@ -1,0 +1,28 @@
+module.exports.description = '<Put your description here>';
+
+module.exports.up = (migration) => {
+  const news = migration.editContentType('news');
+
+  news
+    .createField('thumbnail')
+    .name('Thumbnail')
+    .type('Link')
+    .localized(false)
+    .required(false)
+    .validations([
+      {
+        linkMimetypeGroup: ['image'],
+      },
+    ])
+    .disabled(false)
+    .omitted(false)
+    .linkType('Asset');
+
+  news.changeFieldControl('thumbnail', 'builtin', 'assetLinkEditor', {});
+  news.moveField('thumbnail').afterField('shortText');
+};
+
+module.exports.down = (migration) => {
+  const news = migration.editContentType('news');
+  news.deleteField('thumbnail');
+};

--- a/packages/contentful/src/gp2/autogenerated-gql/gql.ts
+++ b/packages/contentful/src/gp2/autogenerated-gql/gql.ts
@@ -51,7 +51,7 @@ const documents = {
     types.KeywordsContentDataFragmentDoc,
   '\n  query FetchKeywords($limit: Int, $order: [KeywordsOrder]) {\n    keywordsCollection(limit: $limit, order: $order) {\n      total\n      items {\n        ...KeywordsContentData\n      }\n    }\n  }\n  \n':
     types.FetchKeywordsDocument,
-  '\n  fragment NewsContentData on News {\n    sys {\n      id\n      firstPublishedAt\n    }\n    title\n    shortText\n    link\n    linkText\n    publishDate\n    type\n  }\n':
+  '\n  fragment NewsContentData on News {\n    sys {\n      id\n      firstPublishedAt\n    }\n    title\n    shortText\n    thumbnail {\n      url\n    }\n    link\n    linkText\n    publishDate\n    type\n  }\n':
     types.NewsContentDataFragmentDoc,
   '\n  query FetchNewsById($id: String!) {\n    news(id: $id) {\n      ...NewsContentData\n    }\n  }\n  \n':
     types.FetchNewsByIdDocument,
@@ -241,8 +241,8 @@ export function gql(
  * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function gql(
-  source: '\n  fragment NewsContentData on News {\n    sys {\n      id\n      firstPublishedAt\n    }\n    title\n    shortText\n    link\n    linkText\n    publishDate\n    type\n  }\n',
-): (typeof documents)['\n  fragment NewsContentData on News {\n    sys {\n      id\n      firstPublishedAt\n    }\n    title\n    shortText\n    link\n    linkText\n    publishDate\n    type\n  }\n'];
+  source: '\n  fragment NewsContentData on News {\n    sys {\n      id\n      firstPublishedAt\n    }\n    title\n    shortText\n    thumbnail {\n      url\n    }\n    link\n    linkText\n    publishDate\n    type\n  }\n',
+): (typeof documents)['\n  fragment NewsContentData on News {\n    sys {\n      id\n      firstPublishedAt\n    }\n    title\n    shortText\n    thumbnail {\n      url\n    }\n    link\n    linkText\n    publishDate\n    type\n  }\n'];
 /**
  * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/packages/contentful/src/gp2/autogenerated-gql/graphql.ts
+++ b/packages/contentful/src/gp2/autogenerated-gql/graphql.ts
@@ -293,6 +293,7 @@ export type AssetLinkingCollections = {
   entryCollection?: Maybe<EntryCollection>;
   eventsCollection?: Maybe<EventsCollection>;
   guideCollection?: Maybe<GuideCollection>;
+  newsCollection?: Maybe<NewsCollection>;
   usersCollection?: Maybe<UsersCollection>;
 };
 
@@ -318,6 +319,16 @@ export type AssetLinkingCollectionsGuideCollectionArgs = {
   locale?: InputMaybe<Scalars['String']>;
   order?: InputMaybe<
     Array<InputMaybe<AssetLinkingCollectionsGuideCollectionOrder>>
+  >;
+  preview?: InputMaybe<Scalars['Boolean']>;
+  skip?: InputMaybe<Scalars['Int']>;
+};
+
+export type AssetLinkingCollectionsNewsCollectionArgs = {
+  limit?: InputMaybe<Scalars['Int']>;
+  locale?: InputMaybe<Scalars['String']>;
+  order?: InputMaybe<
+    Array<InputMaybe<AssetLinkingCollectionsNewsCollectionOrder>>
   >;
   preview?: InputMaybe<Scalars['Boolean']>;
   skip?: InputMaybe<Scalars['Int']>;
@@ -393,6 +404,25 @@ export enum AssetLinkingCollectionsGuideCollectionOrder {
   SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
   TitleAsc = 'title_ASC',
   TitleDesc = 'title_DESC',
+}
+
+export enum AssetLinkingCollectionsNewsCollectionOrder {
+  LinkTextAsc = 'linkText_ASC',
+  LinkTextDesc = 'linkText_DESC',
+  LinkAsc = 'link_ASC',
+  LinkDesc = 'link_DESC',
+  PublishDateAsc = 'publishDate_ASC',
+  PublishDateDesc = 'publishDate_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  TypeAsc = 'type_ASC',
+  TypeDesc = 'type_DESC',
 }
 
 export enum AssetLinkingCollectionsUsersCollectionOrder {
@@ -3050,6 +3080,7 @@ export type News = Entry & {
   publishDate?: Maybe<Scalars['DateTime']>;
   shortText?: Maybe<Scalars['String']>;
   sys: Sys;
+  thumbnail?: Maybe<Asset>;
   title?: Maybe<Scalars['String']>;
   type?: Maybe<Scalars['String']>;
 };
@@ -3077,6 +3108,12 @@ export type NewsPublishDateArgs = {
 /** Hub News [See type definition](https://app.contentful.com/spaces/6ekgyp1432o9/content_types/news) */
 export type NewsShortTextArgs = {
   locale?: InputMaybe<Scalars['String']>;
+};
+
+/** Hub News [See type definition](https://app.contentful.com/spaces/6ekgyp1432o9/content_types/news) */
+export type NewsThumbnailArgs = {
+  locale?: InputMaybe<Scalars['String']>;
+  preview?: InputMaybe<Scalars['Boolean']>;
 };
 
 /** Hub News [See type definition](https://app.contentful.com/spaces/6ekgyp1432o9/content_types/news) */
@@ -3131,6 +3168,7 @@ export type NewsFilter = {
   shortText_not_contains?: InputMaybe<Scalars['String']>;
   shortText_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
   sys?: InputMaybe<SysFilter>;
+  thumbnail_exists?: InputMaybe<Scalars['Boolean']>;
   title?: InputMaybe<Scalars['String']>;
   title_contains?: InputMaybe<Scalars['String']>;
   title_exists?: InputMaybe<Scalars['Boolean']>;
@@ -8715,7 +8753,10 @@ export type FetchKeywordsQuery = {
 export type NewsContentDataFragment = Pick<
   News,
   'title' | 'shortText' | 'link' | 'linkText' | 'publishDate' | 'type'
-> & { sys: Pick<Sys, 'id' | 'firstPublishedAt'> };
+> & {
+  sys: Pick<Sys, 'id' | 'firstPublishedAt'>;
+  thumbnail?: Maybe<Pick<Asset, 'url'>>;
+};
 
 export type FetchNewsByIdQueryVariables = Exact<{
   id: Scalars['String'];
@@ -8726,7 +8767,10 @@ export type FetchNewsByIdQuery = {
     Pick<
       News,
       'title' | 'shortText' | 'link' | 'linkText' | 'publishDate' | 'type'
-    > & { sys: Pick<Sys, 'id' | 'firstPublishedAt'> }
+    > & {
+      sys: Pick<Sys, 'id' | 'firstPublishedAt'>;
+      thumbnail?: Maybe<Pick<Asset, 'url'>>;
+    }
   >;
 };
 
@@ -8745,7 +8789,10 @@ export type FetchNewsQuery = {
           Pick<
             News,
             'title' | 'shortText' | 'link' | 'linkText' | 'publishDate' | 'type'
-          > & { sys: Pick<Sys, 'id' | 'firstPublishedAt'> }
+          > & {
+            sys: Pick<Sys, 'id' | 'firstPublishedAt'>;
+            thumbnail?: Maybe<Pick<Asset, 'url'>>;
+          }
         >
       >;
     }
@@ -9109,6 +9156,9 @@ export type FetchOutputsByExternalUserIdQuery = {
                 | 'documentType'
                 | 'type'
                 | 'subtype'
+                | 'description'
+                | 'gp2Supported'
+                | 'sharingStatus'
                 | 'link'
                 | 'addedDate'
                 | 'publishDate'
@@ -12056,6 +12106,16 @@ export const NewsContentDataFragmentDoc = {
           },
           { kind: 'Field', name: { kind: 'Name', value: 'title' } },
           { kind: 'Field', name: { kind: 'Name', value: 'shortText' } },
+          {
+            kind: 'Field',
+            name: { kind: 'Name', value: 'thumbnail' },
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                { kind: 'Field', name: { kind: 'Name', value: 'url' } },
+              ],
+            },
+          },
           { kind: 'Field', name: { kind: 'Name', value: 'link' } },
           { kind: 'Field', name: { kind: 'Name', value: 'linkText' } },
           { kind: 'Field', name: { kind: 'Name', value: 'publishDate' } },

--- a/packages/contentful/src/gp2/queries/news.queries.ts
+++ b/packages/contentful/src/gp2/queries/news.queries.ts
@@ -9,6 +9,9 @@ export const newsContentQueryFragment = gql`
     }
     title
     shortText
+    thumbnail {
+      url
+    }
     link
     linkText
     publishDate

--- a/packages/contentful/src/gp2/schema/autogenerated-schema.graphql
+++ b/packages/contentful/src/gp2/schema/autogenerated-schema.graphql
@@ -2,9 +2,7 @@ schema {
   query: Query
 }
 
-"""
-[See type definition](https://app.contentful.com/spaces/6ekgyp1432o9/content_types/announcements)
-"""
+"""[See type definition](https://app.contentful.com/spaces/6ekgyp1432o9/content_types/announcements)"""
 type Announcements implements Entry {
   contentfulMetadata: ContentfulMetadata!
   deadline(locale: String): DateTime
@@ -52,19 +50,8 @@ input AnnouncementsFilter {
 }
 
 type AnnouncementsLinkingCollections {
-  dashboardCollection(
-    limit: Int = 100
-    locale: String
-    order: [AnnouncementsLinkingCollectionsDashboardCollectionOrder]
-    preview: Boolean
-    skip: Int = 0
-  ): DashboardCollection
-  entryCollection(
-    limit: Int = 100
-    locale: String
-    preview: Boolean
-    skip: Int = 0
-  ): EntryCollection
+  dashboardCollection(limit: Int = 100, locale: String, order: [AnnouncementsLinkingCollectionsDashboardCollectionOrder], preview: Boolean, skip: Int = 0): DashboardCollection
+  entryCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): EntryCollection
 }
 
 enum AnnouncementsLinkingCollectionsDashboardCollectionOrder {
@@ -95,9 +82,7 @@ enum AnnouncementsOrder {
   sys_publishedVersion_DESC
 }
 
-"""
-Represents a binary file in a space. An asset can be any file type.
-"""
+"""Represents a binary file in a space. An asset can be any file type."""
 type Asset {
   contentType(locale: String): String
   contentfulMetadata: ContentfulMetadata!
@@ -189,33 +174,11 @@ input AssetFilter {
 }
 
 type AssetLinkingCollections {
-  entryCollection(
-    limit: Int = 100
-    locale: String
-    preview: Boolean
-    skip: Int = 0
-  ): EntryCollection
-  eventsCollection(
-    limit: Int = 100
-    locale: String
-    order: [AssetLinkingCollectionsEventsCollectionOrder]
-    preview: Boolean
-    skip: Int = 0
-  ): EventsCollection
-  guideCollection(
-    limit: Int = 100
-    locale: String
-    order: [AssetLinkingCollectionsGuideCollectionOrder]
-    preview: Boolean
-    skip: Int = 0
-  ): GuideCollection
-  usersCollection(
-    limit: Int = 100
-    locale: String
-    order: [AssetLinkingCollectionsUsersCollectionOrder]
-    preview: Boolean
-    skip: Int = 0
-  ): UsersCollection
+  entryCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): EntryCollection
+  eventsCollection(limit: Int = 100, locale: String, order: [AssetLinkingCollectionsEventsCollectionOrder], preview: Boolean, skip: Int = 0): EventsCollection
+  guideCollection(limit: Int = 100, locale: String, order: [AssetLinkingCollectionsGuideCollectionOrder], preview: Boolean, skip: Int = 0): GuideCollection
+  newsCollection(limit: Int = 100, locale: String, order: [AssetLinkingCollectionsNewsCollectionOrder], preview: Boolean, skip: Int = 0): NewsCollection
+  usersCollection(limit: Int = 100, locale: String, order: [AssetLinkingCollectionsUsersCollectionOrder], preview: Boolean, skip: Int = 0): UsersCollection
 }
 
 enum AssetLinkingCollectionsEventsCollectionOrder {
@@ -278,6 +241,25 @@ enum AssetLinkingCollectionsGuideCollectionOrder {
   sys_publishedVersion_DESC
   title_ASC
   title_DESC
+}
+
+enum AssetLinkingCollectionsNewsCollectionOrder {
+  linkText_ASC
+  linkText_DESC
+  link_ASC
+  link_DESC
+  publishDate_ASC
+  publishDate_DESC
+  sys_firstPublishedAt_ASC
+  sys_firstPublishedAt_DESC
+  sys_id_ASC
+  sys_id_DESC
+  sys_publishedAt_ASC
+  sys_publishedAt_DESC
+  sys_publishedVersion_ASC
+  sys_publishedVersion_DESC
+  type_ASC
+  type_DESC
 }
 
 enum AssetLinkingCollectionsUsersCollectionOrder {
@@ -354,9 +336,7 @@ enum AssetOrder {
   width_DESC
 }
 
-"""
-[See type definition](https://app.contentful.com/spaces/6ekgyp1432o9/content_types/calendars)
-"""
+"""[See type definition](https://app.contentful.com/spaces/6ekgyp1432o9/content_types/calendars)"""
 type Calendars implements Entry {
   color(locale: String): String
   contentfulMetadata: ContentfulMetadata!
@@ -404,33 +384,10 @@ input CalendarsFilter {
 }
 
 type CalendarsLinkingCollections {
-  entryCollection(
-    limit: Int = 100
-    locale: String
-    preview: Boolean
-    skip: Int = 0
-  ): EntryCollection
-  eventsCollection(
-    limit: Int = 100
-    locale: String
-    order: [CalendarsLinkingCollectionsEventsCollectionOrder]
-    preview: Boolean
-    skip: Int = 0
-  ): EventsCollection
-  projectsCollection(
-    limit: Int = 100
-    locale: String
-    order: [CalendarsLinkingCollectionsProjectsCollectionOrder]
-    preview: Boolean
-    skip: Int = 0
-  ): ProjectsCollection
-  workingGroupsCollection(
-    limit: Int = 100
-    locale: String
-    order: [CalendarsLinkingCollectionsWorkingGroupsCollectionOrder]
-    preview: Boolean
-    skip: Int = 0
-  ): WorkingGroupsCollection
+  entryCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): EntryCollection
+  eventsCollection(limit: Int = 100, locale: String, order: [CalendarsLinkingCollectionsEventsCollectionOrder], preview: Boolean, skip: Int = 0): EventsCollection
+  projectsCollection(limit: Int = 100, locale: String, order: [CalendarsLinkingCollectionsProjectsCollectionOrder], preview: Boolean, skip: Int = 0): ProjectsCollection
+  workingGroupsCollection(limit: Int = 100, locale: String, order: [CalendarsLinkingCollectionsWorkingGroupsCollectionOrder], preview: Boolean, skip: Int = 0): WorkingGroupsCollection
 }
 
 enum CalendarsLinkingCollectionsEventsCollectionOrder {
@@ -573,9 +530,7 @@ type ContentfulTag {
   name: String
 }
 
-"""
-[See type definition](https://app.contentful.com/spaces/6ekgyp1432o9/content_types/contributingCohorts)
-"""
+"""[See type definition](https://app.contentful.com/spaces/6ekgyp1432o9/content_types/contributingCohorts)"""
 type ContributingCohorts implements Entry {
   contentfulMetadata: ContentfulMetadata!
   linkedFrom(allowedLocales: [String]): ContributingCohortsLinkingCollections
@@ -605,19 +560,8 @@ input ContributingCohortsFilter {
 }
 
 type ContributingCohortsLinkingCollections {
-  contributingCohortsMembershipCollection(
-    limit: Int = 100
-    locale: String
-    order: [ContributingCohortsLinkingCollectionsContributingCohortsMembershipCollectionOrder]
-    preview: Boolean
-    skip: Int = 0
-  ): ContributingCohortsMembershipCollection
-  entryCollection(
-    limit: Int = 100
-    locale: String
-    preview: Boolean
-    skip: Int = 0
-  ): EntryCollection
+  contributingCohortsMembershipCollection(limit: Int = 100, locale: String, order: [ContributingCohortsLinkingCollectionsContributingCohortsMembershipCollectionOrder], preview: Boolean, skip: Int = 0): ContributingCohortsMembershipCollection
+  entryCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): EntryCollection
 }
 
 enum ContributingCohortsLinkingCollectionsContributingCohortsMembershipCollectionOrder {
@@ -635,19 +579,11 @@ enum ContributingCohortsLinkingCollectionsContributingCohortsMembershipCollectio
   sys_publishedVersion_DESC
 }
 
-"""
-[See type definition](https://app.contentful.com/spaces/6ekgyp1432o9/content_types/contributingCohortsMembership)
-"""
+"""[See type definition](https://app.contentful.com/spaces/6ekgyp1432o9/content_types/contributingCohortsMembership)"""
 type ContributingCohortsMembership implements Entry {
   contentfulMetadata: ContentfulMetadata!
-  contributingCohort(
-    locale: String
-    preview: Boolean
-    where: ContributingCohortsFilter
-  ): ContributingCohorts
-  linkedFrom(
-    allowedLocales: [String]
-  ): ContributingCohortsMembershipLinkingCollections
+  contributingCohort(locale: String, preview: Boolean, where: ContributingCohortsFilter): ContributingCohorts
+  linkedFrom(allowedLocales: [String]): ContributingCohortsMembershipLinkingCollections
   role(locale: String): String
   studyLink(locale: String): String
   sys: Sys!
@@ -684,19 +620,8 @@ input ContributingCohortsMembershipFilter {
 }
 
 type ContributingCohortsMembershipLinkingCollections {
-  entryCollection(
-    limit: Int = 100
-    locale: String
-    preview: Boolean
-    skip: Int = 0
-  ): EntryCollection
-  usersCollection(
-    limit: Int = 100
-    locale: String
-    order: [ContributingCohortsMembershipLinkingCollectionsUsersCollectionOrder]
-    preview: Boolean
-    skip: Int = 0
-  ): UsersCollection
+  entryCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): EntryCollection
+  usersCollection(limit: Int = 100, locale: String, order: [ContributingCohortsMembershipLinkingCollectionsUsersCollectionOrder], preview: Boolean, skip: Int = 0): UsersCollection
 }
 
 enum ContributingCohortsMembershipLinkingCollectionsUsersCollectionOrder {
@@ -778,32 +703,12 @@ enum ContributingCohortsOrder {
   sys_publishedVersion_DESC
 }
 
-"""
-[See type definition](https://app.contentful.com/spaces/6ekgyp1432o9/content_types/dashboard)
-"""
+"""[See type definition](https://app.contentful.com/spaces/6ekgyp1432o9/content_types/dashboard)"""
 type Dashboard implements Entry {
-  announcementsCollection(
-    limit: Int = 100
-    locale: String
-    order: [DashboardAnnouncementsCollectionOrder]
-    preview: Boolean
-    skip: Int = 0
-    where: AnnouncementsFilter
-  ): DashboardAnnouncementsCollection
+  announcementsCollection(limit: Int = 100, locale: String, order: [DashboardAnnouncementsCollectionOrder], preview: Boolean, skip: Int = 0, where: AnnouncementsFilter): DashboardAnnouncementsCollection
   contentfulMetadata: ContentfulMetadata!
-  guidesCollection(
-    limit: Int = 100
-    locale: String
-    order: [DashboardGuidesCollectionOrder]
-    preview: Boolean
-    skip: Int = 0
-    where: GuideFilter
-  ): DashboardGuidesCollection
-  latestStats(
-    locale: String
-    preview: Boolean
-    where: LatestStatsFilter
-  ): LatestStats
+  guidesCollection(limit: Int = 100, locale: String, order: [DashboardGuidesCollectionOrder], preview: Boolean, skip: Int = 0, where: GuideFilter): DashboardGuidesCollection
+  latestStats(locale: String, preview: Boolean, where: LatestStatsFilter): LatestStats
   linkedFrom(allowedLocales: [String]): DashboardLinkingCollections
   sys: Sys!
 }
@@ -873,12 +778,7 @@ enum DashboardGuidesCollectionOrder {
 }
 
 type DashboardLinkingCollections {
-  entryCollection(
-    limit: Int = 100
-    locale: String
-    preview: Boolean
-    skip: Int = 0
-  ): EntryCollection
+  entryCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): EntryCollection
 }
 
 enum DashboardOrder {
@@ -900,9 +800,7 @@ A date-time string at UTC, such as 2007-12-03T10:15:30Z,
 """
 scalar DateTime
 
-"""
-The 'Dimension' type represents dimensions as whole numeric values between `1` and `4000`.
-"""
+"""The 'Dimension' type represents dimensions as whole numeric values between `1` and `4000`."""
 scalar Dimension
 
 interface Entry {
@@ -935,19 +833,13 @@ enum EntryOrder {
   sys_publishedVersion_DESC
 }
 
-"""
-[See type definition](https://app.contentful.com/spaces/6ekgyp1432o9/content_types/eventSpeakers)
-"""
+"""[See type definition](https://app.contentful.com/spaces/6ekgyp1432o9/content_types/eventSpeakers)"""
 type EventSpeakers implements Entry {
   contentfulMetadata: ContentfulMetadata!
   linkedFrom(allowedLocales: [String]): EventSpeakersLinkingCollections
   sys: Sys!
   title(locale: String): String
-  user(
-    locale: String
-    preview: Boolean
-    where: EventSpeakersUserFilter
-  ): EventSpeakersUser
+  user(locale: String, preview: Boolean, where: EventSpeakersUserFilter): EventSpeakersUser
 }
 
 type EventSpeakersCollection {
@@ -974,19 +866,8 @@ input EventSpeakersFilter {
 }
 
 type EventSpeakersLinkingCollections {
-  entryCollection(
-    limit: Int = 100
-    locale: String
-    preview: Boolean
-    skip: Int = 0
-  ): EntryCollection
-  eventsCollection(
-    limit: Int = 100
-    locale: String
-    order: [EventSpeakersLinkingCollectionsEventsCollectionOrder]
-    preview: Boolean
-    skip: Int = 0
-  ): EventsCollection
+  entryCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): EntryCollection
+  eventsCollection(limit: Int = 100, locale: String, order: [EventSpeakersLinkingCollectionsEventsCollectionOrder], preview: Boolean, skip: Int = 0): EventsCollection
 }
 
 enum EventSpeakersLinkingCollectionsEventsCollectionOrder {
@@ -1067,9 +948,7 @@ input EventSpeakersUserFilter {
   sys: SysFilter
 }
 
-"""
-[See type definition](https://app.contentful.com/spaces/6ekgyp1432o9/content_types/events)
-"""
+"""[See type definition](https://app.contentful.com/spaces/6ekgyp1432o9/content_types/events)"""
 type Events implements Entry {
   calendar(locale: String, preview: Boolean, where: CalendarsFilter): Calendars
   contentfulMetadata: ContentfulMetadata!
@@ -1081,14 +960,7 @@ type Events implements Entry {
   googleId(locale: String): String
   hidden(locale: String): Boolean
   hideMeetingLink(locale: String): Boolean
-  keywordsCollection(
-    limit: Int = 100
-    locale: String
-    order: [EventsKeywordsCollectionOrder]
-    preview: Boolean
-    skip: Int = 0
-    where: KeywordsFilter
-  ): EventsKeywordsCollection
+  keywordsCollection(limit: Int = 100, locale: String, order: [EventsKeywordsCollectionOrder], preview: Boolean, skip: Int = 0, where: KeywordsFilter): EventsKeywordsCollection
   linkedFrom(allowedLocales: [String]): EventsLinkingCollections
   meetingLink(locale: String): String
   meetingMaterials(locale: String): JSON
@@ -1099,14 +971,7 @@ type Events implements Entry {
   presentation(locale: String): EventsPresentation
   presentationPermanentlyUnavailable(locale: String): Boolean
   presentationUpdatedAt(locale: String): DateTime
-  speakersCollection(
-    limit: Int = 100
-    locale: String
-    order: [EventsSpeakersCollectionOrder]
-    preview: Boolean
-    skip: Int = 0
-    where: EventSpeakersFilter
-  ): EventsSpeakersCollection
+  speakersCollection(limit: Int = 100, locale: String, order: [EventsSpeakersCollectionOrder], preview: Boolean, skip: Int = 0, where: EventSpeakersFilter): EventsSpeakersCollection
   startDate(locale: String): DateTime
   startDateTimeZone(locale: String): String
   status(locale: String): String
@@ -1292,12 +1157,7 @@ enum EventsKeywordsCollectionOrder {
 }
 
 type EventsLinkingCollections {
-  entryCollection(
-    limit: Int = 100
-    locale: String
-    preview: Boolean
-    skip: Int = 0
-  ): EntryCollection
+  entryCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): EntryCollection
 }
 
 type EventsNotes {
@@ -1447,9 +1307,7 @@ type EventsVideoRecordingResources {
   block: [ResourceLink!]!
 }
 
-"""
-[See type definition](https://app.contentful.com/spaces/6ekgyp1432o9/content_types/externalUsers)
-"""
+"""[See type definition](https://app.contentful.com/spaces/6ekgyp1432o9/content_types/externalUsers)"""
 type ExternalUsers implements Entry {
   contentfulMetadata: ContentfulMetadata!
   linkedFrom(allowedLocales: [String]): ExternalUsersLinkingCollections
@@ -1487,26 +1345,9 @@ input ExternalUsersFilter {
 }
 
 type ExternalUsersLinkingCollections {
-  entryCollection(
-    limit: Int = 100
-    locale: String
-    preview: Boolean
-    skip: Int = 0
-  ): EntryCollection
-  eventSpeakersCollection(
-    limit: Int = 100
-    locale: String
-    order: [ExternalUsersLinkingCollectionsEventSpeakersCollectionOrder]
-    preview: Boolean
-    skip: Int = 0
-  ): EventSpeakersCollection
-  outputsCollection(
-    limit: Int = 100
-    locale: String
-    order: [ExternalUsersLinkingCollectionsOutputsCollectionOrder]
-    preview: Boolean
-    skip: Int = 0
-  ): OutputsCollection
+  entryCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): EntryCollection
+  eventSpeakersCollection(limit: Int = 100, locale: String, order: [ExternalUsersLinkingCollectionsEventSpeakersCollectionOrder], preview: Boolean, skip: Int = 0): EventSpeakersCollection
+  outputsCollection(limit: Int = 100, locale: String, order: [ExternalUsersLinkingCollectionsOutputsCollectionOrder], preview: Boolean, skip: Int = 0): OutputsCollection
 }
 
 enum ExternalUsersLinkingCollectionsEventSpeakersCollectionOrder {
@@ -1570,19 +1411,10 @@ enum ExternalUsersOrder {
   sys_publishedVersion_DESC
 }
 
-"""
-Model for Tools and Tutorials guides [See type definition](https://app.contentful.com/spaces/6ekgyp1432o9/content_types/guide)
-"""
+"""Model for Tools and Tutorials guides [See type definition](https://app.contentful.com/spaces/6ekgyp1432o9/content_types/guide)"""
 type Guide implements Entry {
   contentfulMetadata: ContentfulMetadata!
-  descriptionCollection(
-    limit: Int = 100
-    locale: String
-    order: [GuideDescriptionCollectionOrder]
-    preview: Boolean
-    skip: Int = 0
-    where: GuideDescriptionFilter
-  ): GuideDescriptionCollection
+  descriptionCollection(limit: Int = 100, locale: String, order: [GuideDescriptionCollectionOrder], preview: Boolean, skip: Int = 0, where: GuideDescriptionFilter): GuideDescriptionCollection
   icon(locale: String, preview: Boolean): Asset
   linkedFrom(allowedLocales: [String]): GuideLinkingCollections
   sys: Sys!
@@ -1596,9 +1428,7 @@ type GuideCollection {
   total: Int!
 }
 
-"""
-[See type definition](https://app.contentful.com/spaces/6ekgyp1432o9/content_types/guideDescription)
-"""
+"""[See type definition](https://app.contentful.com/spaces/6ekgyp1432o9/content_types/guideDescription)"""
 type GuideDescription implements Entry {
   bodyText(locale: String): String
   contentfulMetadata: ContentfulMetadata!
@@ -1669,19 +1499,8 @@ input GuideDescriptionFilter {
 }
 
 type GuideDescriptionLinkingCollections {
-  entryCollection(
-    limit: Int = 100
-    locale: String
-    preview: Boolean
-    skip: Int = 0
-  ): EntryCollection
-  guideCollection(
-    limit: Int = 100
-    locale: String
-    order: [GuideDescriptionLinkingCollectionsGuideCollectionOrder]
-    preview: Boolean
-    skip: Int = 0
-  ): GuideCollection
+  entryCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): EntryCollection
+  guideCollection(limit: Int = 100, locale: String, order: [GuideDescriptionLinkingCollectionsGuideCollectionOrder], preview: Boolean, skip: Int = 0): GuideCollection
 }
 
 enum GuideDescriptionLinkingCollectionsGuideCollectionOrder {
@@ -1732,19 +1551,8 @@ input GuideFilter {
 }
 
 type GuideLinkingCollections {
-  dashboardCollection(
-    limit: Int = 100
-    locale: String
-    order: [GuideLinkingCollectionsDashboardCollectionOrder]
-    preview: Boolean
-    skip: Int = 0
-  ): DashboardCollection
-  entryCollection(
-    limit: Int = 100
-    locale: String
-    preview: Boolean
-    skip: Int = 0
-  ): EntryCollection
+  dashboardCollection(limit: Int = 100, locale: String, order: [GuideLinkingCollectionsDashboardCollectionOrder], preview: Boolean, skip: Int = 0): DashboardCollection
+  entryCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): EntryCollection
 }
 
 enum GuideLinkingCollectionsDashboardCollectionOrder {
@@ -1771,16 +1579,12 @@ enum GuideOrder {
   title_DESC
 }
 
-"""
-The 'HexColor' type represents color in `rgb:ffffff` string format.
-"""
+"""The 'HexColor' type represents color in `rgb:ffffff` string format."""
 scalar HexColor
 
 enum ImageFormat {
   AVIF
-  """
-  JPG image format.
-  """
+  """JPG image format."""
   JPG
   """
   Progressive JPG format stores multiple passes of an image in progressively higher detail.
@@ -1789,93 +1593,57 @@ enum ImageFormat {
           early as possible to make the layout look as designed.
   """
   JPG_PROGRESSIVE
-  """
-  PNG image format
-  """
+  """PNG image format"""
   PNG
   """
   8-bit PNG images support up to 256 colors and weigh less than the standard 24-bit PNG equivalent.
           The 8-bit PNG format is mostly used for simple images, such as icons or logos.
   """
   PNG8
-  """
-  WebP image format.
-  """
+  """WebP image format."""
   WEBP
 }
 
 enum ImageResizeFocus {
-  """
-  Focus the resizing on the bottom.
-  """
+  """Focus the resizing on the bottom."""
   BOTTOM
-  """
-  Focus the resizing on the bottom left.
-  """
+  """Focus the resizing on the bottom left."""
   BOTTOM_LEFT
-  """
-  Focus the resizing on the bottom right.
-  """
+  """Focus the resizing on the bottom right."""
   BOTTOM_RIGHT
-  """
-  Focus the resizing on the center.
-  """
+  """Focus the resizing on the center."""
   CENTER
-  """
-  Focus the resizing on the largest face.
-  """
+  """Focus the resizing on the largest face."""
   FACE
-  """
-  Focus the resizing on the area containing all the faces.
-  """
+  """Focus the resizing on the area containing all the faces."""
   FACES
-  """
-  Focus the resizing on the left.
-  """
+  """Focus the resizing on the left."""
   LEFT
-  """
-  Focus the resizing on the right.
-  """
+  """Focus the resizing on the right."""
   RIGHT
-  """
-  Focus the resizing on the top.
-  """
+  """Focus the resizing on the top."""
   TOP
-  """
-  Focus the resizing on the top left.
-  """
+  """Focus the resizing on the top left."""
   TOP_LEFT
-  """
-  Focus the resizing on the top right.
-  """
+  """Focus the resizing on the top right."""
   TOP_RIGHT
 }
 
 enum ImageResizeStrategy {
-  """
-  Crops a part of the original image to fit into the specified dimensions.
-  """
+  """Crops a part of the original image to fit into the specified dimensions."""
   CROP
-  """
-  Resizes the image to the specified dimensions, cropping the image if needed.
-  """
+  """Resizes the image to the specified dimensions, cropping the image if needed."""
   FILL
-  """
-  Resizes the image to fit into the specified dimensions.
-  """
+  """Resizes the image to fit into the specified dimensions."""
   FIT
   """
   Resizes the image to the specified dimensions, padding the image if needed.
           Uses desired background color as padding color.
   """
   PAD
-  """
-  Resizes the image to the specified dimensions, changing the original aspect ratio if needed.
-  """
+  """Resizes the image to the specified dimensions, changing the original aspect ratio if needed."""
   SCALE
-  """
-  Creates a thumbnail from the image.
-  """
+  """Creates a thumbnail from the image."""
   THUMB
 }
 
@@ -1892,41 +1660,27 @@ input ImageTransformOptions {
           unless the format is `JPG` or `JPG_PROGRESSIVE` and resize strategy is `PAD`, then defaults to white.
   """
   cornerRadius: Int
-  """
-  Desired image format. Defaults to the original image format.
-  """
+  """Desired image format. Defaults to the original image format."""
   format: ImageFormat
-  """
-  Desired height in pixels. Defaults to the original image height.
-  """
+  """Desired height in pixels. Defaults to the original image height."""
   height: Dimension
   """
   Desired quality of the image in percents.
           Used for `PNG8`, `JPG`, `JPG_PROGRESSIVE` and `WEBP` formats.
   """
   quality: Quality
-  """
-  Desired resize focus area. Defaults to `CENTER`.
-  """
+  """Desired resize focus area. Defaults to `CENTER`."""
   resizeFocus: ImageResizeFocus
-  """
-  Desired resize strategy. Defaults to `FIT`.
-  """
+  """Desired resize strategy. Defaults to `FIT`."""
   resizeStrategy: ImageResizeStrategy
-  """
-  Desired width in pixels. Defaults to the original image width.
-  """
+  """Desired width in pixels. Defaults to the original image width."""
   width: Dimension
 }
 
-"""
-The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
-"""
+"""The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf)."""
 scalar JSON
 
-"""
-[See type definition](https://app.contentful.com/spaces/6ekgyp1432o9/content_types/keywords)
-"""
+"""[See type definition](https://app.contentful.com/spaces/6ekgyp1432o9/content_types/keywords)"""
 type Keywords implements Entry {
   contentfulMetadata: ContentfulMetadata!
   linkedFrom(allowedLocales: [String]): KeywordsLinkingCollections
@@ -1956,47 +1710,12 @@ input KeywordsFilter {
 }
 
 type KeywordsLinkingCollections {
-  entryCollection(
-    limit: Int = 100
-    locale: String
-    preview: Boolean
-    skip: Int = 0
-  ): EntryCollection
-  eventsCollection(
-    limit: Int = 100
-    locale: String
-    order: [KeywordsLinkingCollectionsEventsCollectionOrder]
-    preview: Boolean
-    skip: Int = 0
-  ): EventsCollection
-  outputsCollection(
-    limit: Int = 100
-    locale: String
-    order: [KeywordsLinkingCollectionsOutputsCollectionOrder]
-    preview: Boolean
-    skip: Int = 0
-  ): OutputsCollection
-  projectsCollection(
-    limit: Int = 100
-    locale: String
-    order: [KeywordsLinkingCollectionsProjectsCollectionOrder]
-    preview: Boolean
-    skip: Int = 0
-  ): ProjectsCollection
-  usersCollection(
-    limit: Int = 100
-    locale: String
-    order: [KeywordsLinkingCollectionsUsersCollectionOrder]
-    preview: Boolean
-    skip: Int = 0
-  ): UsersCollection
-  workingGroupsCollection(
-    limit: Int = 100
-    locale: String
-    order: [KeywordsLinkingCollectionsWorkingGroupsCollectionOrder]
-    preview: Boolean
-    skip: Int = 0
-  ): WorkingGroupsCollection
+  entryCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): EntryCollection
+  eventsCollection(limit: Int = 100, locale: String, order: [KeywordsLinkingCollectionsEventsCollectionOrder], preview: Boolean, skip: Int = 0): EventsCollection
+  outputsCollection(limit: Int = 100, locale: String, order: [KeywordsLinkingCollectionsOutputsCollectionOrder], preview: Boolean, skip: Int = 0): OutputsCollection
+  projectsCollection(limit: Int = 100, locale: String, order: [KeywordsLinkingCollectionsProjectsCollectionOrder], preview: Boolean, skip: Int = 0): ProjectsCollection
+  usersCollection(limit: Int = 100, locale: String, order: [KeywordsLinkingCollectionsUsersCollectionOrder], preview: Boolean, skip: Int = 0): UsersCollection
+  workingGroupsCollection(limit: Int = 100, locale: String, order: [KeywordsLinkingCollectionsWorkingGroupsCollectionOrder], preview: Boolean, skip: Int = 0): WorkingGroupsCollection
 }
 
 enum KeywordsLinkingCollectionsEventsCollectionOrder {
@@ -2195,9 +1914,7 @@ enum KeywordsOrder {
   sys_publishedVersion_DESC
 }
 
-"""
-[See type definition](https://app.contentful.com/spaces/6ekgyp1432o9/content_types/latestStats)
-"""
+"""[See type definition](https://app.contentful.com/spaces/6ekgyp1432o9/content_types/latestStats)"""
 type LatestStats implements Entry {
   articleCount(locale: String): Int
   cohortCount(locale: String): Int
@@ -2249,19 +1966,8 @@ input LatestStatsFilter {
 }
 
 type LatestStatsLinkingCollections {
-  dashboardCollection(
-    limit: Int = 100
-    locale: String
-    order: [LatestStatsLinkingCollectionsDashboardCollectionOrder]
-    preview: Boolean
-    skip: Int = 0
-  ): DashboardCollection
-  entryCollection(
-    limit: Int = 100
-    locale: String
-    preview: Boolean
-    skip: Int = 0
-  ): EntryCollection
+  dashboardCollection(limit: Int = 100, locale: String, order: [LatestStatsLinkingCollectionsDashboardCollectionOrder], preview: Boolean, skip: Int = 0): DashboardCollection
+  entryCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): EntryCollection
 }
 
 enum LatestStatsLinkingCollectionsDashboardCollectionOrder {
@@ -2292,9 +1998,7 @@ enum LatestStatsOrder {
   sys_publishedVersion_DESC
 }
 
-"""
-Videos and PDFs [See type definition](https://app.contentful.com/spaces/6ekgyp1432o9/content_types/media)
-"""
+"""Videos and PDFs [See type definition](https://app.contentful.com/spaces/6ekgyp1432o9/content_types/media)"""
 type Media implements Entry {
   contentfulMetadata: ContentfulMetadata!
   linkedFrom(allowedLocales: [String]): MediaLinkingCollections
@@ -2324,12 +2028,7 @@ input MediaFilter {
 }
 
 type MediaLinkingCollections {
-  entryCollection(
-    limit: Int = 100
-    locale: String
-    preview: Boolean
-    skip: Int = 0
-  ): EntryCollection
+  entryCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): EntryCollection
 }
 
 enum MediaOrder {
@@ -2345,9 +2044,7 @@ enum MediaOrder {
   url_DESC
 }
 
-"""
-Meta data to store the state of content model through migrations [See type definition](https://app.contentful.com/spaces/6ekgyp1432o9/content_types/migration)
-"""
+"""Meta data to store the state of content model through migrations [See type definition](https://app.contentful.com/spaces/6ekgyp1432o9/content_types/migration)"""
 type Migration implements Entry {
   contentTypeId(locale: String): String
   contentfulMetadata: ContentfulMetadata!
@@ -2379,12 +2076,7 @@ input MigrationFilter {
 }
 
 type MigrationLinkingCollections {
-  entryCollection(
-    limit: Int = 100
-    locale: String
-    preview: Boolean
-    skip: Int = 0
-  ): EntryCollection
+  entryCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): EntryCollection
 }
 
 enum MigrationOrder {
@@ -2400,9 +2092,7 @@ enum MigrationOrder {
   sys_publishedVersion_DESC
 }
 
-"""
-[See type definition](https://app.contentful.com/spaces/6ekgyp1432o9/content_types/milestones)
-"""
+"""[See type definition](https://app.contentful.com/spaces/6ekgyp1432o9/content_types/milestones)"""
 type Milestones implements Entry {
   contentfulMetadata: ContentfulMetadata!
   description(locale: String): String
@@ -2456,26 +2146,9 @@ input MilestonesFilter {
 }
 
 type MilestonesLinkingCollections {
-  entryCollection(
-    limit: Int = 100
-    locale: String
-    preview: Boolean
-    skip: Int = 0
-  ): EntryCollection
-  projectsCollection(
-    limit: Int = 100
-    locale: String
-    order: [MilestonesLinkingCollectionsProjectsCollectionOrder]
-    preview: Boolean
-    skip: Int = 0
-  ): ProjectsCollection
-  workingGroupsCollection(
-    limit: Int = 100
-    locale: String
-    order: [MilestonesLinkingCollectionsWorkingGroupsCollectionOrder]
-    preview: Boolean
-    skip: Int = 0
-  ): WorkingGroupsCollection
+  entryCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): EntryCollection
+  projectsCollection(limit: Int = 100, locale: String, order: [MilestonesLinkingCollectionsProjectsCollectionOrder], preview: Boolean, skip: Int = 0): ProjectsCollection
+  workingGroupsCollection(limit: Int = 100, locale: String, order: [MilestonesLinkingCollectionsWorkingGroupsCollectionOrder], preview: Boolean, skip: Int = 0): WorkingGroupsCollection
 }
 
 enum MilestonesLinkingCollectionsProjectsCollectionOrder {
@@ -2547,9 +2220,7 @@ enum MilestonesOrder {
   title_DESC
 }
 
-"""
-Hub News [See type definition](https://app.contentful.com/spaces/6ekgyp1432o9/content_types/news)
-"""
+"""Hub News [See type definition](https://app.contentful.com/spaces/6ekgyp1432o9/content_types/news)"""
 type News implements Entry {
   contentfulMetadata: ContentfulMetadata!
   link(locale: String): String
@@ -2558,6 +2229,7 @@ type News implements Entry {
   publishDate(locale: String): DateTime
   shortText(locale: String): String
   sys: Sys!
+  thumbnail(locale: String, preview: Boolean): Asset
   title(locale: String): String
   type(locale: String): String
 }
@@ -2604,6 +2276,7 @@ input NewsFilter {
   shortText_not_contains: String
   shortText_not_in: [String]
   sys: SysFilter
+  thumbnail_exists: Boolean
   title: String
   title_contains: String
   title_exists: Boolean
@@ -2621,12 +2294,7 @@ input NewsFilter {
 }
 
 type NewsLinkingCollections {
-  entryCollection(
-    limit: Int = 100
-    locale: String
-    preview: Boolean
-    skip: Int = 0
-  ): EntryCollection
+  entryCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): EntryCollection
 }
 
 enum NewsOrder {
@@ -2648,19 +2316,11 @@ enum NewsOrder {
   type_DESC
 }
 
-"""
-[See type definition](https://app.contentful.com/spaces/6ekgyp1432o9/content_types/outputs)
-"""
+"""[See type definition](https://app.contentful.com/spaces/6ekgyp1432o9/content_types/outputs)"""
 type Outputs implements Entry {
   addedDate(locale: String): DateTime
   adminNotes(locale: String): String
-  authorsCollection(
-    limit: Int = 100
-    locale: String
-    preview: Boolean
-    skip: Int = 0
-    where: OutputsAuthorsFilter
-  ): OutputsAuthorsCollection
+  authorsCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0, where: OutputsAuthorsFilter): OutputsAuthorsCollection
   contentfulMetadata: ContentfulMetadata!
   createdBy(locale: String, preview: Boolean, where: UsersFilter): Users
   description(locale: String): String
@@ -2674,14 +2334,7 @@ type Outputs implements Entry {
   sharingStatus(locale: String): String
   subtype(locale: String): String
   sys: Sys!
-  tagsCollection(
-    limit: Int = 100
-    locale: String
-    order: [OutputsTagsCollectionOrder]
-    preview: Boolean
-    skip: Int = 0
-    where: KeywordsFilter
-  ): OutputsTagsCollection
+  tagsCollection(limit: Int = 100, locale: String, order: [OutputsTagsCollectionOrder], preview: Boolean, skip: Int = 0, where: KeywordsFilter): OutputsTagsCollection
   title(locale: String): String
   type(locale: String): String
   updatedBy(locale: String, preview: Boolean, where: UsersFilter): Users
@@ -2824,12 +2477,7 @@ input OutputsFilter {
 }
 
 type OutputsLinkingCollections {
-  entryCollection(
-    limit: Int = 100
-    locale: String
-    preview: Boolean
-    skip: Int = 0
-  ): EntryCollection
+  entryCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): EntryCollection
 }
 
 enum OutputsOrder {
@@ -2887,9 +2535,7 @@ enum OutputsTagsCollectionOrder {
   sys_publishedVersion_DESC
 }
 
-"""
-[See type definition](https://app.contentful.com/spaces/6ekgyp1432o9/content_types/pages)
-"""
+"""[See type definition](https://app.contentful.com/spaces/6ekgyp1432o9/content_types/pages)"""
 type Pages implements Entry {
   contentfulMetadata: ContentfulMetadata!
   link(locale: String): String
@@ -2955,12 +2601,7 @@ input PagesFilter {
 }
 
 type PagesLinkingCollections {
-  entryCollection(
-    limit: Int = 100
-    locale: String
-    preview: Boolean
-    skip: Int = 0
-  ): EntryCollection
+  entryCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): EntryCollection
 }
 
 enum PagesOrder {
@@ -3006,9 +2647,7 @@ type PagesTextResources {
   block: [ResourceLink!]!
 }
 
-"""
-[See type definition](https://app.contentful.com/spaces/6ekgyp1432o9/content_types/projectMembership)
-"""
+"""[See type definition](https://app.contentful.com/spaces/6ekgyp1432o9/content_types/projectMembership)"""
 type ProjectMembership implements Entry {
   contentfulMetadata: ContentfulMetadata!
   linkedFrom(allowedLocales: [String]): ProjectMembershipLinkingCollections
@@ -3041,19 +2680,8 @@ input ProjectMembershipFilter {
 }
 
 type ProjectMembershipLinkingCollections {
-  entryCollection(
-    limit: Int = 100
-    locale: String
-    preview: Boolean
-    skip: Int = 0
-  ): EntryCollection
-  projectsCollection(
-    limit: Int = 100
-    locale: String
-    order: [ProjectMembershipLinkingCollectionsProjectsCollectionOrder]
-    preview: Boolean
-    skip: Int = 0
-  ): ProjectsCollection
+  entryCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): EntryCollection
+  projectsCollection(limit: Int = 100, locale: String, order: [ProjectMembershipLinkingCollectionsProjectsCollectionOrder], preview: Boolean, skip: Int = 0): ProjectsCollection
 }
 
 enum ProjectMembershipLinkingCollectionsProjectsCollectionOrder {
@@ -3098,9 +2726,7 @@ enum ProjectMembershipOrder {
   sys_publishedVersion_DESC
 }
 
-"""
-[See type definition](https://app.contentful.com/spaces/6ekgyp1432o9/content_types/projects)
-"""
+"""[See type definition](https://app.contentful.com/spaces/6ekgyp1432o9/content_types/projects)"""
 type Projects implements Entry {
   calendar(locale: String, preview: Boolean, where: CalendarsFilter): Calendars
   contentfulMetadata: ContentfulMetadata!
@@ -3108,44 +2734,16 @@ type Projects implements Entry {
   endDate(locale: String): DateTime
   leadEmail(locale: String): String
   linkedFrom(allowedLocales: [String]): ProjectsLinkingCollections
-  membersCollection(
-    limit: Int = 100
-    locale: String
-    order: [ProjectsMembersCollectionOrder]
-    preview: Boolean
-    skip: Int = 0
-    where: ProjectMembershipFilter
-  ): ProjectsMembersCollection
-  milestonesCollection(
-    limit: Int = 100
-    locale: String
-    order: [ProjectsMilestonesCollectionOrder]
-    preview: Boolean
-    skip: Int = 0
-    where: MilestonesFilter
-  ): ProjectsMilestonesCollection
+  membersCollection(limit: Int = 100, locale: String, order: [ProjectsMembersCollectionOrder], preview: Boolean, skip: Int = 0, where: ProjectMembershipFilter): ProjectsMembersCollection
+  milestonesCollection(limit: Int = 100, locale: String, order: [ProjectsMilestonesCollectionOrder], preview: Boolean, skip: Int = 0, where: MilestonesFilter): ProjectsMilestonesCollection
   opportunitiesLink(locale: String): String
   pmEmail(locale: String): String
   projectProposal(locale: String): String
-  resourcesCollection(
-    limit: Int = 100
-    locale: String
-    order: [ProjectsResourcesCollectionOrder]
-    preview: Boolean
-    skip: Int = 0
-    where: ResourcesFilter
-  ): ProjectsResourcesCollection
+  resourcesCollection(limit: Int = 100, locale: String, order: [ProjectsResourcesCollectionOrder], preview: Boolean, skip: Int = 0, where: ResourcesFilter): ProjectsResourcesCollection
   startDate(locale: String): DateTime
   status(locale: String): String
   sys: Sys!
-  tagsCollection(
-    limit: Int = 100
-    locale: String
-    order: [ProjectsTagsCollectionOrder]
-    preview: Boolean
-    skip: Int = 0
-    where: KeywordsFilter
-  ): ProjectsTagsCollection
+  tagsCollection(limit: Int = 100, locale: String, order: [ProjectsTagsCollectionOrder], preview: Boolean, skip: Int = 0, where: KeywordsFilter): ProjectsTagsCollection
   title(locale: String): String
   traineeProject(locale: String): Boolean
 }
@@ -3245,19 +2843,8 @@ input ProjectsFilter {
 }
 
 type ProjectsLinkingCollections {
-  entryCollection(
-    limit: Int = 100
-    locale: String
-    preview: Boolean
-    skip: Int = 0
-  ): EntryCollection
-  outputsCollection(
-    limit: Int = 100
-    locale: String
-    order: [ProjectsLinkingCollectionsOutputsCollectionOrder]
-    preview: Boolean
-    skip: Int = 0
-  ): OutputsCollection
+  entryCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): EntryCollection
+  outputsCollection(limit: Int = 100, locale: String, order: [ProjectsLinkingCollectionsOutputsCollectionOrder], preview: Boolean, skip: Int = 0): OutputsCollection
 }
 
 enum ProjectsLinkingCollectionsOutputsCollectionOrder {
@@ -3414,278 +3001,63 @@ enum ProjectsTagsCollectionOrder {
   sys_publishedVersion_DESC
 }
 
-"""
-The 'Quality' type represents quality as whole numeric values between `1` and `100`.
-"""
+"""The 'Quality' type represents quality as whole numeric values between `1` and `100`."""
 scalar Quality
 
 type Query {
   announcements(id: String!, locale: String, preview: Boolean): Announcements
-  announcementsCollection(
-    limit: Int = 100
-    locale: String
-    order: [AnnouncementsOrder]
-    preview: Boolean
-    skip: Int = 0
-    where: AnnouncementsFilter
-  ): AnnouncementsCollection
+  announcementsCollection(limit: Int = 100, locale: String, order: [AnnouncementsOrder], preview: Boolean, skip: Int = 0, where: AnnouncementsFilter): AnnouncementsCollection
   asset(id: String!, locale: String, preview: Boolean): Asset
-  assetCollection(
-    limit: Int = 100
-    locale: String
-    order: [AssetOrder]
-    preview: Boolean
-    skip: Int = 0
-    where: AssetFilter
-  ): AssetCollection
+  assetCollection(limit: Int = 100, locale: String, order: [AssetOrder], preview: Boolean, skip: Int = 0, where: AssetFilter): AssetCollection
   calendars(id: String!, locale: String, preview: Boolean): Calendars
-  calendarsCollection(
-    limit: Int = 100
-    locale: String
-    order: [CalendarsOrder]
-    preview: Boolean
-    skip: Int = 0
-    where: CalendarsFilter
-  ): CalendarsCollection
-  contributingCohorts(
-    id: String!
-    locale: String
-    preview: Boolean
-  ): ContributingCohorts
-  contributingCohortsCollection(
-    limit: Int = 100
-    locale: String
-    order: [ContributingCohortsOrder]
-    preview: Boolean
-    skip: Int = 0
-    where: ContributingCohortsFilter
-  ): ContributingCohortsCollection
-  contributingCohortsMembership(
-    id: String!
-    locale: String
-    preview: Boolean
-  ): ContributingCohortsMembership
-  contributingCohortsMembershipCollection(
-    limit: Int = 100
-    locale: String
-    order: [ContributingCohortsMembershipOrder]
-    preview: Boolean
-    skip: Int = 0
-    where: ContributingCohortsMembershipFilter
-  ): ContributingCohortsMembershipCollection
+  calendarsCollection(limit: Int = 100, locale: String, order: [CalendarsOrder], preview: Boolean, skip: Int = 0, where: CalendarsFilter): CalendarsCollection
+  contributingCohorts(id: String!, locale: String, preview: Boolean): ContributingCohorts
+  contributingCohortsCollection(limit: Int = 100, locale: String, order: [ContributingCohortsOrder], preview: Boolean, skip: Int = 0, where: ContributingCohortsFilter): ContributingCohortsCollection
+  contributingCohortsMembership(id: String!, locale: String, preview: Boolean): ContributingCohortsMembership
+  contributingCohortsMembershipCollection(limit: Int = 100, locale: String, order: [ContributingCohortsMembershipOrder], preview: Boolean, skip: Int = 0, where: ContributingCohortsMembershipFilter): ContributingCohortsMembershipCollection
   dashboard(id: String!, locale: String, preview: Boolean): Dashboard
-  dashboardCollection(
-    limit: Int = 100
-    locale: String
-    order: [DashboardOrder]
-    preview: Boolean
-    skip: Int = 0
-    where: DashboardFilter
-  ): DashboardCollection
-  entryCollection(
-    limit: Int = 100
-    locale: String
-    order: [EntryOrder]
-    preview: Boolean
-    skip: Int = 0
-    where: EntryFilter
-  ): EntryCollection
+  dashboardCollection(limit: Int = 100, locale: String, order: [DashboardOrder], preview: Boolean, skip: Int = 0, where: DashboardFilter): DashboardCollection
+  entryCollection(limit: Int = 100, locale: String, order: [EntryOrder], preview: Boolean, skip: Int = 0, where: EntryFilter): EntryCollection
   eventSpeakers(id: String!, locale: String, preview: Boolean): EventSpeakers
-  eventSpeakersCollection(
-    limit: Int = 100
-    locale: String
-    order: [EventSpeakersOrder]
-    preview: Boolean
-    skip: Int = 0
-    where: EventSpeakersFilter
-  ): EventSpeakersCollection
+  eventSpeakersCollection(limit: Int = 100, locale: String, order: [EventSpeakersOrder], preview: Boolean, skip: Int = 0, where: EventSpeakersFilter): EventSpeakersCollection
   events(id: String!, locale: String, preview: Boolean): Events
-  eventsCollection(
-    limit: Int = 100
-    locale: String
-    order: [EventsOrder]
-    preview: Boolean
-    skip: Int = 0
-    where: EventsFilter
-  ): EventsCollection
+  eventsCollection(limit: Int = 100, locale: String, order: [EventsOrder], preview: Boolean, skip: Int = 0, where: EventsFilter): EventsCollection
   externalUsers(id: String!, locale: String, preview: Boolean): ExternalUsers
-  externalUsersCollection(
-    limit: Int = 100
-    locale: String
-    order: [ExternalUsersOrder]
-    preview: Boolean
-    skip: Int = 0
-    where: ExternalUsersFilter
-  ): ExternalUsersCollection
+  externalUsersCollection(limit: Int = 100, locale: String, order: [ExternalUsersOrder], preview: Boolean, skip: Int = 0, where: ExternalUsersFilter): ExternalUsersCollection
   guide(id: String!, locale: String, preview: Boolean): Guide
-  guideCollection(
-    limit: Int = 100
-    locale: String
-    order: [GuideOrder]
-    preview: Boolean
-    skip: Int = 0
-    where: GuideFilter
-  ): GuideCollection
-  guideDescription(
-    id: String!
-    locale: String
-    preview: Boolean
-  ): GuideDescription
-  guideDescriptionCollection(
-    limit: Int = 100
-    locale: String
-    order: [GuideDescriptionOrder]
-    preview: Boolean
-    skip: Int = 0
-    where: GuideDescriptionFilter
-  ): GuideDescriptionCollection
+  guideCollection(limit: Int = 100, locale: String, order: [GuideOrder], preview: Boolean, skip: Int = 0, where: GuideFilter): GuideCollection
+  guideDescription(id: String!, locale: String, preview: Boolean): GuideDescription
+  guideDescriptionCollection(limit: Int = 100, locale: String, order: [GuideDescriptionOrder], preview: Boolean, skip: Int = 0, where: GuideDescriptionFilter): GuideDescriptionCollection
   keywords(id: String!, locale: String, preview: Boolean): Keywords
-  keywordsCollection(
-    limit: Int = 100
-    locale: String
-    order: [KeywordsOrder]
-    preview: Boolean
-    skip: Int = 0
-    where: KeywordsFilter
-  ): KeywordsCollection
+  keywordsCollection(limit: Int = 100, locale: String, order: [KeywordsOrder], preview: Boolean, skip: Int = 0, where: KeywordsFilter): KeywordsCollection
   latestStats(id: String!, locale: String, preview: Boolean): LatestStats
-  latestStatsCollection(
-    limit: Int = 100
-    locale: String
-    order: [LatestStatsOrder]
-    preview: Boolean
-    skip: Int = 0
-    where: LatestStatsFilter
-  ): LatestStatsCollection
+  latestStatsCollection(limit: Int = 100, locale: String, order: [LatestStatsOrder], preview: Boolean, skip: Int = 0, where: LatestStatsFilter): LatestStatsCollection
   media(id: String!, locale: String, preview: Boolean): Media
-  mediaCollection(
-    limit: Int = 100
-    locale: String
-    order: [MediaOrder]
-    preview: Boolean
-    skip: Int = 0
-    where: MediaFilter
-  ): MediaCollection
+  mediaCollection(limit: Int = 100, locale: String, order: [MediaOrder], preview: Boolean, skip: Int = 0, where: MediaFilter): MediaCollection
   migration(id: String!, locale: String, preview: Boolean): Migration
-  migrationCollection(
-    limit: Int = 100
-    locale: String
-    order: [MigrationOrder]
-    preview: Boolean
-    skip: Int = 0
-    where: MigrationFilter
-  ): MigrationCollection
+  migrationCollection(limit: Int = 100, locale: String, order: [MigrationOrder], preview: Boolean, skip: Int = 0, where: MigrationFilter): MigrationCollection
   milestones(id: String!, locale: String, preview: Boolean): Milestones
-  milestonesCollection(
-    limit: Int = 100
-    locale: String
-    order: [MilestonesOrder]
-    preview: Boolean
-    skip: Int = 0
-    where: MilestonesFilter
-  ): MilestonesCollection
+  milestonesCollection(limit: Int = 100, locale: String, order: [MilestonesOrder], preview: Boolean, skip: Int = 0, where: MilestonesFilter): MilestonesCollection
   news(id: String!, locale: String, preview: Boolean): News
-  newsCollection(
-    limit: Int = 100
-    locale: String
-    order: [NewsOrder]
-    preview: Boolean
-    skip: Int = 0
-    where: NewsFilter
-  ): NewsCollection
+  newsCollection(limit: Int = 100, locale: String, order: [NewsOrder], preview: Boolean, skip: Int = 0, where: NewsFilter): NewsCollection
   outputs(id: String!, locale: String, preview: Boolean): Outputs
-  outputsCollection(
-    limit: Int = 100
-    locale: String
-    order: [OutputsOrder]
-    preview: Boolean
-    skip: Int = 0
-    where: OutputsFilter
-  ): OutputsCollection
+  outputsCollection(limit: Int = 100, locale: String, order: [OutputsOrder], preview: Boolean, skip: Int = 0, where: OutputsFilter): OutputsCollection
   pages(id: String!, locale: String, preview: Boolean): Pages
-  pagesCollection(
-    limit: Int = 100
-    locale: String
-    order: [PagesOrder]
-    preview: Boolean
-    skip: Int = 0
-    where: PagesFilter
-  ): PagesCollection
-  projectMembership(
-    id: String!
-    locale: String
-    preview: Boolean
-  ): ProjectMembership
-  projectMembershipCollection(
-    limit: Int = 100
-    locale: String
-    order: [ProjectMembershipOrder]
-    preview: Boolean
-    skip: Int = 0
-    where: ProjectMembershipFilter
-  ): ProjectMembershipCollection
+  pagesCollection(limit: Int = 100, locale: String, order: [PagesOrder], preview: Boolean, skip: Int = 0, where: PagesFilter): PagesCollection
+  projectMembership(id: String!, locale: String, preview: Boolean): ProjectMembership
+  projectMembershipCollection(limit: Int = 100, locale: String, order: [ProjectMembershipOrder], preview: Boolean, skip: Int = 0, where: ProjectMembershipFilter): ProjectMembershipCollection
   projects(id: String!, locale: String, preview: Boolean): Projects
-  projectsCollection(
-    limit: Int = 100
-    locale: String
-    order: [ProjectsOrder]
-    preview: Boolean
-    skip: Int = 0
-    where: ProjectsFilter
-  ): ProjectsCollection
+  projectsCollection(limit: Int = 100, locale: String, order: [ProjectsOrder], preview: Boolean, skip: Int = 0, where: ProjectsFilter): ProjectsCollection
   resources(id: String!, locale: String, preview: Boolean): Resources
-  resourcesCollection(
-    limit: Int = 100
-    locale: String
-    order: [ResourcesOrder]
-    preview: Boolean
-    skip: Int = 0
-    where: ResourcesFilter
-  ): ResourcesCollection
+  resourcesCollection(limit: Int = 100, locale: String, order: [ResourcesOrder], preview: Boolean, skip: Int = 0, where: ResourcesFilter): ResourcesCollection
   users(id: String!, locale: String, preview: Boolean): Users
-  usersCollection(
-    limit: Int = 100
-    locale: String
-    order: [UsersOrder]
-    preview: Boolean
-    skip: Int = 0
-    where: UsersFilter
-  ): UsersCollection
-  workingGroupMembership(
-    id: String!
-    locale: String
-    preview: Boolean
-  ): WorkingGroupMembership
-  workingGroupMembershipCollection(
-    limit: Int = 100
-    locale: String
-    order: [WorkingGroupMembershipOrder]
-    preview: Boolean
-    skip: Int = 0
-    where: WorkingGroupMembershipFilter
-  ): WorkingGroupMembershipCollection
-  workingGroupNetwork(
-    id: String!
-    locale: String
-    preview: Boolean
-  ): WorkingGroupNetwork
-  workingGroupNetworkCollection(
-    limit: Int = 100
-    locale: String
-    order: [WorkingGroupNetworkOrder]
-    preview: Boolean
-    skip: Int = 0
-    where: WorkingGroupNetworkFilter
-  ): WorkingGroupNetworkCollection
+  usersCollection(limit: Int = 100, locale: String, order: [UsersOrder], preview: Boolean, skip: Int = 0, where: UsersFilter): UsersCollection
+  workingGroupMembership(id: String!, locale: String, preview: Boolean): WorkingGroupMembership
+  workingGroupMembershipCollection(limit: Int = 100, locale: String, order: [WorkingGroupMembershipOrder], preview: Boolean, skip: Int = 0, where: WorkingGroupMembershipFilter): WorkingGroupMembershipCollection
+  workingGroupNetwork(id: String!, locale: String, preview: Boolean): WorkingGroupNetwork
+  workingGroupNetworkCollection(limit: Int = 100, locale: String, order: [WorkingGroupNetworkOrder], preview: Boolean, skip: Int = 0, where: WorkingGroupNetworkFilter): WorkingGroupNetworkCollection
   workingGroups(id: String!, locale: String, preview: Boolean): WorkingGroups
-  workingGroupsCollection(
-    limit: Int = 100
-    locale: String
-    order: [WorkingGroupsOrder]
-    preview: Boolean
-    skip: Int = 0
-    where: WorkingGroupsFilter
-  ): WorkingGroupsCollection
+  workingGroupsCollection(limit: Int = 100, locale: String, order: [WorkingGroupsOrder], preview: Boolean, skip: Int = 0, where: WorkingGroupsFilter): WorkingGroupsCollection
 }
 
 type ResourceLink {
@@ -3698,9 +3070,7 @@ type ResourceSys {
   urn: String!
 }
 
-"""
-[See type definition](https://app.contentful.com/spaces/6ekgyp1432o9/content_types/resources)
-"""
+"""[See type definition](https://app.contentful.com/spaces/6ekgyp1432o9/content_types/resources)"""
 type Resources implements Entry {
   contentfulMetadata: ContentfulMetadata!
   description(locale: String): String
@@ -3754,26 +3124,9 @@ input ResourcesFilter {
 }
 
 type ResourcesLinkingCollections {
-  entryCollection(
-    limit: Int = 100
-    locale: String
-    preview: Boolean
-    skip: Int = 0
-  ): EntryCollection
-  projectsCollection(
-    limit: Int = 100
-    locale: String
-    order: [ResourcesLinkingCollectionsProjectsCollectionOrder]
-    preview: Boolean
-    skip: Int = 0
-  ): ProjectsCollection
-  workingGroupsCollection(
-    limit: Int = 100
-    locale: String
-    order: [ResourcesLinkingCollectionsWorkingGroupsCollectionOrder]
-    preview: Boolean
-    skip: Int = 0
-  ): WorkingGroupsCollection
+  entryCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): EntryCollection
+  projectsCollection(limit: Int = 100, locale: String, order: [ResourcesLinkingCollectionsProjectsCollectionOrder], preview: Boolean, skip: Int = 0): ProjectsCollection
+  workingGroupsCollection(limit: Int = 100, locale: String, order: [ResourcesLinkingCollectionsWorkingGroupsCollectionOrder], preview: Boolean, skip: Int = 0): WorkingGroupsCollection
 }
 
 enum ResourcesLinkingCollectionsProjectsCollectionOrder {
@@ -3891,9 +3244,7 @@ input SysFilter {
   publishedVersion_not_in: [Float]
 }
 
-"""
-[See type definition](https://app.contentful.com/spaces/6ekgyp1432o9/content_types/users)
-"""
+"""[See type definition](https://app.contentful.com/spaces/6ekgyp1432o9/content_types/users)"""
 type Users implements Entry {
   activatedDate(locale: String): DateTime
   alternativeEmail(locale: String): String
@@ -3903,14 +3254,7 @@ type Users implements Entry {
   city(locale: String): String
   connections(locale: String): [String]
   contentfulMetadata: ContentfulMetadata!
-  contributingCohortsCollection(
-    limit: Int = 100
-    locale: String
-    order: [UsersContributingCohortsCollectionOrder]
-    preview: Boolean
-    skip: Int = 0
-    where: ContributingCohortsMembershipFilter
-  ): UsersContributingCohortsCollection
+  contributingCohortsCollection(limit: Int = 100, locale: String, order: [UsersContributingCohortsCollectionOrder], preview: Boolean, skip: Int = 0, where: ContributingCohortsMembershipFilter): UsersContributingCohortsCollection
   country(locale: String): String
   degrees(locale: String): [String]
   email(locale: String): String
@@ -3930,14 +3274,7 @@ type Users implements Entry {
   researcherId(locale: String): String
   role(locale: String): String
   sys: Sys!
-  tagsCollection(
-    limit: Int = 100
-    locale: String
-    order: [UsersTagsCollectionOrder]
-    preview: Boolean
-    skip: Int = 0
-    where: KeywordsFilter
-  ): UsersTagsCollection
+  tagsCollection(limit: Int = 100, locale: String, order: [UsersTagsCollectionOrder], preview: Boolean, skip: Int = 0, where: KeywordsFilter): UsersTagsCollection
   telephoneCountryCode(locale: String): String
   telephoneNumber(locale: String): String
   twitter(locale: String): String
@@ -4150,40 +3487,11 @@ input UsersFilter {
 }
 
 type UsersLinkingCollections {
-  entryCollection(
-    limit: Int = 100
-    locale: String
-    preview: Boolean
-    skip: Int = 0
-  ): EntryCollection
-  eventSpeakersCollection(
-    limit: Int = 100
-    locale: String
-    order: [UsersLinkingCollectionsEventSpeakersCollectionOrder]
-    preview: Boolean
-    skip: Int = 0
-  ): EventSpeakersCollection
-  outputsCollection(
-    limit: Int = 100
-    locale: String
-    order: [UsersLinkingCollectionsOutputsCollectionOrder]
-    preview: Boolean
-    skip: Int = 0
-  ): OutputsCollection
-  projectMembershipCollection(
-    limit: Int = 100
-    locale: String
-    order: [UsersLinkingCollectionsProjectMembershipCollectionOrder]
-    preview: Boolean
-    skip: Int = 0
-  ): ProjectMembershipCollection
-  workingGroupMembershipCollection(
-    limit: Int = 100
-    locale: String
-    order: [UsersLinkingCollectionsWorkingGroupMembershipCollectionOrder]
-    preview: Boolean
-    skip: Int = 0
-  ): WorkingGroupMembershipCollection
+  entryCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): EntryCollection
+  eventSpeakersCollection(limit: Int = 100, locale: String, order: [UsersLinkingCollectionsEventSpeakersCollectionOrder], preview: Boolean, skip: Int = 0): EventSpeakersCollection
+  outputsCollection(limit: Int = 100, locale: String, order: [UsersLinkingCollectionsOutputsCollectionOrder], preview: Boolean, skip: Int = 0): OutputsCollection
+  projectMembershipCollection(limit: Int = 100, locale: String, order: [UsersLinkingCollectionsProjectMembershipCollectionOrder], preview: Boolean, skip: Int = 0): ProjectMembershipCollection
+  workingGroupMembershipCollection(limit: Int = 100, locale: String, order: [UsersLinkingCollectionsWorkingGroupMembershipCollectionOrder], preview: Boolean, skip: Int = 0): WorkingGroupMembershipCollection
 }
 
 enum UsersLinkingCollectionsEventSpeakersCollectionOrder {
@@ -4329,9 +3637,7 @@ enum UsersTagsCollectionOrder {
   sys_publishedVersion_DESC
 }
 
-"""
-[See type definition](https://app.contentful.com/spaces/6ekgyp1432o9/content_types/workingGroupMembership)
-"""
+"""[See type definition](https://app.contentful.com/spaces/6ekgyp1432o9/content_types/workingGroupMembership)"""
 type WorkingGroupMembership implements Entry {
   contentfulMetadata: ContentfulMetadata!
   linkedFrom(allowedLocales: [String]): WorkingGroupMembershipLinkingCollections
@@ -4364,19 +3670,8 @@ input WorkingGroupMembershipFilter {
 }
 
 type WorkingGroupMembershipLinkingCollections {
-  entryCollection(
-    limit: Int = 100
-    locale: String
-    preview: Boolean
-    skip: Int = 0
-  ): EntryCollection
-  workingGroupsCollection(
-    limit: Int = 100
-    locale: String
-    order: [WorkingGroupMembershipLinkingCollectionsWorkingGroupsCollectionOrder]
-    preview: Boolean
-    skip: Int = 0
-  ): WorkingGroupsCollection
+  entryCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): EntryCollection
+  workingGroupsCollection(limit: Int = 100, locale: String, order: [WorkingGroupMembershipLinkingCollectionsWorkingGroupsCollectionOrder], preview: Boolean, skip: Int = 0): WorkingGroupsCollection
 }
 
 enum WorkingGroupMembershipLinkingCollectionsWorkingGroupsCollectionOrder {
@@ -4413,44 +3708,14 @@ enum WorkingGroupMembershipOrder {
   sys_publishedVersion_DESC
 }
 
-"""
-[See type definition](https://app.contentful.com/spaces/6ekgyp1432o9/content_types/workingGroupNetwork)
-"""
+"""[See type definition](https://app.contentful.com/spaces/6ekgyp1432o9/content_types/workingGroupNetwork)"""
 type WorkingGroupNetwork implements Entry {
-  complexDiseaseCollection(
-    limit: Int = 100
-    locale: String
-    order: [WorkingGroupNetworkComplexDiseaseCollectionOrder]
-    preview: Boolean
-    skip: Int = 0
-    where: WorkingGroupsFilter
-  ): WorkingGroupNetworkComplexDiseaseCollection
+  complexDiseaseCollection(limit: Int = 100, locale: String, order: [WorkingGroupNetworkComplexDiseaseCollectionOrder], preview: Boolean, skip: Int = 0, where: WorkingGroupsFilter): WorkingGroupNetworkComplexDiseaseCollection
   contentfulMetadata: ContentfulMetadata!
   linkedFrom(allowedLocales: [String]): WorkingGroupNetworkLinkingCollections
-  monogenicCollection(
-    limit: Int = 100
-    locale: String
-    order: [WorkingGroupNetworkMonogenicCollectionOrder]
-    preview: Boolean
-    skip: Int = 0
-    where: WorkingGroupsFilter
-  ): WorkingGroupNetworkMonogenicCollection
-  operationalCollection(
-    limit: Int = 100
-    locale: String
-    order: [WorkingGroupNetworkOperationalCollectionOrder]
-    preview: Boolean
-    skip: Int = 0
-    where: WorkingGroupsFilter
-  ): WorkingGroupNetworkOperationalCollection
-  supportCollection(
-    limit: Int = 100
-    locale: String
-    order: [WorkingGroupNetworkSupportCollectionOrder]
-    preview: Boolean
-    skip: Int = 0
-    where: WorkingGroupsFilter
-  ): WorkingGroupNetworkSupportCollection
+  monogenicCollection(limit: Int = 100, locale: String, order: [WorkingGroupNetworkMonogenicCollectionOrder], preview: Boolean, skip: Int = 0, where: WorkingGroupsFilter): WorkingGroupNetworkMonogenicCollection
+  operationalCollection(limit: Int = 100, locale: String, order: [WorkingGroupNetworkOperationalCollectionOrder], preview: Boolean, skip: Int = 0, where: WorkingGroupsFilter): WorkingGroupNetworkOperationalCollection
+  supportCollection(limit: Int = 100, locale: String, order: [WorkingGroupNetworkSupportCollectionOrder], preview: Boolean, skip: Int = 0, where: WorkingGroupsFilter): WorkingGroupNetworkSupportCollection
   sys: Sys!
 }
 
@@ -4505,12 +3770,7 @@ input WorkingGroupNetworkFilter {
 }
 
 type WorkingGroupNetworkLinkingCollections {
-  entryCollection(
-    limit: Int = 100
-    locale: String
-    preview: Boolean
-    skip: Int = 0
-  ): EntryCollection
+  entryCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): EntryCollection
 }
 
 type WorkingGroupNetworkMonogenicCollection {
@@ -4608,51 +3868,21 @@ enum WorkingGroupNetworkSupportCollectionOrder {
   title_DESC
 }
 
-"""
-[See type definition](https://app.contentful.com/spaces/6ekgyp1432o9/content_types/workingGroups)
-"""
+"""[See type definition](https://app.contentful.com/spaces/6ekgyp1432o9/content_types/workingGroups)"""
 type WorkingGroups implements Entry {
   calendar(locale: String, preview: Boolean, where: CalendarsFilter): Calendars
   contentfulMetadata: ContentfulMetadata!
   description(locale: String): WorkingGroupsDescription
   leadingMembers(locale: String): String
   linkedFrom(allowedLocales: [String]): WorkingGroupsLinkingCollections
-  membersCollection(
-    limit: Int = 100
-    locale: String
-    order: [WorkingGroupsMembersCollectionOrder]
-    preview: Boolean
-    skip: Int = 0
-    where: WorkingGroupMembershipFilter
-  ): WorkingGroupsMembersCollection
-  milestonesCollection(
-    limit: Int = 100
-    locale: String
-    order: [WorkingGroupsMilestonesCollectionOrder]
-    preview: Boolean
-    skip: Int = 0
-    where: MilestonesFilter
-  ): WorkingGroupsMilestonesCollection
+  membersCollection(limit: Int = 100, locale: String, order: [WorkingGroupsMembersCollectionOrder], preview: Boolean, skip: Int = 0, where: WorkingGroupMembershipFilter): WorkingGroupsMembersCollection
+  milestonesCollection(limit: Int = 100, locale: String, order: [WorkingGroupsMilestonesCollectionOrder], preview: Boolean, skip: Int = 0, where: MilestonesFilter): WorkingGroupsMilestonesCollection
   primaryEmail(locale: String): String
-  resourcesCollection(
-    limit: Int = 100
-    locale: String
-    order: [WorkingGroupsResourcesCollectionOrder]
-    preview: Boolean
-    skip: Int = 0
-    where: ResourcesFilter
-  ): WorkingGroupsResourcesCollection
+  resourcesCollection(limit: Int = 100, locale: String, order: [WorkingGroupsResourcesCollectionOrder], preview: Boolean, skip: Int = 0, where: ResourcesFilter): WorkingGroupsResourcesCollection
   secondaryEmail(locale: String): String
   shortDescription(locale: String): String
   sys: Sys!
-  tagsCollection(
-    limit: Int = 100
-    locale: String
-    order: [WorkingGroupsTagsCollectionOrder]
-    preview: Boolean
-    skip: Int = 0
-    where: KeywordsFilter
-  ): WorkingGroupsTagsCollection
+  tagsCollection(limit: Int = 100, locale: String, order: [WorkingGroupsTagsCollectionOrder], preview: Boolean, skip: Int = 0, where: KeywordsFilter): WorkingGroupsTagsCollection
   title(locale: String): String
 }
 
@@ -4745,26 +3975,9 @@ input WorkingGroupsFilter {
 }
 
 type WorkingGroupsLinkingCollections {
-  entryCollection(
-    limit: Int = 100
-    locale: String
-    preview: Boolean
-    skip: Int = 0
-  ): EntryCollection
-  outputsCollection(
-    limit: Int = 100
-    locale: String
-    order: [WorkingGroupsLinkingCollectionsOutputsCollectionOrder]
-    preview: Boolean
-    skip: Int = 0
-  ): OutputsCollection
-  workingGroupNetworkCollection(
-    limit: Int = 100
-    locale: String
-    order: [WorkingGroupsLinkingCollectionsWorkingGroupNetworkCollectionOrder]
-    preview: Boolean
-    skip: Int = 0
-  ): WorkingGroupNetworkCollection
+  entryCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0): EntryCollection
+  outputsCollection(limit: Int = 100, locale: String, order: [WorkingGroupsLinkingCollectionsOutputsCollectionOrder], preview: Boolean, skip: Int = 0): OutputsCollection
+  workingGroupNetworkCollection(limit: Int = 100, locale: String, order: [WorkingGroupsLinkingCollectionsWorkingGroupNetworkCollectionOrder], preview: Boolean, skip: Int = 0): WorkingGroupNetworkCollection
 }
 
 enum WorkingGroupsLinkingCollectionsOutputsCollectionOrder {

--- a/packages/gp2-components/src/molecules/NewsItem.tsx
+++ b/packages/gp2-components/src/molecules/NewsItem.tsx
@@ -35,10 +35,22 @@ const newsItemStyles = css({
   },
 });
 
-const imageStyles = css({
+const imageContainerStyles = css({
+  flexShrink: 0,
+  borderRadius: '8px',
+  height: rem(192),
+  width: rem(192),
+  overflow: 'hidden',
+
   gridArea: 'image',
   svg: { borderRadius: '8px' },
   [mobileQuery]: { display: 'none' },
+});
+
+const imageStyles = css({
+  objectFit: 'cover',
+  width: '100%',
+  height: '100%',
 });
 
 const contentStyles = css({
@@ -50,6 +62,7 @@ type NewsItemProps = gp2.NewsResponse;
 
 const NewsItem: React.FC<NewsItemProps> = ({
   title,
+  thumbnail,
   shortText,
   created,
   linkText,
@@ -57,7 +70,17 @@ const NewsItem: React.FC<NewsItemProps> = ({
 }) => (
   <Card padding={false}>
     <article css={newsItemStyles}>
-      <div css={imageStyles}>{newsPlaceholder}</div>
+      <div css={imageContainerStyles}>
+        {thumbnail ? (
+          <img
+            alt={`"${title}"'s thumbnail`}
+            src={thumbnail}
+            css={imageStyles}
+          />
+        ) : (
+          newsPlaceholder
+        )}
+      </div>
       <div css={css({ gridArea: 'headline' })}>
         <Subtitle noMargin styleAsHeading={4}>
           {title}

--- a/packages/gp2-components/src/molecules/__tests__/NewsItem.test.tsx
+++ b/packages/gp2-components/src/molecules/__tests__/NewsItem.test.tsx
@@ -5,6 +5,7 @@ describe('NewsItem', () => {
   const newsProps = {
     title: 'News Title',
     shortText: 'News short text',
+    thumbnail: 'http://image.com/assets/thumbnail-uuid1',
     created: '2021-01-01T00:00:00.000Z',
     linkText: 'News link text',
     link: 'https://www.google.com',
@@ -19,6 +20,11 @@ describe('NewsItem', () => {
     ).toBeInTheDocument();
     expect(screen.getByText('News short text')).toBeInTheDocument();
     expect(screen.getByText('News link text')).toBeInTheDocument();
+    expect(
+      screen.getByRole('img', {
+        name: /"News Title"'s thumbnail/i,
+      }),
+    ).toBeInTheDocument();
     expect(
       screen.getByRole('link', { name: /News link text/i }),
     ).toHaveAttribute('href', 'https://www.google.com');

--- a/packages/model/src/gp2/news.ts
+++ b/packages/model/src/gp2/news.ts
@@ -9,6 +9,7 @@ export type NewsDataObject = {
   created: string;
   title: string;
   shortText: string;
+  thumbnail?: string;
   link?: string;
   linkText?: string;
   type: NewsType;


### PR DESCRIPTION
This PR
- Adds a migration to add thumbnail field
- Adds thumbnail to gp2 query and updates news data provider
- Updates NewsItem so it displays the thumbnail properly on the FE


---
Contentful with thumbnail field 
![app contentful com_spaces_6ekgyp1432o9_environments_gp2-3720_entries_4rrB9LbGnZZy9zpJFnfp2A](https://github.com/yldio/asap-hub/assets/16595804/41014e0e-3e1a-410a-a6dc-a6daccf990b0)

Thumbnail in the FE
 ![3720 gp2 asap science_news](https://github.com/yldio/asap-hub/assets/16595804/3a813389-0b55-4b5b-9e01-ebf25dd0223f)



