### PR TITLE
ASAP-44 Add tags to working groups

### DIFF
--- a/packages/contentful/migrations/crn/workingGroups/20231113103854-add-tags-field.js
+++ b/packages/contentful/migrations/crn/workingGroups/20231113103854-add-tags-field.js
@@ -1,0 +1,31 @@
+module.exports.description = 'Add tags field';
+
+module.exports.up = (migration) => {
+  const workingGroups = migration.editContentType('workingGroups');
+  workingGroups
+    .createField('tags')
+    .name('Tags')
+    .type('Array')
+    .localized(false)
+    .required(false)
+    .validations([])
+    .disabled(false)
+    .omitted(false)
+    .items({
+      type: 'Link',
+
+      validations: [
+        {
+          linkContentType: ['researchTags'],
+        },
+      ],
+
+      linkType: 'Entry',
+    });
+  workingGroups.moveField('tags').afterField('deliverables');
+};
+
+module.exports.down = (migration) => {
+  const workingGroups = migration.editContentType('workingGroups');
+  workingGroups.deleteField('tags');
+};


### PR DESCRIPTION
This PR adds the `tags` field to working groups (ticket: [[CRN] Add tags to Working Groups](https://asaphub.atlassian.net/browse/ASAP-44)). This is a blocker for the ticket on the current sprint: [[CRN] Add Working Groups to Algolia and Tag search](https://asaphub.atlassian.net/browse/ASAP-45). But this [[CRN] Add tags to Working Groups](https://asaphub.atlassian.net/browse/ASAP-44) only mentions adding tags to the CMS and I couldn’t find a ticket for CRN mentioning to add the tags component to the working group page or the figma designs related to it. But I believe it should be in another ticket. So this PR simply adds `tags` to working groups.