### PR TITLE
(fix): on-demand-algolia-sync

### DIFF
--- a/.github/workflows/on-demand-crn-algolia-sync.yml
+++ b/.github/workflows/on-demand-crn-algolia-sync.yml
@@ -37,6 +37,7 @@ jobs:
       environment-name: ${{ github.event.inputs.environment-name }}
       entity: ${{ github.event.inputs.entity }}
       pr-number: ${{ github.event.inputs.pr-number }}
+      crn-create-env: ${{ inputs.environment-name == 'Branch' }}
       contentful-environment-id: ${{ github.event.inputs.contentful-environment-id }}
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/on-demand-gp2-algolia-sync.yml
+++ b/.github/workflows/on-demand-gp2-algolia-sync.yml
@@ -37,6 +37,7 @@ jobs:
       environment-name: ${{ github.event.inputs.environment-name }}
       entity: ${{ github.event.inputs.entity }}
       pr-number: ${{ github.event.inputs.pr-number }}
+      gp2-create-env: ${{ inputs.environment-name == 'Branch' }}
       contentful-environment-id: ${{ github.event.inputs.contentful-environment-id }}
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/reusable-crn-algolia-sync.yml
+++ b/.github/workflows/reusable-crn-algolia-sync.yml
@@ -17,6 +17,11 @@ on:
         required: false
         type: string
         description: The PR number to run for
+      crn-create-env:
+        required: false
+        type: boolean
+        description: This should be true when syncing a PR env
+
       contentful-environment-id:
         description: 'CRN Contentful environment name'
         required: true
@@ -61,6 +66,7 @@ jobs:
         with:
           environment-name: ${{ inputs.environment-name }}
           pr-number: ${{ inputs.pr-number }}
+          crn-create-env: ${{ inputs.crn-create-env }}
       - name: Get Algolia Keys
         id: algolia-keys
         uses: ./.github/actions/algolia-keys

--- a/.github/workflows/reusable-gp2-algolia-sync.yml
+++ b/.github/workflows/reusable-gp2-algolia-sync.yml
@@ -21,6 +21,10 @@ on:
         description: 'GP2 Contentful environment name'
         required: true
         type: string
+      gp2-create-env:
+        required: false
+        type: boolean
+        description: This should be true when syncing a PR env
     secrets:
       AWS_ACCESS_KEY_ID:
         description: 'AWS Access Key ID'
@@ -61,6 +65,8 @@ jobs:
         with:
           environment-name: ${{ inputs.environment-name }}
           pr-number: ${{ inputs.pr-number }}
+          gp2-create-env: ${{ inputs.gp2-create-env }}
+
       - name: Get Algolia Keys
         id: algolia-keys
         uses: ./.github/actions/algolia-keys


### PR DESCRIPTION
When we trigger [on-demand-crn-algolia-sync.yml](https://github.com/yldio/asap-hub/blob/master/.github/workflows/on-demand-crn-algolia-sync.yml) or [on-demand-gp2-algolia-sync.yml](https://github.com/yldio/asap-hub/blob/master/.github/workflows/on-demand-gp2-algolia-sync.yml) it syncs using `asap-hub_dev` index even when we select environment `Branch` and pass a contentful environment other than `Development`.

So in order to change this, if the person selects `Branch`, crn-create-env | gp2-create-env will be set to true so we can have an algolia index linked to the PR number. Check this code to understand the change: https://github.com/yldio/asap-hub/blob/master/.github/actions/setup-environment/action.yml#L281:L312.