### PR TITLE
fix: Invalid bundle URL bug

### DIFF
--- a/apps/crn-auth-frontend/vite.config.ts
+++ b/apps/crn-auth-frontend/vite.config.ts
@@ -10,4 +10,13 @@ export default defineConfig({
     open: true,
     port: 3000,
   },
+  build: {
+    rollupOptions: {
+      output: {
+        entryFileNames: `assets/[name].js`,
+        chunkFileNames: `assets/[name].js`,
+        assetFileNames: `assets/[name].[ext]`,
+      },
+    },
+  },
 });

--- a/apps/gp2-auth-frontend/vite.config.ts
+++ b/apps/gp2-auth-frontend/vite.config.ts
@@ -10,4 +10,13 @@ export default defineConfig({
     open: true,
     port: 3000,
   },
+  build: {
+    rollupOptions: {
+      output: {
+        entryFileNames: `assets/[name].js`,
+        chunkFileNames: `assets/[name].js`,
+        assetFileNames: `assets/[name].[ext]`,
+      },
+    },
+  },
 });


### PR DESCRIPTION
Changes the settings for vite bundle in such a way that it produces the bundle with the same name each time, which is how it was done previously.