### PR TITLE
fix: Support null ORCID last modified date

### DIFF
--- a/apps/crn-server/src/controllers/user.controller.ts
+++ b/apps/crn-server/src/controllers/user.controller.ts
@@ -9,7 +9,11 @@ import {
 } from '@asap-hub/model';
 import Intercept from 'apr-intercept';
 import { AssetDataProvider, UserDataProvider } from '../data-providers/types';
-import { fetchOrcidProfile, transformOrcidWorks } from '../utils/fetch-orcid';
+import {
+  fetchOrcidProfile,
+  ORCIDWorksResponse,
+  transformOrcidWorks,
+} from '../utils/fetch-orcid';
 import logger from '../utils/logger';
 
 export default class UserController {
@@ -110,7 +114,7 @@ export default class UserController {
       email: user.email,
       orcidLastSyncDate: new Date().toISOString(),
     };
-    if (!error) {
+    if (!error && isValidOrcidResponse(res)) {
       const { lastModifiedDate, works } = transformOrcidWorks(res);
       updateToUser.orcidLastModifiedDate = new Date(
         parseInt(lastModifiedDate, 10),
@@ -146,3 +150,9 @@ export const parseUserToResponse = ({
     onboarded,
   };
 };
+
+const isValidOrcidResponse = (
+  res: ORCIDWorksResponse,
+): res is {
+  [K in keyof ORCIDWorksResponse]: NonNullable<ORCIDWorksResponse[K]>;
+} => res['last-modified-date'] !== null;

--- a/apps/crn-server/src/utils/fetch-orcid.ts
+++ b/apps/crn-server/src/utils/fetch-orcid.ts
@@ -51,7 +51,7 @@ interface ORCIDWork {
 }
 
 export interface ORCIDWorksResponse {
-  'last-modified-date': { value: number };
+  'last-modified-date': { value: number } | null;
   group: ORCIDWork[];
   path: string;
 }
@@ -59,9 +59,9 @@ export interface ORCIDWorksResponse {
 export const fetchOrcidProfile = (orcid: string): Promise<ORCIDWorksResponse> =>
   Got.get(`https://pub.orcid.org/v2.1/${orcid}/works`).json();
 
-export const transformOrcidWorks = (
-  orcidWorks: ORCIDWorksResponse,
-): { lastModifiedDate: string; works: CMSOrcidWork[] } =>
+export const transformOrcidWorks = (orcidWorks: {
+  [K in keyof ORCIDWorksResponse]: NonNullable<ORCIDWorksResponse[K]>;
+}): { lastModifiedDate: string; works: CMSOrcidWork[] } =>
   // parse & stringify to remove undefined values
   ({
     lastModifiedDate: `${orcidWorks['last-modified-date']?.value}`,


### PR DESCRIPTION
Fixes the issue with null last-modified-date:
![image](https://github.com/yldio/asap-hub/assets/11645956/ffb6bbc8-824e-41ac-a755-e4ead13fc9b0)

With this change we will support null and in such case we will simply update the sync date in the CMS without making any changes to orcid fields (same way we do for 500s coming from ORCID API)