### PR TITLE
CRN-1545 Add users to tag search

### DIFF
--- a/apps/crn-frontend/src/dashboard/Body.tsx
+++ b/apps/crn-frontend/src/dashboard/Body.tsx
@@ -1,6 +1,6 @@
 import { ComponentProps, FC } from 'react';
 import { User } from '@asap-hub/auth';
-import { DashboardPageBody } from '@asap-hub/react-components';
+import { DashboardPageBody, eventMapper } from '@asap-hub/react-components';
 import { activeUserMembershipStatus } from '@asap-hub/model';
 import { getEventListOptions } from '@asap-hub/frontend-utils';
 
@@ -8,7 +8,6 @@ import { useEvents } from '../events/state';
 import { useGuidesByCollection } from '../guides/state';
 import { useResearchOutputs } from '../shared-research/state';
 import { useUsers } from '../network/users/state';
-import { eventMapper } from '../events/EventList';
 
 type BodyProps = Omit<
   ComponentProps<typeof DashboardPageBody>,

--- a/apps/crn-frontend/src/events/EventList.tsx
+++ b/apps/crn-frontend/src/events/EventList.tsx
@@ -1,10 +1,4 @@
-import {
-  EventsList,
-  EventOwner,
-  EventTeams,
-  EventNumberOfSpeakers,
-} from '@asap-hub/react-components';
-import { EventResponse } from '@asap-hub/model';
+import { EventsList, eventMapper } from '@asap-hub/react-components';
 import { getEventListOptions } from '@asap-hub/frontend-utils';
 
 import { useEvents, usePrefetchEvents } from './state';
@@ -17,24 +11,6 @@ type EventListProps = {
 
   readonly searchQuery: string;
 };
-
-export const eventMapper = ({
-  speakers,
-  interestGroup,
-  workingGroup,
-  ...event
-}: EventResponse) => ({
-  ...event,
-  hasSpeakersToBeAnnounced: !!(
-    speakers.length === 0 ||
-    speakers.find((speaker) => 'team' in speaker && !('user' in speaker))
-  ),
-  eventTeams: <EventTeams speakers={speakers} />,
-  eventSpeakers: <EventNumberOfSpeakers speakers={speakers} />,
-  eventOwner: (
-    <EventOwner interestGroup={interestGroup} workingGroup={workingGroup} />
-  ),
-});
 
 const EventList: React.FC<EventListProps> = ({
   currentTime,

--- a/apps/crn-frontend/src/network/EventsEmbedList.tsx
+++ b/apps/crn-frontend/src/network/EventsEmbedList.tsx
@@ -1,9 +1,12 @@
 import { getEventListOptions, SearchFrame } from '@asap-hub/frontend-utils';
 import { EventConstraint, ListEventResponse } from '@asap-hub/model';
-import { EventSearch, EventsList } from '@asap-hub/react-components';
+import {
+  EventSearch,
+  EventsList,
+  eventMapper,
+} from '@asap-hub/react-components';
 import { usePagination, usePaginationParams, useSearch } from '../hooks';
 import { useEvents } from '../events/state';
-import { eventMapper } from '../events/EventList';
 
 type EventsEmbedListProps = {
   readonly currentTime: Date;

--- a/apps/crn-frontend/src/shared-research/state.ts
+++ b/apps/crn-frontend/src/shared-research/state.ts
@@ -1,4 +1,3 @@
-import { EMPTY_ALGOLIA_RESPONSE } from '@asap-hub/algolia';
 import {
   ListResearchOutputResponse,
   ResearchOutputResponse,
@@ -155,15 +154,6 @@ export const useResearchOutputs = (options: ResearchOutputListOptions) => {
   const { client } = useAlgolia();
   const authorization = useRecoilValue(authorizationState);
   if (researchOutputs === undefined) {
-    if (
-      options.noResultsWithoutCriteria &&
-      options.searchQuery === '' &&
-      options.filters.size === 0 &&
-      (options.tags?.length ?? 0) === 0
-    ) {
-      return EMPTY_ALGOLIA_RESPONSE;
-    }
-
     throw (
       options.draftsOnly
         ? getDraftResearchOutputs(options, authorization)

--- a/apps/crn-frontend/src/tags/Routes.tsx
+++ b/apps/crn-frontend/src/tags/Routes.tsx
@@ -1,4 +1,4 @@
-import { EntityResponses } from '@asap-hub/algolia';
+import { CRNTagEntitiesList } from '@asap-hub/algolia';
 import { Switch, Route, useRouteMatch } from 'react-router-dom';
 import { NotFoundPage, TagsPage } from '@asap-hub/react-components';
 import { Frame } from '@asap-hub/frontend-utils';
@@ -12,10 +12,7 @@ const Routes: React.FC<Record<string, never>> = () => {
   const { client } = useAlgolia();
   const { tags, setTags } = useSearch();
 
-  const entities: Array<keyof EntityResponses['crn']> = [
-    'research-output',
-    'user',
-  ];
+  const entities: CRNTagEntitiesList = ['research-output', 'user'];
 
   return (
     <Switch>

--- a/apps/crn-frontend/src/tags/Routes.tsx
+++ b/apps/crn-frontend/src/tags/Routes.tsx
@@ -1,3 +1,4 @@
+import { EntityResponses } from '@asap-hub/algolia';
 import { Switch, Route, useRouteMatch } from 'react-router-dom';
 import { NotFoundPage, TagsPage } from '@asap-hub/react-components';
 import { Frame } from '@asap-hub/frontend-utils';
@@ -11,6 +12,11 @@ const Routes: React.FC<Record<string, never>> = () => {
   const { client } = useAlgolia();
   const { tags, setTags } = useSearch();
 
+  const entities: Array<keyof EntityResponses['crn']> = [
+    'research-output',
+    'user',
+  ];
+
   return (
     <Switch>
       <Route exact path={path}>
@@ -19,7 +25,7 @@ const Routes: React.FC<Record<string, never>> = () => {
           setTags={setTags}
           loadTags={async (tagQuery) => {
             const searchedTags = await client.searchForTagValues(
-              ['research-output'],
+              entities,
               tagQuery,
               { tagFilters: tags },
             );
@@ -30,7 +36,7 @@ const Routes: React.FC<Record<string, never>> = () => {
           }}
         >
           <Frame title="Search">
-            <Tags />
+            <Tags entities={entities} />
           </Frame>
         </TagsPage>
       </Route>

--- a/apps/crn-frontend/src/tags/Routes.tsx
+++ b/apps/crn-frontend/src/tags/Routes.tsx
@@ -7,12 +7,12 @@ import Tags from './TagsList';
 import { useAlgolia } from '../hooks/algolia';
 import { useSearch } from '../hooks';
 
+export const entities: CRNTagSearchEntitiesList = ['research-output', 'user'];
+
 const Routes: React.FC<Record<string, never>> = () => {
   const { path } = useRouteMatch();
   const { client } = useAlgolia();
   const { tags, setTags } = useSearch();
-
-  const entities: CRNTagSearchEntitiesList = ['research-output', 'user'];
 
   return (
     <Switch>

--- a/apps/crn-frontend/src/tags/Routes.tsx
+++ b/apps/crn-frontend/src/tags/Routes.tsx
@@ -1,4 +1,4 @@
-import { CRNTagEntitiesList } from '@asap-hub/algolia';
+import { CRNTagSearchEntitiesList } from '@asap-hub/algolia';
 import { Switch, Route, useRouteMatch } from 'react-router-dom';
 import { NotFoundPage, TagsPage } from '@asap-hub/react-components';
 import { Frame } from '@asap-hub/frontend-utils';
@@ -12,7 +12,7 @@ const Routes: React.FC<Record<string, never>> = () => {
   const { client } = useAlgolia();
   const { tags, setTags } = useSearch();
 
-  const entities: CRNTagEntitiesList = ['research-output', 'user'];
+  const entities: CRNTagSearchEntitiesList = ['research-output', 'user'];
 
   return (
     <Switch>

--- a/apps/crn-frontend/src/tags/TagsList.tsx
+++ b/apps/crn-frontend/src/tags/TagsList.tsx
@@ -1,10 +1,10 @@
-import { EntityResponses } from '@asap-hub/algolia';
+import { CRNTagEntitiesList } from '@asap-hub/algolia';
 import { TagsPageBody } from '@asap-hub/react-components';
 import { usePagination, usePaginationParams, useSearch } from '../hooks';
 import { useTagSearch } from './state';
 
 type TagsProps = {
-  entities: Array<keyof EntityResponses['crn']>;
+  entities: CRNTagEntitiesList;
 };
 const Tags: React.FC<TagsProps> = ({ entities }) => {
   const { tags, searchQuery, filters } = useSearch();

--- a/apps/crn-frontend/src/tags/TagsList.tsx
+++ b/apps/crn-frontend/src/tags/TagsList.tsx
@@ -14,7 +14,6 @@ const Tags: React.FC<TagsProps> = ({ entities }) => {
     filters,
     currentPage,
     pageSize,
-    noResultsWithoutCriteria: true,
     tags,
   });
 

--- a/apps/crn-frontend/src/tags/TagsList.tsx
+++ b/apps/crn-frontend/src/tags/TagsList.tsx
@@ -1,11 +1,15 @@
+import { EntityResponses } from '@asap-hub/algolia';
 import { TagsPageBody } from '@asap-hub/react-components';
 import { usePagination, usePaginationParams, useSearch } from '../hooks';
-import { useResearchOutputs } from '../shared-research/state';
+import { useTagSearch } from './state';
 
-const Tags: React.FC<Record<string, never>> = () => {
+type TagsProps = {
+  entities: Array<keyof EntityResponses['crn']>;
+};
+const Tags: React.FC<TagsProps> = ({ entities }) => {
   const { tags, searchQuery, filters } = useSearch();
   const { currentPage, pageSize } = usePaginationParams();
-  const { items, total } = useResearchOutputs({
+  const { items, total } = useTagSearch(entities, {
     searchQuery,
     filters,
     currentPage,
@@ -13,6 +17,7 @@ const Tags: React.FC<Record<string, never>> = () => {
     noResultsWithoutCriteria: true,
     tags,
   });
+
   const { numberOfPages, renderPageHref } = usePagination(total, pageSize);
   return (
     <TagsPageBody

--- a/apps/crn-frontend/src/tags/TagsList.tsx
+++ b/apps/crn-frontend/src/tags/TagsList.tsx
@@ -1,10 +1,10 @@
-import { CRNTagEntitiesList } from '@asap-hub/algolia';
+import { CRNTagSearchEntitiesList } from '@asap-hub/algolia';
 import { TagsPageBody } from '@asap-hub/react-components';
 import { usePagination, usePaginationParams, useSearch } from '../hooks';
 import { useTagSearch } from './state';
 
 type TagsProps = {
-  entities: CRNTagEntitiesList;
+  entities: CRNTagSearchEntitiesList;
 };
 const Tags: React.FC<TagsProps> = ({ entities }) => {
   const { tags, searchQuery, filters } = useSearch();

--- a/apps/crn-frontend/src/tags/__tests__/Routes.test.tsx
+++ b/apps/crn-frontend/src/tags/__tests__/Routes.test.tsx
@@ -22,7 +22,7 @@ import { useAlgolia } from '../../hooks/algolia';
 import { getTagSearch } from '../api';
 import { refreshTagSearchIndex } from '../state';
 
-import Routes from '../Routes';
+import Routes, { entities } from '../Routes';
 
 jest.mock('../api');
 jest.mock('../../hooks/algolia', () => ({
@@ -84,11 +84,9 @@ it('allows typing in tag queries', async () => {
   userEvent.type(searchBox, 'test123');
   expect(searchBox.value).toEqual('test123');
   await waitFor(() => {
-    expect(mockSearchForTagValues).toHaveBeenCalledWith(
-      ['research-output', 'user'],
-      'test123',
-      { tagFilters: [] },
-    );
+    expect(mockSearchForTagValues).toHaveBeenCalledWith(entities, 'test123', {
+      tagFilters: [],
+    });
   });
 });
 

--- a/apps/crn-frontend/src/tags/__tests__/Routes.test.tsx
+++ b/apps/crn-frontend/src/tags/__tests__/Routes.test.tsx
@@ -3,10 +3,7 @@ import {
   EMPTY_ALGOLIA_FACET_HITS,
   EMPTY_ALGOLIA_RESPONSE,
 } from '@asap-hub/algolia';
-import {
-  Auth0Provider,
-  WhenReady,
-} from '@asap-hub/crn-frontend/src/auth/test-utils';
+import { createUserResponse } from '@asap-hub/fixtures';
 import {
   render,
   screen,
@@ -18,18 +15,22 @@ import { Suspense } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { RecoilRoot } from 'recoil';
 
+import { createAlgoliaResponse } from '../../__fixtures__/algolia';
+import { Auth0Provider, WhenReady } from '../../auth/test-utils';
 import { useAlgolia } from '../../hooks/algolia';
-import { getResearchOutputs } from '../../shared-research/api';
-import { refreshResearchOutputIndex } from '../../shared-research/state';
+
+import { getTagSearch } from '../api';
+import { refreshTagSearchIndex } from '../state';
+
 import Routes from '../Routes';
 
-jest.mock('../../shared-research/api');
+jest.mock('../api');
 jest.mock('../../hooks/algolia', () => ({
   useAlgolia: jest.fn(),
 }));
 
-const mockGetResearchOutputs = getResearchOutputs as jest.MockedFunction<
-  typeof getResearchOutputs
+const mockGetTagSearch = getTagSearch as jest.MockedFunction<
+  typeof getTagSearch
 >;
 
 const mockSearchForTagValues = jest.fn() as jest.MockedFunction<
@@ -48,6 +49,7 @@ beforeEach(() => {
   mockUseAlgolia.mockReturnValue({
     client: mockAlgoliaClient as unknown as AlgoliaSearchClient<'crn'>,
   });
+  mockGetTagSearch.mockResolvedValue(EMPTY_ALGOLIA_RESPONSE);
   mockAlgoliaClient.search.mockResolvedValue(EMPTY_ALGOLIA_RESPONSE);
   mockAlgoliaClient.searchForTagValues.mockResolvedValue(
     EMPTY_ALGOLIA_FACET_HITS,
@@ -58,7 +60,7 @@ const renderTagsPage = async (query = '') => {
   render(
     <RecoilRoot
       initializeState={({ set }) => {
-        set(refreshResearchOutputIndex, Math.random());
+        set(refreshTagSearchIndex, Math.random());
       }}
     >
       <Suspense fallback="loading">
@@ -83,7 +85,7 @@ it('allows typing in tag queries', async () => {
   expect(searchBox.value).toEqual('test123');
   await waitFor(() => {
     expect(mockSearchForTagValues).toHaveBeenCalledWith(
-      ['research-output'],
+      ['research-output', 'user'],
       'test123',
       { tagFilters: [] },
     );
@@ -101,8 +103,9 @@ it('Will search algolia using selected tag', async () => {
   userEvent.click(screen.getByRole('textbox'));
   userEvent.click(screen.getByText('LGW'));
   await waitFor(() =>
-    expect(mockGetResearchOutputs).toHaveBeenCalledWith(
+    expect(mockGetTagSearch).toHaveBeenCalledWith(
       expect.anything(),
+      ['research-output', 'user'],
       expect.objectContaining({ tags: ['LGW'] }),
     ),
   );
@@ -121,11 +124,82 @@ it('will lookup new "default options" using previously selected tag filter', asy
   userEvent.click(screen.getByRole('textbox'));
   userEvent.click(screen.getByText('LGW'));
   await waitFor(() => {
-    expect(mockGetResearchOutputs).toHaveBeenCalled();
+    expect(mockGetTagSearch).toHaveBeenCalled();
     expect(mockSearchForTagValues).toHaveBeenCalledWith(
       expect.anything(),
       expect.anything(),
       expect.objectContaining({ tagFilters: ['LGW'] }),
     );
   });
+});
+
+it('Will show algolia results', async () => {
+  mockSearchForTagValues.mockResolvedValue({
+    ...EMPTY_ALGOLIA_FACET_HITS,
+    facetHits: [{ value: 'LGW', count: 1, highlighted: 'LGW' }],
+  });
+  const userResponse = createUserResponse();
+  const algoliaResponse = createAlgoliaResponse([
+    {
+      ...userResponse,
+      displayName: 'Tom Cruise',
+      objectID: userResponse.id,
+      __meta: { type: 'user' },
+    },
+  ]);
+  mockGetTagSearch.mockResolvedValueOnce(algoliaResponse);
+
+  await renderTagsPage();
+
+  userEvent.click(screen.getByRole('textbox'));
+  userEvent.click(screen.getByText('LGW'));
+  await waitFor(() =>
+    expect(screen.getByText('Tom Cruise')).toBeInTheDocument(),
+  );
+});
+
+it('Will show page when algolia rejects with undefined', async () => {
+  mockSearchForTagValues.mockResolvedValue({
+    ...EMPTY_ALGOLIA_FACET_HITS,
+    facetHits: [{ value: 'LGW', count: 1, highlighted: 'LGW' }],
+  });
+
+  mockGetTagSearch.mockRejectedValueOnce(undefined);
+
+  await renderTagsPage();
+
+  userEvent.click(screen.getByRole('textbox'));
+  userEvent.click(screen.getByText('LGW'));
+  await waitFor(() =>
+    expect(mockGetTagSearch).toHaveBeenCalledWith(
+      expect.anything(),
+      ['research-output', 'user'],
+      expect.objectContaining({ tags: ['LGW'] }),
+    ),
+  );
+  expect(screen.getByText('Tags Search')).toBeInTheDocument();
+});
+
+it('Will show page when algolia rejects with error', async () => {
+  jest.spyOn(console, 'error').mockImplementation();
+
+  mockSearchForTagValues.mockResolvedValue({
+    ...EMPTY_ALGOLIA_FACET_HITS,
+    facetHits: [{ value: 'LGW', count: 1, highlighted: 'LGW' }],
+  });
+
+  mockGetTagSearch.mockRejectedValueOnce(new Error('ops'));
+
+  await renderTagsPage();
+
+  userEvent.click(screen.getByRole('textbox'));
+  userEvent.click(screen.getByText('LGW'));
+  await waitFor(() =>
+    expect(mockGetTagSearch).toHaveBeenCalledWith(
+      expect.anything(),
+      ['research-output', 'user'],
+      expect.objectContaining({ tags: ['LGW'] }),
+    ),
+  );
+  expect(screen.getByText('Tags Search')).toBeInTheDocument();
 });

--- a/apps/crn-frontend/src/tags/__tests__/Routes.test.tsx
+++ b/apps/crn-frontend/src/tags/__tests__/Routes.test.tsx
@@ -105,7 +105,7 @@ it('Will search algolia using selected tag', async () => {
   await waitFor(() =>
     expect(mockGetTagSearch).toHaveBeenCalledWith(
       expect.anything(),
-      ['research-output', 'user'],
+      expect.anything(),
       expect.objectContaining({ tags: ['LGW'] }),
     ),
   );
@@ -173,7 +173,7 @@ it('Will show page when algolia rejects with undefined', async () => {
   await waitFor(() =>
     expect(mockGetTagSearch).toHaveBeenCalledWith(
       expect.anything(),
-      ['research-output', 'user'],
+      expect.anything(),
       expect.objectContaining({ tags: ['LGW'] }),
     ),
   );
@@ -197,7 +197,7 @@ it('Will show page when algolia rejects with error', async () => {
   await waitFor(() =>
     expect(mockGetTagSearch).toHaveBeenCalledWith(
       expect.anything(),
-      ['research-output', 'user'],
+      expect.anything(),
       expect.objectContaining({ tags: ['LGW'] }),
     ),
   );

--- a/apps/crn-frontend/src/tags/__tests__/TagsList.test.tsx
+++ b/apps/crn-frontend/src/tags/__tests__/TagsList.test.tsx
@@ -6,6 +6,7 @@ import { RecoilRoot } from 'recoil';
 import { WhenReady, Auth0Provider } from '../../auth/test-utils';
 
 import TagList from '../TagsList';
+import { entities } from '../Routes';
 
 const renderTags = async (): Promise<RenderResult> =>
   render(
@@ -15,7 +16,7 @@ const renderTags = async (): Promise<RenderResult> =>
           <Suspense fallback="Loading...">
             <MemoryRouter initialEntries={['/']}>
               <Route path="/">
-                <TagList entities={['research-output', 'user']} />
+                <TagList entities={entities} />
               </Route>
             </MemoryRouter>
           </Suspense>

--- a/apps/crn-frontend/src/tags/__tests__/TagsList.test.tsx
+++ b/apps/crn-frontend/src/tags/__tests__/TagsList.test.tsx
@@ -15,7 +15,7 @@ const renderTags = async (): Promise<RenderResult> =>
           <Suspense fallback="Loading...">
             <MemoryRouter initialEntries={['/']}>
               <Route path="/">
-                <TagList />
+                <TagList entities={['research-output', 'user']} />
               </Route>
             </MemoryRouter>
           </Suspense>

--- a/apps/crn-frontend/src/tags/__tests__/api.test.ts
+++ b/apps/crn-frontend/src/tags/__tests__/api.test.ts
@@ -1,4 +1,4 @@
-import { AlgoliaSearchClient, EntityResponses } from '@asap-hub/algolia';
+import { AlgoliaSearchClient, CRNTagSearchEntities } from '@asap-hub/algolia';
 import { GetListOptions } from '@asap-hub/frontend-utils';
 
 import nock from 'nock';
@@ -19,10 +19,8 @@ const options: GetListOptions = {
   searchQuery: '',
 };
 
-type Entities = Array<keyof EntityResponses['crn']>;
-
 describe('getTagSearch', () => {
-  const entityTypes: Entities = ['research-output', 'user'];
+  const entityTypes: CRNTagSearchEntities[] = ['research-output', 'user'];
 
   const mockAlgoliaSearchClient = {
     search: jest

--- a/apps/crn-frontend/src/tags/__tests__/api.test.ts
+++ b/apps/crn-frontend/src/tags/__tests__/api.test.ts
@@ -1,0 +1,67 @@
+import { AlgoliaSearchClient, EntityResponses } from '@asap-hub/algolia';
+import { GetListOptions } from '@asap-hub/frontend-utils';
+
+import nock from 'nock';
+import { CARD_VIEW_PAGE_SIZE } from '../../hooks';
+import { createResearchOutputListAlgoliaResponse } from '../../__fixtures__/algolia';
+import { getTagSearch } from '../api';
+
+jest.mock('../../config');
+
+afterEach(() => {
+  nock.cleanAll();
+});
+
+const options: GetListOptions = {
+  filters: new Set<string>(),
+  pageSize: CARD_VIEW_PAGE_SIZE,
+  currentPage: 0,
+  searchQuery: '',
+};
+
+type Entities = Array<keyof EntityResponses['crn']>;
+
+describe('getTagSearch', () => {
+  const entityTypes: Entities = ['research-output', 'user'];
+
+  const mockAlgoliaSearchClient = {
+    search: jest
+      .fn()
+      .mockResolvedValue(createResearchOutputListAlgoliaResponse(1)),
+  } as unknown as jest.Mocked<AlgoliaSearchClient<'crn'>>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('makes a search request with query, default page and page size', async () => {
+    await getTagSearch(mockAlgoliaSearchClient, entityTypes, {
+      ...options,
+      searchQuery: 'test',
+      currentPage: null,
+      pageSize: null,
+      tags: [],
+    });
+
+    expect(mockAlgoliaSearchClient.search).toHaveBeenLastCalledWith(
+      entityTypes,
+      'test',
+      expect.objectContaining({ hitsPerPage: 10, page: 0 }),
+    );
+  });
+
+  it('passes page number, page size and tags to request', async () => {
+    await getTagSearch(mockAlgoliaSearchClient, entityTypes, {
+      ...options,
+      currentPage: 1,
+      pageSize: 20,
+      tags: ['Blood', 'Cas9'],
+    });
+
+    expect(mockAlgoliaSearchClient.search).toHaveBeenLastCalledWith(
+      entityTypes,
+      '',
+      expect.objectContaining({ hitsPerPage: 20, page: 1 }),
+    );
+  });
+});

--- a/apps/crn-frontend/src/tags/api.ts
+++ b/apps/crn-frontend/src/tags/api.ts
@@ -1,11 +1,11 @@
-import { AlgoliaClient, EntityResponses } from '@asap-hub/algolia';
+import { AlgoliaClient, CRNTagSearchEntities } from '@asap-hub/algolia';
 import { GetListOptions } from '@asap-hub/frontend-utils';
 
 export type TagSearchListOptions = GetListOptions & {
   tags: string[];
 };
 
-export const getTagSearch = <ResponsesKey extends keyof EntityResponses['crn']>(
+export const getTagSearch = <ResponsesKey extends CRNTagSearchEntities>(
   client: AlgoliaClient<'crn'>,
   entityTypes: ResponsesKey[],
   options: TagSearchListOptions,

--- a/apps/crn-frontend/src/tags/api.ts
+++ b/apps/crn-frontend/src/tags/api.ts
@@ -3,7 +3,6 @@ import { GetListOptions } from '@asap-hub/frontend-utils';
 
 export type TagSearchListOptions = GetListOptions & {
   tags: string[];
-  noResultsWithoutCriteria?: boolean;
 };
 
 export const getTagSearch = <ResponsesKey extends keyof EntityResponses['crn']>(

--- a/apps/crn-frontend/src/tags/api.ts
+++ b/apps/crn-frontend/src/tags/api.ts
@@ -1,0 +1,18 @@
+import { AlgoliaClient, EntityResponses } from '@asap-hub/algolia';
+import { GetListOptions } from '@asap-hub/frontend-utils';
+
+export type TagSearchListOptions = GetListOptions & {
+  tags: string[];
+  noResultsWithoutCriteria?: boolean;
+};
+
+export const getTagSearch = <ResponsesKey extends keyof EntityResponses['crn']>(
+  client: AlgoliaClient<'crn'>,
+  entityTypes: ResponsesKey[],
+  options: TagSearchListOptions,
+) =>
+  client.search(entityTypes, options.searchQuery, {
+    page: options.currentPage ?? 0,
+    hitsPerPage: options.pageSize ?? 10,
+    tagFilters: options.tags,
+  });

--- a/apps/crn-frontend/src/tags/state.ts
+++ b/apps/crn-frontend/src/tags/state.ts
@@ -126,7 +126,6 @@ export const useTagSearch = <ResponsesKey extends keyof EntityResponses['crn']>(
 
   if (tagSearch === undefined) {
     if (
-      options.noResultsWithoutCriteria &&
       options.searchQuery === '' &&
       options.filters.size === 0 &&
       (options.tags?.length ?? 0) === 0

--- a/apps/crn-frontend/src/tags/state.ts
+++ b/apps/crn-frontend/src/tags/state.ts
@@ -3,12 +3,7 @@ import {
   EMPTY_ALGOLIA_RESPONSE,
 } from '@asap-hub/algolia';
 import { GetListOptions } from '@asap-hub/frontend-utils';
-import {
-  EventResponse,
-  ListResponse,
-  ResearchOutputResponse,
-  UserResponse,
-} from '@asap-hub/model';
+import { TagSearchResponse, ListResponse } from '@asap-hub/model';
 
 import {
   atom,
@@ -24,8 +19,6 @@ import { getTagSearch, TagSearchListOptions } from './api';
 type RefreshTagSearchListOptions = GetListOptions & {
   refreshToken: number;
 };
-
-type TagSearchResponse = ResearchOutputResponse | UserResponse | EventResponse;
 
 const tagSearchIndexState = atomFamily<
   | {

--- a/apps/crn-frontend/src/tags/state.ts
+++ b/apps/crn-frontend/src/tags/state.ts
@@ -1,8 +1,10 @@
-import { EMPTY_ALGOLIA_RESPONSE, EntityResponses } from '@asap-hub/algolia';
+import {
+  CRNTagSearchEntities,
+  EMPTY_ALGOLIA_RESPONSE,
+} from '@asap-hub/algolia';
 import { GetListOptions } from '@asap-hub/frontend-utils';
 import {
   EventResponse,
-  ExternalAuthorResponse,
   ListResponse,
   ResearchOutputResponse,
   UserResponse,
@@ -23,11 +25,7 @@ type RefreshTagSearchListOptions = GetListOptions & {
   refreshToken: number;
 };
 
-type TagSearchResponse =
-  | ResearchOutputResponse
-  | UserResponse
-  | ExternalAuthorResponse
-  | EventResponse;
+type TagSearchResponse = ResearchOutputResponse | UserResponse | EventResponse;
 
 const tagSearchIndexState = atomFamily<
   | {
@@ -117,7 +115,7 @@ export const tagSearchListState = atomFamily<
   default: tagSearchState,
 });
 
-export const useTagSearch = <ResponsesKey extends keyof EntityResponses['crn']>(
+export const useTagSearch = <ResponsesKey extends CRNTagSearchEntities>(
   entityTypes: ResponsesKey[],
   options: TagSearchListOptions,
 ) => {

--- a/apps/crn-frontend/src/tags/state.ts
+++ b/apps/crn-frontend/src/tags/state.ts
@@ -1,0 +1,151 @@
+import { EMPTY_ALGOLIA_RESPONSE, EntityResponses } from '@asap-hub/algolia';
+import { GetListOptions } from '@asap-hub/frontend-utils';
+import {
+  EventResponse,
+  ExternalAuthorResponse,
+  ListResponse,
+  ResearchOutputResponse,
+  UserResponse,
+} from '@asap-hub/model';
+
+import {
+  atom,
+  atomFamily,
+  DefaultValue,
+  selectorFamily,
+  useRecoilState,
+} from 'recoil';
+
+import { useAlgolia } from '../hooks/algolia';
+import { getTagSearch, TagSearchListOptions } from './api';
+
+type RefreshTagSearchListOptions = GetListOptions & {
+  refreshToken: number;
+};
+
+type TagSearchResponse =
+  | ResearchOutputResponse
+  | UserResponse
+  | ExternalAuthorResponse
+  | EventResponse;
+
+const tagSearchIndexState = atomFamily<
+  | {
+      ids: ReadonlyArray<string>;
+      total: number;
+      algoliaQueryId?: string;
+      algoliaIndexName?: string;
+    }
+  | Error
+  | undefined,
+  RefreshTagSearchListOptions
+>({
+  key: 'tagSearchIndex',
+  default: undefined,
+});
+
+export const refreshTagSearchIndex = atom<number>({
+  key: 'refreshTagSearchIndex',
+  default: 0,
+});
+
+export const tagsSearchState = selectorFamily<
+  ListResponse<TagSearchResponse> | Error | undefined,
+  TagSearchListOptions
+>({
+  key: 'tagSearch',
+  get:
+    (options) =>
+    ({ get }) => {
+      const refreshToken = get(refreshTagSearchIndex);
+      const index = get(
+        tagSearchIndexState({
+          ...options,
+          refreshToken,
+        }),
+      );
+      if (index === undefined || index instanceof Error) return index;
+      const tagSearchList: TagSearchResponse[] = [];
+      for (const id of index.ids) {
+        const tagSearch = get(tagSearchListState(id));
+        if (tagSearch === undefined) return undefined;
+        tagSearchList.push(tagSearch);
+      }
+      return {
+        total: index.total,
+        items: tagSearchList,
+        algoliaQueryId: index.algoliaQueryId,
+        algoliaIndexName: index.algoliaIndexName,
+      };
+    },
+  set:
+    (options) =>
+    ({ get, set, reset }, tagSearch) => {
+      const refreshToken = get(refreshTagSearchIndex);
+      const indexStateOptions = { ...options, refreshToken };
+
+      if (tagSearch === undefined || tagSearch instanceof DefaultValue) {
+        reset(tagSearchIndexState(indexStateOptions));
+      } else if (tagSearch instanceof Error) {
+        set(tagSearchIndexState(indexStateOptions), tagSearch);
+      } else {
+        tagSearch.items.forEach((item) =>
+          set(tagSearchListState(item.id), item),
+        );
+        set(tagSearchIndexState(indexStateOptions), {
+          total: tagSearch.total,
+          ids: tagSearch.items.map(({ id }) => id),
+          algoliaIndexName: tagSearch.algoliaIndexName,
+          algoliaQueryId: tagSearch.algoliaQueryId,
+        });
+      }
+    },
+});
+
+export const tagSearchState = atomFamily<TagSearchResponse | undefined, string>(
+  {
+    key: 'tagSearch',
+    default: undefined,
+  },
+);
+
+export const tagSearchListState = atomFamily<
+  TagSearchResponse | undefined,
+  string
+>({
+  key: 'tagSearchList',
+  default: tagSearchState,
+});
+
+export const useTagSearch = <ResponsesKey extends keyof EntityResponses['crn']>(
+  entityTypes: ResponsesKey[],
+  options: TagSearchListOptions,
+) => {
+  const [tagSearch, setTagSearch] = useRecoilState(tagsSearchState(options));
+  const { client } = useAlgolia();
+
+  if (tagSearch === undefined) {
+    if (
+      options.noResultsWithoutCriteria &&
+      options.searchQuery === '' &&
+      options.filters.size === 0 &&
+      (options.tags?.length ?? 0) === 0
+    ) {
+      return EMPTY_ALGOLIA_RESPONSE;
+    }
+
+    throw getTagSearch(client, entityTypes, options)
+      .then((data) => ({
+        total: data.nbHits,
+        items: data.hits,
+        algoliaQueryId: data.queryID,
+        algoliaIndexName: data.index,
+      }))
+      .then(setTagSearch)
+      .catch(setTagSearch);
+  }
+  if (tagSearch instanceof Error) {
+    throw tagSearch;
+  }
+  return tagSearch;
+};

--- a/apps/crn-server/scripts/export-entity.ts
+++ b/apps/crn-server/scripts/export-entity.ts
@@ -112,5 +112,12 @@ const transformRecords = <T extends EntityResponsesCRN, K extends keyof T>(
     };
   }
 
+  if (type === 'user' && 'expertiseAndResourceTags' in record) {
+    return {
+      ...payload,
+      _tags: record.expertiseAndResourceTags,
+    };
+  }
+
   return payload;
 };

--- a/apps/crn-server/src/handlers/lab/algolia-index-lab-users-handler.ts
+++ b/apps/crn-server/src/handlers/lab/algolia-index-lab-users-handler.ts
@@ -48,7 +48,10 @@ export const indexLabUsersHandler =
         foundUsers.items
           .filter((user) => user.onboarded && user.role !== 'Hidden')
           .map((data) => ({
-            data,
+            data: {
+              ...data,
+              _tags: data.expertiseAndResourceTags,
+            },
             type: 'user',
           })),
       );

--- a/apps/crn-server/src/handlers/user/algolia-index-user-handler.ts
+++ b/apps/crn-server/src/handlers/user/algolia-index-user-handler.ts
@@ -1,5 +1,5 @@
 import { AlgoliaClient, algoliaSearchClientFactory } from '@asap-hub/algolia';
-import { UserEvent } from '@asap-hub/model';
+import { UserEvent, UserResponse } from '@asap-hub/model';
 import { EventBridgeHandler, UserPayload } from '@asap-hub/server-common';
 import { NotFoundError } from '@asap-hub/errors';
 import { Boom, isBoom } from '@hapi/boom';
@@ -29,7 +29,10 @@ export const indexUserHandler =
 
       if (user.onboarded && user.role !== 'Hidden') {
         await algoliaClient.save({
-          data: user,
+          data: {
+            ...user,
+            _tags: user.expertiseAndResourceTags,
+          } as UserResponse & { _tags: string[] },
           type: 'user',
         });
 

--- a/apps/crn-server/test/handlers/lab/algolia-index-lab-users-handler.test.ts
+++ b/apps/crn-server/test/handlers/lab/algolia-index-lab-users-handler.test.ts
@@ -87,7 +87,7 @@ describe('Index Users on Lab event handler', () => {
     await indexHandler(updateEvent('lab-1234'));
 
     expect(algoliaSearchClientMock.saveMany).toHaveBeenCalledWith([
-      mapPayload(getUserResponse()),
+      mapPayload(expect.objectContaining(getUserResponse())),
     ]);
   });
 
@@ -102,7 +102,9 @@ describe('Index Users on Lab event handler', () => {
       await indexHandler(event);
 
       expect(algoliaSearchClientMock.saveMany).toHaveBeenCalledWith(
-        usersResponse.items.map(mapPayload),
+        usersResponse.items.map((item) =>
+          mapPayload(expect.objectContaining(item)),
+        ),
       );
     },
   );
@@ -124,11 +126,15 @@ describe('Index Users on Lab event handler', () => {
         expect(algoliaSearchClientMock.saveMany).toHaveBeenCalledTimes(2);
         expect(algoliaSearchClientMock.saveMany).toHaveBeenNthCalledWith(
           1,
-          usersResponse.items.map(mapPayload),
+          usersResponse.items.map((item) =>
+            mapPayload(expect.objectContaining(item)),
+          ),
         );
         expect(algoliaSearchClientMock.saveMany).toHaveBeenNthCalledWith(
           2,
-          usersResponse.items.map(mapPayload),
+          usersResponse.items.map((item) =>
+            mapPayload(expect.objectContaining(item)),
+          ),
         );
       },
     );

--- a/apps/crn-server/test/handlers/user/algolia-index-user-handler.test.ts
+++ b/apps/crn-server/test/handlers/user/algolia-index-user-handler.test.ts
@@ -25,7 +25,7 @@ describe('User index handler', () => {
       event.detail.resourceId,
     );
     expect(algoliaSearchClientMock.save).toHaveBeenCalledWith({
-      data: userResponse,
+      data: expect.objectContaining(userResponse),
       type: 'user',
     });
   });
@@ -37,7 +37,7 @@ describe('User index handler', () => {
     await indexHandler(updateEvent());
 
     expect(algoliaSearchClientMock.save).toHaveBeenCalledWith({
-      data: userResponse,
+      data: expect.objectContaining(userResponse),
       type: 'user',
     });
   });
@@ -108,6 +108,27 @@ describe('User index handler', () => {
     );
   });
 
+  test('Should populate _tags field before saving the user to Algolia', async () => {
+    const event = createEvent();
+    const userResponse = getUserResponse();
+    userResponse.expertiseAndResourceTags = [
+      'Bitopertin',
+      'A53T',
+      'Adapter ligation',
+    ];
+    userControllerMock.fetchById.mockResolvedValueOnce(userResponse);
+
+    await indexHandler(event);
+
+    expect(algoliaSearchClientMock.save).toHaveBeenCalledWith({
+      data: {
+        ...userResponse,
+        _tags: ['Bitopertin', 'A53T', 'Adapter ligation'],
+      },
+      type: 'user',
+    });
+  });
+
   test('Should throw an error and do not trigger algolia when the user request fails with another error code', async () => {
     userControllerMock.fetchById.mockRejectedValue(Boom.badData());
 
@@ -152,7 +173,7 @@ describe('User index handler', () => {
       expect(algoliaSearchClientMock.remove).not.toHaveBeenCalled();
       expect(algoliaSearchClientMock.save).toHaveBeenCalledTimes(2);
       expect(algoliaSearchClientMock.save).toHaveBeenCalledWith({
-        data: userResponse,
+        data: expect.objectContaining(userResponse),
         type: 'user',
       });
     });
@@ -172,7 +193,7 @@ describe('User index handler', () => {
       expect(algoliaSearchClientMock.remove).not.toHaveBeenCalled();
       expect(algoliaSearchClientMock.save).toHaveBeenCalledTimes(2);
       expect(algoliaSearchClientMock.save).toHaveBeenCalledWith({
-        data: userResponse,
+        data: expect.objectContaining(userResponse),
         type: 'user',
       });
     });

--- a/packages/algolia/src/client.ts
+++ b/packages/algolia/src/client.ts
@@ -185,6 +185,9 @@ export class AlgoliaSearchClient<App extends Apps> implements SearchClient {
   }
 }
 
-export type CRNTagEntities = keyof EntityResponses['crn'];
+export type CRNEntities = keyof EntityResponses['crn'];
 
-export type CRNTagEntitiesList = Array<CRNTagEntities>;
+// we don't show external author cards
+export type CRNTagSearchEntities = Exclude<CRNEntities, 'external-author'>;
+
+export type CRNTagSearchEntitiesList = Array<CRNTagSearchEntities>;

--- a/packages/algolia/src/client.ts
+++ b/packages/algolia/src/client.ts
@@ -184,3 +184,7 @@ export class AlgoliaSearchClient<App extends Apps> implements SearchClient {
     }
   }
 }
+
+export type CRNTagEntities = keyof EntityResponses['crn'];
+
+export type CRNTagEntitiesList = Array<CRNTagEntities>;

--- a/packages/model/src/index.ts
+++ b/packages/model/src/index.ts
@@ -19,6 +19,7 @@ export * from './page';
 export * from './reminder';
 export * from './research-output';
 export * from './research-tag';
+export * from './tag';
 export * from './team';
 export * from './tutorials';
 export * from './user';

--- a/packages/model/src/tag.ts
+++ b/packages/model/src/tag.ts
@@ -1,0 +1,8 @@
+import { EventResponse } from './event';
+import { ResearchOutputResponse } from './research-output';
+import { UserResponse } from './user';
+
+export type TagSearchResponse =
+  | ResearchOutputResponse
+  | UserResponse
+  | EventResponse;

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -21,6 +21,7 @@
     "react-router-dom": "5.3.4"
   },
   "dependencies": {
+    "@asap-hub/algolia": "workspace:*",
     "@asap-hub/flags": "workspace:*",
     "@asap-hub/model": "workspace:*",
     "@asap-hub/routing": "workspace:*",

--- a/packages/react-components/src/event-mapper.tsx
+++ b/packages/react-components/src/event-mapper.tsx
@@ -1,0 +1,20 @@
+import { EventResponse } from '@asap-hub/model';
+import { EventNumberOfSpeakers, EventOwner, EventTeams } from './molecules';
+
+export const eventMapper = ({
+  speakers,
+  interestGroup,
+  workingGroup,
+  ...event
+}: EventResponse) => ({
+  ...event,
+  hasSpeakersToBeAnnounced: !!(
+    speakers.length === 0 ||
+    speakers.find((speaker) => 'team' in speaker && !('user' in speaker))
+  ),
+  eventTeams: <EventTeams speakers={speakers} />,
+  eventSpeakers: <EventNumberOfSpeakers speakers={speakers} />,
+  eventOwner: (
+    <EventOwner interestGroup={interestGroup} workingGroup={workingGroup} />
+  ),
+});

--- a/packages/react-components/src/index.ts
+++ b/packages/react-components/src/index.ts
@@ -7,6 +7,7 @@ import * as utils from './utils';
 import * as colors from './colors';
 
 export * from './button';
+export * from './event-mapper';
 export * from './appearance';
 export {
   accents,

--- a/packages/react-components/src/templates/TagsPageBody.tsx
+++ b/packages/react-components/src/templates/TagsPageBody.tsx
@@ -1,9 +1,14 @@
-import { ListResearchOutputResponse } from '@asap-hub/model';
+import {
+  ListEventResponse,
+  ListExternalAuthorResponse,
+  ListResearchOutputResponse,
+  ListUserResponse,
+} from '@asap-hub/model';
 import { css } from '@emotion/react';
 import { Headline3, Paragraph } from '../atoms';
 import { charcoal } from '../colors';
 import { tagsIcon } from '../icons';
-import { ResultList, SharedResearchCard } from '../organisms';
+import { PeopleCard, ResultList, SharedResearchCard } from '../organisms';
 import { perRem } from '../pixels';
 
 const wrapperStyle = css({
@@ -30,7 +35,12 @@ const MessageBody: React.FC<{ title: string; body: string }> = ({
 );
 
 interface TagsPageBodyProps {
-  readonly results: ListResearchOutputResponse['items'];
+  readonly results: (
+    | ListUserResponse['items'][number]
+    | ListResearchOutputResponse['items'][number]
+    | ListExternalAuthorResponse['items'][number]
+    | ListEventResponse['items'][number]
+  )[];
   readonly numberOfItems: number;
   readonly numberOfPages: number;
   readonly currentPage: number;
@@ -56,11 +66,25 @@ const TagsPageBody: React.FC<TagsPageBodyProps> = ({
       />
     }
   >
-    {results.map((data) => (
-      <div key={data.id}>
-        <SharedResearchCard {...data} />
-      </div>
-    ))}
+    {results.map((data) => {
+      if ('documentType' in data) {
+        return (
+          <div key={data.id}>
+            <SharedResearchCard {...data} />
+          </div>
+        );
+      }
+
+      if ('expertiseAndResourceTags' in data) {
+        return (
+          <div key={data.id}>
+            <PeopleCard {...data} />
+          </div>
+        );
+      }
+
+      return null;
+    })}
   </ResultList>
 );
 

--- a/packages/react-components/src/templates/TagsPageBody.tsx
+++ b/packages/react-components/src/templates/TagsPageBody.tsx
@@ -34,6 +34,20 @@ const MessageBody: React.FC<{ title: string; body: string }> = ({
   </main>
 );
 
+const EntityCard: React.FC<TagsPageBodyProps['results'][number]> = ({
+  ...data
+}) => {
+  if ('keywords' in data) {
+    return <SharedResearchCard {...data} />;
+  }
+
+  if ('expertiseAndResourceTags' in data) {
+    return <PeopleCard {...data} />;
+  }
+
+  return null;
+};
+
 interface TagsPageBodyProps {
   readonly results: (
     | ListUserResponse['items'][number]
@@ -66,25 +80,11 @@ const TagsPageBody: React.FC<TagsPageBodyProps> = ({
       />
     }
   >
-    {results.map((data) => {
-      if ('documentType' in data) {
-        return (
-          <div key={data.id}>
-            <SharedResearchCard {...data} />
-          </div>
-        );
-      }
-
-      if ('expertiseAndResourceTags' in data) {
-        return (
-          <div key={data.id}>
-            <PeopleCard {...data} />
-          </div>
-        );
-      }
-
-      return null;
-    })}
+    {results.map((data) => (
+      <div key={data.id}>
+        <EntityCard {...data} />
+      </div>
+    ))}
   </ResultList>
 );
 

--- a/packages/react-components/src/templates/TagsPageBody.tsx
+++ b/packages/react-components/src/templates/TagsPageBody.tsx
@@ -1,6 +1,6 @@
+import { CRNTagSearchEntities } from '@asap-hub/algolia';
 import {
   ListEventResponse,
-  ListExternalAuthorResponse,
   ListResearchOutputResponse,
   ListUserResponse,
 } from '@asap-hub/model';
@@ -8,8 +8,15 @@ import { css } from '@emotion/react';
 import { Headline3, Paragraph } from '../atoms';
 import { charcoal } from '../colors';
 import { tagsIcon } from '../icons';
-import { PeopleCard, ResultList, SharedResearchCard } from '../organisms';
+import { ErrorCard } from '../molecules';
+import {
+  EventCard,
+  PeopleCard,
+  ResultList,
+  SharedResearchCard,
+} from '../organisms';
 import { perRem } from '../pixels';
+import { eventMapper } from '..';
 
 const wrapperStyle = css({
   textAlign: 'center',
@@ -34,25 +41,42 @@ const MessageBody: React.FC<{ title: string; body: string }> = ({
   </main>
 );
 
+export enum TagFieldByEntity {
+  'research-output' = 'keywords',
+  user = 'expertiseAndResourceTags',
+  event = 'calendar',
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const assert = <T extends never>() => undefined;
+type TypeEqualityGuard<A, B> = Exclude<A, B> | Exclude<B, A>;
+
 const EntityCard: React.FC<TagsPageBodyProps['results'][number]> = ({
   ...data
-}) => {
-  if ('keywords' in data) {
+}): JSX.Element => {
+  assert<
+    TypeEqualityGuard<keyof typeof TagFieldByEntity, CRNTagSearchEntities>
+  >;
+
+  if (TagFieldByEntity['research-output'] in data) {
     return <SharedResearchCard {...data} />;
   }
 
-  if ('expertiseAndResourceTags' in data) {
+  if (TagFieldByEntity.user in data) {
     return <PeopleCard {...data} />;
   }
 
-  return null;
+  if (TagFieldByEntity.event in data) {
+    return <EventCard {...eventMapper(data)} />;
+  }
+
+  return <ErrorCard />;
 };
 
 interface TagsPageBodyProps {
   readonly results: (
     | ListUserResponse['items'][number]
     | ListResearchOutputResponse['items'][number]
-    | ListExternalAuthorResponse['items'][number]
     | ListEventResponse['items'][number]
   )[];
   readonly numberOfItems: number;

--- a/packages/react-components/src/templates/TagsPageBody.tsx
+++ b/packages/react-components/src/templates/TagsPageBody.tsx
@@ -1,9 +1,5 @@
 import { CRNTagSearchEntities } from '@asap-hub/algolia';
-import {
-  ListEventResponse,
-  ListResearchOutputResponse,
-  ListUserResponse,
-} from '@asap-hub/model';
+import { TagSearchResponse } from '@asap-hub/model';
 import { css } from '@emotion/react';
 import { Headline3, Paragraph } from '../atoms';
 import { charcoal } from '../colors';
@@ -69,11 +65,7 @@ const EntityCard: React.FC<TagsPageBodyProps['results'][number]> = ({
 };
 
 interface TagsPageBodyProps {
-  readonly results: (
-    | ListUserResponse['items'][number]
-    | ListResearchOutputResponse['items'][number]
-    | ListEventResponse['items'][number]
-  )[];
+  readonly results: TagSearchResponse[];
   readonly numberOfItems: number;
   readonly numberOfPages: number;
   readonly currentPage: number;

--- a/packages/react-components/src/templates/TagsPageBody.tsx
+++ b/packages/react-components/src/templates/TagsPageBody.tsx
@@ -8,7 +8,6 @@ import { css } from '@emotion/react';
 import { Headline3, Paragraph } from '../atoms';
 import { charcoal } from '../colors';
 import { tagsIcon } from '../icons';
-import { ErrorCard } from '../molecules';
 import {
   EventCard,
   PeopleCard,
@@ -66,11 +65,7 @@ const EntityCard: React.FC<TagsPageBodyProps['results'][number]> = ({
     return <PeopleCard {...data} />;
   }
 
-  if (TagFieldByEntity.event in data) {
-    return <EventCard {...eventMapper(data)} />;
-  }
-
-  return <ErrorCard />;
+  return <EventCard {...eventMapper(data)} />;
 };
 
 interface TagsPageBodyProps {

--- a/packages/react-components/src/templates/__tests__/TagsPageBody.test.tsx
+++ b/packages/react-components/src/templates/__tests__/TagsPageBody.test.tsx
@@ -1,4 +1,8 @@
-import { createResearchOutputResponse } from '@asap-hub/fixtures';
+import {
+  createEventResponse,
+  createResearchOutputResponse,
+  createUserResponse,
+} from '@asap-hub/fixtures';
 import { render, screen } from '@testing-library/react';
 import { ComponentProps } from 'react';
 import TagsPageBody from '../TagsPageBody';
@@ -26,9 +30,24 @@ it('renders a list of cards', () => {
   render(
     <TagsPageBody
       {...props}
-      numberOfItems={1}
-      results={[{ ...createResearchOutputResponse(), title: 'Example result' }]}
+      numberOfItems={2}
+      results={[
+        {
+          ...createResearchOutputResponse(),
+          title: 'Research about CRISPR/Cas9',
+        },
+        { ...createUserResponse(), displayName: 'John Doe', degree: 'PhD' },
+        { ...createEventResponse(), title: 'ASAP Collaborative Meeting' },
+      ]}
     />,
   );
-  expect(screen.getByText('Example result')).toBeVisible();
+  expect(screen.getByText('Research about CRISPR/Cas9')).toBeVisible();
+  expect(screen.getByText('Working Group')).toBeVisible();
+
+  expect(screen.getByText('John Doe, PhD')).toBeVisible();
+
+  // events will be implemented in the future
+  expect(
+    screen.queryByText('ASAP Collaborative Meeting'),
+  ).not.toBeInTheDocument();
 });

--- a/packages/react-components/src/templates/__tests__/TagsPageBody.test.tsx
+++ b/packages/react-components/src/templates/__tests__/TagsPageBody.test.tsx
@@ -38,6 +38,8 @@ it('renders a list of cards', () => {
         },
         { ...createUserResponse(), displayName: 'John Doe', degree: 'PhD' },
         { ...createEventResponse(), title: 'ASAP Collaborative Meeting' },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { id: 'unknown-id', name: 'unknown card' } as any,
       ]}
     />,
   );
@@ -46,8 +48,8 @@ it('renders a list of cards', () => {
 
   expect(screen.getByText('John Doe, PhD')).toBeVisible();
 
-  // events will be implemented in the future
-  expect(
-    screen.queryByText('ASAP Collaborative Meeting'),
-  ).not.toBeInTheDocument();
+  expect(screen.getByText('ASAP Collaborative Meeting')).toBeInTheDocument();
+
+  expect(screen.getByText('Something went wrong!')).toBeInTheDocument();
+  expect(screen.queryByText('unknown card')).not.toBeInTheDocument();
 });

--- a/packages/react-components/src/templates/__tests__/TagsPageBody.test.tsx
+++ b/packages/react-components/src/templates/__tests__/TagsPageBody.test.tsx
@@ -38,8 +38,6 @@ it('renders a list of cards', () => {
         },
         { ...createUserResponse(), displayName: 'John Doe', degree: 'PhD' },
         { ...createEventResponse(), title: 'ASAP Collaborative Meeting' },
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        { id: 'unknown-id', name: 'unknown card' } as any,
       ]}
     />,
   );
@@ -49,7 +47,4 @@ it('renders a list of cards', () => {
   expect(screen.getByText('John Doe, PhD')).toBeVisible();
 
   expect(screen.getByText('ASAP Collaborative Meeting')).toBeInTheDocument();
-
-  expect(screen.getByText('Something went wrong!')).toBeInTheDocument();
-  expect(screen.queryByText('unknown card')).not.toBeInTheDocument();
 });

--- a/packages/react-components/tsconfig.json
+++ b/packages/react-components/tsconfig.json
@@ -10,6 +10,7 @@
   },
   "include": ["src"],
   "references": [
+    { "path": "../algolia" },
     { "path": "../auth" },
     { "path": "../dom-test-utils" },
     { "path": "../fixtures" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1563,6 +1563,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@asap-hub/react-components@workspace:packages/react-components"
   dependencies:
+    "@asap-hub/algolia": "workspace:*"
     "@asap-hub/auth": "workspace:*"
     "@asap-hub/dom-test-utils": "workspace:*"
     "@asap-hub/eslint-config-asap-hub": "workspace:*"


### PR DESCRIPTION
![tags](https://github.com/yldio/asap-hub/assets/16595804/a8f546c4-e9f4-44b1-bcf4-1824a6a5f49d)

This PR:
- adds `_tags` to user data in algolia handlers
- adds `tags/state` and `tags/api` files to query more than one entity ("research-output" | "user" | "external-author" | "event") in algolia using tags. So for the next entities we'll just need to update the data we sent to algolia (using `_tags`), update `entities` in [here](https://github.com/yldio/asap-hub/blob/CRN-1545-populate-user-tags-field/apps/crn-frontend/src/tags/Routes.tsx#L15) and add the card to `TagsPageBody`.