### PR TITLE
(refactor): adapt webhook types to contentful

### DIFF
--- a/apps/crn-server/serverless.ts
+++ b/apps/crn-server/serverless.ts
@@ -338,7 +338,9 @@ const serverlessConfig: AWS = {
             eventBus: 'asap-events-${self:provider.stage}',
             pattern: {
               source: [eventBusSourceContentful],
-              'detail-type': ['CalendarsPublished'],
+              'detail-type': [
+                'CalendarsPublished',
+              ] satisfies WebhookDetailType[],
             },
           },
         },
@@ -373,7 +375,7 @@ const serverlessConfig: AWS = {
             eventBus: 'asap-events-${self:provider.stage}',
             pattern: {
               source: [eventBusSourceContentful],
-              'detail-type': ['UsersPublished'],
+              'detail-type': ['UsersPublished'] satisfies WebhookDetailType[],
             },
             retryPolicy: {
               maximumRetryAttempts: 2,
@@ -394,7 +396,7 @@ const serverlessConfig: AWS = {
             eventBus: 'asap-events-${self:provider.stage}',
             pattern: {
               source: [eventBusSourceContentful],
-              'detail-type': ['UsersPublished'],
+              'detail-type': ['UsersPublished'] satisfies WebhookDetailType[],
             },
             retryPolicy: {
               maximumRetryAttempts: 2,
@@ -421,9 +423,7 @@ const serverlessConfig: AWS = {
               source: [eventBusSourceContentful],
               'detail-type': [
                 'ResearchOutputsPublished',
-                'ResearchOutputsUpdated',
                 'ResearchOutputsUnpublished',
-                'ResearchOutputsDeleted',
               ] satisfies WebhookDetailType[],
             },
           },
@@ -445,10 +445,7 @@ const serverlessConfig: AWS = {
               source: [eventBusSourceContentful],
               'detail-type': [
                 'UsersPublished',
-                'UsersUpdated',
-                'UsersCreated',
                 'UsersUnpublished',
-                'UsersDeleted',
               ] satisfies WebhookDetailType[],
             },
           },
@@ -471,9 +468,7 @@ const serverlessConfig: AWS = {
               source: [eventBusSourceContentful],
               'detail-type': [
                 'ExternalAuthorsPublished',
-                'ExternalAuthorsUpdated',
                 'ExternalAuthorsUnpublished',
-                'ExternalAuthorsDeleted',
               ] satisfies WebhookDetailType[],
             },
           },
@@ -495,7 +490,7 @@ const serverlessConfig: AWS = {
               source: [eventBusSourceContentful],
               'detail-type': [
                 'EventsPublished',
-                'EventsDeleted',
+                'EventsUnpublished',
               ] satisfies WebhookDetailType[],
             },
           },
@@ -517,9 +512,7 @@ const serverlessConfig: AWS = {
               source: [eventBusSourceContentful],
               'detail-type': [
                 'UsersPublished',
-                'UsersUpdated',
                 'UsersUnpublished',
-                'UsersDeleted',
               ] satisfies WebhookDetailType[],
             },
           },
@@ -542,9 +535,7 @@ const serverlessConfig: AWS = {
               source: [eventBusSourceContentful],
               'detail-type': [
                 'ExternalAuthorsPublished',
-                'ExternalAuthorsUpdated',
                 'ExternalAuthorsUnpublished',
-                'ExternalAuthorsDeleted',
               ] satisfies WebhookDetailType[],
             },
           },
@@ -566,9 +557,7 @@ const serverlessConfig: AWS = {
               source: [eventBusSourceContentful],
               'detail-type': [
                 'TeamsPublished',
-                'TeamsUpdated',
                 'TeamsUnpublished',
-                'TeamsDeleted',
               ] satisfies WebhookDetailType[],
             },
           },
@@ -591,9 +580,7 @@ const serverlessConfig: AWS = {
               source: [eventBusSourceContentful],
               'detail-type': [
                 'InterestGroupsPublished',
-                'InterestGroupsUpdated',
                 'InterestGroupsUnpublished',
-                'InterestGroupsDeleted',
               ] satisfies WebhookDetailType[],
             },
           },
@@ -615,9 +602,7 @@ const serverlessConfig: AWS = {
               source: [eventBusSourceContentful],
               'detail-type': [
                 'LabsPublished',
-                'LabsUpdated',
                 'LabsUnpublished',
-                'LabsDeleted',
               ] satisfies WebhookDetailType[],
             },
           },
@@ -705,8 +690,7 @@ const serverlessConfig: AWS = {
               source: [eventBusSourceContentful],
               'detail-type': [
                 'TeamsPublished',
-                'TeamsUpdated',
-                'TeamsDeleted',
+                'TeamsUnpublished',
               ] satisfies WebhookDetailType[],
             },
           },
@@ -727,7 +711,10 @@ const serverlessConfig: AWS = {
             eventBus: 'asap-events-${self:provider.stage}',
             pattern: {
               source: [eventBusSourceContentful],
-              'detail-type': ['TeamsPublished', 'TeamsUpdated', 'TeamsDeleted'],
+              'detail-type': [
+                'TeamsPublished',
+                'TeamsUnpublished',
+              ] satisfies WebhookDetailType[],
             },
           },
         },
@@ -746,7 +733,10 @@ const serverlessConfig: AWS = {
             eventBus: 'asap-events-${self:provider.stage}',
             pattern: {
               source: [eventBusSourceContentful],
-              'detail-type': ['TeamsPublished', 'TeamsUpdated', 'TeamsDeleted'],
+              'detail-type': [
+                'TeamsPublished',
+                'TeamsUnpublished',
+              ] satisfies WebhookDetailType[],
             },
           },
         },
@@ -789,7 +779,9 @@ const serverlessConfig: AWS = {
             eventBus: 'asap-events-${self:provider.stage}',
             pattern: {
               source: [eventBusSourceContentful],
-              'detail-type': ['WorkingGroupsPublished'],
+              'detail-type': [
+                'WorkingGroupsPublished',
+              ] satisfies WebhookDetailType[],
             },
           },
         },

--- a/apps/crn-server/test/fixtures/labs.fixtures.ts
+++ b/apps/crn-server/test/fixtures/labs.fixtures.ts
@@ -84,14 +84,8 @@ export const getLabEvent = (
 export const getLabUnpublishedEvent: LabEventGenerator = (id: string) =>
   getLabEvent(id, 'LabsUnpublished') as EventBridgeEvent<LabEvent, LabPayload>;
 
-export const getLabDeleteEvent: LabEventGenerator = (id: string) =>
-  getLabEvent(id, 'LabsDeleted') as EventBridgeEvent<LabEvent, LabPayload>;
-
-export const getLabCreateEvent: LabEventGenerator = (id: string) =>
+export const getLabPublishedEvent: LabEventGenerator = (id: string) =>
   getLabEvent(id, 'LabsPublished') as EventBridgeEvent<LabEvent, LabPayload>;
-
-export const updateEvent: LabEventGenerator = (id: string) =>
-  getLabEvent(id, 'LabsUpdated') as EventBridgeEvent<LabEvent, LabPayload>;
 
 export const getLabDataObject = (): LabDataObject => ({
   name: 'Simpson',

--- a/apps/crn-server/test/fixtures/teams.fixtures.ts
+++ b/apps/crn-server/test/fixtures/teams.fixtures.ts
@@ -148,13 +148,7 @@ export type TeamEventGenerator = (
 export const getTeamUnpublishedEvent: TeamEventGenerator = (id: string) =>
   getTeamEvent(id, 'TeamsUnpublished');
 
-export const getTeamDeleteEvent: TeamEventGenerator = (id: string) =>
-  getTeamEvent(id, 'TeamsUnpublished');
-
-export const getTeamCreateEvent: TeamEventGenerator = (id: string) =>
-  getTeamEvent(id, 'TeamsPublished');
-
-export const getTeamUpdateEvent: TeamEventGenerator = (id: string) =>
+export const getTeamPublishedEvent: TeamEventGenerator = (id: string) =>
   getTeamEvent(id, 'TeamsPublished');
 
 export const getTeamContentfulWebhookDetail = (

--- a/apps/crn-server/test/handlers/event/algolia-index-external-author-events-handler.test.ts
+++ b/apps/crn-server/test/handlers/event/algolia-index-external-author-events-handler.test.ts
@@ -20,17 +20,10 @@ const possibleEvents: [
   EventBridgeEvent<ExternalAuthorEvent, ExternalAuthorContentfulPayload>,
 ][] = [
   [
-    'created',
+    'published',
     getExternalAuthorContentfulEvent(
       'external-author-id',
-      'ExternalAuthorsCreated',
-    ),
-  ],
-  [
-    'updated',
-    getExternalAuthorContentfulEvent(
-      'external-author-id',
-      'ExternalAuthorsUpdated',
+      'ExternalAuthorsPublished',
     ),
   ],
   [
@@ -38,13 +31,6 @@ const possibleEvents: [
     getExternalAuthorContentfulEvent(
       'external-author-id',
       'ExternalAuthorsUnpublished',
-    ),
-  ],
-  [
-    'deleted',
-    getExternalAuthorContentfulEvent(
-      'external-author-id',
-      'ExternalAuthorsDeleted',
     ),
   ],
 ];
@@ -64,7 +50,7 @@ describe('Index Events on External Author event handler', () => {
       indexHandler(
         getExternalAuthorContentfulEvent(
           'external-author-id',
-          'ExternalAuthorsCreated',
+          'ExternalAuthorsPublished',
         ),
       ),
     ).rejects.toThrow(Boom.badData());
@@ -82,7 +68,7 @@ describe('Index Events on External Author event handler', () => {
       indexHandler(
         getExternalAuthorContentfulEvent(
           'external-author-id',
-          'ExternalAuthorsUpdated',
+          'ExternalAuthorsPublished',
         ),
       ),
     ).rejects.toThrow(algoliaError);

--- a/apps/crn-server/test/handlers/event/algolia-index-group-events-handler.test.ts
+++ b/apps/crn-server/test/handlers/event/algolia-index-group-events-handler.test.ts
@@ -19,13 +19,11 @@ const possibleEvents: [
   string,
   EventBridgeEvent<InterestGroupEvent, InterestGroupPayload>,
 ][] = [
-  ['created', getInterestGroupEvent('group-id', 'InterestGroupsCreated')],
-  ['updated', getInterestGroupEvent('group-id', 'InterestGroupsUpdated')],
+  ['created', getInterestGroupEvent('group-id', 'InterestGroupsPublished')],
   [
     'unpublished',
     getInterestGroupEvent('group-id', 'InterestGroupsUnpublished'),
   ],
-  ['deleted', getInterestGroupEvent('group-id', 'InterestGroupsDeleted')],
 ];
 
 jest.mock('../../../src/utils/logger');
@@ -40,7 +38,9 @@ describe('Index Events on Group event handler', () => {
     eventControllerMock.fetch.mockRejectedValue(Boom.badData());
 
     await expect(
-      indexHandler(getInterestGroupEvent('group-id', 'InterestGroupsCreated')),
+      indexHandler(
+        getInterestGroupEvent('group-id', 'InterestGroupsPublished'),
+      ),
     ).rejects.toThrow(Boom.badData());
     expect(algoliaSearchClientMock.saveMany).not.toHaveBeenCalled();
   });
@@ -53,7 +53,9 @@ describe('Index Events on Group event handler', () => {
     algoliaSearchClientMock.saveMany.mockRejectedValueOnce(algoliaError);
 
     await expect(
-      indexHandler(getInterestGroupEvent('group-id', 'InterestGroupsUpdated')),
+      indexHandler(
+        getInterestGroupEvent('group-id', 'InterestGroupsPublished'),
+      ),
     ).rejects.toThrow(algoliaError);
   });
 

--- a/apps/crn-server/test/handlers/event/algolia-index-team-events-handler.test.ts
+++ b/apps/crn-server/test/handlers/event/algolia-index-team-events-handler.test.ts
@@ -5,11 +5,9 @@ import {
   getEventDataObject,
 } from '../../fixtures/events.fixtures';
 import {
-  getTeamCreateEvent,
-  getTeamDeleteEvent,
+  getTeamPublishedEvent,
   TeamEventGenerator,
   getTeamUnpublishedEvent,
-  getTeamUpdateEvent,
 } from '../../fixtures/teams.fixtures';
 import { toPayload } from '../../helpers/algolia';
 import { getAlgoliaSearchClientMock } from '../../mocks/algolia-client.mock';
@@ -19,10 +17,8 @@ const mapPayload = toPayload('event');
 
 const algoliaSearchClientMock = getAlgoliaSearchClientMock();
 const possibleEvents: [string, TeamEventGenerator][] = [
-  ['created', getTeamCreateEvent],
-  ['updated', getTeamUpdateEvent],
+  ['published', getTeamPublishedEvent],
   ['unpublished', getTeamUnpublishedEvent],
-  ['deleted', getTeamDeleteEvent],
 ];
 
 jest.mock('../../../src/utils/logger');
@@ -36,9 +32,9 @@ describe('Index Events on Team event handler', () => {
   test('Should throw an error and do not trigger algolia when the team request fails with another error code', async () => {
     eventControllerMock.fetch.mockRejectedValue(Boom.badData());
 
-    await expect(indexHandler(getTeamCreateEvent('team-id'))).rejects.toThrow(
-      Boom.badData(),
-    );
+    await expect(
+      indexHandler(getTeamPublishedEvent('team-id')),
+    ).rejects.toThrow(Boom.badData());
     expect(algoliaSearchClientMock.saveMany).not.toHaveBeenCalled();
   });
 
@@ -49,9 +45,9 @@ describe('Index Events on Team event handler', () => {
     eventControllerMock.fetch.mockResolvedValueOnce(listEventResponse);
     algoliaSearchClientMock.saveMany.mockRejectedValueOnce(algoliaError);
 
-    await expect(indexHandler(getTeamUpdateEvent('team-id'))).rejects.toThrow(
-      algoliaError,
-    );
+    await expect(
+      indexHandler(getTeamPublishedEvent('team-id')),
+    ).rejects.toThrow(algoliaError);
   });
 
   test('Should not index hidden events', async () => {
@@ -76,7 +72,7 @@ describe('Index Events on Team event handler', () => {
       ],
     });
 
-    await indexHandler(getTeamUpdateEvent('team-id'));
+    await indexHandler(getTeamPublishedEvent('team-id'));
 
     expect(algoliaSearchClientMock.saveMany).toHaveBeenCalledWith([
       {
@@ -102,7 +98,7 @@ describe('Index Events on Team event handler', () => {
       ],
     });
 
-    await indexHandler(getTeamUpdateEvent('team-id'));
+    await indexHandler(getTeamPublishedEvent('team-id'));
 
     expect(algoliaSearchClientMock.saveMany).toHaveBeenCalledWith([
       {

--- a/apps/crn-server/test/handlers/event/algolia-index-user-events-handler.test.ts
+++ b/apps/crn-server/test/handlers/event/algolia-index-user-events-handler.test.ts
@@ -16,10 +16,8 @@ const mapPayload = toPayload('event');
 
 const algoliaSearchClientMock = getAlgoliaSearchClientMock();
 const possibleEvents: [string, EventBridgeEvent<UserEvent, UserPayload>][] = [
-  ['created', getUserEvent('user-id', 'UsersCreated')],
-  ['updated', getUserEvent('user-id', 'UsersUpdated')],
+  ['created', getUserEvent('user-id', 'UsersPublished')],
   ['unpublished', getUserEvent('user-id', 'UsersUnpublished')],
-  ['deleted', getUserEvent('user-id', 'UsersDeleted')],
 ];
 
 jest.mock('../../../src/utils/logger');
@@ -34,7 +32,7 @@ describe('Index Events on User event handler', () => {
     eventControllerMock.fetch.mockRejectedValue(Boom.badData());
 
     await expect(
-      indexHandler(getUserEvent('user-id', 'UsersCreated')),
+      indexHandler(getUserEvent('user-id', 'UsersPublished')),
     ).rejects.toThrow(Boom.badData());
     expect(algoliaSearchClientMock.saveMany).not.toHaveBeenCalled();
   });
@@ -47,7 +45,7 @@ describe('Index Events on User event handler', () => {
     algoliaSearchClientMock.saveMany.mockRejectedValueOnce(algoliaError);
 
     await expect(
-      indexHandler(getUserEvent('user-id', 'UsersUpdated')),
+      indexHandler(getUserEvent('user-id', 'UsersPublished')),
     ).rejects.toThrow(algoliaError);
   });
 
@@ -73,7 +71,7 @@ describe('Index Events on User event handler', () => {
       ],
     });
 
-    await indexHandler(getUserEvent('user-id', 'UsersCreated'));
+    await indexHandler(getUserEvent('user-id', 'UsersPublished'));
 
     expect(algoliaSearchClientMock.saveMany).toHaveBeenCalledWith([
       {
@@ -99,7 +97,7 @@ describe('Index Events on User event handler', () => {
       ],
     });
 
-    await indexHandler(getUserEvent('user-id', 'UsersCreated'));
+    await indexHandler(getUserEvent('user-id', 'UsersPublished'));
 
     expect(algoliaSearchClientMock.saveMany).toHaveBeenCalledWith([
       {

--- a/apps/crn-server/test/handlers/teams/algolia-index-team-research-outputs-handler.test.ts
+++ b/apps/crn-server/test/handlers/teams/algolia-index-team-research-outputs-handler.test.ts
@@ -1,6 +1,6 @@
 import { indexResearchOutputByTeamHandler } from '../../../src/handlers/teams/algolia-index-team-research-outputs-handler';
 import { getResearchOutputResponse } from '../../fixtures/research-output.fixtures';
-import { getTeamUpdateEvent } from '../../fixtures/teams.fixtures';
+import { getTeamPublishedEvent } from '../../fixtures/teams.fixtures';
 import { getAlgoliaSearchClientMock } from '../../mocks/algolia-client.mock';
 import { researchOutputControllerMock } from '../../mocks/research-output.controller.mock';
 
@@ -27,7 +27,7 @@ describe('Team Research Outputs Index', () => {
       items,
     });
 
-    const updateEvent = getTeamUpdateEvent('teamId');
+    const updateEvent = getTeamPublishedEvent('teamId');
 
     await indexHandler(updateEvent);
 
@@ -51,7 +51,7 @@ describe('Team Research Outputs Index', () => {
       items: [],
     });
 
-    const updateEvent = getTeamUpdateEvent('teamId');
+    const updateEvent = getTeamPublishedEvent('teamId');
 
     await indexHandler(updateEvent);
 

--- a/apps/crn-server/test/handlers/user/sync-orcid-handler.test.ts
+++ b/apps/crn-server/test/handlers/user/sync-orcid-handler.test.ts
@@ -9,7 +9,7 @@ describe('POST /webhook/users/orcid', () => {
   afterEach(jest.clearAllMocks);
 
   test('Should sync when orcid is present and orcidLastSyncDate is empty', async () => {
-    const event = createEvent();
+    const event = publishedEvent();
     const userResponse = getUserResponse();
     userResponse.orcid = '0000-0000-0000-0001';
     userResponse.orcidLastSyncDate = undefined;
@@ -25,7 +25,7 @@ describe('POST /webhook/users/orcid', () => {
   });
 
   test('Should skip the sync when orcidLastSyncDate is present', async () => {
-    const event = createEvent();
+    const event = publishedEvent();
     const userResponse = getUserResponse();
     userResponse.orcid = '0000-0000-0000-0001';
     userResponse.orcidLastSyncDate = new Date().toISOString();
@@ -37,7 +37,7 @@ describe('POST /webhook/users/orcid', () => {
   });
 
   test('Should skip the sync when orcid is not present', async () => {
-    const event = createEvent();
+    const event = publishedEvent();
     const userResponse = getUserResponse();
     userResponse.orcid = undefined;
     userResponse.orcidLastSyncDate = undefined;
@@ -48,6 +48,6 @@ describe('POST /webhook/users/orcid', () => {
     expect(userControllerMock.syncOrcidProfile).not.toHaveBeenCalled();
   });
 
-  const createEvent = (id: string = 'user-1234') =>
-    getUserEvent(id, 'UsersCreated');
+  const publishedEvent = (id: string = 'user-1234') =>
+    getUserEvent(id, 'UsersPublished');
 });

--- a/apps/gp2-server/serverless.ts
+++ b/apps/gp2-server/serverless.ts
@@ -282,7 +282,9 @@ const serverlessConfig: AWS = {
             eventBus,
             pattern: {
               source: [eventBusSource],
-              'detail-type': ['CalendarsPublished'],
+              'detail-type': [
+                'CalendarsPublished',
+              ] satisfies gp2.WebhookDetailType[],
             },
           },
         },
@@ -320,7 +322,9 @@ const serverlessConfig: AWS = {
             eventBus,
             pattern: {
               source: [eventBusSource],
-              'detail-type': ['UsersPublished'],
+              'detail-type': [
+                'UsersPublished',
+              ] satisfies gp2.WebhookDetailType[],
             },
             retryPolicy: {
               maximumRetryAttempts: 2,
@@ -346,9 +350,7 @@ const serverlessConfig: AWS = {
               source: [eventBusSource],
               'detail-type': [
                 'OutputsPublished',
-                'OutputsUpdated',
                 'OutputsUnpublished',
-                'OutputsDeleted',
               ] satisfies gp2.WebhookDetailType[],
             },
           },
@@ -370,9 +372,7 @@ const serverlessConfig: AWS = {
               source: [eventBusSource],
               'detail-type': [
                 'UsersPublished',
-                'UsersUpdated',
                 'UsersUnpublished',
-                'UsersDeleted',
               ] satisfies gp2.WebhookDetailType[],
             },
           },
@@ -395,9 +395,7 @@ const serverlessConfig: AWS = {
               source: [eventBusSource],
               'detail-type': [
                 'ExternalUsersPublished',
-                'ExternalUsersUpdated',
                 'ExternalUsersUnpublished',
-                'ExternalUsersDeleted',
               ] satisfies gp2.WebhookDetailType[],
             },
           },
@@ -419,9 +417,7 @@ const serverlessConfig: AWS = {
               source: [eventBusSource],
               'detail-type': [
                 'ProjectsPublished',
-                'ProjectsUpdated',
                 'ProjectsUnpublished',
-                'ProjectsDeleted',
               ] satisfies gp2.WebhookDetailType[],
             },
           },
@@ -444,9 +440,7 @@ const serverlessConfig: AWS = {
               source: [eventBusSource],
               'detail-type': [
                 'WorkingGroupsPublished',
-                'WorkingGroupsUpdated',
                 'WorkingGroupsUnpublished',
-                'WorkingGroupsDeleted',
               ] satisfies gp2.WebhookDetailType[],
             },
           },
@@ -468,9 +462,7 @@ const serverlessConfig: AWS = {
               source: [eventBusSource],
               'detail-type': [
                 'EventsPublished',
-                'EventsUpdated',
                 'EventsUnpublished',
-                'EventsDeleted',
               ] satisfies gp2.WebhookDetailType[],
             },
           },
@@ -492,9 +484,7 @@ const serverlessConfig: AWS = {
               source: [eventBusSource],
               'detail-type': [
                 'ProjectsPublished',
-                'ProjectsUpdated',
                 'ProjectsUnpublished',
-                'ProjectsDeleted',
               ] satisfies gp2.WebhookDetailType[],
             },
           },
@@ -516,9 +506,7 @@ const serverlessConfig: AWS = {
               source: [eventBusSource],
               'detail-type': [
                 'UsersPublished',
-                'UsersUpdated',
                 'UsersUnpublished',
-                'UsersDeleted',
               ] satisfies gp2.WebhookDetailType[],
             },
           },
@@ -540,9 +528,7 @@ const serverlessConfig: AWS = {
               source: [eventBusSource],
               'detail-type': [
                 'EventsPublished',
-                'EventsUpdated',
                 'EventsUnpublished',
-                'EventsDeleted',
               ] satisfies gp2.WebhookDetailType[],
             },
           },
@@ -564,9 +550,7 @@ const serverlessConfig: AWS = {
               source: [eventBusSource],
               'detail-type': [
                 'CalendarsPublished',
-                'CalendarsUpdated',
                 'CalendarsUnpublished',
-                'CalendarsDeleted',
               ] satisfies gp2.WebhookDetailType[],
             },
           },
@@ -588,9 +572,7 @@ const serverlessConfig: AWS = {
               source: [eventBusSource],
               'detail-type': [
                 'UsersPublished',
-                'UsersUpdated',
                 'UsersUnpublished',
-                'UsersDeleted',
               ] satisfies gp2.WebhookDetailType[],
             },
           },
@@ -613,9 +595,7 @@ const serverlessConfig: AWS = {
               source: [eventBusSource],
               'detail-type': [
                 'ExternalUsersPublished',
-                'ExternalUsersUpdated',
                 'ExternalUsersUnpublished',
-                'ExternalUsersDeleted',
               ] satisfies gp2.WebhookDetailType[],
             },
           },
@@ -637,9 +617,7 @@ const serverlessConfig: AWS = {
               source: [eventBusSource],
               'detail-type': [
                 'UsersPublished',
-                'UsersUpdated',
                 'UsersUnpublished',
-                'UsersDeleted',
               ] satisfies gp2.WebhookDetailType[],
             },
           },
@@ -661,9 +639,7 @@ const serverlessConfig: AWS = {
               source: [eventBusSource],
               'detail-type': [
                 'ProjectsPublished',
-                'ProjectsUpdated',
                 'ProjectsUnpublished',
-                'ProjectsDeleted',
               ] satisfies gp2.WebhookDetailType[],
             },
           },
@@ -686,9 +662,7 @@ const serverlessConfig: AWS = {
               source: [eventBusSource],
               'detail-type': [
                 'WorkingGroupsPublished',
-                'WorkingGroupsUpdated',
                 'WorkingGroupsUnpublished',
-                'WorkingGroupsDeleted',
               ] satisfies gp2.WebhookDetailType[],
             },
           },
@@ -710,9 +684,7 @@ const serverlessConfig: AWS = {
               source: [eventBusSource],
               'detail-type': [
                 'NewsPublished',
-                'NewsUpdated',
                 'NewsUnpublished',
-                'NewsDeleted',
               ] satisfies gp2.WebhookDetailType[],
             },
           },
@@ -734,9 +706,7 @@ const serverlessConfig: AWS = {
               source: [eventBusSource],
               'detail-type': [
                 'ExternalUsersPublished',
-                'ExternalUsersUpdated',
                 'ExternalUsersUnpublished',
-                'ExternalUsersDeleted',
               ] satisfies gp2.WebhookDetailType[],
             },
           },
@@ -760,7 +730,6 @@ const serverlessConfig: AWS = {
               source: [eventBusSource],
               'detail-type': [
                 'EventsPublished',
-                'EventsUpdated',
               ] satisfies gp2.WebhookDetailType[],
             },
           },
@@ -883,7 +852,9 @@ const serverlessConfig: AWS = {
             eventBus,
             pattern: {
               source: [eventBusSource],
-              'detail-type': ['UsersPublished'],
+              'detail-type': [
+                'UsersPublished',
+              ] satisfies gp2.WebhookDetailType[],
             },
             retryPolicy: {
               maximumRetryAttempts: 2,

--- a/apps/gp2-server/test/handlers/event/algolia-index-calendar-handler.test.ts
+++ b/apps/gp2-server/test/handlers/event/algolia-index-calendar-handler.test.ts
@@ -16,10 +16,8 @@ const possibleEvents: [
   string,
   EventBridgeEvent<gp2Model.CalendarEvent, CalendarPayload>,
 ][] = [
-  ['created', getCalendarEvent('calendar-id', 'CalendarsCreated')],
-  ['updated', getCalendarEvent('calendar-id', 'CalendarsUpdated')],
+  ['created', getCalendarEvent('calendar-id', 'CalendarsPublished')],
   ['unpublished', getCalendarEvent('calendar-id', 'CalendarsUnpublished')],
-  ['deleted', getCalendarEvent('calendar-id', 'CalendarsDeleted')],
 ];
 
 jest.mock('../../../src/utils/logger');
@@ -34,7 +32,7 @@ describe('Index Events on External User event handler', () => {
     eventControllerMock.fetch.mockRejectedValue(Boom.badData());
 
     await expect(
-      indexHandler(getCalendarEvent('calendar-id', 'CalendarsCreated')),
+      indexHandler(getCalendarEvent('calendar-id', 'CalendarsPublished')),
     ).rejects.toThrow(Boom.badData());
     expect(algoliaSearchClientMock.saveMany).not.toHaveBeenCalled();
   });
@@ -47,7 +45,7 @@ describe('Index Events on External User event handler', () => {
     algoliaSearchClientMock.saveMany.mockRejectedValueOnce(algoliaError);
 
     await expect(
-      indexHandler(getCalendarEvent('calendar-id', 'CalendarsUpdated')),
+      indexHandler(getCalendarEvent('calendar-id', 'CalendarsPublished')),
     ).rejects.toThrow(algoliaError);
   });
 

--- a/apps/gp2-server/test/handlers/event/algolia-index-external-user-handler.test.ts
+++ b/apps/gp2-server/test/handlers/event/algolia-index-external-user-handler.test.ts
@@ -16,13 +16,14 @@ const possibleEvents: [
   string,
   EventBridgeEvent<gp2Model.ExternalUserEvent, ExternalUserPayload>,
 ][] = [
-  ['created', getExternalUserEvent('external-user-id', 'ExternalUsersCreated')],
-  ['updated', getExternalUserEvent('external-user-id', 'ExternalUsersUpdated')],
+  [
+    'published',
+    getExternalUserEvent('external-user-id', 'ExternalUsersPublished'),
+  ],
   [
     'unpublished',
     getExternalUserEvent('external-user-id', 'ExternalUsersUnpublished'),
   ],
-  ['deleted', getExternalUserEvent('external-user-id', 'ExternalUsersDeleted')],
 ];
 
 jest.mock('../../../src/utils/logger');
@@ -38,7 +39,7 @@ describe('Index Events on External User event handler', () => {
 
     await expect(
       indexHandler(
-        getExternalUserEvent('external-user-id', 'ExternalUsersCreated'),
+        getExternalUserEvent('external-user-id', 'ExternalUsersPublished'),
       ),
     ).rejects.toThrow(Boom.badData());
     expect(algoliaSearchClientMock.saveMany).not.toHaveBeenCalled();
@@ -53,7 +54,7 @@ describe('Index Events on External User event handler', () => {
 
     await expect(
       indexHandler(
-        getExternalUserEvent('external-user-id', 'ExternalUsersUpdated'),
+        getExternalUserEvent('external-user-id', 'ExternalUsersPublished'),
       ),
     ).rejects.toThrow(algoliaError);
   });

--- a/apps/gp2-server/test/handlers/event/algolia-index-user-handler.test.ts
+++ b/apps/gp2-server/test/handlers/event/algolia-index-user-handler.test.ts
@@ -16,10 +16,8 @@ const possibleEvents: [
   string,
   EventBridgeEvent<gp2Model.UserEvent, UserPayload>,
 ][] = [
-  ['created', getUserEvent('user-id', 'UsersCreated')],
-  ['updated', getUserEvent('user-id', 'UsersUpdated')],
+  ['published', getUserEvent('user-id', 'UsersPublished')],
   ['unpublished', getUserEvent('user-id', 'UsersUnpublished')],
-  ['deleted', getUserEvent('user-id', 'UsersDeleted')],
 ];
 
 jest.mock('../../../src/utils/logger');
@@ -34,7 +32,7 @@ describe('Index Events on User event handler', () => {
     eventControllerMock.fetch.mockRejectedValue(Boom.badData());
 
     await expect(
-      indexHandler(getUserEvent('user-id', 'UsersCreated')),
+      indexHandler(getUserEvent('user-id', 'UsersPublished')),
     ).rejects.toThrow(Boom.badData());
     expect(algoliaSearchClientMock.saveMany).not.toHaveBeenCalled();
   });
@@ -47,7 +45,7 @@ describe('Index Events on User event handler', () => {
     algoliaSearchClientMock.saveMany.mockRejectedValueOnce(algoliaError);
 
     await expect(
-      indexHandler(getUserEvent('user-id', 'UsersUpdated')),
+      indexHandler(getUserEvent('user-id', 'UsersPublished')),
     ).rejects.toThrow(algoliaError);
   });
 

--- a/apps/gp2-server/test/handlers/news/algolia-index-handler.test.ts
+++ b/apps/gp2-server/test/handlers/news/algolia-index-handler.test.ts
@@ -17,23 +17,11 @@ describe('News index handler', () => {
   );
   beforeEach(jest.resetAllMocks);
 
-  test('Should fetch the news and create a record in Algolia when news is created', async () => {
+  test('Should fetch the news and create a record in Algolia when news is published', async () => {
     const newsResponse = getNewsResponse();
     newsControllerMock.fetchById.mockResolvedValueOnce(newsResponse);
 
-    await indexHandler(createEvent('42'));
-
-    expect(algoliaSearchClientMock.save).toHaveBeenCalledWith({
-      data: newsResponse,
-      type: 'news',
-    });
-  });
-
-  test('Should fetch the news and create a record in Algolia when news is updated', async () => {
-    const newsResponse = getNewsResponse();
-    newsControllerMock.fetchById.mockResolvedValueOnce(newsResponse);
-
-    await indexHandler(updateEvent('42'));
+    await indexHandler(publishedEvent('42'));
 
     expect(algoliaSearchClientMock.save).toHaveBeenCalledWith({
       data: newsResponse,
@@ -55,24 +43,10 @@ describe('News index handler', () => {
     );
   });
 
-  test('Should fetch the news and remove the record in Algolia when news is deleted', async () => {
-    const event = deleteEvent('42');
-
-    newsControllerMock.fetchById.mockRejectedValue(Boom.notFound());
-
-    await indexHandler(event);
-
-    expect(algoliaSearchClientMock.save).not.toHaveBeenCalled();
-    expect(algoliaSearchClientMock.remove).toHaveBeenCalledTimes(1);
-    expect(algoliaSearchClientMock.remove).toHaveBeenCalledWith(
-      event.detail.resourceId,
-    );
-  });
-
   test('Should throw an error and do not trigger algolia when the news request fails with another error code', async () => {
     newsControllerMock.fetchById.mockRejectedValue(Boom.badData());
 
-    await expect(indexHandler(createEvent('42'))).rejects.toThrow(
+    await expect(indexHandler(publishedEvent('42'))).rejects.toThrow(
       Boom.badData(),
     );
     expect(algoliaSearchClientMock.remove).not.toHaveBeenCalled();
@@ -84,7 +58,9 @@ describe('News index handler', () => {
     newsControllerMock.fetchById.mockResolvedValueOnce(getNewsResponse());
     algoliaSearchClientMock.save.mockRejectedValueOnce(algoliaError);
 
-    await expect(indexHandler(updateEvent('42'))).rejects.toThrow(algoliaError);
+    await expect(indexHandler(publishedEvent('42'))).rejects.toThrow(
+      algoliaError,
+    );
   });
 
   test('Should throw the algolia error when deleting the record fails', async () => {
@@ -94,55 +70,15 @@ describe('News index handler', () => {
 
     algoliaSearchClientMock.remove.mockRejectedValueOnce(algoliaError);
 
-    await expect(indexHandler(deleteEvent('42'))).rejects.toThrow(algoliaError);
+    await expect(indexHandler(unpublishedEvent('42'))).rejects.toThrow(
+      algoliaError,
+    );
   });
 
   describe('Should process the events, handle race conditions and not rely on the order of the events', () => {
-    test('receives the events created and updated in correct order', async () => {
+    test('receives the events published and unpublished in correct order', async () => {
       const id = '42';
-      const newsResponse = {
-        ...getNewsResponse(),
-        id,
-      };
-
-      newsControllerMock.fetchById.mockResolvedValue({
-        ...newsResponse,
-      });
-
-      await indexHandler(createEvent(id));
-      await indexHandler(updateEvent(id));
-
-      expect(algoliaSearchClientMock.remove).not.toHaveBeenCalled();
-      expect(algoliaSearchClientMock.save).toHaveBeenCalledTimes(2);
-      expect(algoliaSearchClientMock.save).toHaveBeenCalledWith({
-        data: newsResponse,
-        type: 'news',
-      });
-    });
-
-    test('receives the events created and updated in reverse order', async () => {
-      const id = '42';
-      const newsResponse = {
-        ...getNewsResponse(),
-        id,
-      };
-
-      newsControllerMock.fetchById.mockResolvedValue(newsResponse);
-
-      await indexHandler(updateEvent(id));
-      await indexHandler(createEvent(id));
-
-      expect(algoliaSearchClientMock.remove).not.toHaveBeenCalled();
-      expect(algoliaSearchClientMock.save).toHaveBeenCalledTimes(2);
-      expect(algoliaSearchClientMock.save).toHaveBeenCalledWith({
-        data: newsResponse,
-        type: 'news',
-      });
-    });
-
-    test('receives the events created and unpublished in correct order', async () => {
-      const id = '42';
-      const createEv = createEvent(id);
+      const createEv = publishedEvent(id);
       const unpublishedEv = unpublishedEvent(id);
       const algoliaError = new Error('ERROR');
 
@@ -160,9 +96,9 @@ describe('News index handler', () => {
       );
     });
 
-    test('receives the events created and unpublished in reverse order', async () => {
+    test('receives the events published and unpublished in reverse order', async () => {
       const id = '42';
-      const createEv = createEvent(id);
+      const createEv = publishedEvent(id);
       const unpublishedEv = unpublishedEvent(id);
       const algoliaError = new Error('ERROR');
 
@@ -172,125 +108,6 @@ describe('News index handler', () => {
 
       await indexHandler(unpublishedEv);
       await expect(indexHandler(createEv)).rejects.toEqual(algoliaError);
-
-      expect(algoliaSearchClientMock.save).not.toHaveBeenCalled();
-      expect(algoliaSearchClientMock.remove).toHaveBeenCalledTimes(2);
-      expect(algoliaSearchClientMock.remove).toHaveBeenCalledWith(
-        unpublishedEv.detail.resourceId,
-      );
-    });
-
-    test('receives the events created and deleted in correct order', async () => {
-      const id = '42';
-      const createEv = createEvent(id);
-      const deleteEv = deleteEvent(id);
-      const algoliaError = new Error('ERROR');
-
-      newsControllerMock.fetchById.mockRejectedValue(Boom.notFound());
-      algoliaSearchClientMock.remove.mockResolvedValueOnce(undefined);
-      algoliaSearchClientMock.remove.mockRejectedValue(algoliaError);
-
-      await indexHandler(createEv);
-      await expect(indexHandler(deleteEv)).rejects.toEqual(algoliaError);
-
-      expect(algoliaSearchClientMock.save).not.toHaveBeenCalled();
-      expect(algoliaSearchClientMock.remove).toHaveBeenCalledTimes(2);
-      expect(algoliaSearchClientMock.remove).toHaveBeenCalledWith(
-        deleteEv.detail.resourceId,
-      );
-    });
-
-    test('receives the events created and deleted in reverse order', async () => {
-      const id = '42';
-      const createEv = createEvent(id);
-      const deleteEv = deleteEvent(id);
-      const algoliaError = new Error('ERROR');
-
-      newsControllerMock.fetchById.mockRejectedValue(Boom.notFound());
-      algoliaSearchClientMock.remove.mockResolvedValueOnce(undefined);
-      algoliaSearchClientMock.remove.mockRejectedValue(algoliaError);
-
-      await indexHandler(deleteEv);
-      await expect(indexHandler(createEv)).rejects.toEqual(algoliaError);
-
-      expect(algoliaSearchClientMock.save).not.toHaveBeenCalled();
-      expect(algoliaSearchClientMock.remove).toHaveBeenCalledTimes(2);
-      expect(algoliaSearchClientMock.remove).toHaveBeenCalledWith(
-        deleteEv.detail.resourceId,
-      );
-    });
-
-    test('receives the events updated and deleted in correct order', async () => {
-      const id = '42';
-      const updateEv = updateEvent(id);
-      const deleteEv = deleteEvent(id);
-      const algoliaError = new Error('ERROR');
-
-      newsControllerMock.fetchById.mockRejectedValue(Boom.notFound());
-      algoliaSearchClientMock.remove.mockResolvedValueOnce(undefined);
-      algoliaSearchClientMock.remove.mockRejectedValue(algoliaError);
-
-      await indexHandler(updateEv);
-      await expect(indexHandler(deleteEv)).rejects.toEqual(algoliaError);
-
-      expect(algoliaSearchClientMock.save).not.toHaveBeenCalled();
-      expect(algoliaSearchClientMock.remove).toHaveBeenCalledTimes(2);
-      expect(algoliaSearchClientMock.remove).toHaveBeenCalledWith(
-        deleteEv.detail.resourceId,
-      );
-    });
-
-    test('receives the events updated and deleted in reverse order', async () => {
-      const id = '42';
-      const updateEv = updateEvent(id);
-      const deleteEv = deleteEvent(id);
-      const algoliaError = new Error('ERROR');
-
-      newsControllerMock.fetchById.mockRejectedValue(Boom.notFound());
-      algoliaSearchClientMock.remove.mockResolvedValueOnce(undefined);
-      algoliaSearchClientMock.remove.mockRejectedValue(algoliaError);
-
-      await indexHandler(deleteEv);
-      await expect(indexHandler(updateEv)).rejects.toEqual(algoliaError);
-
-      expect(algoliaSearchClientMock.save).not.toHaveBeenCalled();
-      expect(algoliaSearchClientMock.remove).toHaveBeenCalledTimes(2);
-      expect(algoliaSearchClientMock.remove).toHaveBeenCalledWith(
-        deleteEv.detail.resourceId,
-      );
-    });
-    test('receives the events updated and unpublished in correct order', async () => {
-      const id = '42';
-      const updateEv = updateEvent(id);
-      const unpublishedEv = unpublishedEvent(id);
-      const algoliaError = new Error('ERROR');
-
-      newsControllerMock.fetchById.mockRejectedValue(Boom.notFound());
-      algoliaSearchClientMock.remove.mockResolvedValueOnce(undefined);
-      algoliaSearchClientMock.remove.mockRejectedValue(algoliaError);
-
-      await indexHandler(updateEv);
-      await expect(indexHandler(unpublishedEv)).rejects.toEqual(algoliaError);
-
-      expect(algoliaSearchClientMock.save).not.toHaveBeenCalled();
-      expect(algoliaSearchClientMock.remove).toHaveBeenCalledTimes(2);
-      expect(algoliaSearchClientMock.remove).toHaveBeenCalledWith(
-        unpublishedEv.detail.resourceId,
-      );
-    });
-
-    test('receives the events updated and unpublished in reverse order', async () => {
-      const id = '42';
-      const updateEv = updateEvent(id);
-      const unpublishedEv = unpublishedEvent(id);
-      const algoliaError = new Error('ERROR');
-
-      newsControllerMock.fetchById.mockRejectedValue(Boom.notFound());
-      algoliaSearchClientMock.remove.mockResolvedValueOnce(undefined);
-      algoliaSearchClientMock.remove.mockRejectedValue(algoliaError);
-
-      await indexHandler(unpublishedEv);
-      await expect(indexHandler(updateEv)).rejects.toEqual(algoliaError);
 
       expect(algoliaSearchClientMock.save).not.toHaveBeenCalled();
       expect(algoliaSearchClientMock.remove).toHaveBeenCalledTimes(2);
@@ -307,20 +124,8 @@ const unpublishedEvent = (id: string) =>
     NewsPayload
   >;
 
-const deleteEvent = (id: string) =>
-  getNewsEvent(id, 'NewsDeleted') as EventBridgeEvent<
-    gp2Model.NewsEvent,
-    NewsPayload
-  >;
-
-const createEvent = (id: string) =>
+const publishedEvent = (id: string) =>
   getNewsEvent(id, 'NewsPublished') as EventBridgeEvent<
-    gp2Model.NewsEvent,
-    NewsPayload
-  >;
-
-const updateEvent = (id: string) =>
-  getNewsEvent(id, 'NewsUpdated') as EventBridgeEvent<
     gp2Model.NewsEvent,
     NewsPayload
   >;

--- a/apps/gp2-server/test/handlers/output/algolia-index-event-handler.test.ts
+++ b/apps/gp2-server/test/handlers/output/algolia-index-event-handler.test.ts
@@ -16,10 +16,8 @@ const possibleEvents: [
   string,
   EventBridgeEvent<gp2Model.EventEvent, EventPayload>,
 ][] = [
-  ['created', getEventEvent('event-id', 'EventsCreated')],
-  ['updated', getEventEvent('event-id', 'EventsUpdated')],
+  ['published', getEventEvent('event-id', 'EventsPublished')],
   ['unpublished', getEventEvent('event-id', 'EventsUnpublished')],
-  ['deleted', getEventEvent('event-id', 'EventsDeleted')],
 ];
 
 jest.mock('../../../src/utils/logger');
@@ -34,7 +32,7 @@ describe('Index Outputs on Event event handler', () => {
     outputControllerMock.fetch.mockRejectedValue(Boom.badData());
 
     await expect(
-      indexHandler(getEventEvent('event-id', 'EventsCreated')),
+      indexHandler(getEventEvent('event-id', 'EventsPublished')),
     ).rejects.toThrow(Boom.badData());
     expect(algoliaSearchClientMock.saveMany).not.toHaveBeenCalled();
   });
@@ -47,7 +45,7 @@ describe('Index Outputs on Event event handler', () => {
     algoliaSearchClientMock.saveMany.mockRejectedValueOnce(algoliaError);
 
     await expect(
-      indexHandler(getEventEvent('event-id', 'EventsUpdated')),
+      indexHandler(getEventEvent('event-id', 'EventsPublished')),
     ).rejects.toThrow(algoliaError);
   });
 

--- a/apps/gp2-server/test/handlers/output/algolia-index-external-user-handler.test.ts
+++ b/apps/gp2-server/test/handlers/output/algolia-index-external-user-handler.test.ts
@@ -16,13 +16,14 @@ const possibleEvents: [
   string,
   EventBridgeEvent<gp2Model.ExternalUserEvent, ExternalUserPayload>,
 ][] = [
-  ['created', getExternalUserEvent('external-user-id', 'ExternalUsersCreated')],
-  ['updated', getExternalUserEvent('external-user-id', 'ExternalUsersUpdated')],
+  [
+    'created',
+    getExternalUserEvent('external-user-id', 'ExternalUsersPublished'),
+  ],
   [
     'unpublished',
     getExternalUserEvent('external-user-id', 'ExternalUsersUnpublished'),
   ],
-  ['deleted', getExternalUserEvent('external-user-id', 'ExternalUsersDeleted')],
 ];
 
 jest.mock('../../../src/utils/logger');
@@ -38,7 +39,7 @@ describe('Index Outputs on External User event handler', () => {
 
     await expect(
       indexHandler(
-        getExternalUserEvent('external-user-id', 'ExternalUsersCreated'),
+        getExternalUserEvent('external-user-id', 'ExternalUsersPublished'),
       ),
     ).rejects.toThrow(Boom.badData());
     expect(algoliaSearchClientMock.saveMany).not.toHaveBeenCalled();
@@ -53,7 +54,7 @@ describe('Index Outputs on External User event handler', () => {
 
     await expect(
       indexHandler(
-        getExternalUserEvent('external-user-id', 'ExternalUsersUpdated'),
+        getExternalUserEvent('external-user-id', 'ExternalUsersPublished'),
       ),
     ).rejects.toThrow(algoliaError);
   });

--- a/apps/gp2-server/test/handlers/output/algolia-index-handler.test.ts
+++ b/apps/gp2-server/test/handlers/output/algolia-index-handler.test.ts
@@ -20,12 +20,12 @@ describe('Output index handler', () => {
   );
   beforeEach(jest.resetAllMocks);
 
-  test('Should fetch the output and create a record in Algolia when output is created', async () => {
+  test('Should fetch the output and create a record in Algolia when output is published', async () => {
     const outputResponse = getOutputResponse();
     outputResponse.relatedOutputs = [];
     outputControllerMock.fetchById.mockResolvedValueOnce(outputResponse);
 
-    await indexHandler(createEvent('42'));
+    await indexHandler(publishedEvent('42'));
 
     expect(algoliaSearchClientMock.save).toHaveBeenCalledWith({
       data: expect.objectContaining(outputResponse),
@@ -52,7 +52,7 @@ describe('Output index handler', () => {
       .mockResolvedValueOnce(outputResponse)
       .mockResolvedValueOnce(relatedOutputResponse);
 
-    await indexHandler(createEvent('ro-1234'));
+    await indexHandler(publishedEvent('ro-1234'));
 
     expect(algoliaSearchClientMock.save).toHaveBeenCalledTimes(2);
     expect(algoliaSearchClientMock.save).toHaveBeenCalledWith({
@@ -71,22 +71,9 @@ describe('Output index handler', () => {
     outputResponse.relatedOutputs = [];
     outputControllerMock.fetchById.mockResolvedValueOnce(outputResponse);
 
-    await indexHandler(createEvent('42'));
+    await indexHandler(publishedEvent('42'));
     expect(algoliaSearchClientMock.save).toHaveBeenCalledWith({
       data: { ...outputResponse, _tags: ['output tag'] },
-      type: 'output',
-    });
-  });
-
-  test('Should fetch the output and create a record in Algolia when output is updated', async () => {
-    const outputResponse = getOutputResponse();
-    outputResponse.relatedOutputs = [];
-    outputControllerMock.fetchById.mockResolvedValueOnce(outputResponse);
-
-    await indexHandler(updateEvent('42'));
-
-    expect(algoliaSearchClientMock.save).toHaveBeenCalledWith({
-      data: expect.objectContaining(outputResponse),
       type: 'output',
     });
   });
@@ -105,96 +92,42 @@ describe('Output index handler', () => {
     );
   });
 
-  test('Should fetch the output and remove the record in Algolia when output is deleted', async () => {
-    const event = deleteEvent('42');
-
-    outputControllerMock.fetchById.mockRejectedValue(Boom.notFound());
-
-    await indexHandler(event);
-
-    expect(algoliaSearchClientMock.save).not.toHaveBeenCalled();
-    expect(algoliaSearchClientMock.remove).toHaveBeenCalledTimes(1);
-    expect(algoliaSearchClientMock.remove).toHaveBeenCalledWith(
-      event.detail.resourceId,
-    );
-  });
-
   test('Should throw an error and do not trigger algolia when the output request fails with another error code', async () => {
     outputControllerMock.fetchById.mockRejectedValue(Boom.badData());
 
-    await expect(indexHandler(createEvent('42'))).rejects.toThrow(
+    await expect(indexHandler(publishedEvent('42'))).rejects.toThrow(
       Boom.badData(),
     );
     expect(algoliaSearchClientMock.remove).not.toHaveBeenCalled();
   });
 
-  test('Should throw the algolia error when saving the record fails', async () => {
+  test('Should throw the algolia error when publishing the record fails', async () => {
     const algoliaError = new Error('ERROR');
 
     outputControllerMock.fetchById.mockResolvedValueOnce(getOutputResponse());
     algoliaSearchClientMock.save.mockRejectedValueOnce(algoliaError);
 
-    await expect(indexHandler(updateEvent('42'))).rejects.toThrow(algoliaError);
+    await expect(indexHandler(publishedEvent('42'))).rejects.toThrow(
+      algoliaError,
+    );
   });
 
-  test('Should throw the algolia error when deleting the record fails', async () => {
+  test('Should throw the algolia error when unpublishing the record fails', async () => {
     const algoliaError = new Error('ERROR');
 
     outputControllerMock.fetchById.mockRejectedValue(Boom.notFound());
 
     algoliaSearchClientMock.remove.mockRejectedValueOnce(algoliaError);
 
-    await expect(indexHandler(deleteEvent('42'))).rejects.toThrow(algoliaError);
+    await expect(indexHandler(unpublishedEvent('42'))).rejects.toThrow(
+      algoliaError,
+    );
   });
 
   describe('Should process the events, handle race conditions and not rely on the order of the events', () => {
-    test('receives the events created and updated in correct order', async () => {
+    test('receives the events published and unpublished in correct order', async () => {
       const id = '42';
-      const outputResponse = {
-        ...getOutputResponse(),
-        relatedOutputs: [],
-        id,
-      };
-
-      outputControllerMock.fetchById.mockResolvedValue({
-        ...outputResponse,
-      });
-
-      await indexHandler(createEvent(id));
-      await indexHandler(updateEvent(id));
-
-      expect(algoliaSearchClientMock.remove).not.toHaveBeenCalled();
-      expect(algoliaSearchClientMock.save).toHaveBeenCalledTimes(2);
-      expect(algoliaSearchClientMock.save).toHaveBeenCalledWith({
-        data: expect.objectContaining(outputResponse),
-        type: 'output',
-      });
-    });
-
-    test('receives the events created and updated in reverse order', async () => {
-      const id = '42';
-      const outputResponse = {
-        ...getOutputResponse(),
-        relatedOutputs: [],
-        id,
-      };
-
-      outputControllerMock.fetchById.mockResolvedValue(outputResponse);
-
-      await indexHandler(updateEvent(id));
-      await indexHandler(createEvent(id));
-
-      expect(algoliaSearchClientMock.remove).not.toHaveBeenCalled();
-      expect(algoliaSearchClientMock.save).toHaveBeenCalledTimes(2);
-      expect(algoliaSearchClientMock.save).toHaveBeenCalledWith({
-        data: expect.objectContaining(outputResponse),
-        type: 'output',
-      });
-    });
-
-    test('receives the events created and unpublished in correct order', async () => {
-      const id = '42';
-      const createEv = createEvent(id);
+      const publishedEv = publishedEvent(id);
       const unpublishedEv = unpublishedEvent(id);
       const algoliaError = new Error('ERROR');
 
@@ -202,7 +135,7 @@ describe('Output index handler', () => {
       algoliaSearchClientMock.remove.mockResolvedValueOnce(undefined);
       algoliaSearchClientMock.remove.mockRejectedValue(algoliaError);
 
-      await indexHandler(createEv);
+      await indexHandler(publishedEv);
       await expect(indexHandler(unpublishedEv)).rejects.toEqual(algoliaError);
 
       expect(algoliaSearchClientMock.save).not.toHaveBeenCalled();
@@ -212,9 +145,9 @@ describe('Output index handler', () => {
       );
     });
 
-    test('receives the events created and unpublished in reverse order', async () => {
+    test('receives the events published and unpublished in reverse order', async () => {
       const id = '42';
-      const createEv = createEvent(id);
+      const publishedEv = publishedEvent(id);
       const unpublishedEv = unpublishedEvent(id);
       const algoliaError = new Error('ERROR');
 
@@ -223,126 +156,7 @@ describe('Output index handler', () => {
       algoliaSearchClientMock.remove.mockRejectedValue(algoliaError);
 
       await indexHandler(unpublishedEv);
-      await expect(indexHandler(createEv)).rejects.toEqual(algoliaError);
-
-      expect(algoliaSearchClientMock.save).not.toHaveBeenCalled();
-      expect(algoliaSearchClientMock.remove).toHaveBeenCalledTimes(2);
-      expect(algoliaSearchClientMock.remove).toHaveBeenCalledWith(
-        unpublishedEv.detail.resourceId,
-      );
-    });
-
-    test('receives the events created and deleted in correct order', async () => {
-      const id = '42';
-      const createEv = createEvent(id);
-      const deleteEv = deleteEvent(id);
-      const algoliaError = new Error('ERROR');
-
-      outputControllerMock.fetchById.mockRejectedValue(Boom.notFound());
-      algoliaSearchClientMock.remove.mockResolvedValueOnce(undefined);
-      algoliaSearchClientMock.remove.mockRejectedValue(algoliaError);
-
-      await indexHandler(createEv);
-      await expect(indexHandler(deleteEv)).rejects.toEqual(algoliaError);
-
-      expect(algoliaSearchClientMock.save).not.toHaveBeenCalled();
-      expect(algoliaSearchClientMock.remove).toHaveBeenCalledTimes(2);
-      expect(algoliaSearchClientMock.remove).toHaveBeenCalledWith(
-        deleteEv.detail.resourceId,
-      );
-    });
-
-    test('receives the events created and deleted in reverse order', async () => {
-      const id = '42';
-      const createEv = createEvent(id);
-      const deleteEv = deleteEvent(id);
-      const algoliaError = new Error('ERROR');
-
-      outputControllerMock.fetchById.mockRejectedValue(Boom.notFound());
-      algoliaSearchClientMock.remove.mockResolvedValueOnce(undefined);
-      algoliaSearchClientMock.remove.mockRejectedValue(algoliaError);
-
-      await indexHandler(deleteEv);
-      await expect(indexHandler(createEv)).rejects.toEqual(algoliaError);
-
-      expect(algoliaSearchClientMock.save).not.toHaveBeenCalled();
-      expect(algoliaSearchClientMock.remove).toHaveBeenCalledTimes(2);
-      expect(algoliaSearchClientMock.remove).toHaveBeenCalledWith(
-        deleteEv.detail.resourceId,
-      );
-    });
-
-    test('receives the events updated and deleted in correct order', async () => {
-      const id = '42';
-      const updateEv = updateEvent(id);
-      const deleteEv = deleteEvent(id);
-      const algoliaError = new Error('ERROR');
-
-      outputControllerMock.fetchById.mockRejectedValue(Boom.notFound());
-      algoliaSearchClientMock.remove.mockResolvedValueOnce(undefined);
-      algoliaSearchClientMock.remove.mockRejectedValue(algoliaError);
-
-      await indexHandler(updateEv);
-      await expect(indexHandler(deleteEv)).rejects.toEqual(algoliaError);
-
-      expect(algoliaSearchClientMock.save).not.toHaveBeenCalled();
-      expect(algoliaSearchClientMock.remove).toHaveBeenCalledTimes(2);
-      expect(algoliaSearchClientMock.remove).toHaveBeenCalledWith(
-        deleteEv.detail.resourceId,
-      );
-    });
-
-    test('receives the events updated and deleted in reverse order', async () => {
-      const id = '42';
-      const updateEv = updateEvent(id);
-      const deleteEv = deleteEvent(id);
-      const algoliaError = new Error('ERROR');
-
-      outputControllerMock.fetchById.mockRejectedValue(Boom.notFound());
-      algoliaSearchClientMock.remove.mockResolvedValueOnce(undefined);
-      algoliaSearchClientMock.remove.mockRejectedValue(algoliaError);
-
-      await indexHandler(deleteEv);
-      await expect(indexHandler(updateEv)).rejects.toEqual(algoliaError);
-
-      expect(algoliaSearchClientMock.save).not.toHaveBeenCalled();
-      expect(algoliaSearchClientMock.remove).toHaveBeenCalledTimes(2);
-      expect(algoliaSearchClientMock.remove).toHaveBeenCalledWith(
-        deleteEv.detail.resourceId,
-      );
-    });
-    test('receives the events updated and unpublished in correct order', async () => {
-      const id = '42';
-      const updateEv = updateEvent(id);
-      const unpublishedEv = unpublishedEvent(id);
-      const algoliaError = new Error('ERROR');
-
-      outputControllerMock.fetchById.mockRejectedValue(Boom.notFound());
-      algoliaSearchClientMock.remove.mockResolvedValueOnce(undefined);
-      algoliaSearchClientMock.remove.mockRejectedValue(algoliaError);
-
-      await indexHandler(updateEv);
-      await expect(indexHandler(unpublishedEv)).rejects.toEqual(algoliaError);
-
-      expect(algoliaSearchClientMock.save).not.toHaveBeenCalled();
-      expect(algoliaSearchClientMock.remove).toHaveBeenCalledTimes(2);
-      expect(algoliaSearchClientMock.remove).toHaveBeenCalledWith(
-        unpublishedEv.detail.resourceId,
-      );
-    });
-
-    test('receives the events updated and unpublished in reverse order', async () => {
-      const id = '42';
-      const updateEv = updateEvent(id);
-      const unpublishedEv = unpublishedEvent(id);
-      const algoliaError = new Error('ERROR');
-
-      outputControllerMock.fetchById.mockRejectedValue(Boom.notFound());
-      algoliaSearchClientMock.remove.mockResolvedValueOnce(undefined);
-      algoliaSearchClientMock.remove.mockRejectedValue(algoliaError);
-
-      await indexHandler(unpublishedEv);
-      await expect(indexHandler(updateEv)).rejects.toEqual(algoliaError);
+      await expect(indexHandler(publishedEv)).rejects.toEqual(algoliaError);
 
       expect(algoliaSearchClientMock.save).not.toHaveBeenCalled();
       expect(algoliaSearchClientMock.remove).toHaveBeenCalledTimes(2);
@@ -359,20 +173,8 @@ const unpublishedEvent = (id: string) =>
     OutputPayload
   >;
 
-const deleteEvent = (id: string) =>
-  getOutputEvent(id, 'OutputsDeleted') as EventBridgeEvent<
-    gp2Model.OutputEvent,
-    OutputPayload
-  >;
-
-const createEvent = (id: string) =>
+const publishedEvent = (id: string) =>
   getOutputEvent(id, 'OutputsPublished') as EventBridgeEvent<
-    gp2Model.OutputEvent,
-    OutputPayload
-  >;
-
-const updateEvent = (id: string) =>
-  getOutputEvent(id, 'OutputsUpdated') as EventBridgeEvent<
     gp2Model.OutputEvent,
     OutputPayload
   >;

--- a/apps/gp2-server/test/handlers/output/algolia-index-project-handler.test.ts
+++ b/apps/gp2-server/test/handlers/output/algolia-index-project-handler.test.ts
@@ -16,10 +16,8 @@ const possibleEvents: [
   string,
   EventBridgeEvent<gp2Model.ProjectEvent, ProjectPayload>,
 ][] = [
-  ['created', getProjectEvent('project-id', 'ProjectsCreated')],
-  ['updated', getProjectEvent('project-id', 'ProjectsUpdated')],
+  ['published', getProjectEvent('project-id', 'ProjectsPublished')],
   ['unpublished', getProjectEvent('project-id', 'ProjectsUnpublished')],
-  ['deleted', getProjectEvent('project-id', 'ProjectsDeleted')],
 ];
 
 jest.mock('../../../src/utils/logger');
@@ -34,7 +32,7 @@ describe('Index Outputs on Project event handler', () => {
     outputControllerMock.fetch.mockRejectedValue(Boom.badData());
 
     await expect(
-      indexHandler(getProjectEvent('project-id', 'ProjectsCreated')),
+      indexHandler(getProjectEvent('project-id', 'ProjectsPublished')),
     ).rejects.toThrow(Boom.badData());
     expect(algoliaSearchClientMock.saveMany).not.toHaveBeenCalled();
   });
@@ -47,7 +45,7 @@ describe('Index Outputs on Project event handler', () => {
     algoliaSearchClientMock.saveMany.mockRejectedValueOnce(algoliaError);
 
     await expect(
-      indexHandler(getProjectEvent('project-id', 'ProjectsUpdated')),
+      indexHandler(getProjectEvent('project-id', 'ProjectsPublished')),
     ).rejects.toThrow(algoliaError);
   });
 

--- a/apps/gp2-server/test/handlers/output/algolia-index-user-handler.test.ts
+++ b/apps/gp2-server/test/handlers/output/algolia-index-user-handler.test.ts
@@ -16,10 +16,8 @@ const possibleEvents: [
   string,
   EventBridgeEvent<gp2Model.UserEvent, UserPayload>,
 ][] = [
-  ['created', getUserEvent('user-id', 'UsersCreated')],
-  ['updated', getUserEvent('user-id', 'UsersUpdated')],
+  ['created', getUserEvent('user-id', 'UsersPublished')],
   ['unpublished', getUserEvent('user-id', 'UsersUnpublished')],
-  ['deleted', getUserEvent('user-id', 'UsersDeleted')],
 ];
 
 jest.mock('../../../src/utils/logger');
@@ -34,7 +32,7 @@ describe('Index Outputs on User event handler', () => {
     outputControllerMock.fetch.mockRejectedValue(Boom.badData());
 
     await expect(
-      indexHandler(getUserEvent('user-id', 'UsersCreated')),
+      indexHandler(getUserEvent('user-id', 'UsersPublished')),
     ).rejects.toThrow(Boom.badData());
     expect(algoliaSearchClientMock.saveMany).not.toHaveBeenCalled();
   });
@@ -47,7 +45,7 @@ describe('Index Outputs on User event handler', () => {
     algoliaSearchClientMock.saveMany.mockRejectedValueOnce(algoliaError);
 
     await expect(
-      indexHandler(getUserEvent('user-id', 'UsersUpdated')),
+      indexHandler(getUserEvent('user-id', 'UsersPublished')),
     ).rejects.toThrow(algoliaError);
   });
 

--- a/apps/gp2-server/test/handlers/output/algolia-index-working-group-handler.test.ts
+++ b/apps/gp2-server/test/handlers/output/algolia-index-working-group-handler.test.ts
@@ -16,13 +16,14 @@ const possibleEvents: [
   string,
   EventBridgeEvent<gp2Model.WorkingGroupEvent, WorkingGroupPayload>,
 ][] = [
-  ['created', getWorkingGroupEvent('working-group-id', 'WorkingGroupsCreated')],
-  ['updated', getWorkingGroupEvent('working-group-id', 'WorkingGroupsUpdated')],
+  [
+    'created',
+    getWorkingGroupEvent('working-group-id', 'WorkingGroupsPublished'),
+  ],
   [
     'unpublished',
     getWorkingGroupEvent('working-group-id', 'WorkingGroupsUnpublished'),
   ],
-  ['deleted', getWorkingGroupEvent('working-group-id', 'WorkingGroupsDeleted')],
 ];
 
 jest.mock('../../../src/utils/logger');
@@ -38,7 +39,7 @@ describe('Index Outputs on Working Group event handler', () => {
 
     await expect(
       indexHandler(
-        getWorkingGroupEvent('working-group-id', 'WorkingGroupsCreated'),
+        getWorkingGroupEvent('working-group-id', 'WorkingGroupsPublished'),
       ),
     ).rejects.toThrow(Boom.badData());
     expect(algoliaSearchClientMock.saveMany).not.toHaveBeenCalled();
@@ -52,7 +53,9 @@ describe('Index Outputs on Working Group event handler', () => {
     algoliaSearchClientMock.saveMany.mockRejectedValueOnce(algoliaError);
 
     await expect(
-      indexHandler(getWorkingGroupEvent('project-id', 'WorkingGroupsUpdated')),
+      indexHandler(
+        getWorkingGroupEvent('project-id', 'WorkingGroupsPublished'),
+      ),
     ).rejects.toThrow(algoliaError);
   });
 

--- a/apps/gp2-server/test/handlers/project/algolia-index-user-handler.test.ts
+++ b/apps/gp2-server/test/handlers/project/algolia-index-user-handler.test.ts
@@ -16,10 +16,8 @@ const possibleEvents: [
   string,
   EventBridgeEvent<gp2Model.UserEvent, UserPayload>,
 ][] = [
-  ['created', getUserEvent('user-id', 'UsersCreated')],
-  ['updated', getUserEvent('user-id', 'UsersUpdated')],
+  ['published', getUserEvent('user-id', 'UsersPublished')],
   ['unpublished', getUserEvent('user-id', 'UsersUnpublished')],
-  ['deleted', getUserEvent('user-id', 'UsersDeleted')],
 ];
 
 jest.mock('../../../src/utils/logger');
@@ -34,7 +32,7 @@ describe('Index Projects on User event handler', () => {
     projectControllerMock.fetch.mockRejectedValue(Boom.badData());
 
     await expect(
-      indexHandler(getUserEvent('user-id', 'UsersCreated')),
+      indexHandler(getUserEvent('user-id', 'UsersPublished')),
     ).rejects.toThrow(Boom.badData());
     expect(algoliaSearchClientMock.saveMany).not.toHaveBeenCalled();
   });
@@ -47,7 +45,7 @@ describe('Index Projects on User event handler', () => {
     algoliaSearchClientMock.saveMany.mockRejectedValueOnce(algoliaError);
 
     await expect(
-      indexHandler(getUserEvent('user-id', 'UsersUpdated')),
+      indexHandler(getUserEvent('user-id', 'UsersPublished')),
     ).rejects.toThrow(algoliaError);
   });
 

--- a/apps/gp2-server/test/handlers/user/algolia-index-project-handler.test.ts
+++ b/apps/gp2-server/test/handlers/user/algolia-index-project-handler.test.ts
@@ -29,10 +29,8 @@ const possibleEvents: [
   string,
   EventBridgeEvent<gp2Model.ProjectEvent, ProjectPayload>,
 ][] = [
-  ['created', getProjectEvent(projectId, 'ProjectsCreated')],
-  ['updated', getProjectEvent(projectId, 'ProjectsUpdated')],
+  ['published', getProjectEvent(projectId, 'ProjectsPublished')],
   ['unpublished', getProjectEvent(projectId, 'ProjectsUnpublished')],
-  ['deleted', getProjectEvent(projectId, 'ProjectsDeleted')],
 ];
 
 jest.mock('../../../src/utils/logger');
@@ -48,7 +46,7 @@ describe('Index Users on Project event handler', () => {
     projectControllerMock.fetchById.mockRejectedValue(Boom.badData());
 
     await expect(
-      indexHandler(getProjectEvent(projectId, 'ProjectsCreated')),
+      indexHandler(getProjectEvent(projectId, 'ProjectsPublished')),
     ).rejects.toThrow(Boom.badData());
     expect(userControllerMock.fetch).not.toHaveBeenCalled();
     expect(algoliaSearchClientMock.search).not.toHaveBeenCalled();
@@ -69,7 +67,7 @@ describe('Index Users on Project event handler', () => {
     algoliaSearchClientMock.saveMany.mockRejectedValueOnce(algoliaError);
 
     await expect(
-      indexHandler(getProjectEvent(projectId, 'ProjectsUpdated')),
+      indexHandler(getProjectEvent(projectId, 'ProjectsPublished')),
     ).rejects.toThrow(algoliaError);
   });
   test('Should throw the algolia error when searching the record fails', async () => {
@@ -83,7 +81,7 @@ describe('Index Users on Project event handler', () => {
     algoliaSearchClientMock.saveMany.mockRejectedValueOnce(algoliaError);
 
     await expect(
-      indexHandler(getProjectEvent(projectId, 'ProjectsUpdated')),
+      indexHandler(getProjectEvent(projectId, 'ProjectsPublished')),
     ).rejects.toThrow(algoliaError);
     expect(userControllerMock.fetch).not.toHaveBeenCalled();
     expect(algoliaSearchClientMock.saveMany).not.toHaveBeenCalled();
@@ -98,7 +96,7 @@ describe('Index Users on Project event handler', () => {
     userControllerMock.fetch.mockRejectedValue(Boom.badData());
 
     await expect(
-      indexHandler(getProjectEvent(projectId, 'ProjectsUpdated')),
+      indexHandler(getProjectEvent(projectId, 'ProjectsPublished')),
     ).rejects.toThrow(Boom.badData());
     expect(algoliaSearchClientMock.saveMany).not.toHaveBeenCalled();
   });

--- a/apps/gp2-server/test/handlers/user/algolia-index-working-group-handler.test.ts
+++ b/apps/gp2-server/test/handlers/user/algolia-index-working-group-handler.test.ts
@@ -29,13 +29,11 @@ const possibleEvents: [
   string,
   EventBridgeEvent<gp2Model.WorkingGroupEvent, WorkingGroupPayload>,
 ][] = [
-  ['created', getWorkingGroupEvent(workingGroupId, 'WorkingGroupsCreated')],
-  ['updated', getWorkingGroupEvent(workingGroupId, 'WorkingGroupsUpdated')],
+  ['published', getWorkingGroupEvent(workingGroupId, 'WorkingGroupsPublished')],
   [
     'unpublished',
     getWorkingGroupEvent(workingGroupId, 'WorkingGroupsUnpublished'),
   ],
-  ['deleted', getWorkingGroupEvent(workingGroupId, 'WorkingGroupsDeleted')],
 ];
 
 jest.mock('../../../src/utils/logger');
@@ -52,7 +50,7 @@ describe('Index Users on Working Group event handler', () => {
 
     await expect(
       indexHandler(
-        getWorkingGroupEvent(workingGroupId, 'WorkingGroupsCreated'),
+        getWorkingGroupEvent(workingGroupId, 'WorkingGroupsPublished'),
       ),
     ).rejects.toThrow(Boom.badData());
     expect(userControllerMock.fetch).not.toHaveBeenCalled();
@@ -77,7 +75,7 @@ describe('Index Users on Working Group event handler', () => {
 
     await expect(
       indexHandler(
-        getWorkingGroupEvent(workingGroupId, 'WorkingGroupsUpdated'),
+        getWorkingGroupEvent(workingGroupId, 'WorkingGroupsPublished'),
       ),
     ).rejects.toThrow(algoliaError);
   });
@@ -95,7 +93,7 @@ describe('Index Users on Working Group event handler', () => {
 
     await expect(
       indexHandler(
-        getWorkingGroupEvent(workingGroupId, 'WorkingGroupsUpdated'),
+        getWorkingGroupEvent(workingGroupId, 'WorkingGroupsPublished'),
       ),
     ).rejects.toThrow(algoliaError);
     expect(userControllerMock.fetch).not.toHaveBeenCalled();
@@ -114,7 +112,7 @@ describe('Index Users on Working Group event handler', () => {
 
     await expect(
       indexHandler(
-        getWorkingGroupEvent(workingGroupId, 'WorkingGroupsUpdated'),
+        getWorkingGroupEvent(workingGroupId, 'WorkingGroupsPublished'),
       ),
     ).rejects.toThrow(Boom.badData());
     expect(algoliaSearchClientMock.saveMany).not.toHaveBeenCalled();

--- a/packages/contentful/src/crn/types/webhook.ts
+++ b/packages/contentful/src/crn/types/webhook.ts
@@ -1,11 +1,17 @@
 export type ContentfulWebhookPayloadType =
-  | 'teams'
-  | 'news'
-  | 'externalAuthors'
-  | 'users'
-  | 'labs'
   | 'calendars'
   | 'events'
+  | 'externalAuthors'
   | 'interestGroups'
+  | 'labs'
+  | 'news'
   | 'researchOutputs'
+  | 'teams'
+  | 'users'
   | 'workingGroups';
+
+type CapitalizeFirstLetter<S extends string> =
+  S extends `${infer First}${infer Rest}` ? `${Uppercase<First>}${Rest}` : S;
+
+export type WebhookPayloadTypeFirstLetterCapitalized =
+  CapitalizeFirstLetter<ContentfulWebhookPayloadType>;

--- a/packages/model/src/webhook.ts
+++ b/packages/model/src/webhook.ts
@@ -1,9 +1,4 @@
-export type EntityEventAction =
-  | 'Created'
-  | 'Published'
-  | 'Updated'
-  | 'Unpublished'
-  | 'Deleted';
+export type EntityEventAction = 'Published' | 'Unpublished';
 
 export type EventEvent = `Events${EntityEventAction}`;
 export type ExternalAuthorEvent = `ExternalAuthors${EntityEventAction}`;

--- a/packages/model/src/webhook.ts
+++ b/packages/model/src/webhook.ts
@@ -18,9 +18,9 @@ export type WebhookDetailType =
   | InterestGroupEvent
   | LabEvent
   | NewsEvent
+  | ResearchOutputEvent
   | TeamEvent
   | UserEvent
-  | ResearchOutputEvent
   | WorkingGroupEvent;
 
 export type WebhookDetail<T extends object = object> = {

--- a/packages/server-common/src/handlers/webhooks/contentful.handler.ts
+++ b/packages/server-common/src/handlers/webhooks/contentful.handler.ts
@@ -6,11 +6,22 @@ import { APIGatewayProxyResult } from 'aws-lambda';
 import { Logger } from '../../utils';
 import { validateContentfulRequest } from '../../utils/validate-contentful-request';
 
+type ContentfulActions =
+  | 'publish'
+  | 'unpublish'
+  | 'create'
+  | 'save'
+  | 'autosave'
+  | 'archive'
+  | 'unarchive'
+  | 'delete'
+  | 'complete';
+
 const getActionFromRequest = (
   request: lambda.Request<ContentfulWebhookPayload>,
-): 'publish' | 'unpublish' => {
+): ContentfulActions => {
   const actions = request.headers['x-contentful-topic']?.split('.') ?? [];
-  return actions[actions.length - 1] as 'publish' | 'unpublish';
+  return actions[actions.length - 1] as ContentfulActions;
 };
 
 const getDetailTypeFromRequest = (

--- a/packages/server-common/src/handlers/webhooks/contentful.handler.ts
+++ b/packages/server-common/src/handlers/webhooks/contentful.handler.ts
@@ -1,4 +1,8 @@
-import { ContentfulWebhookPayload } from '@asap-hub/contentful';
+import {
+  ContentfulWebhookPayload,
+  ContentfulWebhookPayloadType,
+  WebhookPayloadTypeFirstLetterCapitalized,
+} from '@asap-hub/contentful';
 import { WebhookDetail, WebhookDetailType } from '@asap-hub/model';
 import { framework as lambda } from '@asap-hub/services-common';
 import { SendMessageCommand, SQSClient } from '@aws-sdk/client-sqs';
@@ -24,17 +28,30 @@ const getActionFromRequest = (
   return actions[actions.length - 1] as ContentfulActions;
 };
 
+const getWebhookAction = (action: 'publish' | 'unpublish') =>
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  `${action[0]!.toUpperCase()}${action.slice(1)}ed` as
+    | 'Published'
+    | 'Unpublished';
+
+const getWebhookContentType = (
+  contentType: ContentfulWebhookPayloadType,
+): WebhookPayloadTypeFirstLetterCapitalized =>
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  (contentType[0]!.toUpperCase() +
+    contentType.slice(1)) as WebhookPayloadTypeFirstLetterCapitalized;
+
 const getDetailTypeFromRequest = (
   request: lambda.Request<ContentfulWebhookPayload>,
 ): WebhookDetailType => {
   const action = getActionFromRequest(request);
   const contentType = request.payload.sys.contentType.sys.id;
 
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  return `${contentType[0]!.toUpperCase()}${contentType.slice(
-    1,
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  )}${action[0]!.toUpperCase()}${action.slice(1)}ed` as WebhookDetailType;
+  if (action !== 'publish' && action !== 'unpublish') {
+    throw Error(`Action ${action} not supported by handlers.`);
+  }
+
+  return `${getWebhookContentType(contentType)}${getWebhookAction(action)}`;
 };
 
 const getDetailFromRequest = (

--- a/packages/server-common/test/handlers/webhooks/contentful.handler.test.ts
+++ b/packages/server-common/test/handlers/webhooks/contentful.handler.test.ts
@@ -62,6 +62,28 @@ describe('Contentful event webhook', () => {
       expect.stringMatching(/Event added to queue queue-url/i),
     );
   });
+
+  test.each([
+    'create',
+    'save',
+    'autosave',
+    'archive',
+    'unarchive',
+    'delete',
+    'complete',
+  ])('Should throw an error when the request action is %s', async (action) => {
+    const payload = getNewsPublishContentfulWebhookPayload();
+    const event = getLambdaRequest(payload, {
+      ...headers,
+      'x-contentful-topic': `ContentManagement.Entry.${action}`,
+    });
+
+    await expect(handler(event)).rejects.toThrow(
+      `Action ${action} not supported by handlers.`,
+    );
+    expect(sqsMock.send).not.toHaveBeenCalled();
+  });
+
   test('Should throw an error when the request has no Authorization header', async () => {
     const payload = getNewsPublishContentfulWebhookPayload();
     const event = getLambdaRequest(payload, {});


### PR DESCRIPTION
As discussed in this [thread](https://yld.slack.com/archives/G01A6J33G8H/p1700045781352039), currently we're only triggering `Publish` and `Unpublish` events on Contentful.

![Screenshot 2023-11-15 at 07 54 27](https://github.com/yldio/asap-hub/assets/16595804/9b8b55b6-fa9c-4386-ad7c-dd70057c4243)


So the `EntityEventAction` type was changed from

```
export type EntityEventAction =
  | 'Created'
  | 'Published'
  | 'Updated'
  | 'Unpublished'
  | 'Deleted';
```

to 

```
export type EntityEventAction = 'Published' | 'Unpublished';
```

and it was added a type with all possible actions from the print above

```
type ContentfulActions =
  | 'publish'
  | 'unpublish'
  | 'create'
  | 'save'
  | 'autosave'
  | 'archive'
  | 'unarchive'
  | 'delete'
  | 'complete';
```

even though we're not processing all of them.