### PR TITLE
Remove is contentful enabled references

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -188,9 +188,6 @@ outputs:
   gp2-contentful-space-id:
     description: 'GP2 Contentful Space ID'
     value: ${{ steps.vars.outputs.gp2-contentful-space-id }}
-  gp2-contentful-enabled:
-    description: 'Is GP2 data fetched from Contentful'
-    value: ${{ steps.vars.outputs.gp2-contentful-enabled }}
   gp2-hostname:
     description: 'GP2 Hostname'
     value: ${{ steps.vars.outputs.gp2-hostname }}
@@ -206,9 +203,6 @@ outputs:
   gp2-ses-region:
     description: 'GP2 SES Region'
     value: ${{ steps.vars.outputs.gp2-ses-region }}
-  is-contentful-enabled:
-    description: 'Is the data fetched from Contentful'
-    value: ${{ steps.vars.outputs.is-contentful-enabled }}
   pr-number:
     description: 'PR Number'
     value: ${{ steps.vars.outputs.pr-number }}

--- a/.github/actions/sls-deployment/action.yml
+++ b/.github/actions/sls-deployment/action.yml
@@ -38,9 +38,6 @@ inputs:
   gp2-contentful-preview-access-token:
     description: 'GP2 Contentful Preview Access Token'
     required: false
-  gp2-contentful-enabled:
-    description: 'Is GP2 Contentful Enabled'
-    required: false
   gp2-contentful-management-access-token:
     description: 'GP2 Contentful Management Access Token'
     required: false
@@ -128,7 +125,6 @@ runs:
         GP2_SENTRY_DSN_API: ${{ steps.setup.outputs.gp2-sentry-dsn-api }}
         GP2_SENTRY_DSN_HANDLERS: ${{ steps.setup.outputs.gp2-sentry-dsn-handlers }}
         GP2_SES_REGION: ${{ steps.setup.outputs.gp2-ses-region }}
-        IS_CONTENTFUL_ENABLED: ${{ steps.setup.outputs.is-contentful-enabled }}
         NODE_ENV: 'production'
         NODE_OPTIONS: '--max-old-space-size=8192'
         SLS_STAGE: ${{ steps.setup.outputs.sls-stage}}

--- a/.github/actions/sls-package/action.yml
+++ b/.github/actions/sls-package/action.yml
@@ -112,7 +112,6 @@ runs:
         GP2_SENTRY_DSN_API: ${{ steps.setup.outputs.gp2-sentry-dsn-api }}
         GP2_SENTRY_DSN_HANDLERS: ${{ steps.setup.outputs.gp2-sentry-dsn-handlers }}
         GP2_SES_REGION: ${{ steps.setup.outputs.gp2-ses-region }}
-        IS_CONTENTFUL_ENABLED: ${{ steps.setup.outputs.is-contentful-enabled }}
         NODE_ENV: 'production'
         NODE_OPTIONS: '--max-old-space-size=8192'
         SLS_STAGE: ${{ steps.setup.outputs.sls-stage }}

--- a/.github/environment/Base
+++ b/.github/environment/Base
@@ -25,7 +25,6 @@ crn-aws-acm-certificate-arn=arn:aws:acm:us-east-1:249832953260:certificate/91e95
 crn-base-pr-app-domain=hub.asap.science
 crn-contentful-env-id=Production
 crn-contentful-space-id=5v6w5j61tndm
-is-contentful-enabled=true
 # reserve one environment for integration tests
 crn-max-contentful-envs=6
 crn-sentry-dsn-api=https://c61a36e015ef481bb29e0bd2a9f84aa3@o850903.ingest.sentry.io/5817859

--- a/.github/environment/Branch
+++ b/.github/environment/Branch
@@ -12,7 +12,6 @@ gp2-auth0-audience=https://dev.gp2.asap.science
 gp2-auth0-client-id=sUSMSrBS3FMhb58bxiwQZOTPbZMPWIje
 gp2-auth0-domain=dev-gp2-hub.us.auth0.com
 gp2-ci-auth0-client-id=o6NEEPm9WVKt1aqRr25tbFDlAV8WQVnR
-gp2-contentful-enabled=true
 gp2-ses-region=eu-west-1
 react-app-environment=development
 react-app-gp2-sentry-dsn=https://a087618d35f54407bf1919bf82da2cc6@o850903.ingest.sentry.io/4504769246461952

--- a/.github/environment/Development
+++ b/.github/environment/Development
@@ -23,7 +23,6 @@ gp2-auth0-client-id=sUSMSrBS3FMhb58bxiwQZOTPbZMPWIje
 gp2-auth0-domain=dev-gp2-hub.us.auth0.com
 gp2-ci-auth0-client-id=o6NEEPm9WVKt1aqRr25tbFDlAV8WQVnR
 gp2-contentful-backup-bucket-name=gp2-hub-dev-contentful-backup
-gp2-contentful-enabled=true
 gp2-contentful-env-id=Development
 gp2-ses-region=eu-west-1
 react-app-crn-sentry-dsn=https://8cd3c59be8ec4118aa6f6c59487b9e56@o850903.ingest.sentry.io/5893160

--- a/.github/environment/Production
+++ b/.github/environment/Production
@@ -24,7 +24,6 @@ gp2-auth0-client-id=nkvJ30ZNuGX6HghQfoNZfmWtaT2uC8Bl
 gp2-auth0-domain=gp2-hub.us.auth0.com
 gp2-ci-auth0-client-id=mZrN52GaL7hXoBFcpt20FJpWQ1MY8sil
 gp2-contentful-backup-bucket-name=gp2-hub-production-contentful-backup
-gp2-contentful-enabled=true
 gp2-ses-region=us-east-1
 react-app-crn-sentry-dsn=https://8cd3c59be8ec4118aa6f6c59487b9e56@o850903.ingest.sentry.io/5893160
 react-app-environment=production

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -128,7 +128,6 @@ jobs:
           CONTENTFUL_ENV_ID: integration-${{ github.run_id }}
           CONTENTFUL_ACCESS_TOKEN: ${{ secrets.CRN_CONTENTFUL_ACCESS_TOKEN }}
           CONTENTFUL_PREVIEW_ACCESS_TOKEN: ${{ secrets.CRN_CONTENTFUL_PREVIEW_ACCESS_TOKEN }}
-          IS_CONTENTFUL_ENABLED: true
       - name: Delete app
         shell: bash
         if: always()

--- a/apps/crn-frontend/src/about/api.ts
+++ b/apps/crn-frontend/src/about/api.ts
@@ -1,8 +1,5 @@
 import { DiscoverResponse } from '@asap-hub/model';
-import {
-  createSentryHeaders,
-  createFeatureFlagHeaders,
-} from '@asap-hub/frontend-utils';
+import { createSentryHeaders } from '@asap-hub/frontend-utils';
 import { API_BASE_URL } from '../config';
 
 export const getDiscover = async (
@@ -12,7 +9,6 @@ export const getDiscover = async (
     headers: {
       authorization,
       ...createSentryHeaders(),
-      ...createFeatureFlagHeaders(),
     },
   });
   if (!resp.ok) {

--- a/apps/crn-frontend/src/dashboard/api.ts
+++ b/apps/crn-frontend/src/dashboard/api.ts
@@ -1,7 +1,4 @@
-import {
-  createSentryHeaders,
-  createFeatureFlagHeaders,
-} from '@asap-hub/frontend-utils';
+import { createSentryHeaders } from '@asap-hub/frontend-utils';
 import { DashboardResponse, ListReminderResponse } from '@asap-hub/model';
 
 import { API_BASE_URL } from '../config';
@@ -13,7 +10,6 @@ export const getDashboard = async (
     headers: {
       authorization,
       ...createSentryHeaders(),
-      ...createFeatureFlagHeaders(),
     },
   });
   if (!resp.ok) {
@@ -37,7 +33,6 @@ export const getReminders = async (
       headers: {
         authorization,
         ...createSentryHeaders(),
-        ...createFeatureFlagHeaders(),
       },
     },
   );

--- a/apps/crn-frontend/src/discover/tutorials/api.ts
+++ b/apps/crn-frontend/src/discover/tutorials/api.ts
@@ -1,8 +1,5 @@
 import { ListTutorialsResponse, TutorialsResponse } from '@asap-hub/model';
-import {
-  createFeatureFlagHeaders,
-  GetListOptions,
-} from '@asap-hub/frontend-utils';
+import { GetListOptions } from '@asap-hub/frontend-utils';
 import { API_BASE_URL } from '../../config';
 import createListApiUrl from '../../CreateListApiUrl';
 
@@ -26,7 +23,7 @@ export const getTutorialById = async (
   authorization: string,
 ): Promise<TutorialsResponse | undefined> => {
   const resp = await fetch(`${API_BASE_URL}/tutorials/${id}`, {
-    headers: { authorization, ...createFeatureFlagHeaders() },
+    headers: { authorization },
   });
   if (!resp.ok) {
     if (resp.status === 404) {

--- a/apps/crn-frontend/src/events/api.ts
+++ b/apps/crn-frontend/src/events/api.ts
@@ -1,6 +1,5 @@
 import { AlgoliaClient, getEventFilters } from '@asap-hub/algolia';
 import {
-  createFeatureFlagHeaders,
   createSentryHeaders,
   GetEventListOptions,
 } from '@asap-hub/frontend-utils';
@@ -47,7 +46,6 @@ export const getEvent = async (
     headers: {
       authorization,
       ...createSentryHeaders(),
-      ...createFeatureFlagHeaders(),
     },
   });
   if (!resp.ok) {

--- a/apps/crn-frontend/src/events/calendar/api.ts
+++ b/apps/crn-frontend/src/events/calendar/api.ts
@@ -1,10 +1,7 @@
 import { ListCalendarResponse } from '@asap-hub/model';
 
 import { API_BASE_URL } from '@asap-hub/crn-frontend/src/config';
-import {
-  createSentryHeaders,
-  createFeatureFlagHeaders,
-} from '@asap-hub/frontend-utils';
+import { createSentryHeaders } from '@asap-hub/frontend-utils';
 
 export const getCalendars = async (
   authorization: string,
@@ -13,7 +10,6 @@ export const getCalendars = async (
     headers: {
       authorization,
       ...createSentryHeaders(),
-      ...createFeatureFlagHeaders(),
     },
   });
   if (!resp.ok) {

--- a/apps/crn-frontend/src/guides/api.ts
+++ b/apps/crn-frontend/src/guides/api.ts
@@ -1,8 +1,5 @@
 import { ListGuideResponse } from '@asap-hub/model';
-import {
-  createSentryHeaders,
-  createFeatureFlagHeaders,
-} from '@asap-hub/frontend-utils';
+import { createSentryHeaders } from '@asap-hub/frontend-utils';
 import { API_BASE_URL } from '../config';
 
 export const getGuides = async (
@@ -13,7 +10,6 @@ export const getGuides = async (
     headers: {
       authorization,
       ...createSentryHeaders(),
-      ...createFeatureFlagHeaders(),
     },
   });
   if (!resp.ok) {

--- a/apps/crn-frontend/src/network/interest-groups/api.ts
+++ b/apps/crn-frontend/src/network/interest-groups/api.ts
@@ -2,11 +2,7 @@ import {
   ListInterestGroupResponse,
   InterestGroupResponse,
 } from '@asap-hub/model';
-import {
-  GetListOptions,
-  createSentryHeaders,
-  createFeatureFlagHeaders,
-} from '@asap-hub/frontend-utils';
+import { GetListOptions, createSentryHeaders } from '@asap-hub/frontend-utils';
 import { API_BASE_URL } from '../../config';
 import createListApiUrl from '../../CreateListApiUrl';
 
@@ -20,7 +16,6 @@ export const getInterestGroups = async (
       headers: {
         authorization,
         ...createSentryHeaders(),
-        ...createFeatureFlagHeaders(),
       },
     },
   );
@@ -40,7 +35,6 @@ export const getInterestGroup = async (
     headers: {
       authorization,
       ...createSentryHeaders(),
-      ...createFeatureFlagHeaders(),
     },
   });
   if (!resp.ok) {

--- a/apps/crn-frontend/src/network/teams/api.ts
+++ b/apps/crn-frontend/src/network/teams/api.ts
@@ -2,7 +2,6 @@ import {
   BackendError,
   createSentryHeaders,
   GetListOptions,
-  createFeatureFlagHeaders,
 } from '@asap-hub/frontend-utils';
 import {
   ListLabsResponse,
@@ -24,7 +23,6 @@ export const getTeam = async (
     headers: {
       authorization,
       ...createSentryHeaders(),
-      ...createFeatureFlagHeaders(),
     },
   });
   if (!resp.ok) {
@@ -46,7 +44,6 @@ export const getTeams = async (
     headers: {
       authorization,
       ...createSentryHeaders(),
-      ...createFeatureFlagHeaders(),
     },
   });
 
@@ -69,7 +66,6 @@ export const patchTeam = async (
       authorization,
       'content-type': 'application/json',
       ...createSentryHeaders(),
-      ...createFeatureFlagHeaders(),
     },
     body: JSON.stringify(patch),
   });
@@ -91,7 +87,6 @@ export const createResearchOutput = async (
       authorization,
       'content-type': 'application/json',
       ...createSentryHeaders(),
-      ...createFeatureFlagHeaders(),
     },
     body: JSON.stringify(researchOutput),
   });
@@ -123,7 +118,6 @@ export const updateTeamResearchOutput = async (
         authorization,
         'content-type': 'application/json',
         ...createSentryHeaders(),
-        ...createFeatureFlagHeaders(),
       },
       body: JSON.stringify(researchOutput),
     },
@@ -151,7 +145,6 @@ export const getLabs = async (
       authorization,
       'content-type': 'application/json',
       ...createSentryHeaders(),
-      ...createFeatureFlagHeaders(),
     },
   });
   if (!resp.ok) {

--- a/apps/crn-frontend/src/network/teams/interest-groups/api.ts
+++ b/apps/crn-frontend/src/network/teams/interest-groups/api.ts
@@ -1,8 +1,5 @@
 import { ListInterestGroupResponse } from '@asap-hub/model';
-import {
-  createSentryHeaders,
-  createFeatureFlagHeaders,
-} from '@asap-hub/frontend-utils';
+import { createSentryHeaders } from '@asap-hub/frontend-utils';
 
 import { API_BASE_URL } from '../../../config';
 
@@ -14,7 +11,6 @@ export const getTeamInterestGroups = async (
     headers: {
       authorization,
       ...createSentryHeaders(),
-      ...createFeatureFlagHeaders(),
     },
   });
   if (!resp.ok) {

--- a/apps/crn-frontend/src/network/users/__tests__/api.test.ts
+++ b/apps/crn-frontend/src/network/users/__tests__/api.test.ts
@@ -261,7 +261,7 @@ describe('getUsersAndExternalAuthors', () => {
 describe('getUser', () => {
   it('makes an authorized GET request for the user id', async () => {
     nock(API_BASE_URL, {
-      reqheaders: { authorization: 'Bearer x', 'X-Contentful-Enabled': 'true' },
+      reqheaders: { authorization: 'Bearer x' },
     })
       .get('/users/42')
       .reply(200, {});

--- a/apps/crn-frontend/src/network/users/api.ts
+++ b/apps/crn-frontend/src/network/users/api.ts
@@ -1,9 +1,5 @@
 import type { AlgoliaClient } from '@asap-hub/algolia';
-import {
-  createFeatureFlagHeaders,
-  createSentryHeaders,
-  GetListOptions,
-} from '@asap-hub/frontend-utils';
+import { createSentryHeaders, GetListOptions } from '@asap-hub/frontend-utils';
 import {
   ExternalAuthorResponse,
   InstitutionsResponse,
@@ -25,7 +21,6 @@ export const getUser = async (
     headers: {
       authorization,
       ...createSentryHeaders(),
-      ...createFeatureFlagHeaders(),
     },
   });
 
@@ -111,7 +106,6 @@ export const patchUser = async (
       authorization,
       'content-type': 'application/json',
       ...createSentryHeaders(),
-      ...createFeatureFlagHeaders(),
     },
     body: JSON.stringify(patch),
   });
@@ -134,7 +128,6 @@ export const postUserAvatar = async (
       authorization,
       'content-type': 'application/json',
       ...createSentryHeaders(),
-      ...createFeatureFlagHeaders(),
     },
     body: JSON.stringify(post),
   });

--- a/apps/crn-frontend/src/network/users/interest-groups/api.ts
+++ b/apps/crn-frontend/src/network/users/interest-groups/api.ts
@@ -1,8 +1,5 @@
 import { ListInterestGroupResponse } from '@asap-hub/model';
-import {
-  createSentryHeaders,
-  createFeatureFlagHeaders,
-} from '@asap-hub/frontend-utils';
+import { createSentryHeaders } from '@asap-hub/frontend-utils';
 
 import { API_BASE_URL } from '../../../config';
 
@@ -14,7 +11,6 @@ export const getUserInterestGroups = async (
     headers: {
       authorization,
       ...createSentryHeaders(),
-      ...createFeatureFlagHeaders(),
     },
   });
   if (!resp.ok) {

--- a/apps/crn-frontend/src/network/working-groups/api.ts
+++ b/apps/crn-frontend/src/network/working-groups/api.ts
@@ -1,8 +1,4 @@
-import {
-  createFeatureFlagHeaders,
-  createSentryHeaders,
-  GetListOptions,
-} from '@asap-hub/frontend-utils';
+import { createSentryHeaders, GetListOptions } from '@asap-hub/frontend-utils';
 import {
   WorkingGroupListResponse,
   WorkingGroupResponse,
@@ -20,7 +16,6 @@ export const getWorkingGroups = async (
       headers: {
         authorization,
         ...createSentryHeaders(),
-        ...createFeatureFlagHeaders(),
       },
     },
   );
@@ -41,7 +36,6 @@ export const getWorkingGroup = async (
     headers: {
       authorization,
       ...createSentryHeaders(),
-      ...createFeatureFlagHeaders(),
     },
   });
   if (!resp.ok) {

--- a/apps/crn-frontend/src/shared-research/api.ts
+++ b/apps/crn-frontend/src/shared-research/api.ts
@@ -1,9 +1,5 @@
 import { AlgoliaClient } from '@asap-hub/algolia';
-import {
-  createFeatureFlagHeaders,
-  createSentryHeaders,
-  GetListOptions,
-} from '@asap-hub/frontend-utils';
+import { createSentryHeaders, GetListOptions } from '@asap-hub/frontend-utils';
 import {
   FetchResearchTagsOptions,
   ListResponse,
@@ -48,7 +44,6 @@ export const getResearchOutput = async (
     headers: {
       authorization,
       ...createSentryHeaders(),
-      ...createFeatureFlagHeaders(),
     },
   });
   if (!resp.ok) {
@@ -165,7 +160,6 @@ export const getResearchTags = async (
     headers: {
       authorization,
       ...createSentryHeaders(),
-      ...createFeatureFlagHeaders(),
     },
   });
 

--- a/apps/crn-server/serverless.ts
+++ b/apps/crn-server/serverless.ts
@@ -130,7 +130,6 @@ const serverlessConfig: AWS = {
         allowedHeaders: [
           'authorization',
           'x-transaction-id',
-          'x-contentful-enabled',
           'content-type',
           'accept',
           'origin',
@@ -158,7 +157,6 @@ const serverlessConfig: AWS = {
       NODE_OPTIONS: '--enable-source-maps',
       ALGOLIA_APP_ID: `\${ssm:crn-algolia-app-id-${envAlias}}`,
       CURRENT_REVISION: CI_COMMIT_SHA || '${env:CURRENT_REVISION}',
-      IS_CONTENTFUL_ENABLED: 'true',
       CONTENTFUL_ENV_ID: contentfulEnvironment,
       CONTENTFUL_ACCESS_TOKEN: contentfulAccessToken,
       CONTENTFUL_PREVIEW_ACCESS_TOKEN: contentfulPreviewAccessToken,
@@ -338,7 +336,6 @@ const serverlessConfig: AWS = {
         GOOGLE_API_TOKEN: `\${ssm:google-api-token-${envAlias}}`,
         SENTRY_DSN: sentryDsnHandlers,
         LOG_LEVEL: 'warn',
-        IS_CONTENTFUL_ENABLED: 'true',
       },
     },
     gcalResubscribeCalendarsContentful: {
@@ -354,7 +351,6 @@ const serverlessConfig: AWS = {
         GOOGLE_API_TOKEN: `\${ssm:google-api-token-${envAlias}}`,
         SENTRY_DSN: sentryDsnHandlers,
         LOG_LEVEL: 'warn',
-        IS_CONTENTFUL_ENABLED: 'true',
       },
     },
     syncUserOrcidContentful: {
@@ -375,7 +371,6 @@ const serverlessConfig: AWS = {
       ],
       environment: {
         SENTRY_DSN: sentryDsnHandlers,
-        IS_CONTENTFUL_ENABLED: 'true',
       },
     },
     inviteUserContentful: {
@@ -401,7 +396,6 @@ const serverlessConfig: AWS = {
         EMAIL_BCC: `\${ssm:email-invite-bcc-${envAlias}}`,
         EMAIL_RETURN: `\${ssm:email-invite-return-${envAlias}}`,
         SENTRY_DSN: sentryDsnHandlers,
-        IS_CONTENTFUL_ENABLED: 'true',
       },
     },
     algoliaIndexResearchOutput: {
@@ -427,7 +421,6 @@ const serverlessConfig: AWS = {
         ALGOLIA_API_KEY: `\${ssm:crn-algolia-index-api-key-${envAlias}}`,
         ALGOLIA_INDEX: `${algoliaIndex}`,
         SENTRY_DSN: sentryDsnHandlers,
-        IS_CONTENTFUL_ENABLED: 'true',
       },
     },
     algoliaIndexUser: {
@@ -453,7 +446,6 @@ const serverlessConfig: AWS = {
         ALGOLIA_API_KEY: `\${ssm:crn-algolia-index-api-key-${envAlias}}`,
         ALGOLIA_INDEX: `${algoliaIndex}`,
         SENTRY_DSN: sentryDsnHandlers,
-        IS_CONTENTFUL_ENABLED: 'true',
       },
     },
     algoliaIndexExternalAuthor: {
@@ -479,7 +471,6 @@ const serverlessConfig: AWS = {
         ALGOLIA_API_KEY: `\${ssm:crn-algolia-index-api-key-${envAlias}}`,
         ALGOLIA_INDEX: `${algoliaIndex}`,
         SENTRY_DSN: sentryDsnHandlers,
-        IS_CONTENTFUL_ENABLED: 'true',
       },
     },
     algoliaIndexEvents: {
@@ -502,7 +493,6 @@ const serverlessConfig: AWS = {
         ALGOLIA_API_KEY: `\${ssm:crn-algolia-index-api-key-${envAlias}}`,
         ALGOLIA_INDEX: `${algoliaIndex}`,
         SENTRY_DSN: sentryDsnHandlers,
-        IS_CONTENTFUL_ENABLED: 'true',
       },
     },
     algoliaIndexUserEvents: {
@@ -527,7 +517,6 @@ const serverlessConfig: AWS = {
         ALGOLIA_API_KEY: `\${ssm:crn-algolia-index-api-key-${envAlias}}`,
         ALGOLIA_INDEX: `${algoliaIndex}`,
         SENTRY_DSN: sentryDsnHandlers,
-        IS_CONTENTFUL_ENABLED: 'true',
       },
     },
     algoliaIndexExternalUserEvents: {
@@ -553,7 +542,6 @@ const serverlessConfig: AWS = {
         ALGOLIA_API_KEY: `\${ssm:crn-algolia-index-api-key-${envAlias}}`,
         ALGOLIA_INDEX: `${algoliaIndex}`,
         SENTRY_DSN: sentryDsnHandlers,
-        IS_CONTENTFUL_ENABLED: 'true',
       },
     },
     algoliaIndexTeamEvents: {
@@ -578,7 +566,6 @@ const serverlessConfig: AWS = {
         ALGOLIA_API_KEY: `\${ssm:crn-algolia-index-api-key-${envAlias}}`,
         ALGOLIA_INDEX: `${algoliaIndex}`,
         SENTRY_DSN: sentryDsnHandlers,
-        IS_CONTENTFUL_ENABLED: 'true',
       },
     },
     algoliaIndexGroupEvents: {
@@ -604,7 +591,6 @@ const serverlessConfig: AWS = {
         ALGOLIA_API_KEY: `\${ssm:crn-algolia-index-api-key-${envAlias}}`,
         ALGOLIA_INDEX: `${algoliaIndex}`,
         SENTRY_DSN: sentryDsnHandlers,
-        IS_CONTENTFUL_ENABLED: 'true',
       },
     },
     algoliaIndexLabUsers: {
@@ -629,7 +615,6 @@ const serverlessConfig: AWS = {
         ALGOLIA_API_KEY: `\${ssm:crn-algolia-index-api-key-${envAlias}}`,
         ALGOLIA_INDEX: `${algoliaIndex}`,
         SENTRY_DSN: sentryDsnHandlers,
-        IS_CONTENTFUL_ENABLED: 'true',
       },
     },
     gcalEventsUpdatedContentful: {
@@ -648,7 +633,6 @@ const serverlessConfig: AWS = {
         GOOGLE_API_TOKEN: `\${ssm:google-api-token-${envAlias}}`,
         SENTRY_DSN: sentryDsnHandlers,
         LOG_LEVEL: 'warn',
-        IS_CONTENTFUL_ENABLED: 'true',
       },
     },
     invalidateCache: {
@@ -695,7 +679,6 @@ const serverlessConfig: AWS = {
         ALGOLIA_API_KEY: `\${ssm:crn-algolia-index-api-key-${envAlias}}`,
         ALGOLIA_INDEX: `${algoliaIndex}`,
         SENTRY_DSN: sentryDsnHandlers,
-        IS_CONTENTFUL_ENABLED: 'true',
       },
     },
     algoliaIndexTeamUsers: {
@@ -715,7 +698,6 @@ const serverlessConfig: AWS = {
         ALGOLIA_API_KEY: `\${ssm:crn-algolia-index-api-key-${envAlias}}`,
         ALGOLIA_INDEX: `${algoliaIndex}`,
         SENTRY_DSN: sentryDsnHandlers,
-        IS_CONTENTFUL_ENABLED: 'true',
       },
     },
     updateContentfulWorkingGroupDeliverables: {
@@ -734,7 +716,6 @@ const serverlessConfig: AWS = {
       ],
       environment: {
         SENTRY_DSN: sentryDsnHandlers,
-        IS_CONTENTFUL_ENABLED: 'true',
       },
     },
     contentfulWebhook: {
@@ -787,7 +768,6 @@ const serverlessConfig: AWS = {
       ],
       environment: {
         SENTRY_DSN: sentryDsnHandlers,
-        IS_CONTENTFUL_ENABLED: 'true',
       },
     },
     sendSlackAlert: {

--- a/apps/crn-server/src/config.ts
+++ b/apps/crn-server/src/config.ts
@@ -81,7 +81,6 @@ export const googleApiCredentialsSecretId =
   GOOGLE_API_CREDENTIALS_SECRET_ID || 'google-api-credentials-dev';
 export const googleApiToken = GOOGLE_API_TOKEN || 'asap-google-api-token';
 export const googleApiUrl = 'https://www.googleapis.com/';
-export const isContentfulEnabled = true;
 export const logEnabled = NODE_ENV === 'production' || LOG_ENABLED === 'true';
 export const logLevel = LOG_LEVEL || 'info';
 export const origin = APP_ORIGIN || 'https://dev.hub.asap.science';

--- a/apps/crn-server/src/handlers/calendar/gcal-resubscribe-handler.ts
+++ b/apps/crn-server/src/handlers/calendar/gcal-resubscribe-handler.ts
@@ -10,7 +10,6 @@ import {
   googleApiToken,
   googleApiUrl,
   region,
-  isContentfulEnabled,
 } from '../../config';
 import { getCalendarDataProvider } from '../../dependencies/calendars.dependencies';
 import logger from '../../utils/logger';
@@ -24,8 +23,7 @@ const getJWTCredentials = getJWTCredentialsFactory({
 });
 
 /* istanbul ignore next */
-const getCalendarId = (id: string): string =>
-  isContentfulEnabled ? getCalendarSubscriptionId(id) : id;
+const getCalendarId = (id: string): string => getCalendarSubscriptionId(id);
 
 export const handler = sentryWrapper(
   resubscribeCalendarsHandlerFactory(

--- a/apps/crn-server/test/integration/reminders.integration-test.ts
+++ b/apps/crn-server/test/integration/reminders.integration-test.ts
@@ -22,8 +22,6 @@ import { getCalendarFixture } from './fixtures/calendar';
 
 jest.mock('../../src/config', () => ({
   ...jest.requireActual('../../src/config'),
-  isContentfulEnabled:
-    process.env.INTEGRATION_TEST_CMS === 'contentful' ? 'true' : undefined,
   logLevel: 'silent',
 }));
 

--- a/apps/gp2-server/serverless.ts
+++ b/apps/gp2-server/serverless.ts
@@ -872,7 +872,6 @@ const serverlessConfig: AWS = {
       ],
       environment: {
         SENTRY_DSN: sentryDsnHandlers,
-        IS_CONTENTFUL_ENABLED: 'true',
       },
     },
   },

--- a/packages/frontend-utils/src/api-util/__test__/api-util.test.tsx
+++ b/packages/frontend-utils/src/api-util/__test__/api-util.test.tsx
@@ -1,4 +1,3 @@
-import { setCurrentOverrides } from '@asap-hub/flags';
 import { ValidationErrorResponse } from '@asap-hub/model';
 import {
   BackendError,
@@ -6,7 +5,6 @@ import {
   createSentryHeaders,
   validationErrorsAreSupported,
   clearAjvErrorForPath,
-  createFeatureFlagHeaders,
 } from '../api-util';
 
 const mockSetTag = jest.fn();
@@ -103,23 +101,6 @@ describe('createSentryHeaders', () => {
       'transaction_id',
       transactionId,
     );
-  });
-});
-
-describe('createFeatureFlagHeaders', () => {
-  it('set a contentful feature flag header when the flag is on', () => {
-    setCurrentOverrides({ CONTENTFUL: true });
-
-    expect(createFeatureFlagHeaders()).toEqual({
-      'X-Contentful-Enabled': 'true',
-    });
-  });
-  it('set a contentful feature flag header when the flag is off', () => {
-    setCurrentOverrides({ CONTENTFUL: false });
-
-    expect(createFeatureFlagHeaders()).toEqual({
-      'X-Contentful-Enabled': 'false',
-    });
   });
 });
 

--- a/packages/frontend-utils/src/api-util/api-util.ts
+++ b/packages/frontend-utils/src/api-util/api-util.ts
@@ -1,5 +1,4 @@
 import { ErrorResponse, ValidationErrorResponse } from '@asap-hub/model';
-import { isEnabled } from '@asap-hub/flags';
 import { configureScope } from '@sentry/react';
 
 export type GetListOptions = {
@@ -39,10 +38,6 @@ export const createSentryHeaders = (): {
     'X-Transaction-Id': transactionId,
   };
 };
-
-export const createFeatureFlagHeaders = () => ({
-  'X-Contentful-Enabled': isEnabled('CONTENTFUL') ? 'true' : 'false',
-});
 
 export class BackendError extends Error {
   public response;


### PR DESCRIPTION
There's an unused `IS_CONTENTFUL_ENABLED` and `X-Contentful-Enabled` header left on the codebase. This PR removes both of them.