### PR TITLE
CRN-1507 nested <u> tags in headings

### DIFF
--- a/packages/react-components/src/__tests__/text.test.ts
+++ b/packages/react-components/src/__tests__/text.test.ts
@@ -61,6 +61,7 @@ describe.each([
   [[[false, 42], 'text']],
   [createElement('i')],
   [createElement('em')],
+  [createElement('u')],
   [createElement('i', { children: ['Italic Text'] })],
 ])('for the allowed children %p', (children) => {
   describe('isAllowedChildren', () => {

--- a/packages/react-components/src/text.ts
+++ b/packages/react-components/src/text.ts
@@ -41,7 +41,7 @@ const isAllowedElement = (child: unknown): child is AllowedElement => {
     typeof child === 'object' &&
     isValidElement(child) &&
     typeof child.type === 'string' &&
-    ['i', 'em', 'b', 'strong'].includes(child.type.toLowerCase())
+    ['i', 'em', 'b', 'strong', 'u'].includes(child.type.toLowerCase())
   )
     return true;
   return false;


### PR DESCRIPTION
This pr adds the <u> tag to the accepted children element list so that nested <u> tags in h1 - h3 tags render correctly.
ref: https://asaphub.atlassian.net/jira/software/c/projects/CRN/boards/6?modal=detail&selectedIssue=CRN-1507
update: <img width="940" alt="Screenshot 2023-10-09 at 13 32 08" src="https://github.com/yldio/asap-hub/assets/25244556/4da27432-9eb6-47e5-b345-e9f740d61daf">