### PR TITLE
fix: hide scrollbar in output detail page

### DIFF
--- a/packages/gp2-components/src/templates/OutputDetailPage.tsx
+++ b/packages/gp2-components/src/templates/OutputDetailPage.tsx
@@ -13,7 +13,7 @@ const containerStyles = css({
   display: 'flex',
   flexDirection: 'column',
   gap: rem(32),
-  overflow: 'scroll',
+  overflow: 'auto',
 });
 
 const commonStyles = {


### PR DESCRIPTION
This PR fixes the issue with the scrollbar appearing when not needed in output detail page

<img width="1437" alt="Screenshot 2023-10-16 at 12 12 29" src="https://github.com/yldio/asap-hub/assets/16595804/b2b855be-90bf-4e6f-a169-42b60fa3761c">
