### PR TITLE
[CRN-1533] fix(reminders): add fallback timezone detector

### DIFF
--- a/apps/crn-frontend/src/dashboard/__tests__/api.test.tsx
+++ b/apps/crn-frontend/src/dashboard/__tests__/api.test.tsx
@@ -1,7 +1,7 @@
 import { DashboardResponse, ListReminderResponse } from '@asap-hub/model';
 import nock from 'nock';
 import { API_BASE_URL } from '../../config';
-import { getDashboard, getReminders } from '../api';
+import { getDashboard, getReminders, getTimezone } from '../api';
 
 jest.mock('../../config');
 
@@ -81,5 +81,37 @@ describe('getReminders', () => {
     ).rejects.toThrowErrorMatchingInlineSnapshot(
       `"Failed to fetch reminders. Expected status 2xx. Received status 500."`,
     );
+  });
+});
+
+describe('getTimezone', () => {
+  it('returns UTC+{hours} for timezone ahead of UTC', async () => {
+    const date = {
+      getTimezoneOffset() {
+        return -600;
+      },
+    } as Date;
+
+    expect(getTimezone(date)).toBe('UTC+10');
+  });
+
+  it('returns UTC-{hours} for timezone behind of UTC', async () => {
+    const date = {
+      getTimezoneOffset() {
+        return 180;
+      },
+    } as Date;
+
+    expect(getTimezone(date)).toBe('UTC-3');
+  });
+
+  it('returns UTC for timezone equal to UTC', async () => {
+    const date = {
+      getTimezoneOffset() {
+        return 0;
+      },
+    } as Date;
+
+    expect(getTimezone(date)).toBe('UTC');
   });
 });

--- a/apps/crn-frontend/src/dashboard/api.ts
+++ b/apps/crn-frontend/src/dashboard/api.ts
@@ -27,9 +27,11 @@ export const getDashboard = async (
 export const getReminders = async (
   authorization: string,
 ): Promise<ListReminderResponse> => {
+  const timezone =
+    Intl.DateTimeFormat().resolvedOptions().timeZone || getTimezone(new Date());
   const resp = await fetch(
     `${API_BASE_URL}/reminders?${new URLSearchParams({
-      timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      timezone,
     })}`,
     {
       headers: {
@@ -45,4 +47,21 @@ export const getReminders = async (
     );
   }
   return resp.json();
+};
+
+export const getTimezone = (date: Date) => {
+  const offset = date.getTimezoneOffset();
+  // The number of minutes returned by getTimezoneOffset() is positive if the local time zone is behind UTC,
+  // and negative if the local time zone is ahead of UTC. For example, for UTC+10, -600 will be returned.
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getTimezoneOffset#negative_values_and_positive_values
+
+  if (offset > 0) {
+    return `UTC-${offset / 60}`;
+  }
+
+  if (offset < 0) {
+    return `UTC+${offset / -60}`;
+  }
+
+  return 'UTC';
 };


### PR DESCRIPTION
https://asaphub.atlassian.net/browse/CRN-1533

### Problem 
Intl.DateTimeFormat().resolvedOptions().timeZone is possibly undefined when using various browsers. This can happen when the user has not set a timezone in their browser.

### Solution
fallback to getting timezone offset and sending `UTC-{hours}` or `UTC+{hours}` to backend as these are valid timezone for luxon date package we use 