### PR TITLE
GP2HUB-140 Add rate limits to contentful clients

### DIFF
--- a/apps/gp2-server/src/handlers/webhooks/events-updated.ts
+++ b/apps/gp2-server/src/handlers/webhooks/events-updated.ts
@@ -1,12 +1,6 @@
 /* istanbul ignore file */
-import { RateLimiter } from 'limiter';
 import { Handler } from 'aws-lambda';
-import {
-  getRestClient,
-  GraphQLClient,
-  MakeRequestOptions,
-  RestAdapter,
-} from '@asap-hub/contentful';
+
 import {
   getJWTCredentialsFactory,
   syncCalendarFactory,
@@ -14,17 +8,14 @@ import {
   webhookEventUpdatedHandlerFactory,
 } from '@asap-hub/server-common';
 import {
-  contentfulAccessToken,
-  contentfulEnvId,
-  contentfulManagementAccessToken,
-  contentfulSpaceId,
   googleApiCredentialsSecretId,
   googleApiToken,
   region,
 } from '../../config';
 import Events from '../../controllers/event.controller';
-import { EventContentfulDataProvider } from '../../data-providers/event.data-provider';
 import { getCalendarDataProvider } from '../../dependencies/calendar.dependency';
+import { getEventDataProvider } from '../../dependencies/event.dependency';
+import { getContentfulGraphQLClientFactory } from '../../dependencies/clients.dependency';
 import logger from '../../utils/logger';
 import { sentryWrapper } from '../../utils/sentry-wrapper';
 
@@ -33,57 +24,9 @@ const getJWTCredentials = getJWTCredentialsFactory({
   region,
 });
 
-const contentfulManagementApiRateLimiter = new RateLimiter({
-  tokensPerInterval: 3,
-  interval: 'second',
-});
+const graphQLClient = getContentfulGraphQLClientFactory();
 
-const contentDeliveryApiRateLimiter = new RateLimiter({
-  tokensPerInterval: 15,
-  interval: 'second',
-});
-
-class RateLimitedRestAdapter extends RestAdapter {
-  async makeRequest<R>(options: MakeRequestOptions): Promise<R> {
-    await contentfulManagementApiRateLimiter.removeTokens(1);
-    return super.makeRequest(options);
-  }
-}
-
-class RateLimitedGraphqlClient extends GraphQLClient {
-  request = (async (
-    ...args: Parameters<GraphQLClient['request']>
-  ): Promise<ReturnType<GraphQLClient['request']>> => {
-    await contentDeliveryApiRateLimiter.removeTokens(1);
-    return super.request(...args);
-  }) as GraphQLClient['request'];
-}
-
-const contentfulGraphQLClient = new RateLimitedGraphqlClient(
-  `https://graphql.contentful.com/content/v1/spaces/${contentfulSpaceId}/environments/${contentfulEnvId}`,
-  {
-    errorPolicy: 'ignore',
-    headers: {
-      authorization: `Bearer ${contentfulAccessToken}`,
-    },
-  },
-);
-
-const contentfulRestClient = getRestClient({
-  space: contentfulSpaceId,
-  accessToken: contentfulManagementAccessToken,
-  environment: contentfulEnvId,
-  apiAdapter: new RateLimitedRestAdapter({
-    accessToken: contentfulManagementAccessToken,
-  }),
-});
-
-const eventDataProvider = new EventContentfulDataProvider(
-  contentfulGraphQLClient,
-  () => contentfulRestClient,
-);
-
-const eventController = new Events(eventDataProvider);
+const eventController = new Events(getEventDataProvider(graphQLClient));
 const syncCalendar = syncCalendarFactory(
   syncEventFactory(eventController, logger),
   getJWTCredentials,
@@ -92,10 +35,7 @@ const syncCalendar = syncCalendarFactory(
 
 export const handler: Handler = sentryWrapper(
   webhookEventUpdatedHandlerFactory(
-    getCalendarDataProvider(
-      contentfulGraphQLClient,
-      () => contentfulRestClient,
-    ),
+    getCalendarDataProvider(graphQLClient),
     syncCalendar,
     logger,
     { googleApiToken },

--- a/packages/contentful/package.json
+++ b/packages/contentful/package.json
@@ -38,6 +38,7 @@
     "graphql": "15.8.0",
     "graphql-request": "6.1.0",
     "graphql-tag": "2.12.6",
+    "limiter": "^2.1.0",
     "minimist": "^1.2.8"
   },
   "devDependencies": {

--- a/packages/contentful/src/client.ts
+++ b/packages/contentful/src/client.ts
@@ -1,5 +1,12 @@
+/* eslint-disable max-classes-per-file */
 import { createClient as createCDAClient } from 'contentful';
-import { Adapter, createClient, Environment } from 'contentful-management';
+import {
+  createClient,
+  Environment,
+  MakeRequestOptions,
+  RestAdapter,
+} from 'contentful-management';
+import { RateLimiter } from 'limiter';
 import { GraphQLClient } from 'graphql-request';
 
 export type { MakeRequestOptions } from 'contentful-management';
@@ -7,11 +14,36 @@ export { RestAdapter } from 'contentful-management';
 
 const cache = new Map<string, Environment>();
 
+const contentfulManagementApiRateLimiter = new RateLimiter({
+  tokensPerInterval: 3,
+  interval: 'second',
+});
+
+const contentDeliveryApiRateLimiter = new RateLimiter({
+  tokensPerInterval: 15,
+  interval: 'second',
+});
+
+class RateLimitedRestAdapter extends RestAdapter {
+  async makeRequest<R>(options: MakeRequestOptions): Promise<R> {
+    await contentfulManagementApiRateLimiter.removeTokens(1);
+    return super.makeRequest(options);
+  }
+}
+
+class RateLimitedGraphqlClient extends GraphQLClient {
+  request = (async (
+    ...args: Parameters<GraphQLClient['request']>
+  ): Promise<ReturnType<GraphQLClient['request']>> => {
+    await contentDeliveryApiRateLimiter.removeTokens(1);
+    return super.request(...args);
+  }) as GraphQLClient['request'];
+}
+
 export type CreateClientParams = {
   space: string;
   environment: string;
   accessToken: string;
-  apiAdapter?: Adapter;
 };
 
 type CreatePreviewClientParams = {
@@ -24,7 +56,7 @@ export const getGraphQLClient = ({
   accessToken,
   environment,
 }: CreateClientParams) =>
-  new GraphQLClient(
+  new RateLimitedGraphqlClient(
     `https://graphql.contentful.com/content/v1/spaces/${space}/environments/${environment}`,
     {
       errorPolicy: 'ignore',
@@ -32,28 +64,24 @@ export const getGraphQLClient = ({
         authorization: `Bearer ${accessToken}`,
       },
     },
-  );
+  ) as GraphQLClient;
 
 export const getRestClient = async ({
   space: spaceId,
   accessToken,
   environment: environmentId,
-  apiAdapter,
 }: CreateClientParams): Promise<Environment> => {
   const key = `${accessToken}-${spaceId}-${environmentId}`;
   const cached = cache.get(key);
   if (cached) {
     return cached;
   }
-  const client = createClient(
-    apiAdapter
-      ? {
-          apiAdapter,
-        }
-      : {
-          accessToken,
-        },
-  );
+  const client = createClient({
+    apiAdapter: new RateLimitedRestAdapter({
+      accessToken,
+    }),
+  });
+
   const space = await client.getSpace(spaceId);
   const environment = await space.getEnvironment(environmentId);
   cache.set(key, environment);

--- a/packages/contentful/src/client.ts
+++ b/packages/contentful/src/client.ts
@@ -14,24 +14,24 @@ export { RestAdapter } from 'contentful-management';
 
 const cache = new Map<string, Environment>();
 
-const contentfulManagementApiRateLimiter = new RateLimiter({
+export const contentfulManagementApiRateLimiter = new RateLimiter({
   tokensPerInterval: 3,
   interval: 'second',
 });
 
-const contentDeliveryApiRateLimiter = new RateLimiter({
+export const contentDeliveryApiRateLimiter = new RateLimiter({
   tokensPerInterval: 15,
   interval: 'second',
 });
 
-class RateLimitedRestAdapter extends RestAdapter {
+export class RateLimitedRestAdapter extends RestAdapter {
   async makeRequest<R>(options: MakeRequestOptions): Promise<R> {
     await contentfulManagementApiRateLimiter.removeTokens(1);
     return super.makeRequest(options);
   }
 }
 
-class RateLimitedGraphqlClient extends GraphQLClient {
+export class RateLimitedGraphqlClient extends GraphQLClient {
   request = (async (
     ...args: Parameters<GraphQLClient['request']>
   ): Promise<ReturnType<GraphQLClient['request']>> => {

--- a/packages/contentful/test/client.test.ts
+++ b/packages/contentful/test/client.test.ts
@@ -41,27 +41,7 @@ describe('graphQL and Rest clients', () => {
       });
 
       expect(contentfulManagement.createClient).toHaveBeenCalledWith({
-        accessToken,
-      });
-      expect(getSpaceFn).toHaveBeenCalledWith(spaceId);
-      expect(getEnvironment).toHaveBeenCalledWith(environmentId);
-    });
-
-    it('should create a client using custom api-adapter', async () => {
-      const accessToken = 'token-2';
-      const spaceId = 'space-id';
-      const environmentId = 'env-id';
-      const apiAdapter = {} as contentfulManagement.Adapter;
-
-      await getRestClient({
-        space: spaceId,
-        accessToken,
-        environment: environmentId,
-        apiAdapter,
-      });
-
-      expect(contentfulManagement.createClient).toHaveBeenCalledWith({
-        apiAdapter,
+        apiAdapter: expect.anything(),
       });
       expect(getSpaceFn).toHaveBeenCalledWith(spaceId);
       expect(getEnvironment).toHaveBeenCalledWith(environmentId);

--- a/packages/server-common/src/utils/sync-google-event.ts
+++ b/packages/server-common/src/utils/sync-google-event.ts
@@ -46,7 +46,9 @@ export const syncEventFactory =
     logger.debug({ googleEvent }, 'google event');
 
     if (googleEvent.organizer?.email !== googleCalendarId) {
-      logger.error('The calendar is not the organiser of the event');
+      logger.error(
+        `The calendar is not the organiser of the event. Google Event Id: ${googleEvent.id}. Organizer: ${googleEvent.organizer?.email}. GoogleCalendarId: ${googleCalendarId}`,
+      );
       throw new Error('Invalid organiser');
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -793,6 +793,7 @@ __metadata:
     graphql-request: 6.1.0
     graphql-tag: 2.12.6
     graphql-typescript-integration: 1.2.1
+    limiter: ^2.1.0
     minimist: ^1.2.8
     prettier: 2.8.8
     ts-node: 10.9.1


### PR DESCRIPTION
Jira ticket: https://asaphub.atlassian.net/browse/GP2HUB-140

This PR moves the RateLimiter from `apps/gp2-server/src/handlers/webhooks/events-updated.ts` to `packages/contentful/src/client.ts` so every time we call `getGraphQLClient` or `getRestClient` it will be already created with rate limit and it adds more information in the log of `'Invalid organiser'` error.

---

About the specific event mentioned in the ticket `“Microbiome Working group 5th meeting” from the Microbiome WG calendar` (https://app.contentful.com/spaces/5v6w5j61tndm/environments/Production/entries/7ISTd1fUckDb7WGk2OIMSv) I couldn't find any log in cloudwatch

![bug03](https://github.com/yldio/asap-hub/assets/16595804/3cb6078f-8a0c-4ef5-bd6e-3c39f7e1ce36)

And I could check for other events that had 429 errors that they appear using the same query but changing the id
![bug01](https://github.com/yldio/asap-hub/assets/16595804/33b1756f-fbc3-424e-b277-3158aac3edd5)
![bug02](https://github.com/yldio/asap-hub/assets/16595804/6a8ca53e-8ca6-46df-af46-051bbd33981d)

So it seems there wasn't a 429 error for this specific event.

I also observed that there were a lot of errors due to `'Invalid organiser'` as we can see in the query below 8k in the last 3 days. I could reproduce this when I create an event in "Calendar 1", for example, then edit it and change it to "Calendar 2". So the event does not sync.

![Screenshot 2023-10-19 at 07 25 46](https://github.com/yldio/asap-hub/assets/16595804/041c1920-8bd3-4f8d-9a97-20054ee834e0)

I thought this could be the case for “Microbiome Working group 5th meeting” since we don't log the event id in this case. But then I created an env in contentful and added the "Microbiome WG" calendar and I could see that the event “Microbiome Working group 5th meeting” was synced without any errors.

So I've subscribed to `Microbiome WG calendar` and I saw the description of the event in Google Calendar UI and it was pretty much the same as what we have in Contentful. The difference in the hour is because in the left side is appearing in America/Sao_Paulo timezone

![Screenshot 2023-10-19 at 07 31 05](https://github.com/yldio/asap-hub/assets/16595804/ebccf66d-1270-49f9-9f58-6b806b6e3cf6)

So it seems this particular event from the card is synced after all.

---

After the changes made in this PR I also added another calendar (ASAP) to check if I would get any 429 errors and apparently I haven't (https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fgp2-hub-3830-eventsUpdated/log-events/2023$252F10$252F18$252F$255B$2524LATEST$255D6a9e21ee95ec49eea21936a9114c93cd$3FfilterPattern$3D) so it seems that it's working fine.

