### PR TITLE
GP2HUB-109 gp2Supported as not required

### DIFF
--- a/apps/gp2-server/test/routes/output.route.test.ts
+++ b/apps/gp2-server/test/routes/output.route.test.ts
@@ -193,6 +193,18 @@ describe('/outputs/ route', () => {
         },
       );
 
+      test('Should not return a validation error when gp2Supported is missing', async () => {
+        const { app: adminApp } = getApp({ role: 'Administrator' });
+        const response = await supertest(adminApp)
+          .post('/outputs/')
+          .send({
+            ...output,
+            gp2Supported: undefined,
+          });
+
+        expect(response.status).toBe(201);
+      });
+
       describe('Authors validation', () => {
         const { ...outputPostRequest } = getOutputPostRequest();
 
@@ -380,6 +392,18 @@ describe('/outputs/ route', () => {
           });
         },
       );
+
+      test('Should not return a validation error when gp2Supported is missing', async () => {
+        const { app: adminApp } = getApp({ role: 'Administrator' });
+        const response = await supertest(adminApp)
+          .put('/outputs/abc123')
+          .send({
+            ...outputPutRequest,
+            gp2Supported: undefined,
+          });
+
+        expect(response.status).toBe(200);
+      });
 
       describe('Authors validation', () => {
         test('Should return a validation error when required field is missing', async () => {

--- a/packages/contentful/migrations/gp2/outputs/20230927125340-make-gp2supported-not-required.js
+++ b/packages/contentful/migrations/gp2/outputs/20230927125340-make-gp2supported-not-required.js
@@ -1,0 +1,18 @@
+module.exports.description = 'Make gp2Supported not required';
+
+module.exports.up = (migration) => {
+  const outputs = migration.editContentType('outputs');
+  outputs.editField('gp2Supported').required(false);
+  outputs.changeFieldControl('gp2Supported', 'builtin', 'dropdown', {
+    helpText:
+      'Has this output been supported by GP2? This field is not required for Training Materials and Procedural Form',
+  });
+};
+
+module.exports.down = (migration) => {
+  const outputs = migration.editContentType('outputs');
+  outputs.editField('gp2Supported').required(true);
+  outputs.changeFieldControl('gp2Supported', 'builtin', 'dropdown', {
+    helpText: 'Has this output been supported by GP2?',
+  });
+};

--- a/packages/gp2-components/src/templates/OutputForm.tsx
+++ b/packages/gp2-components/src/templates/OutputForm.tsx
@@ -25,6 +25,11 @@ import { EntityMappper } from './CreateOutputPage';
 
 const { rem } = pixels;
 
+const DOC_TYPES_GP2_SUPPORTED_NOT_REQUIRED = [
+  'Training Materials',
+  'Procedural Form',
+];
+
 const getBannerMessage = (
   entityType: 'workingGroup' | 'project',
   documentType: gp2Model.OutputDocumentType,
@@ -113,9 +118,9 @@ const OutputForm: React.FC<OutputFormType> = ({
     subtype || '',
   );
   const [newDescription, setDescription] = useState(description || '');
-  const [newGp2Supported, setGp2Supported] = useState<
-    gp2Model.DecisionOption | undefined
-  >(isGP2SupportedAlwaysTrue ? 'Yes' : gp2Supported);
+  const [newGp2Supported, setGp2Supported] = useState<gp2Model.DecisionOption>(
+    isGP2SupportedAlwaysTrue ? 'Yes' : gp2Supported || "Don't Know",
+  );
   const [newSharingStatus, setSharingStatus] =
     useState<gp2Model.OutputSharingStatus>(
       isAlwaysPublic ? 'Public' : sharingStatus || 'GP2 Only',
@@ -150,7 +155,9 @@ const OutputForm: React.FC<OutputFormType> = ({
     type: newType || undefined,
     subtype: newSubtype || undefined,
     description: newDescription || undefined,
-    gp2Supported: newGp2Supported || undefined,
+    gp2Supported: DOC_TYPES_GP2_SUPPORTED_NOT_REQUIRED.includes(documentType)
+      ? undefined
+      : newGp2Supported,
     sharingStatus: newSharingStatus,
     publishDate: newPublishDate?.toISOString(),
     authors: getPostAuthors(newAuthors),
@@ -253,12 +260,10 @@ const OutputForm: React.FC<OutputFormType> = ({
                 ></Markdown>
               }
             />
-            {!['Training Materials', 'Procedural Form'].includes(
-              documentType,
-            ) ? (
+            {!DOC_TYPES_GP2_SUPPORTED_NOT_REQUIRED.includes(documentType) ? (
               <LabeledRadioButtonGroup<gp2Model.DecisionOption>
                 title="Has this output been supported by GP2?"
-                subtitle="(required)"
+                subtitle="(optional)"
                 options={[
                   {
                     value: 'Yes',
@@ -276,7 +281,7 @@ const OutputForm: React.FC<OutputFormType> = ({
                     disabled: isGP2SupportedAlwaysTrue,
                   },
                 ]}
-                value={newGp2Supported ?? "Don't Know"}
+                value={newGp2Supported}
                 onChange={setGp2Supported}
               />
             ) : null}

--- a/packages/gp2-components/src/templates/OutputForm.tsx
+++ b/packages/gp2-components/src/templates/OutputForm.tsx
@@ -263,7 +263,7 @@ const OutputForm: React.FC<OutputFormType> = ({
             {!DOC_TYPES_GP2_SUPPORTED_NOT_REQUIRED.includes(documentType) ? (
               <LabeledRadioButtonGroup<gp2Model.DecisionOption>
                 title="Has this output been supported by GP2?"
-                subtitle="(optional)"
+                subtitle="(required)"
                 options={[
                   {
                     value: 'Yes',

--- a/packages/gp2-components/src/templates/__tests__/OutputForm.test.tsx
+++ b/packages/gp2-components/src/templates/__tests__/OutputForm.test.tsx
@@ -340,6 +340,7 @@ describe('OutputForm', () => {
         type: 'Research',
         subtype: 'Published',
         description: 'Research description',
+        gp2Supported: "Don't Know",
         sharingStatus: 'GP2 Only',
         authors: [{ userId: 'u2' }],
       });


### PR DESCRIPTION
This PR makes the field `gp2Supported` to be not required since for document types Training Materials and Procedural Form this field does not even appear in the form in the hub. It also makes the default value to be "Don't Know" when it doesn't have a previous value in the form.