### PR TITLE
Convert Algolia error into normal error

### DIFF
--- a/apps/crn-frontend/src/events/Events.tsx
+++ b/apps/crn-frontend/src/events/Events.tsx
@@ -2,7 +2,7 @@ import { EventsPage } from '@asap-hub/react-components';
 import { events } from '@asap-hub/routing';
 import { FC, lazy, useEffect, useState } from 'react';
 import { Redirect, Route, Switch, useRouteMatch } from 'react-router-dom';
-import { Frame } from '@asap-hub/frontend-utils';
+import { Frame, SearchFrame } from '@asap-hub/frontend-utils';
 
 import { useSearch } from '../hooks';
 import Event from './Event';
@@ -40,12 +40,12 @@ const Events: FC<Record<string, never>> = () => {
           searchQuery={searchQuery}
           onChangeSearchQuery={setSearchQuery}
         >
-          <Frame title="Upcoming Events">
+          <SearchFrame title="Upcoming Events">
             <EventList
               currentTime={currentTime}
               searchQuery={debouncedSearchQuery}
             />
-          </Frame>
+          </SearchFrame>
         </EventsPage>
       </Route>
       <Route exact path={path + events({}).past.template}>
@@ -53,13 +53,13 @@ const Events: FC<Record<string, never>> = () => {
           searchQuery={searchQuery}
           onChangeSearchQuery={setSearchQuery}
         >
-          <Frame title="Past Events">
+          <SearchFrame title="Past Events">
             <EventList
               past
               currentTime={currentTime}
               searchQuery={debouncedSearchQuery}
             />
-          </Frame>
+          </SearchFrame>
         </EventsPage>
       </Route>
       <Route path={path + events({}).event.template}>

--- a/apps/crn-frontend/src/shared-research/__tests__/api.test.ts
+++ b/apps/crn-frontend/src/shared-research/__tests__/api.test.ts
@@ -218,17 +218,7 @@ describe('getResearchOutputs', () => {
       }),
     );
   });
-
-  it('throws an error of type error', async () => {
-    mockAlgoliaSearchClient.search.mockRejectedValue({
-      message: 'Some Error',
-    });
-    await expect(
-      getResearchOutputs(mockAlgoliaSearchClient, options),
-    ).rejects.toMatchInlineSnapshot(`[Error: Could not search: Some Error]`);
-  });
 });
-
 describe('getResearchOutput', () => {
   it('makes an authorized GET request for the research output id', async () => {
     nock(API_BASE_URL, { reqheaders: { authorization: 'Bearer x' } })

--- a/apps/crn-frontend/src/shared-research/api.ts
+++ b/apps/crn-frontend/src/shared-research/api.ts
@@ -105,21 +105,17 @@ export const getResearchOutputs = (
   client: AlgoliaClient<'crn'>,
   options: ResearchOutputPublishedListOptions,
 ) =>
-  client
-    .search(['research-output'], options.searchQuery, {
-      page: options.currentPage ?? 0,
-      hitsPerPage: options.pageSize ?? 10,
-      tagFilters: options.tags,
-      filters: getAllFilters(
-        options.filters,
-        options.teamId,
-        options.userId,
-        options.workingGroupId,
-      ),
-    })
-    .catch((error: Error) => {
-      throw new Error(`Could not search: ${error.message}`);
-    });
+  client.search(['research-output'], options.searchQuery, {
+    page: options.currentPage ?? 0,
+    hitsPerPage: options.pageSize ?? 10,
+    tagFilters: options.tags,
+    filters: getAllFilters(
+      options.filters,
+      options.teamId,
+      options.userId,
+      options.workingGroupId,
+    ),
+  });
 
 export const getDraftResearchOutputs = async (
   options: ResearchOutputDraftListOptions,

--- a/packages/algolia/src/client.ts
+++ b/packages/algolia/src/client.ts
@@ -171,11 +171,12 @@ export class AlgoliaSearchClient<App extends Apps> implements SearchClient {
     requestOptions?: SearchOptions,
   ): Promise<SearchForFacetValuesResponse> {
     try {
-      return this.index.searchForFacetValues(
+      const result = await this.index.searchForFacetValues(
         '_tags',
         query,
         this.getSearchOptions(entityTypes, requestOptions),
       );
+      return result;
     } catch (error) {
       throw new Error(
         `Could not search for facet values: ${(error as Error).message}`,

--- a/packages/algolia/test/client.test.ts
+++ b/packages/algolia/test/client.test.ts
@@ -143,6 +143,20 @@ describe('Algolia Search Client', () => {
     });
   });
 
+  test('Should throw Error when search throws', async () => {
+    algoliaSearchIndex.search.mockRejectedValue({
+      message: 'Some Algolia ERROR',
+    });
+
+    await expect(
+      algoliaSearchClient.search(['research-output'], 'query', {
+        hitsPerPage: 10,
+        page: 0,
+        filters: 'some-filters',
+      }),
+    ).rejects.toThrow(new Error('Could not search: Some Algolia ERROR'));
+  });
+
   test('Should search user entity', async () => {
     algoliaSearchIndex.search.mockResolvedValueOnce(searchUserResponse);
 
@@ -201,6 +215,20 @@ describe('Algolia Search Client', () => {
       expect.objectContaining({
         filters: '__meta.type:"research-output"',
       }),
+    );
+  });
+  test('Should throw Error when facet search throws', async () => {
+    algoliaSearchIndex.searchForFacetValues.mockRejectedValue({
+      message: 'Some Algolia ERROR',
+    });
+    await expect(
+      algoliaSearchClient.searchForTagValues(['research-output'], 'query', {
+        hitsPerPage: 10,
+        page: 0,
+        filters: 'some-filters',
+      }),
+    ).rejects.toThrow(
+      new Error('Could not search for facet values: Some Algolia ERROR'),
     );
   });
   test('Should do facet value search with tags', async () => {


### PR DESCRIPTION
https://github.com/yldio/asap-hub/assets/1936253/ec3eba4a-a4d5-4064-aef4-ce1173f3c93d


I identified an infinite loop issue caused by nonstandard Algolia errors. To address this, I converted these errors into standard ones, ensuring compatibility with our 'instance of' functionality. The fix has been applied universally in the Algolia client and removed from research outputs.
