### PR TITLE
Hide empty cards

### DIFF
--- a/apps/storybook/src/UserProfileResearch.stories.tsx
+++ b/apps/storybook/src/UserProfileResearch.stories.tsx
@@ -1,5 +1,5 @@
 import { ComponentProps } from 'react';
-import { UserProfileResearch } from '@asap-hub/react-components';
+import { UserProfileResearch, Card } from '@asap-hub/react-components';
 import { array, text, boolean, select } from '@storybook/addon-knobs';
 
 export default {
@@ -31,12 +31,12 @@ const props = (): ComponentProps<typeof UserProfileResearch> => ({
     'Are alpha-synuclein deposits the cause or consequence of somethign deeper wrong with neurons?',
     'How much do we have to knock down extracellular alpha-synuclein to measurably slow cell to cell transmission?',
   ]),
-  userProfileGroupsCard: boolean('User Profile Groups Placeholder', true)
-    ? 'User Profile Groups Placeholder'
-    : undefined,
-  userProfileTeamsCard: boolean('User Profile Teams Placeholder', true)
-    ? 'User Profile Teams Placeholder'
-    : undefined,
+  userProfileGroupsCard: boolean('User Profile Groups Placeholder', true) ? (
+    <Card>User Profile Groups Placeholder</Card>
+  ) : undefined,
+  userProfileTeamsCard: boolean('User Profile Teams Placeholder', true) ? (
+    <Card>User Profile Teams Placeholder</Card>
+  ) : undefined,
   isOwnProfile: boolean(`Is own profile`, false),
   role: select('ASAP Hub Role', ['Staff', 'Grantee', 'Guest'], 'Grantee'),
 });

--- a/packages/react-components/src/organisms/ProfileCardList.tsx
+++ b/packages/react-components/src/organisms/ProfileCardList.tsx
@@ -14,7 +14,8 @@ import { editIcon } from '../icons';
 const styles = (numEntries: number) =>
   css({
     // compensate for cards having more bottom than top padding (see below)
-    paddingBottom: `${24 / perRem}em`,
+    paddingTop: `${24 / perRem}em`,
+    paddingBottom: `${12 / perRem}em`,
 
     display: 'grid',
     gridTemplate: `
@@ -37,8 +38,15 @@ const styles = (numEntries: number) =>
     },
   });
 const cardStyles = css({
+  ':empty': {
+    display: 'none',
+  },
   // bottom only to separate from the pencil belonging to the next card
-  paddingBottom: `${32 / perRem}em`,
+  paddingBottom: `${24 / perRem}em`,
+  [`@media (min-width: ${tabletScreen.width}px)`]: {
+    // top to align with pencil on the side
+    paddingTop: `${12 / perRem}em`,
+  },
 });
 const editButtonStyles = css({
   justifySelf: 'end',


### PR DESCRIPTION
This is a second attempt to fix "padding" in the user profile list. The problem was that if a user hasn't filled out their whole profile you would get empty spaces for the missing cards. I tried to filter these out in the profile list card but its quite difficult to differentiate null from a component. Ive taken the approach of reverting the padding back to how it was as it didn't work with other peoples profiles and or your own with edit buttons. I have used CSS to hide the empty containers which works well enough