### PR TITLE
fix: Sync ORCID handler query complexity error

### DIFF
--- a/apps/crn-server/src/data-providers/contentful/user.data-provider.ts
+++ b/apps/crn-server/src/data-providers/contentful/user.data-provider.ts
@@ -366,18 +366,28 @@ export const parseContentfulGraphQlUsers = (item: UserItem): UserDataObject => {
 const generateFetchQueryFilter = ({
   filter,
 }: FetchUsersOptions): UsersFilter => {
-  const { orcid, code, onboarded = true, hidden = true } = filter || {};
+  const {
+    orcid,
+    orcidLastSyncDate,
+    code,
+    onboarded = true,
+    hidden = true,
+  } = filter || {};
 
   const filterCode = code ? { connections_contains_all: [code] } : {};
   const filterHidden = hidden ? { role_not: 'Hidden' } : {};
   const filterNonOnboarded = onboarded ? { onboarded: true } : {};
   const filterOrcid = orcid ? { orcid_contains: orcid } : {};
+  const filterOrcidLastSyncDate = orcidLastSyncDate
+    ? { orcidLastSyncDate_lt: orcidLastSyncDate }
+    : {};
 
   const queryFilter = {
     ...filterCode,
     ...filterNonOnboarded,
     ...filterHidden,
     ...filterOrcid,
+    ...filterOrcidLastSyncDate,
   };
 
   return queryFilter;

--- a/apps/crn-server/src/handlers/webhooks/cronjob-sync-orcid.ts
+++ b/apps/crn-server/src/handlers/webhooks/cronjob-sync-orcid.ts
@@ -19,7 +19,7 @@ const rawHandler = async (): Promise<lambda.Response> => {
     .toISO();
 
   const { items: outdatedUsers } = await userDataProvider.fetch({
-    take: 50,
+    take: 40,
     filter: {
       orcid: '-',
       orcidLastSyncDate,
@@ -36,9 +36,9 @@ const rawHandler = async (): Promise<lambda.Response> => {
     users.syncOrcidProfile(user.id, user as UserResponse),
   );
 
-  await Promise.all(
-    outdatedUsers.map((user) => throttledSyncOrcidProfile(user)),
-  );
+  for (const outdatedUser of outdatedUsers) {
+    await throttledSyncOrcidProfile(outdatedUser);
+  }
 
   return {
     statusCode: 200,

--- a/apps/crn-server/test/data-providers/contentful/users.data-provider.test.ts
+++ b/apps/crn-server/test/data-providers/contentful/users.data-provider.test.ts
@@ -586,6 +586,23 @@ describe('User data provider', () => {
           }),
         );
       });
+
+      test('should support filtering by orcidLastSyncDate', async () => {
+        await userDataProvider.fetch({
+          filter: {
+            orcidLastSyncDate: 'some-date',
+          },
+        });
+
+        expect(contentfulGraphqlClientMock.request).toHaveBeenCalledWith(
+          FETCH_USERS,
+          expect.objectContaining({
+            where: expect.objectContaining({
+              orcidLastSyncDate_lt: 'some-date',
+            }),
+          }),
+        );
+      });
     });
   });
 

--- a/apps/crn-server/test/integration/events.integration-test.ts
+++ b/apps/crn-server/test/integration/events.integration-test.ts
@@ -1,9 +1,9 @@
 import supertest from 'supertest';
 import { Express } from 'express';
 
-import { PAGE_SIZE } from '../../../scripts/export-entity';
-import { AppHelper } from '../helpers/app';
-import { FixtureFactory, getUserFixture, UserFixture } from '../fixtures';
+import { PAGE_SIZE } from '../../scripts/export-entity';
+import { AppHelper } from './helpers/app';
+import { FixtureFactory, getUserFixture, UserFixture } from './fixtures';
 
 jest.setTimeout(120000);
 

--- a/apps/crn-server/test/integration/orcid.integration-test.ts
+++ b/apps/crn-server/test/integration/orcid.integration-test.ts
@@ -1,0 +1,69 @@
+import nock from 'nock';
+import supertest from 'supertest';
+import Chance from 'chance';
+import { DateTime, Settings } from 'luxon';
+import { unloggedHandler } from '../../src/handlers/webhooks/cronjob-sync-orcid';
+import { AppHelper } from './helpers/app';
+import { FixtureFactory, getUserFixture } from './fixtures';
+import { retryable } from './helpers/retryable';
+import './helpers/matchers';
+
+jest.setTimeout(120000);
+
+const fixtures = FixtureFactory();
+const chance = Chance();
+
+describe('orcid handler', () => {
+  beforeAll(() => {
+    nock('https://pub.orcid.org')
+      .get(/v2\.1\/.*\/works/)
+      .reply(200, {
+        'last-modified-date': { value: 23423423 },
+        group: [],
+        path: '',
+      });
+  });
+
+  test('should fetch a list of users and update their orcids', async () => {
+    // set current time to year 2000
+    // that way when we look for users whose orcid data
+    // has not been synced in the last month
+    // we will not get any of the data that has been created
+    // through normal app use
+    const customDate = new Date('2000-07-06T09:21:23.000Z');
+    const overAMonthBeforeCustomDate = DateTime.fromJSDate(customDate)
+      .minus({ days: 1, months: 1 })
+      .toJSDate();
+
+    // mocking luxon only because using fake timers causes
+    // all of our retryable and throttled functions to freeze
+    Settings.now = () => DateTime.fromJSDate(customDate).toMillis();
+
+    const user = await fixtures.createUser(
+      getUserFixture({
+        orcidLastSyncDate: overAMonthBeforeCustomDate.toISOString(),
+        orcid: `${chance.pad(
+          chance.integer({ max: 9999, min: 0 }),
+          4,
+        )}-${chance.pad(chance.integer({ max: 9999, min: 0 }), 4)}-${chance.pad(
+          chance.integer({ max: 9999, min: 0 }),
+          4,
+        )}-${chance.pad(chance.integer({ max: 9999, min: 0 }), 4)}`,
+      }),
+    );
+
+    const response = await unloggedHandler();
+    expect(response.statusCode).toBe(200);
+
+    const app = AppHelper(() => user);
+
+    await retryable(async () => {
+      const response = await supertest(app).get(`/users/${user.id}`);
+
+      expect(response.body.orcidLastSyncDate).toBeCloseInTimeTo(
+        new Date().toString(),
+        30000,
+      );
+    });
+  });
+});

--- a/apps/crn-server/test/integration/reminders.integration-test.ts
+++ b/apps/crn-server/test/integration/reminders.integration-test.ts
@@ -3,8 +3,8 @@ import { Express } from 'express';
 import { ListReminderResponse, UserCreateDataObject } from '@asap-hub/model';
 import { DateTime } from 'luxon';
 
-import { AppHelper } from '../helpers/app';
-import { retryable } from '../helpers/retryable';
+import { AppHelper } from './helpers/app';
+import { retryable } from './helpers/retryable';
 import {
   EventCreateDataObject,
   EventFixture,
@@ -17,11 +17,11 @@ import {
   TeamFixture,
   UserFixture,
   WorkingGroupFixture,
-} from '../fixtures';
-import { getCalendarFixture } from '../fixtures/calendar';
+} from './fixtures';
+import { getCalendarFixture } from './fixtures/calendar';
 
-jest.mock('../../../src/config', () => ({
-  ...jest.requireActual('../../../src/config'),
+jest.mock('../../src/config', () => ({
+  ...jest.requireActual('../../src/config'),
   isContentfulEnabled:
     process.env.INTEGRATION_TEST_CMS === 'contentful' ? 'true' : undefined,
   logLevel: 'silent',

--- a/apps/crn-server/test/integration/research-outputs.integration-test.ts
+++ b/apps/crn-server/test/integration/research-outputs.integration-test.ts
@@ -3,10 +3,10 @@ import { Express } from 'express';
 import { omit } from 'lodash';
 import { ResearchTagDataObject, ResearchOutputResponse } from '@asap-hub/model';
 
-import { PAGE_SIZE } from '../../../scripts/export-entity';
-import { AppHelper } from '../helpers/app';
-import { retryable } from '../helpers/retryable';
-import '../helpers/matchers';
+import { PAGE_SIZE } from '../../scripts/export-entity';
+import { AppHelper } from './helpers/app';
+import { retryable } from './helpers/retryable';
+import './helpers/matchers';
 
 import {
   FixtureFactory,
@@ -18,7 +18,7 @@ import {
   WorkingGroupFixture,
   getResearchOutputFixture,
   ResearchOutputCreateDataObject,
-} from '../fixtures';
+} from './fixtures';
 
 jest.setTimeout(120000);
 

--- a/apps/crn-server/test/integration/research-tags.integration-test.ts
+++ b/apps/crn-server/test/integration/research-tags.integration-test.ts
@@ -1,8 +1,8 @@
 import supertest from 'supertest';
 import { Express } from 'express';
 
-import { AppHelper } from '../helpers/app';
-import { FixtureFactory, getUserFixture, UserFixture } from '../fixtures';
+import { AppHelper } from './helpers/app';
+import { FixtureFactory, getUserFixture, UserFixture } from './fixtures';
 
 jest.setTimeout(120000);
 

--- a/apps/crn-server/test/integration/teams.integration-test.ts
+++ b/apps/crn-server/test/integration/teams.integration-test.ts
@@ -1,15 +1,15 @@
 import supertest from 'supertest';
 import { Express } from 'express';
 
-import { AppHelper } from '../helpers/app';
-import { retryable } from '../helpers/retryable';
+import { AppHelper } from './helpers/app';
+import { retryable } from './helpers/retryable';
 import {
   FixtureFactory,
   getUserFixture,
   getTeamFixture,
   getInterestGroupFixture,
   UserFixture,
-} from '../fixtures';
+} from './fixtures';
 
 jest.setTimeout(120000);
 

--- a/apps/crn-server/test/integration/users.integration-test.ts
+++ b/apps/crn-server/test/integration/users.integration-test.ts
@@ -3,9 +3,9 @@ import { Express } from 'express';
 import { v4 as uuid } from 'uuid';
 import { omit } from 'lodash';
 
-import { PAGE_SIZE } from '../../../scripts/export-entity';
-import { AppHelper } from '../helpers/app';
-import { retryable } from '../helpers/retryable';
+import { PAGE_SIZE } from '../../scripts/export-entity';
+import { AppHelper } from './helpers/app';
+import { retryable } from './helpers/retryable';
 import {
   FixtureFactory,
   getUserFixture,
@@ -13,7 +13,7 @@ import {
   getInterestGroupFixture,
   getWorkingGroupFixture,
   UserFixture,
-} from '../fixtures';
+} from './fixtures';
 
 jest.setTimeout(120000);
 

--- a/jest-integration.config.js
+++ b/jest-integration.config.js
@@ -6,8 +6,5 @@ const {
 module.exports = {
   ...base,
   collectCoverageFrom: ['<rootDir>/apps/crn-server/src/**/*.{js,jsx,ts,tsx}'],
-  testMatch: [
-    '<rootDir>/**/common/*.integration-test.{js,jsx,ts,tsx}',
-    `<rootDir>/**/contentful/*.integration-test.{js,jsx,ts,tsx}`,
-  ],
+  testMatch: ['<rootDir>/**/*.integration-test.{js,jsx,ts,tsx}'],
 };


### PR DESCRIPTION
* Moves integration tests out of 'common' into root dir
* Fixes the issue with query complexity in cronjob-sync-orcid handler
* Moves away from Promise.all for processing users in cronjob-sync-orcid handler
* Adds an integration test to prevent regression 