### PR TITLE
fix: Ignore Sentry errors

### DIFF
--- a/apps/crn-server/test/utils/sentry-wrapper.test.ts
+++ b/apps/crn-server/test/utils/sentry-wrapper.test.ts
@@ -24,6 +24,8 @@ describe('Sentry wrapper correctly calls functions', () => {
       release: currentRevision,
       sampleRate: 1,
     });
-    expect(Sentry.AWSLambda.wrapHandler).toHaveBeenCalledWith(handler);
+    expect(Sentry.AWSLambda.wrapHandler).toHaveBeenCalledWith(handler, {
+      ignoreSentryErrors: true,
+    });
   });
 });

--- a/apps/gp2-server/test/utils/sentry-wrapper.test.ts
+++ b/apps/gp2-server/test/utils/sentry-wrapper.test.ts
@@ -24,6 +24,8 @@ describe('Sentry wrapper correctly calls functions', () => {
       release: currentRevision,
       sampleRate: 1,
     });
-    expect(Sentry.AWSLambda.wrapHandler).toHaveBeenCalledWith(handler);
+    expect(Sentry.AWSLambda.wrapHandler).toHaveBeenCalledWith(handler, {
+      ignoreSentryErrors: true,
+    });
   });
 });

--- a/packages/server-common/src/utils/sentry-wrapper.ts
+++ b/packages/server-common/src/utils/sentry-wrapper.ts
@@ -22,5 +22,5 @@ export const sentryWrapperFactory =
       release: config.currentRevision,
     });
 
-    return Sentry.AWSLambda.wrapHandler(handler);
+    return Sentry.AWSLambda.wrapHandler(handler, { ignoreSentryErrors: true });
   };

--- a/packages/server-common/test/utils/sentry-wrapper.test.ts
+++ b/packages/server-common/test/utils/sentry-wrapper.test.ts
@@ -28,6 +28,8 @@ describe('Sentry wrapper correctly calls functions', () => {
       release: config.currentRevision,
       sampleRate: 1,
     });
-    expect(Sentry.AWSLambda.wrapHandler).toHaveBeenCalledWith(handler);
+    expect(Sentry.AWSLambda.wrapHandler).toHaveBeenCalledWith(handler, {
+      ignoreSentryErrors: true,
+    });
   });
 });


### PR DESCRIPTION
This will allow us to ignore all the Sentry errors so that in the event of exceeding the quotas the handlers will continue to work as normal