### PR TITLE
fix: PR indexes & api setup and teardown

### DIFF
--- a/.github/actions/contentful-checks/action.yml
+++ b/.github/actions/contentful-checks/action.yml
@@ -5,9 +5,6 @@ inputs:
   contentful-space-id:
     description: 'Contentful Space ID'
     required: true
-  contentful-master-env:
-    description: 'Contentful master environment'
-    required: true
   contentful-token:
     description: 'Contentful access token'
     required: true
@@ -15,22 +12,8 @@ inputs:
     description: 'Contentful environment name'
     required: true
     type: string
-  app:
-    description: 'crn or gp2'
-    required: true
-    type: string
-  create-dedicated-env:
-    description: 'if a dedicated env should be created'
-    required: true
-    type: boolean
 
 outputs:
-  contentful-env:
-    description: 'Contentful environment to be used on branch'
-    value: ${{ steps.determine-environment.outputs.env-id }}
-  on-branch-env:
-    description: 'Whether the Contentful environment being used is a branch environment'
-    value: ${{ steps.determine-environment.outputs.on-branch-env }}
   contentful-env-exists:
     description: 'Whether the Contentful environment already exists'
     value: ${{ steps.check-contentful-exists.outputs.exists }}
@@ -38,28 +21,6 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    # Determine whether a dedicated environment is needed for this branch
-    # otherwise default to $CONTENTFUL_MASTER_ENV
-    - name: Determine Environment
-      id: determine-environment
-      shell: bash
-      run: |
-        CONTENTFUL_ENV=$CONTENTFUL_MASTER_ENV
-        BRANCH_ENV=false
-
-        echo "CREATE_DEDICATED_ENV = $CREATE_DEDICATED_ENV"
-
-        if [ "$CREATE_DEDICATED_ENV" = true ]; then
-          CONTENTFUL_ENV=$CONTENTFUL_ENV_ID
-          BRANCH_ENV=true
-        fi
-
-        echo "env-id=$CONTENTFUL_ENV" >> $GITHUB_OUTPUT
-        echo "on-branch-env=$BRANCH_ENV" >> $GITHUB_OUTPUT
-      env:
-        CONTENTFUL_MASTER_ENV: ${{ inputs.contentful-master-env }}
-        CONTENTFUL_ENV_ID: ${{ inputs.contentful-environment-id }}
-        CREATE_DEDICATED_ENV: ${{ inputs.create-dedicated-env }}
     - name: Determine whether the Contentful environment has been created
       id: check-contentful-exists
       shell: bash
@@ -78,6 +39,6 @@ runs:
           echo "exists=false" >> $GITHUB_OUTPUT
         fi
       env:
-        CONTENTFUL_ENV: ${{ steps.determine-environment.outputs.env-id }}
+        CONTENTFUL_ENV: ${{ inputs.contentful-environment-id }}
         CONTENTFUL_SPACE_ID: ${{ inputs.contentful-space-id }}
         CONTENTFUL_MANAGEMENT_ACCESS_TOKEN: ${{ inputs.contentful-token }}

--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -283,11 +283,21 @@ runs:
           echo "gp2-app-url=https://$PR_NUMBER.gp2.asap.science" >> $GITHUB_OUTPUT
           echo "gp2-api-url=https://api-$PR_NUMBER.gp2.asap.science" >> $GITHUB_OUTPUT
 
-          echo "crn-algolia-index=asap-hub_CI-$PR_NUMBER" >> $GITHUB_OUTPUT
-          echo "gp2-algolia-index=gp2-hub_CI-$PR_NUMBER" >> $GITHUB_OUTPUT
-          
-          echo "crn-contentful-env-id=crn-$PR_NUMBER" >> $GITHUB_OUTPUT
-          echo "gp2-contentful-env-id=gp2-$PR_NUMBER" >> $GITHUB_OUTPUT
+          if [ "$CRN_CREATE_CONTENTFUL_PR_ENV" = true ]; then
+            echo "crn-algolia-index=asap-hub_CI-$PR_NUMBER" >> $GITHUB_OUTPUT
+            echo "crn-contentful-env-id=crn-$PR_NUMBER" >> $GITHUB_OUTPUT
+          else
+            echo "crn-algolia-index=asap-hub_dev" >> $GITHUB_OUTPUT
+            echo "crn-contentful-env-id=Development" >> $GITHUB_OUTPUT
+          fi
+
+          if [ "$GP2_CREATE_CONTENTFUL_PR_ENV" = true ]; then
+            echo "gp2-algolia-index=gp2-hub_CI-$PR_NUMBER" >> $GITHUB_OUTPUT
+            echo "gp2-contentful-env-id=gp2-$PR_NUMBER" >> $GITHUB_OUTPUT
+          else
+            echo "gp2-algolia-index=gp2-hub_dev" >> $GITHUB_OUTPUT
+            echo "gp2-contentful-env-id=Development" >> $GITHUB_OUTPUT
+          fi
 
         elif [ "$ENVIRONMENT_NAME" = 'Development' ]; then
           echo "app-release=${{ github.run_id }}-dev" >> $GITHUB_OUTPUT

--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -239,6 +239,12 @@ outputs:
   sls-stage:
     description: 'SLS Stage'
     value: ${{ steps.vars.outputs.sls-stage }}
+  crn-on-branch-env:
+    description: 'Whether the crn Contentful environment being used is a PR environment'
+    value: ${{ steps.vars.outputs.crn-on-branch-env }}
+  gp2-on-branch-env:
+    description: 'Whether the gp2 Contentful environment being used is a PR environment'
+    value: ${{ steps.vars.outputs.gp2-on-branch-env }}
 runs:
   using: 'composite'
   steps:
@@ -277,8 +283,12 @@ runs:
             echo "crn-ci-auth0-client-id=WHi7btcaXqs2lJnvVyp6SP12onYNbkIA" >> $GITHUB_OUTPUT
             echo "crn-auth0-domain=pr-asap-hub.us.auth0.com" >> $GITHUB_OUTPUT
           fi
+
           CRN_CREATE_CONTENTFUL_PR_ENV=${{ contains(github.event.pull_request.labels.*.name, 'crn-create-environment') || inputs.crn-create-env }}
           GP2_CREATE_CONTENTFUL_PR_ENV=${{ contains(github.event.pull_request.labels.*.name, 'gp2-create-environment') || inputs.gp2-create-env }}
+          
+          echo "crn-on-branch-env=$CRN_CREATE_CONTENTFUL_PR_ENV" >> $GITHUB_OUTPUT
+          echo "gp2-on-branch-env=$GP2_CREATE_CONTENTFUL_PR_ENV" >> $GITHUB_OUTPUT
 
           echo "pr-number=$PR_NUMBER" >> $GITHUB_OUTPUT
           echo "sls-stage=$PR_NUMBER" >> $GITHUB_OUTPUT

--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -7,6 +7,12 @@ inputs:
   pr-number:
     description: 'The PR number'
     required: true
+  crn-create-env:
+    description: 'Setup a dedicated CRN environment'
+    required: false
+  gp2-create-env:
+    description: 'Setup a dedicated GP2 environment'
+    required: false
 outputs:
   app-release:
     description: 'App Release'
@@ -271,8 +277,8 @@ runs:
             echo "crn-ci-auth0-client-id=WHi7btcaXqs2lJnvVyp6SP12onYNbkIA" >> $GITHUB_OUTPUT
             echo "crn-auth0-domain=pr-asap-hub.us.auth0.com" >> $GITHUB_OUTPUT
           fi
-          CRN_CREATE_CONTENTFUL_PR_ENV=${{ contains(github.event.pull_request.labels.*.name, 'crn-create-environment') }}
-          GP2_CREATE_CONTENTFUL_PR_ENV=${{ contains(github.event.pull_request.labels.*.name, 'gp2-create-environment') }}
+          CRN_CREATE_CONTENTFUL_PR_ENV=${{ contains(github.event.pull_request.labels.*.name, 'crn-create-environment') || inputs.crn-create-env }}
+          GP2_CREATE_CONTENTFUL_PR_ENV=${{ contains(github.event.pull_request.labels.*.name, 'gp2-create-environment') || inputs.gp2-create-env }}
 
           echo "pr-number=$PR_NUMBER" >> $GITHUB_OUTPUT
           echo "sls-stage=$PR_NUMBER" >> $GITHUB_OUTPUT
@@ -284,9 +290,11 @@ runs:
           echo "gp2-api-url=https://api-$PR_NUMBER.gp2.asap.science" >> $GITHUB_OUTPUT
 
           if [ "$CRN_CREATE_CONTENTFUL_PR_ENV" = true ]; then
+            echo "setting up dedicated PR env"
             echo "crn-algolia-index=asap-hub_CI-$PR_NUMBER" >> $GITHUB_OUTPUT
             echo "crn-contentful-env-id=crn-$PR_NUMBER" >> $GITHUB_OUTPUT
           else
+            echo "setting up PR pointing to DEV env"
             echo "crn-algolia-index=asap-hub_dev" >> $GITHUB_OUTPUT
             echo "crn-contentful-env-id=Development" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/on-push-branch.yml
+++ b/.github/workflows/on-push-branch.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     environment: Branch
     outputs:
-      crn-contentful-env: ${{ steps.get-crn-contentful-state.outputs.contentful-env }}
-      crn-on-branch-env: ${{ steps.get-crn-contentful-state.outputs.on-branch-env }}
+      crn-contentful-env: ${{ steps.setup.outputs.contentful-env-id }}
+      crn-on-branch-env: ${{ steps.setup.outputs.on-branch-env }}
       crn-contentful-env-exists: ${{ steps.get-crn-contentful-state.outputs.contentful-env-exists }}
       crn-contentful-limit-reached: ${{ steps.get-crn-contentful-state.outputs.contentful-limit-reached }}
-      gp2-contentful-env: ${{ steps.get-gp2-contentful-state.outputs.contentful-env }}
-      gp2-on-branch-env: ${{ steps.get-gp2-contentful-state.outputs.on-branch-env }}
+      gp2-contentful-env: ${{ steps.setup.outputs.contentful-env-id }}
+      gp2-on-branch-env: ${{ steps.setup.outputs.on-branch-env }}
       gp2-contentful-env-exists: ${{ steps.get-gp2-contentful-state.outputs.contentful-env-exists }}
       gp2-contentful-limit-reached: ${{ steps.get-gp2-contentful-state.outputs.contentful-limit-reached }}
     steps:
@@ -33,21 +33,15 @@ jobs:
         uses: ./.github/actions/contentful-checks
         with:
           contentful-space-id: ${{ steps.setup.outputs.crn-contentful-space-id }}
-          contentful-master-env: ${{ steps.setup.outputs.contentful-environment }}
           contentful-token: ${{ secrets.CONTENTFUL_MANAGEMENT_TOKEN }}
           contentful-environment-id: ${{ steps.setup.outputs.crn-contentful-env-id }}
-          app: crn
-          create-dedicated-env: ${{ contains(github.event.pull_request.labels.*.name, 'crn-create-environment') }}
       - name: Get GP2 Contentful Environment state
         id: get-gp2-contentful-state
         uses: ./.github/actions/contentful-checks
         with:
           contentful-space-id: ${{ steps.setup.outputs.gp2-contentful-space-id }}
-          contentful-master-env: ${{ steps.setup.outputs.contentful-environment }}
           contentful-token: ${{ secrets.CONTENTFUL_MANAGEMENT_TOKEN }}
           contentful-environment-id: ${{ steps.setup.outputs.gp2-contentful-env-id }}
-          app: gp2
-          create-dedicated-env: ${{ contains(github.event.pull_request.labels.*.name, 'gp2-create-environment') }}
 
   test:
     uses: ./.github/workflows/reusable-test.yml

--- a/.github/workflows/on-push-branch.yml
+++ b/.github/workflows/on-push-branch.yml
@@ -13,11 +13,11 @@ jobs:
     environment: Branch
     outputs:
       crn-contentful-env: ${{ steps.setup.outputs.crn-contentful-env-id }}
-      crn-on-branch-env: ${{ steps.setup.outputs.on-branch-env }}
+      crn-on-branch-env: ${{ steps.setup.outputs.crn-on-branch-env }}
       crn-contentful-env-exists: ${{ steps.get-crn-contentful-state.outputs.contentful-env-exists }}
       crn-contentful-limit-reached: ${{ steps.get-crn-contentful-state.outputs.contentful-limit-reached }}
       gp2-contentful-env: ${{ steps.setup.outputs.gp2-contentful-env-id }}
-      gp2-on-branch-env: ${{ steps.setup.outputs.on-branch-env }}
+      gp2-on-branch-env: ${{ steps.setup.outputs.gp2-on-branch-env }}
       gp2-contentful-env-exists: ${{ steps.get-gp2-contentful-state.outputs.contentful-env-exists }}
       gp2-contentful-limit-reached: ${{ steps.get-gp2-contentful-state.outputs.contentful-limit-reached }}
     steps:

--- a/.github/workflows/on-push-branch.yml
+++ b/.github/workflows/on-push-branch.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     environment: Branch
     outputs:
-      crn-contentful-env: ${{ steps.setup.outputs.contentful-env-id }}
+      crn-contentful-env: ${{ steps.setup.outputs.crn-contentful-env-id }}
       crn-on-branch-env: ${{ steps.setup.outputs.on-branch-env }}
       crn-contentful-env-exists: ${{ steps.get-crn-contentful-state.outputs.contentful-env-exists }}
       crn-contentful-limit-reached: ${{ steps.get-crn-contentful-state.outputs.contentful-limit-reached }}
-      gp2-contentful-env: ${{ steps.setup.outputs.contentful-env-id }}
+      gp2-contentful-env: ${{ steps.setup.outputs.gp2-contentful-env-id }}
       gp2-on-branch-env: ${{ steps.setup.outputs.on-branch-env }}
       gp2-contentful-env-exists: ${{ steps.get-gp2-contentful-state.outputs.contentful-env-exists }}
       gp2-contentful-limit-reached: ${{ steps.get-gp2-contentful-state.outputs.contentful-limit-reached }}

--- a/.github/workflows/on-remove.yml
+++ b/.github/workflows/on-remove.yml
@@ -83,6 +83,7 @@ jobs:
           CONTENTFUL_MANAGEMENT_ACCESS_TOKEN: ${{ secrets.CONTENTFUL_MANAGEMENT_TOKEN }}
           CONTENTFUL_ENV_ID: ${{ steps.setup.outputs.crn-contentful-env-id }}
       - name: Contentful Webhook Teardown
+        if: ${{ steps.setup.outputs.crn-contentful-env-id != 'Development' }}
         id: contentful-webhook-teardown
         shell: bash
         run: yarn workspace @asap-hub/contentful space:remove-webhook
@@ -122,6 +123,7 @@ jobs:
           CONTENTFUL_MANAGEMENT_ACCESS_TOKEN: ${{ secrets.CONTENTFUL_MANAGEMENT_TOKEN }}
           CONTENTFUL_ENV_ID: ${{ steps.setup.outputs.gp2-contentful-env-id }}
       - name: Contentful Webhook Teardown
+        if: ${{ steps.setup.outputs.gp2-contentful-env-id != 'Development' }}
         id: contentful-webhook-teardown
         shell: bash
         run: yarn workspace @asap-hub/contentful space:remove-webhook

--- a/.github/workflows/on-remove.yml
+++ b/.github/workflows/on-remove.yml
@@ -102,7 +102,7 @@ jobs:
           CONTENTFUL_MANAGEMENT_ACCESS_TOKEN: ${{ secrets.CONTENTFUL_MANAGEMENT_TOKEN }}
           CONTENTFUL_ENV_ID: ${{ steps.setup.outputs.crn-contentful-env-id }}
       - name: Contentful Webhook Teardown
-        if: ${{ steps.setup.outputs.crn-on-branch-env }}
+        if: ${{ steps.setup.outputs.crn-on-branch-env == 'true' }}
         id: contentful-webhook-teardown
         shell: bash
         # run: yarn workspace @asap-hub/contentful space:remove-webhook
@@ -154,7 +154,7 @@ jobs:
           CONTENTFUL_MANAGEMENT_ACCESS_TOKEN: ${{ secrets.CONTENTFUL_MANAGEMENT_TOKEN }}
           CONTENTFUL_ENV_ID: ${{ steps.setup.outputs.gp2-contentful-env-id }}
       - name: Contentful Webhook Teardown
-        if: ${{ steps.setup.outputs.gp2-contentful-env-id != steps.setup-dev.outputs.gp2-contentful-env-id && steps.setup.outputs.gp2-contentful-env-id != steps.setup-prod.outputs.gp2-contentful-env-id }}
+        if: ${{ steps.setup.outputs.gp2-on-branch-env == 'true' }}
         id: contentful-webhook-teardown
         shell: bash
         run: yarn workspace @asap-hub/contentful space:remove-webhook
@@ -207,7 +207,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-default-region: ${{ steps.setup.outputs.aws-default-region }}
       - name: Delete the index
-        if: ${{ steps.setup.outputs.crn-on-branch-env }}
+        if: ${{ steps.setup.outputs.crn-on-branch-env == 'true'}}
         run: |
           # yarn algolia:delete-index -a $ALGOLIA_APP_ID -k $ALGOLIA_API_KEY -n $ALGOLIA_INDEX
           echo "delete $ALGOLIA_INDEX"
@@ -260,7 +260,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-default-region: ${{ steps.setup.outputs.aws-default-region }}
       - name: Delete the index
-        if: ${{ steps.setup.outputs.gp2-algolia-index != steps.setup-dev.outputs.gp2-algolia-index && steps.setup.outputs.gp2-algolia-index != steps.setup-prod.outputs.gp2-algolia-index }}
+        if: ${{ steps.setup.outputs.gp2-on-branch-env == 'true' }}
         run: |
           yarn algolia:delete-index -a $ALGOLIA_APP_ID -k $ALGOLIA_API_KEY -n $ALGOLIA_INDEX
         env:

--- a/.github/workflows/on-remove.yml
+++ b/.github/workflows/on-remove.yml
@@ -163,6 +163,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-default-region: ${{ steps.setup.outputs.aws-default-region }}
       - name: Delete the index
+        if: ${{ steps.setup.outputs.crn-algolia-index != 'asap-hub_dev' }}
         run: |
           yarn algolia:delete-index -a $ALGOLIA_APP_ID -k $ALGOLIA_API_KEY -n $ALGOLIA_INDEX
         env:
@@ -203,6 +204,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-default-region: ${{ steps.setup.outputs.aws-default-region }}
       - name: Delete the index
+        if: ${{ steps.setup.outputs.gp2-algolia-index != 'gp2-hub_dev' }}
         run: |
           yarn algolia:delete-index -a $ALGOLIA_APP_ID -k $ALGOLIA_API_KEY -n $ALGOLIA_INDEX
         env:

--- a/.github/workflows/on-remove.yml
+++ b/.github/workflows/on-remove.yml
@@ -74,6 +74,16 @@ jobs:
         uses: ./.github/actions/setup-environment
         with:
           environment-name: Branch
+      - name: Setup Dev Environment
+        id: setup-dev
+        uses: ./.github/actions/setup-environment
+        with:
+          environment-name: Development
+      - name: Setup Prod Environment
+        id: setup-prod
+        uses: ./.github/actions/setup-environment
+        with:
+          environment-name: Production
       - name: Contentful Environment Teardown
         id: contentful-env-teardown
         shell: bash
@@ -83,7 +93,7 @@ jobs:
           CONTENTFUL_MANAGEMENT_ACCESS_TOKEN: ${{ secrets.CONTENTFUL_MANAGEMENT_TOKEN }}
           CONTENTFUL_ENV_ID: ${{ steps.setup.outputs.crn-contentful-env-id }}
       - name: Contentful Webhook Teardown
-        if: ${{ steps.setup.outputs.crn-contentful-env-id != 'Development' }}
+        if: ${{ steps.setup.outputs.crn-contentful-env-id != steps.setup-dev.outputs.crn-contentful-env-id && steps.setup.outputs.crn-contentful-env-id != steps.setup-prod.outputs.crn-contentful-env-id }}
         id: contentful-webhook-teardown
         shell: bash
         run: yarn workspace @asap-hub/contentful space:remove-webhook
@@ -114,6 +124,16 @@ jobs:
         uses: ./.github/actions/setup-environment
         with:
           environment-name: Branch
+      - name: Setup Dev Environment
+        id: setup-dev
+        uses: ./.github/actions/setup-environment
+        with:
+          environment-name: Development
+      - name: Setup Prod Environment
+        id: setup-prod
+        uses: ./.github/actions/setup-environment
+        with:
+          environment-name: Production
       - name: Contentful Environment Teardown
         id: contentful-env-teardown
         shell: bash
@@ -123,7 +143,7 @@ jobs:
           CONTENTFUL_MANAGEMENT_ACCESS_TOKEN: ${{ secrets.CONTENTFUL_MANAGEMENT_TOKEN }}
           CONTENTFUL_ENV_ID: ${{ steps.setup.outputs.gp2-contentful-env-id }}
       - name: Contentful Webhook Teardown
-        if: ${{ steps.setup.outputs.gp2-contentful-env-id != 'Development' }}
+        if: ${{ steps.setup.outputs.gp2-contentful-env-id != steps.setup-dev.outputs.gp2-contentful-env-id && steps.setup.outputs.gp2-contentful-env-id != steps.setup-prod.outputs.gp2-contentful-env-id }}
         id: contentful-webhook-teardown
         shell: bash
         run: yarn workspace @asap-hub/contentful space:remove-webhook
@@ -153,6 +173,16 @@ jobs:
         uses: ./.github/actions/setup-environment
         with:
           environment-name: Branch
+      - name: Setup Dev Environment
+        id: setup-dev
+        uses: ./.github/actions/setup-environment
+        with:
+          environment-name: Development
+      - name: Setup Prod Environment
+        id: setup-prod
+        uses: ./.github/actions/setup-environment
+        with:
+          environment-name: Production
       - name: Rebuild dependencies
         run: yarn build:babel
       - name: Get Algolia Keys
@@ -165,7 +195,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-default-region: ${{ steps.setup.outputs.aws-default-region }}
       - name: Delete the index
-        if: ${{ steps.setup.outputs.crn-algolia-index != 'asap-hub_dev' }}
+        if: ${{ steps.setup.outputs.crn-algolia-index != steps.setup-dev.outputs.crn-algolia-index && steps.setup.outputs.crn-algolia-index != steps.setup-prod.outputs.crn-algolia-index }}
         run: |
           yarn algolia:delete-index -a $ALGOLIA_APP_ID -k $ALGOLIA_API_KEY -n $ALGOLIA_INDEX
         env:
@@ -194,6 +224,16 @@ jobs:
         uses: ./.github/actions/setup-environment
         with:
           environment-name: Branch
+      - name: Setup Dev Environment
+        id: setup-dev
+        uses: ./.github/actions/setup-environment
+        with:
+          environment-name: Development
+      - name: Setup Prod Environment
+        id: setup-prod
+        uses: ./.github/actions/setup-environment
+        with:
+          environment-name: Production
       - name: Rebuild dependencies
         run: yarn build:babel
       - name: Get Algolia Keys
@@ -206,7 +246,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-default-region: ${{ steps.setup.outputs.aws-default-region }}
       - name: Delete the index
-        if: ${{ steps.setup.outputs.gp2-algolia-index != 'gp2-hub_dev' }}
+        if: ${{ steps.setup.outputs.gp2-algolia-index != steps.setup-dev.outputs.gp2-algolia-index && steps.setup.outputs.gp2-algolia-index != steps.setup-prod.outputs.gp2-algolia-index }}
         run: |
           yarn algolia:delete-index -a $ALGOLIA_APP_ID -k $ALGOLIA_API_KEY -n $ALGOLIA_INDEX
         env:

--- a/.github/workflows/on-remove.yml
+++ b/.github/workflows/on-remove.yml
@@ -83,16 +83,6 @@ jobs:
         with:
           environment-name: Branch
           crn-create-env: ${{inputs.crn-create-env}}
-      - name: Setup Dev Environment
-        id: setup-dev
-        uses: ./.github/actions/setup-environment
-        with:
-          environment-name: Development
-      - name: Setup Prod Environment
-        id: setup-prod
-        uses: ./.github/actions/setup-environment
-        with:
-          environment-name: Production
       - name: Contentful Environment Teardown
         id: contentful-env-teardown
         shell: bash
@@ -105,8 +95,7 @@ jobs:
         if: ${{ steps.setup.outputs.crn-on-branch-env == 'true' }}
         id: contentful-webhook-teardown
         shell: bash
-        # run: yarn workspace @asap-hub/contentful space:remove-webhook
-        run: echo remove-webhook $CONTENTFUL_ENVIRONMENT
+        run: yarn workspace @asap-hub/contentful space:remove-webhook
         env:
           CONTENTFUL_ENVIRONMENT: ${{ steps.setup.outputs.crn-contentful-env-id }}
           CONTENTFUL_MANAGEMENT_ACCESS_TOKEN: ${{ secrets.CONTENTFUL_MANAGEMENT_TOKEN }}
@@ -135,16 +124,6 @@ jobs:
         with:
           environment-name: Branch
           gp2-create-env: ${{inputs.gp2-create-env}}
-      - name: Setup Dev Environment
-        id: setup-dev
-        uses: ./.github/actions/setup-environment
-        with:
-          environment-name: Development
-      - name: Setup Prod Environment
-        id: setup-prod
-        uses: ./.github/actions/setup-environment
-        with:
-          environment-name: Production
       - name: Contentful Environment Teardown
         id: contentful-env-teardown
         shell: bash
@@ -185,16 +164,6 @@ jobs:
         with:
           environment-name: Branch
           crn-create-env: ${{inputs.crn-create-env}}
-      - name: Setup Dev Environment
-        id: setup-dev
-        uses: ./.github/actions/setup-environment
-        with:
-          environment-name: Development
-      - name: Setup Prod Environment
-        id: setup-prod
-        uses: ./.github/actions/setup-environment
-        with:
-          environment-name: Production
       - name: Rebuild dependencies
         run: yarn build:babel
       - name: Get Algolia Keys
@@ -209,8 +178,7 @@ jobs:
       - name: Delete the index
         if: ${{ steps.setup.outputs.crn-on-branch-env == 'true'}}
         run: |
-          # yarn algolia:delete-index -a $ALGOLIA_APP_ID -k $ALGOLIA_API_KEY -n $ALGOLIA_INDEX
-          echo "delete $ALGOLIA_INDEX"
+          yarn algolia:delete-index -a $ALGOLIA_APP_ID -k $ALGOLIA_API_KEY -n $ALGOLIA_INDEX
         env:
           ALGOLIA_API_KEY: ${{ steps.algolia-keys.outputs.algolia-api-key }}
           ALGOLIA_APP_ID: ${{ steps.algolia-keys.outputs.algolia-app-id }}
@@ -238,16 +206,6 @@ jobs:
         with:
           environment-name: Branch
           gp2-create-env: ${{inputs.gp2-create-env}}
-      - name: Setup Dev Environment
-        id: setup-dev
-        uses: ./.github/actions/setup-environment
-        with:
-          environment-name: Development
-      - name: Setup Prod Environment
-        id: setup-prod
-        uses: ./.github/actions/setup-environment
-        with:
-          environment-name: Production
       - name: Rebuild dependencies
         run: yarn build:babel
       - name: Get Algolia Keys

--- a/.github/workflows/on-remove.yml
+++ b/.github/workflows/on-remove.yml
@@ -9,6 +9,14 @@ on:
         required: true
         type: string
         description: Choose which PR number to destroy
+      crn-create-env:
+        required: false
+        type: boolean
+        description: Destroy dedicated CRN enironment
+      gp2-create-env:
+        required: false
+        type: boolean
+        description: Destroy dedicated GP2 enironment
 jobs:
   crn-sls-remove:
     if: ${{ github.event.inputs.pr-number || github.event.pull_request.head.repo.full_name == 'yldio/asap-hub' }}
@@ -74,6 +82,7 @@ jobs:
         uses: ./.github/actions/setup-environment
         with:
           environment-name: Branch
+          crn-create-env: ${{inputs.crn-create-env}}
       - name: Setup Dev Environment
         id: setup-dev
         uses: ./.github/actions/setup-environment
@@ -124,6 +133,7 @@ jobs:
         uses: ./.github/actions/setup-environment
         with:
           environment-name: Branch
+          gp2-create-env: ${{inputs.gp2-create-env}}
       - name: Setup Dev Environment
         id: setup-dev
         uses: ./.github/actions/setup-environment
@@ -173,6 +183,7 @@ jobs:
         uses: ./.github/actions/setup-environment
         with:
           environment-name: Branch
+          crn-create-env: ${{inputs.crn-create-env}}
       - name: Setup Dev Environment
         id: setup-dev
         uses: ./.github/actions/setup-environment
@@ -224,6 +235,7 @@ jobs:
         uses: ./.github/actions/setup-environment
         with:
           environment-name: Branch
+          gp2-create-env: ${{inputs.gp2-create-env}}
       - name: Setup Dev Environment
         id: setup-dev
         uses: ./.github/actions/setup-environment

--- a/.github/workflows/on-remove.yml
+++ b/.github/workflows/on-remove.yml
@@ -102,10 +102,11 @@ jobs:
           CONTENTFUL_MANAGEMENT_ACCESS_TOKEN: ${{ secrets.CONTENTFUL_MANAGEMENT_TOKEN }}
           CONTENTFUL_ENV_ID: ${{ steps.setup.outputs.crn-contentful-env-id }}
       - name: Contentful Webhook Teardown
-        if: ${{ steps.setup.outputs.crn-contentful-env-id != steps.setup-dev.outputs.crn-contentful-env-id && steps.setup.outputs.crn-contentful-env-id != steps.setup-prod.outputs.crn-contentful-env-id }}
+        if: ${{ steps.setup.outputs.crn-on-branch-env }}
         id: contentful-webhook-teardown
         shell: bash
-        run: yarn workspace @asap-hub/contentful space:remove-webhook
+        # run: yarn workspace @asap-hub/contentful space:remove-webhook
+        run: echo remove-webhook $CONTENTFUL_ENVIRONMENT
         env:
           CONTENTFUL_ENVIRONMENT: ${{ steps.setup.outputs.crn-contentful-env-id }}
           CONTENTFUL_MANAGEMENT_ACCESS_TOKEN: ${{ secrets.CONTENTFUL_MANAGEMENT_TOKEN }}
@@ -206,9 +207,10 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-default-region: ${{ steps.setup.outputs.aws-default-region }}
       - name: Delete the index
-        if: ${{ steps.setup.outputs.crn-algolia-index != steps.setup-dev.outputs.crn-algolia-index && steps.setup.outputs.crn-algolia-index != steps.setup-prod.outputs.crn-algolia-index }}
+        if: ${{ steps.setup.outputs.crn-on-branch-env }}
         run: |
-          yarn algolia:delete-index -a $ALGOLIA_APP_ID -k $ALGOLIA_API_KEY -n $ALGOLIA_INDEX
+          # yarn algolia:delete-index -a $ALGOLIA_APP_ID -k $ALGOLIA_API_KEY -n $ALGOLIA_INDEX
+          echo "delete $ALGOLIA_INDEX"
         env:
           ALGOLIA_API_KEY: ${{ steps.algolia-keys.outputs.algolia-api-key }}
           ALGOLIA_APP_ID: ${{ steps.algolia-keys.outputs.algolia-app-id }}

--- a/.github/workflows/reusable-create-environment.yml
+++ b/.github/workflows/reusable-create-environment.yml
@@ -126,6 +126,11 @@ jobs:
         uses: ./.github/actions/setup-environment
         with:
           environment-name: Development
+      - name: Setup Prod Environment
+        id: setup-prod
+        uses: ./.github/actions/setup-environment
+        with:
+          environment-name: Production
       - name: Get Algolia Keys
         id: algolia-keys
         if: ${{ inputs.environment-name=='Branch' }}
@@ -154,7 +159,7 @@ jobs:
           ALGOLIA_ADMIN_API_KEY: ${{ steps.algolia-keys.outputs.algolia-api-key }}
           ALGOLIA_INDEX: ${{ steps.setup.outputs.crn-algolia-index }}
       - name: Copy index from Dev
-        if: ${{ inputs.environment-name=='Branch' && steps.index-exists.outputs.index-exists == 'false' && steps.setup.outputs.crn-algolia-index != 'asap-hub_dev' }}
+        if: ${{ inputs.environment-name=='Branch' && steps.index-exists.outputs.index-exists == 'false' && steps.setup.outputs.crn-algolia-index != steps.setup-dev.outputs.crn-algolia-index && steps.setup.outputs.crn-algolia-index != steps.setup-prod.outputs.crn-algolia-index }}
         shell: bash
         run: |
           algolia indices copy -y -w $ALGOLIA_INDEX_DEV $ALGOLIA_INDEX
@@ -190,6 +195,11 @@ jobs:
         uses: ./.github/actions/setup-environment
         with:
           environment-name: Development
+      - name: Setup Prod Environment
+        id: setup-prod
+        uses: ./.github/actions/setup-environment
+        with:
+          environment-name: Production
       - name: Get Algolia Keys
         id: algolia-keys
         if: ${{ inputs.environment-name=='Branch' }}
@@ -218,7 +228,7 @@ jobs:
           ALGOLIA_ADMIN_API_KEY: ${{ steps.algolia-keys.outputs.algolia-api-key }}
           ALGOLIA_INDEX: ${{ steps.setup.outputs.gp2-algolia-index }}
       - name: Copy index from Dev
-        if: ${{ inputs.environment-name=='Branch' && steps.index-exists.outputs.index-exists == 'false' && steps.setup.outputs.gp2-algolia-index != 'gp2-hub_dev' }}
+        if: ${{ inputs.environment-name=='Branch' && steps.index-exists.outputs.index-exists == 'false' && steps.setup.outputs.gp2-algolia-index != steps.setup-dev.outputs.gp2-algolia-index && steps.setup.outputs.gp2-algolia-index != steps.setup-prod.outputs.gp2-algolia-index }}
         shell: bash
         run: |
           algolia indices copy -y -w $ALGOLIA_INDEX_DEV $ALGOLIA_INDEX

--- a/.github/workflows/reusable-create-environment.yml
+++ b/.github/workflows/reusable-create-environment.yml
@@ -154,7 +154,7 @@ jobs:
           ALGOLIA_ADMIN_API_KEY: ${{ steps.algolia-keys.outputs.algolia-api-key }}
           ALGOLIA_INDEX: ${{ steps.setup.outputs.crn-algolia-index }}
       - name: Copy index from Dev
-        if: ${{ inputs.environment-name=='Branch' && steps.index-exists.outputs.index-exists == 'false' }}
+        if: ${{ inputs.environment-name=='Branch' && steps.index-exists.outputs.index-exists == 'false' && steps.setup.outputs.crn-algolia-index != 'asap-hub_dev' }}
         shell: bash
         run: |
           algolia indices copy -y -w $ALGOLIA_INDEX_DEV $ALGOLIA_INDEX
@@ -218,7 +218,7 @@ jobs:
           ALGOLIA_ADMIN_API_KEY: ${{ steps.algolia-keys.outputs.algolia-api-key }}
           ALGOLIA_INDEX: ${{ steps.setup.outputs.gp2-algolia-index }}
       - name: Copy index from Dev
-        if: ${{ inputs.environment-name=='Branch' && steps.index-exists.outputs.index-exists == 'false' }}
+        if: ${{ inputs.environment-name=='Branch' && steps.index-exists.outputs.index-exists == 'false' && steps.setup.outputs.gp2-algolia-index != 'gp2-hub_dev' }}
         shell: bash
         run: |
           algolia indices copy -y -w $ALGOLIA_INDEX_DEV $ALGOLIA_INDEX

--- a/.github/workflows/reusable-create-environment.yml
+++ b/.github/workflows/reusable-create-environment.yml
@@ -121,6 +121,11 @@ jobs:
         uses: ./.github/actions/setup-environment
         with:
           environment-name: ${{ inputs.environment-name }}
+      - name: Setup Dev Environment
+        id: setup-dev
+        uses: ./.github/actions/setup-environment
+        with:
+          environment-name: Development
       - name: Get Algolia Keys
         id: algolia-keys
         if: ${{ inputs.environment-name=='Branch' }}
@@ -180,6 +185,11 @@ jobs:
         uses: ./.github/actions/setup-environment
         with:
           environment-name: ${{ inputs.environment-name }}
+      - name: Setup Dev Environment
+        id: setup-dev
+        uses: ./.github/actions/setup-environment
+        with:
+          environment-name: Development
       - name: Get Algolia Keys
         id: algolia-keys
         if: ${{ inputs.environment-name=='Branch' }}
@@ -208,7 +218,7 @@ jobs:
           ALGOLIA_ADMIN_API_KEY: ${{ steps.algolia-keys.outputs.algolia-api-key }}
           ALGOLIA_INDEX: ${{ steps.setup.outputs.gp2-algolia-index }}
       - name: Copy index from Dev
-        if: ${{ inputs.environment-name=='Branch' && steps.index-exists.outputs.index-exists == 'false' && inputs.crn-on-branch-env == 'true' }}
+        if: ${{ inputs.environment-name=='Branch' && steps.index-exists.outputs.index-exists == 'false' && inputs.gp2-on-branch-env == 'true' }}
         shell: bash
         run: |
           algolia indices copy -y -w $ALGOLIA_INDEX_DEV $ALGOLIA_INDEX

--- a/.github/workflows/reusable-create-environment.yml
+++ b/.github/workflows/reusable-create-environment.yml
@@ -121,16 +121,6 @@ jobs:
         uses: ./.github/actions/setup-environment
         with:
           environment-name: ${{ inputs.environment-name }}
-      - name: Setup Dev Environment
-        id: setup-dev
-        uses: ./.github/actions/setup-environment
-        with:
-          environment-name: Development
-      - name: Setup Prod Environment
-        id: setup-prod
-        uses: ./.github/actions/setup-environment
-        with:
-          environment-name: Production
       - name: Get Algolia Keys
         id: algolia-keys
         if: ${{ inputs.environment-name=='Branch' }}
@@ -159,7 +149,7 @@ jobs:
           ALGOLIA_ADMIN_API_KEY: ${{ steps.algolia-keys.outputs.algolia-api-key }}
           ALGOLIA_INDEX: ${{ steps.setup.outputs.crn-algolia-index }}
       - name: Copy index from Dev
-        if: ${{ inputs.environment-name=='Branch' && steps.index-exists.outputs.index-exists == 'false' && steps.setup.outputs.crn-algolia-index != steps.setup-dev.outputs.crn-algolia-index && steps.setup.outputs.crn-algolia-index != steps.setup-prod.outputs.crn-algolia-index }}
+        if: ${{ inputs.environment-name=='Branch' && steps.index-exists.outputs.index-exists == 'false' && inputs.crn-on-branch-env == 'true' }}
         shell: bash
         run: |
           algolia indices copy -y -w $ALGOLIA_INDEX_DEV $ALGOLIA_INDEX
@@ -190,16 +180,6 @@ jobs:
         uses: ./.github/actions/setup-environment
         with:
           environment-name: ${{ inputs.environment-name }}
-      - name: Setup Dev Environment
-        id: setup-dev
-        uses: ./.github/actions/setup-environment
-        with:
-          environment-name: Development
-      - name: Setup Prod Environment
-        id: setup-prod
-        uses: ./.github/actions/setup-environment
-        with:
-          environment-name: Production
       - name: Get Algolia Keys
         id: algolia-keys
         if: ${{ inputs.environment-name=='Branch' }}
@@ -228,7 +208,7 @@ jobs:
           ALGOLIA_ADMIN_API_KEY: ${{ steps.algolia-keys.outputs.algolia-api-key }}
           ALGOLIA_INDEX: ${{ steps.setup.outputs.gp2-algolia-index }}
       - name: Copy index from Dev
-        if: ${{ inputs.environment-name=='Branch' && steps.index-exists.outputs.index-exists == 'false' && steps.setup.outputs.gp2-algolia-index != steps.setup-dev.outputs.gp2-algolia-index && steps.setup.outputs.gp2-algolia-index != steps.setup-prod.outputs.gp2-algolia-index }}
+        if: ${{ inputs.environment-name=='Branch' && steps.index-exists.outputs.index-exists == 'false' && inputs.crn-on-branch-env == 'true' }}
         shell: bash
         run: |
           algolia indices copy -y -w $ALGOLIA_INDEX_DEV $ALGOLIA_INDEX


### PR DESCRIPTION
PR adds back setting up api and index based on `crn-create-environment` or `gp2-create-environment` label. That was added in https://github.com/yldio/asap-hub/pull/3862 and reverted

Also fixes the following issue

### Problem
PR that did not have dedicated environment were deleting `asap-hub_dev` and `gp2-hub_dev` indexes during PR clean up workflow

### Solution
only run the delete index step if the index is not dev or prod
only remove webhook if it is PR environment
only copy index if it is a PR environment