### PR TITLE
ASAP-62 Reduce user data

### DIFF
--- a/apps/crn-frontend/src/dashboard/__tests__/Dashboard.test.tsx
+++ b/apps/crn-frontend/src/dashboard/__tests__/Dashboard.test.tsx
@@ -4,7 +4,8 @@ import { render, waitFor, screen } from '@testing-library/react';
 import { RecoilRoot } from 'recoil';
 import {
   createListReminderResponse,
-  createListUserResponse,
+  createUserAlgoliaResponse,
+  createUserListAlgoliaResponse,
   createUserResponse,
 } from '@asap-hub/fixtures';
 import { activeUserMembershipStatus } from '@asap-hub/model';
@@ -25,7 +26,11 @@ jest.mock('../../shared-research/api');
 jest.mock('../../network/teams/api');
 jest.mock('../../network/users/api');
 
-const userResponse = createUserResponse({});
+const userResponse = createUserAlgoliaResponse();
+
+beforeEach(() => {
+  mockGetUsers.mockResolvedValue(createUserListAlgoliaResponse(2));
+});
 afterEach(() => {
   jest.clearAllMocks();
 });
@@ -118,7 +123,7 @@ it('renders reminders', async () => {
 describe('dismissing the getting started option', () => {
   it('toggles the not show getting started', async () => {
     mockGetUser.mockResolvedValue({
-      ...userResponse,
+      ...createUserResponse(),
       dismissedGettingStarted: true,
     });
     await renderDashboard({});
@@ -129,7 +134,7 @@ describe('dismissing the getting started option', () => {
 
   it('shows and can dismiss getting started', async () => {
     mockGetUser.mockResolvedValue({
-      ...userResponse,
+      ...createUserResponse(),
       dismissedGettingStarted: false,
     });
     await renderDashboard({});
@@ -160,7 +165,7 @@ describe('dismissing the getting started option', () => {
   });
   it('correctly renders getting started block when dismissedGettingStarted is undefined', async () => {
     mockGetUser.mockResolvedValue({
-      ...userResponse,
+      ...createUserResponse(),
       dismissedGettingStarted: undefined,
     });
     await renderDashboard({});
@@ -170,7 +175,7 @@ describe('dismissing the getting started option', () => {
 });
 
 it('renders latest users filtered by active users', async () => {
-  mockGetUsers.mockResolvedValueOnce(createListUserResponse(3));
+  mockGetUsers.mockResolvedValueOnce(createUserListAlgoliaResponse(3));
   const { container } = await renderDashboard({});
 
   expect(mockGetUsers).toBeCalledWith(

--- a/apps/crn-frontend/src/network/__tests__/Network.test.tsx
+++ b/apps/crn-frontend/src/network/__tests__/Network.test.tsx
@@ -4,7 +4,7 @@ import {
 } from '@asap-hub/crn-frontend/src/auth/test-utils';
 import {
   createListEventResponse,
-  createListUserResponse,
+  createUserListAlgoliaResponse,
   createWorkingGroupResponse,
 } from '@asap-hub/fixtures';
 import { network } from '@asap-hub/routing';
@@ -63,7 +63,7 @@ const mockGetWorkingGroupEventsFromAlgolia = getEvents as jest.MockedFunction<
 const response = createListEventResponse(7);
 mockGetWorkingGroupEventsFromAlgolia.mockResolvedValue(response);
 
-mockUseUsers.mockReturnValue(createListUserResponse(1));
+mockUseUsers.mockReturnValue(createUserListAlgoliaResponse(1));
 
 const renderNetworkPage = async (pathname: string, query = '') => {
   render(

--- a/apps/crn-frontend/src/network/users/__tests__/UserList.test.tsx
+++ b/apps/crn-frontend/src/network/users/__tests__/UserList.test.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from 'react';
 import { render, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route } from 'react-router-dom';
-import { createListUserResponse } from '@asap-hub/fixtures';
+import { createUserListAlgoliaResponse } from '@asap-hub/fixtures';
 import { RecoilRoot } from 'recoil';
 import {
   Auth0Provider,
@@ -53,7 +53,7 @@ const renderUserList = async () => {
 };
 
 it('renders a list of people when searching with algolia', async () => {
-  const listUserResponse = createListUserResponse(2);
+  const listUserResponse = createUserListAlgoliaResponse(2);
   const names = ['Person A', 'Person B'];
   mockGetUsers.mockResolvedValue({
     ...listUserResponse,
@@ -69,7 +69,7 @@ it('renders a list of people when searching with algolia', async () => {
 });
 
 it('renders an algolia tagged result list and hit', async () => {
-  const listUserResponse = createListUserResponse(1);
+  const listUserResponse = createUserListAlgoliaResponse(1);
   mockGetUsers.mockResolvedValue({
     ...listUserResponse,
     algoliaIndexName: 'index',

--- a/apps/crn-frontend/src/network/users/__tests__/api.test.ts
+++ b/apps/crn-frontend/src/network/users/__tests__/api.test.ts
@@ -1,4 +1,8 @@
-import { createListUserResponse, createUserResponse } from '@asap-hub/fixtures';
+import {
+  createUserResponse,
+  createUserAlgoliaResponse,
+  createUserListAlgoliaResponse,
+} from '@asap-hub/fixtures';
 import {
   inactiveUserMembershipStatus,
   InstitutionsResponse,
@@ -51,7 +55,8 @@ describe('getUsers', () => {
   beforeEach(() => {
     search.mockReset();
 
-    const userResponse = createUserResponse();
+    const userResponse = createUserAlgoliaResponse();
+
     search.mockResolvedValue(
       createAlgoliaResponse<'user'>([
         {
@@ -143,7 +148,8 @@ describe('getUsers', () => {
   });
 
   it('returns successfully fetched users', async () => {
-    const users = createListUserResponse(1);
+    const users = createUserListAlgoliaResponse(1);
+
     const transformedUsers = {
       ...users,
       items: users.items.map((item) => ({
@@ -192,6 +198,7 @@ describe('getUsersAndExternalAuthors', () => {
         ...userResponse,
         objectID: userResponse.id,
         __meta: { type: 'user' },
+        _tags: userResponse.expertiseAndResourceTags,
       },
     ]);
 

--- a/apps/crn-frontend/src/network/users/api.ts
+++ b/apps/crn-frontend/src/network/users/api.ts
@@ -4,11 +4,11 @@ import {
   ExternalAuthorResponse,
   InstitutionsResponse,
   ListResponse,
-  ListUserResponse,
   UserAvatarPostRequest,
   UserPatchRequest,
   UserResponse,
   userMembershipStatus,
+  UserListAlgoliaResponse,
 } from '@asap-hub/model';
 
 import { API_BASE_URL } from '../../config';
@@ -38,7 +38,7 @@ export const getUser = async (
 export const getUsers = async (
   algoliaClient: AlgoliaClient<'crn'>,
   { searchQuery, filters, currentPage, pageSize }: GetListOptions,
-): Promise<ListUserResponse> => {
+): Promise<UserListAlgoliaResponse> => {
   const isMembershipStatusFilter = (filter: string) =>
     (userMembershipStatus as unknown as string[]).includes(filter);
   const filterArray = Array.from(filters);

--- a/apps/crn-frontend/src/network/users/state.ts
+++ b/apps/crn-frontend/src/network/users/state.ts
@@ -1,9 +1,11 @@
 import { authorizationState } from '@asap-hub/crn-frontend/src/auth/state';
 import { GetListOptions } from '@asap-hub/frontend-utils';
 import {
-  ListUserResponse,
+  UserListItem,
   UserPatchRequest,
   UserResponse,
+  WithAlgoliaTags,
+  UserListAlgoliaResponse,
 } from '@asap-hub/model';
 import { useAuth0CRN } from '@asap-hub/react-context';
 import {
@@ -32,7 +34,7 @@ const userIndexState = atomFamily<
   default: undefined,
 });
 export const usersState = selectorFamily<
-  ListUserResponse | Error | undefined,
+  UserListAlgoliaResponse | Error | undefined,
   GetListOptions
 >({
   key: 'users',
@@ -41,7 +43,7 @@ export const usersState = selectorFamily<
     ({ get }) => {
       const index = get(userIndexState(options));
       if (index === undefined || index instanceof Error) return index;
-      const users: UserResponse[] = [];
+      const users: WithAlgoliaTags<UserListItem>[] = [];
       for (const id of index.ids) {
         const user = get(userListState(id));
         if (user === undefined) return undefined;
@@ -101,9 +103,12 @@ const userState = selectorFamily<UserResponse | undefined, string>({
       get(patchedUserState(id)) ?? get(initialUserState(id)),
 });
 
-const userListState = atomFamily<UserResponse | undefined, string>({
+const userListState = atomFamily<
+  WithAlgoliaTags<UserListItem> | undefined,
+  string
+>({
   key: 'userList',
-  default: userState,
+  default: undefined,
 });
 
 export const useUsers = (options: GetListOptions) => {

--- a/apps/crn-frontend/src/tags/__tests__/Routes.test.tsx
+++ b/apps/crn-frontend/src/tags/__tests__/Routes.test.tsx
@@ -4,7 +4,7 @@ import {
   EMPTY_ALGOLIA_FACET_HITS,
   EMPTY_ALGOLIA_RESPONSE,
 } from '@asap-hub/algolia';
-import { createUserResponse } from '@asap-hub/fixtures';
+import { createUserAlgoliaResponse } from '@asap-hub/fixtures';
 import {
   fireEvent,
   render,
@@ -206,7 +206,7 @@ it('Will show algolia results', async () => {
     ...EMPTY_ALGOLIA_FACET_HITS,
     facetHits: [{ value: 'LGW', count: 1, highlighted: 'LGW' }],
   });
-  const userResponse = createUserResponse();
+  const userResponse = createUserAlgoliaResponse();
   const algoliaResponse = createAlgoliaResponse([
     {
       ...userResponse,

--- a/apps/crn-server/scripts/export-entity.ts
+++ b/apps/crn-server/scripts/export-entity.ts
@@ -1,5 +1,5 @@
 import { EntityData, EntityResponses } from '@asap-hub/algolia';
-import { ListResponse } from '@asap-hub/model';
+import { ListResponse, toAlgoliaUserItem, UserResponse } from '@asap-hub/model';
 import { promises as fs } from 'fs';
 import Events from '../src/controllers/event.controller';
 import ExternalAuthors from '../src/controllers/external-author.controller';
@@ -130,8 +130,11 @@ const transformRecords = (
 
   if (type === 'user' && 'expertiseAndResourceTags' in record) {
     return {
-      ...payload,
-      _tags: record.expertiseAndResourceTags,
+      ...toAlgoliaUserItem(record as UserResponse),
+      objectID: record.id,
+      __meta: {
+        type,
+      },
     };
   }
 

--- a/apps/crn-server/src/handlers/lab/algolia-index-lab-users-handler.ts
+++ b/apps/crn-server/src/handlers/lab/algolia-index-lab-users-handler.ts
@@ -1,5 +1,10 @@
 import { AlgoliaClient, algoliaSearchClientFactory } from '@asap-hub/algolia';
-import { LabEvent, ListResponse, UserResponse } from '@asap-hub/model';
+import {
+  LabEvent,
+  ListResponse,
+  toAlgoliaUserItem,
+  UserResponse,
+} from '@asap-hub/model';
 import {
   loopOverCustomCollection,
   LoopOverCustomCollectionFetchOptions,
@@ -48,10 +53,7 @@ export const indexLabUsersHandler =
         foundUsers.items
           .filter((user) => user.onboarded && user.role !== 'Hidden')
           .map((data) => ({
-            data: {
-              ...data,
-              _tags: data.expertiseAndResourceTags,
-            },
+            data: toAlgoliaUserItem(data),
             type: 'user',
           })),
       );

--- a/apps/crn-server/src/handlers/teams/algolia-index-team-users-handler.ts
+++ b/apps/crn-server/src/handlers/teams/algolia-index-team-users-handler.ts
@@ -3,7 +3,12 @@ import {
   algoliaSearchClientFactory,
   Payload,
 } from '@asap-hub/algolia';
-import { ListResponse, TeamEvent, UserResponse } from '@asap-hub/model';
+import {
+  ListResponse,
+  TeamEvent,
+  toAlgoliaUserItem,
+  UserResponse,
+} from '@asap-hub/model';
 import {
   createProcessingFunction,
   loopOverCustomCollection,
@@ -20,7 +25,6 @@ import {
 import logger from '../../utils/logger';
 import { sentryWrapper } from '../../utils/sentry-wrapper';
 import { TeamPayload } from '../event-bus';
-import { addTagsFunction } from '../helper';
 
 export const indexTeamUsersHandler = (
   userController: UserController,
@@ -31,7 +35,7 @@ export const indexTeamUsersHandler = (
     'user',
     logger,
     userFilter,
-    addTagsFunction<Payload>,
+    toAlgoliaUserItem,
   );
   return async (event) => {
     logger.debug(`Event ${event['detail-type']}`);

--- a/apps/crn-server/src/handlers/user/algolia-index-user-handler.ts
+++ b/apps/crn-server/src/handlers/user/algolia-index-user-handler.ts
@@ -1,6 +1,6 @@
 import { AlgoliaClient, algoliaSearchClientFactory } from '@asap-hub/algolia';
 import { NotFoundError } from '@asap-hub/errors';
-import { UserEvent, UserResponse } from '@asap-hub/model';
+import { toAlgoliaUserItem, UserEvent } from '@asap-hub/model';
 import { EventBridgeHandler, UserPayload } from '@asap-hub/server-common';
 import { isBoom } from '@hapi/boom';
 import { EventBridgeEvent } from 'aws-lambda';
@@ -29,10 +29,7 @@ export const indexUserHandler =
 
       if (user.onboarded && user.role !== 'Hidden') {
         await algoliaClient.save({
-          data: {
-            ...user,
-            _tags: user.expertiseAndResourceTags,
-          } as UserResponse & { _tags: string[] },
+          data: toAlgoliaUserItem(user),
           type: 'user',
         });
 

--- a/apps/crn-server/test/handlers/lab/algolia-index-lab-users-handler.test.ts
+++ b/apps/crn-server/test/handlers/lab/algolia-index-lab-users-handler.test.ts
@@ -9,13 +9,11 @@ import {
   getListUserResponse,
   getUserResponse,
 } from '../../fixtures/users.fixtures';
-import { toPayload } from '../../helpers/algolia';
 import { getAlgoliaSearchClientMock } from '../../mocks/algolia-client.mock';
 import { userControllerMock } from '../../mocks/user.controller.mock';
+import { toAlgoliaUserItem } from '@asap-hub/model';
 jest.mock('../../../src/utils/logger');
 const algoliaSearchClientMock = getAlgoliaSearchClientMock();
-
-const mapPayload = toPayload('user');
 
 const possibleEvents: [string, LabEventGenerator][] = [
   ['published', getLabPublishedEvent],
@@ -62,16 +60,22 @@ describe('Index Users on Lab event handler', () => {
     userControllerMock.fetch.mockResolvedValueOnce({
       total: 3,
       items: [
-        getUserResponse(),
-        { ...getUserResponse(), role: 'Hidden' },
-        { ...getUserResponse(), onboarded: false },
+        { ...getUserResponse(), displayName: 'Person A' },
+        { ...getUserResponse(), role: 'Hidden', displayName: 'Person B' },
+        { ...getUserResponse(), onboarded: false, displayName: 'Person C' },
       ],
     });
 
     await indexHandler(getLabPublishedEvent('lab-1234'));
 
     expect(algoliaSearchClientMock.saveMany).toHaveBeenCalledWith([
-      mapPayload(expect.objectContaining(getUserResponse())),
+      {
+        data: expect.objectContaining({
+          role: 'Grantee',
+          displayName: 'Person A',
+        }),
+        type: 'user',
+      },
     ]);
   });
 
@@ -86,16 +90,17 @@ describe('Index Users on Lab event handler', () => {
       await indexHandler(event);
 
       expect(algoliaSearchClientMock.saveMany).toHaveBeenCalledWith(
-        usersResponse.items.map((item) =>
-          mapPayload(expect.objectContaining(item)),
-        ),
+        usersResponse.items.map((item) => ({
+          data: toAlgoliaUserItem(item),
+          type: 'user',
+        })),
       );
     },
   );
 
   describe('Should process the events, handle race conditions and not rely on the order of the events', () => {
     test.each(possibleRacingConditionEvents)(
-      'recieves the events %s when lab exists',
+      'receives the events %s when lab exists',
       async (name, eventA, eventB) => {
         const userID = 'user-1234';
         const usersResponse = {
@@ -110,15 +115,17 @@ describe('Index Users on Lab event handler', () => {
         expect(algoliaSearchClientMock.saveMany).toHaveBeenCalledTimes(2);
         expect(algoliaSearchClientMock.saveMany).toHaveBeenNthCalledWith(
           1,
-          usersResponse.items.map((item) =>
-            mapPayload(expect.objectContaining(item)),
-          ),
+          usersResponse.items.map((item) => ({
+            data: toAlgoliaUserItem(item),
+            type: 'user',
+          })),
         );
         expect(algoliaSearchClientMock.saveMany).toHaveBeenNthCalledWith(
           2,
-          usersResponse.items.map((item) =>
-            mapPayload(expect.objectContaining(item)),
-          ),
+          usersResponse.items.map((item) => ({
+            data: toAlgoliaUserItem(item),
+            type: 'user',
+          })),
         );
       },
     );

--- a/apps/crn-server/test/handlers/teams/algolia-index-team-users-handler.test.ts
+++ b/apps/crn-server/test/handlers/teams/algolia-index-team-users-handler.test.ts
@@ -1,11 +1,10 @@
-import { UserResponse } from '@asap-hub/model';
+import { toAlgoliaUserItem } from '@asap-hub/model';
 import Boom from '@hapi/boom';
 import { indexTeamUsersHandler } from '../../../src/handlers/teams/algolia-index-team-users-handler';
 import {
   getListUserResponse,
   getUserResponse,
 } from '../../fixtures/users.fixtures';
-import { toPayload } from '../../helpers/algolia';
 
 import {
   getTeamPublishedEvent,
@@ -17,7 +16,6 @@ import { getAlgoliaSearchClientMock } from '../../mocks/algolia-client.mock';
 import { userControllerMock } from '../../mocks/user.controller.mock';
 
 jest.mock('../../../src/utils/logger');
-const mapPayload = toPayload('user');
 
 const algoliaSearchClientMock = getAlgoliaSearchClientMock();
 
@@ -76,10 +74,10 @@ describe('Index Users on Team event handler', () => {
     await indexHandler(getTeamPublishedEvent('lab-1234'));
 
     expect(algoliaSearchClientMock.saveMany).toHaveBeenCalledWith([
-      mapPayload({
-        ...userResponse,
-        _tags: userResponse.expertiseAndResourceTags,
-      } as UserResponse & { _tags: string[] }),
+      {
+        data: toAlgoliaUserItem(userResponse),
+        type: 'user',
+      },
     ]);
   });
 
@@ -94,12 +92,10 @@ describe('Index Users on Team event handler', () => {
       await indexHandler(event);
 
       expect(algoliaSearchClientMock.saveMany).toHaveBeenCalledWith(
-        usersResponse.items.map((item) =>
-          mapPayload({
-            ...item,
-            _tags: item.expertiseAndResourceTags,
-          } as UserResponse & { _tags: string[] }),
-        ),
+        usersResponse.items.map((item) => ({
+          data: toAlgoliaUserItem(item),
+          type: 'user',
+        })),
       );
     },
   );
@@ -121,21 +117,17 @@ describe('Index Users on Team event handler', () => {
         expect(algoliaSearchClientMock.saveMany).toHaveBeenCalledTimes(2);
         expect(algoliaSearchClientMock.saveMany).toHaveBeenNthCalledWith(
           1,
-          usersResponse.items.map((item) =>
-            mapPayload({
-              ...item,
-              _tags: item.expertiseAndResourceTags,
-            } as UserResponse & { _tags: string[] }),
-          ),
+          usersResponse.items.map((item) => ({
+            data: toAlgoliaUserItem(item),
+            type: 'user',
+          })),
         );
         expect(algoliaSearchClientMock.saveMany).toHaveBeenNthCalledWith(
           2,
-          usersResponse.items.map((item) =>
-            mapPayload({
-              ...item,
-              _tags: item.expertiseAndResourceTags,
-            } as UserResponse & { _tags: string[] }),
-          ),
+          usersResponse.items.map((item) => ({
+            data: toAlgoliaUserItem(item),
+            type: 'user',
+          })),
         );
       },
     );

--- a/apps/crn-server/test/handlers/user/algolia-index-user-handler.test.ts
+++ b/apps/crn-server/test/handlers/user/algolia-index-user-handler.test.ts
@@ -25,7 +25,49 @@ describe('User index handler', () => {
       event.detail.resourceId,
     );
     expect(algoliaSearchClientMock.save).toHaveBeenCalledWith({
-      data: expect.objectContaining(userResponse),
+      data: {
+        _tags: [
+          'expertise 1',
+          'expertise 2',
+          'expertise 3',
+          'expertise 4',
+          'expertise 5',
+        ],
+        alumniSinceDate: '2020-09-23T20:45:22.000Z',
+        avatarUrl: undefined,
+        city: 'London',
+        country: 'United Kingdom',
+        createdDate: '2020-09-23T20:45:22.000Z',
+        degree: 'MPH',
+        displayName: 'Tom Hardy',
+        firstName: 'Tom',
+        id: 'user-id-1',
+        institution: 'some institution',
+        jobTitle: 'some job title',
+        labs: [
+          {
+            id: 'cd7be4902',
+            name: 'Brighton',
+          },
+          {
+            id: 'cd7be4903',
+            name: 'Liverpool',
+          },
+        ],
+        lastName: 'Hardy',
+        membershipStatus: ['Alumni Member'],
+        role: 'Grantee',
+        teams: [
+          {
+            displayName: 'Team A',
+            id: 'team-id-0',
+            inactiveSinceDate: undefined,
+            proposal: 'proposalId1',
+            role: 'Lead PI (Core Leadership)',
+            teamInactiveSince: '',
+          },
+        ],
+      },
       type: 'user',
     });
   });
@@ -97,10 +139,9 @@ describe('User index handler', () => {
     await indexHandler(event);
 
     expect(algoliaSearchClientMock.save).toHaveBeenCalledWith({
-      data: {
-        ...userResponse,
+      data: expect.objectContaining({
         _tags: ['Bitopertin', 'A53T', 'Adapter ligation'],
-      },
+      }),
       type: 'user',
     });
   });

--- a/apps/storybook/src/DashboardPageBody.stories.tsx
+++ b/apps/storybook/src/DashboardPageBody.stories.tsx
@@ -4,7 +4,7 @@ import {
   createListEventResponse,
   createListReminderResponse,
   createListResearchOutputResponse,
-  createListUserResponse,
+  createUserListAlgoliaResponse,
 } from '@asap-hub/fixtures';
 import { array, number, text } from '@storybook/addon-knobs';
 
@@ -58,7 +58,7 @@ const props = (): ComponentProps<typeof DashboardPageBody> => ({
   recentSharedOutputs: createListResearchOutputResponse(
     number('Number of outputs', 5),
   ),
-  recommendedUsers: createListUserResponse(3).items,
+  recommendedUsers: createUserListAlgoliaResponse(3).items,
 });
 
 export const Normal = () => <DashboardPageBody {...props()} />;

--- a/apps/storybook/src/DashboardRecommendedUsers.stories.tsx
+++ b/apps/storybook/src/DashboardRecommendedUsers.stories.tsx
@@ -1,5 +1,5 @@
 import { DashboardRecommendedUsers } from '@asap-hub/react-components';
-import { createListUserResponse } from '@asap-hub/fixtures';
+import { createUserListAlgoliaResponse } from '@asap-hub/fixtures';
 import { number, text } from '@storybook/addon-knobs';
 
 export default {
@@ -9,7 +9,7 @@ export default {
 
 export const Normal = () => (
   <DashboardRecommendedUsers
-    recommendedUsers={createListUserResponse(3).items.map((user) => ({
+    recommendedUsers={createUserListAlgoliaResponse(3).items.map((user) => ({
       ...user,
       expertiseAndResourceTags: Array.from(
         new Array(number('Number of tags', 8)),

--- a/packages/algolia/src/client.ts
+++ b/packages/algolia/src/client.ts
@@ -11,7 +11,9 @@ import {
   ResearchOutputResponse,
   TeamListItemResponse,
   TutorialsResponse,
+  UserListItem,
   UserResponse,
+  WithAlgoliaTags,
   WithMeta,
   WorkingGroupResponse,
 } from '@asap-hub/model';
@@ -19,13 +21,13 @@ import { SearchIndex } from 'algoliasearch';
 import {
   EVENT_ENTITY_TYPE,
   EXTERNAL_AUTHOR_ENTITY_TYPE,
+  NEWS_ENTITY_TYPE as CRN_NEWS_ENTITY_TYPE,
   Payload,
   RESEARCH_OUTPUT_ENTITY_TYPE,
-  USER_ENTITY_TYPE,
   TEAM_ENTITY_TYPE,
-  WORKING_GROUP_ENTITY_TYPE,
   TUTORIAL_ENTITY_TYPE,
-  NEWS_ENTITY_TYPE as CRN_NEWS_ENTITY_TYPE,
+  USER_ENTITY_TYPE,
+  WORKING_GROUP_ENTITY_TYPE,
 } from './crn';
 import {
   NEWS_ENTITY_TYPE,
@@ -55,7 +57,10 @@ export type EntityResponses = {
       ResearchOutputResponse,
       typeof RESEARCH_OUTPUT_ENTITY_TYPE
     >;
-    [USER_ENTITY_TYPE]: WithMeta<UserResponse, typeof USER_ENTITY_TYPE>;
+    [USER_ENTITY_TYPE]: WithMeta<
+      WithAlgoliaTags<UserListItem>,
+      typeof USER_ENTITY_TYPE
+    >;
     [EXTERNAL_AUTHOR_ENTITY_TYPE]: WithMeta<
       ExternalAuthorResponse,
       typeof EXTERNAL_AUTHOR_ENTITY_TYPE

--- a/packages/algolia/src/crn/types.ts
+++ b/packages/algolia/src/crn/types.ts
@@ -6,7 +6,7 @@ import {
   ResearchOutputResponse,
   TeamListItemResponse,
   TutorialsResponse,
-  UserResponse,
+  UserListItem,
   WithAlgoliaTags,
   WorkingGroupResponse,
 } from '@asap-hub/model';
@@ -42,7 +42,7 @@ export type Payload =
       type: typeof TEAM_ENTITY_TYPE;
     }
   | {
-      data: UserResponse;
+      data: WithAlgoliaTags<UserListItem>;
       type: typeof USER_ENTITY_TYPE;
     }
   | {

--- a/packages/fixtures/src/users.ts
+++ b/packages/fixtures/src/users.ts
@@ -1,4 +1,11 @@
-import { ListUserResponse, UserResponse, UserTeam } from '@asap-hub/model';
+import {
+  ListUserResponse,
+  UserResponse,
+  UserTeam,
+  UserListItem,
+  WithAlgoliaTags,
+  UserListAlgoliaResponse,
+} from '@asap-hub/model';
 import { createLabs } from './labs';
 
 const listUserResponseTeam: Omit<UserTeam, 'id'> = {
@@ -71,6 +78,61 @@ export const createListUserResponse = (
   total: items,
   items: Array.from({ length: items }, (_, itemIndex) =>
     createUserResponse(options, itemIndex),
+  ),
+});
+
+export const createUserAlgoliaResponse = (
+  options: FixtureOptions = {},
+  itemIndex = 0,
+): WithAlgoliaTags<UserListItem> => {
+  const {
+    alumniSinceDate,
+    avatarUrl,
+    city,
+    country,
+    createdDate,
+    degree,
+    displayName,
+    expertiseAndResourceTags,
+    firstName,
+    id,
+    institution,
+    jobTitle,
+    labs,
+    lastName,
+    membershipStatus,
+    role,
+    teams,
+  } = createUserResponse(options, itemIndex);
+
+  return {
+    alumniSinceDate,
+    avatarUrl,
+    city,
+    country,
+    createdDate,
+    degree,
+    displayName,
+    firstName,
+    id,
+    institution,
+    jobTitle,
+    labs,
+    lastName,
+    membershipStatus,
+    role,
+    teams,
+    _tags: expertiseAndResourceTags,
+  };
+};
+
+export const createUserListAlgoliaResponse = (
+  items: number,
+  options: FixtureOptions = {},
+): UserListAlgoliaResponse => ({
+  total: items,
+  items: Array.from({ length: items }, (_, itemIndex) =>
+    createUserAlgoliaResponse(options, itemIndex),
   ),
 });
 

--- a/packages/model/src/tag.ts
+++ b/packages/model/src/tag.ts
@@ -3,7 +3,7 @@ import { NewsResponse } from './news';
 import { ResearchOutputResponse } from './research-output';
 import { TeamListItemResponse } from './team';
 import { TutorialsResponse } from './tutorials';
-import { UserResponse } from './user';
+import { UserListItem } from './user';
 import { WorkingGroupResponse } from './working-group';
 
 export type WithMeta<Response, Type> = Response & { __meta: { type: Type } };
@@ -12,7 +12,7 @@ export type WithAlgoliaTags<Response> = Response & { _tags: string[] };
 
 export type TagSearchResponse =
   | WithMeta<ResearchOutputResponse, 'research-output'>
-  | WithMeta<UserResponse, 'user'>
+  | WithMeta<UserListItem, 'user'>
   | WithMeta<EventResponse, 'event'>
   | WithMeta<TeamListItemResponse, 'team'>
   | WithMeta<WorkingGroupResponse, 'working-group'>

--- a/packages/model/src/user.ts
+++ b/packages/model/src/user.ts
@@ -1,6 +1,7 @@
 import { FetchOptions, ListResponse, OrcidWork } from './common';
 import { InterestGroupMembership } from './interest-group';
 import { LabResponse } from './lab';
+import { WithAlgoliaTags } from './tag';
 import { TeamRole } from './team';
 import { WorkingGroupMembership } from './working-group';
 
@@ -107,6 +108,30 @@ export interface UserResponse
   displayName: string;
 }
 
+export type UserListItem = Pick<
+  UserResponse,
+  | 'alumniSinceDate'
+  | 'avatarUrl'
+  | 'city'
+  | 'country'
+  | 'createdDate'
+  | 'degree'
+  | 'displayName'
+  | 'firstName'
+  | 'id'
+  | 'institution'
+  | 'jobTitle'
+  | 'labs'
+  | 'lastName'
+  | 'membershipStatus'
+  | 'role'
+  | 'teams'
+>;
+
+export type UserListAlgoliaResponse = ListResponse<
+  WithAlgoliaTags<UserListItem>
+>;
+
 export type UserMetadataResponse = Omit<UserResponse, 'labs'> & {
   algoliaApiKey: string | null;
 };
@@ -199,3 +224,47 @@ export type FetchUsersFilter =
 export type FetchUsersOptions = Omit<FetchOptions<FetchUsersFilter>, 'search'>;
 
 export type UserRole = 'Staff' | 'Member' | 'None';
+
+export const toAlgoliaUserItem = (
+  user: UserResponse,
+): WithAlgoliaTags<UserListItem> => {
+  const {
+    alumniSinceDate,
+    avatarUrl,
+    city,
+    country,
+    createdDate,
+    degree,
+    displayName,
+    expertiseAndResourceTags,
+    firstName,
+    id,
+    institution,
+    jobTitle,
+    labs,
+    lastName,
+    membershipStatus,
+    role,
+    teams,
+  } = user;
+
+  return {
+    alumniSinceDate,
+    avatarUrl,
+    city,
+    country,
+    createdDate,
+    degree,
+    displayName,
+    firstName,
+    id,
+    institution,
+    jobTitle,
+    labs,
+    lastName,
+    membershipStatus,
+    role,
+    teams,
+    _tags: expertiseAndResourceTags,
+  };
+};

--- a/packages/model/test/user.test.ts
+++ b/packages/model/test/user.test.ts
@@ -1,4 +1,10 @@
-import { isUserDegree, isUserRole, userDegree, userRole } from '../src';
+import {
+  isUserDegree,
+  isUserRole,
+  userDegree,
+  userRole,
+  toAlgoliaUserItem,
+} from '../src';
 
 describe('User', () => {
   describe('Role', () => {
@@ -18,6 +24,89 @@ describe('User', () => {
 
     it('should not recognise incorrect degree', () => {
       expect(isUserDegree('not-a-degree')).toEqual(false);
+    });
+  });
+
+  describe('toAlgoliaUserItem', () => {
+    it('should convert user response to algolia user item response', () => {
+      expect(
+        toAlgoliaUserItem({
+          id: 'user-1',
+          createdDate: '2020-09-07T17:36:54Z',
+          lastModifiedDate: '2020-09-07T17:36:54Z',
+          onboarded: true,
+          displayName: 'Jane Doe',
+          firstName: 'Jane',
+          lastName: 'Doe',
+          email: 'jane.doe@asap.com',
+          jobTitle: 'Assistant Professor',
+          institution: 'University of Toronto',
+          country: 'Canada',
+          city: 'Toronto',
+          orcid: '0000-0001-8203-6901',
+          orcidWorks: [],
+          expertiseAndResourceTags: ['Blood', 'Parkinson'],
+          questions: [],
+          role: 'Grantee',
+          social: {
+            github: '',
+            googleScholar: '',
+            linkedIn: '',
+            orcid: '',
+            researchGate: '',
+            researcherId: '',
+            twitter: '',
+          },
+          workingGroups: [],
+          interestGroups: [],
+          labs: [{ id: 'cd7be4902', name: 'Brighton' }],
+          teams: [
+            {
+              displayName: 'Alessi',
+              id: 'team-alessi',
+              role: 'Lead PI (Core Leadership)',
+              inactiveSinceDate: '',
+            },
+            {
+              displayName: 'De Camilli',
+              id: 'team-de-camilli',
+              role: 'Project Manager',
+              inactiveSinceDate: '',
+            },
+          ],
+        }),
+      ).toEqual({
+        _tags: ['Blood', 'Parkinson'],
+        alumniSinceDate: undefined,
+        avatarUrl: undefined,
+        city: 'Toronto',
+        country: 'Canada',
+        createdDate: '2020-09-07T17:36:54Z',
+        degree: undefined,
+        displayName: 'Jane Doe',
+        firstName: 'Jane',
+        id: 'user-1',
+        institution: 'University of Toronto',
+        jobTitle: 'Assistant Professor',
+        labs: [{ id: 'cd7be4902', name: 'Brighton' }],
+        lastName: 'Doe',
+        membershipStatus: undefined,
+        role: 'Grantee',
+        teams: [
+          {
+            displayName: 'Alessi',
+            id: 'team-alessi',
+            inactiveSinceDate: '',
+            role: 'Lead PI (Core Leadership)',
+          },
+          {
+            displayName: 'De Camilli',
+            id: 'team-de-camilli',
+            inactiveSinceDate: '',
+            role: 'Project Manager',
+          },
+        ],
+      });
     });
   });
 });

--- a/packages/react-components/src/organisms/DashboardRecommendedUsers.tsx
+++ b/packages/react-components/src/organisms/DashboardRecommendedUsers.tsx
@@ -1,4 +1,4 @@
-import { UserResponse } from '@asap-hub/model';
+import { UserListItem, WithAlgoliaTags } from '@asap-hub/model';
 import { network } from '@asap-hub/routing';
 import { css } from '@emotion/react';
 import { Card, Avatar, Ellipsis, Paragraph } from '../atoms';
@@ -37,7 +37,7 @@ const roleStyles = css({
 });
 
 type DashboardRecommendedUsersProps = {
-  recommendedUsers: UserResponse[];
+  recommendedUsers: WithAlgoliaTags<UserListItem>[];
 };
 
 const DashboardRecommendedUsers: React.FC<DashboardRecommendedUsersProps> = ({
@@ -80,7 +80,8 @@ const DashboardRecommendedUsers: React.FC<DashboardRecommendedUsersProps> = ({
           )}
           <TagList
             centerContent
-            tags={user.expertiseAndResourceTags}
+            // eslint-disable-next-line no-underscore-dangle
+            tags={user._tags}
             max={NUMBER_OF_TAGS_TO_DISPLAY}
           />
         </div>

--- a/packages/react-components/src/organisms/PeopleCard.tsx
+++ b/packages/react-components/src/organisms/PeopleCard.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { UserResponse } from '@asap-hub/model';
+import { UserListItem } from '@asap-hub/model';
 import { network } from '@asap-hub/routing';
 
 import { Card, Avatar, Caption, StateTag } from '../atoms';
@@ -44,23 +44,7 @@ const moveStyles = css({
 
 const alumniBadgeStyles = css({});
 
-type PeopleCardProps = Pick<
-  UserResponse,
-  | 'id'
-  | 'alumniSinceDate'
-  | 'avatarUrl'
-  | 'displayName'
-  | 'firstName'
-  | 'institution'
-  | 'jobTitle'
-  | 'createdDate'
-  | 'lastName'
-  | 'role'
-  | 'teams'
-  | 'degree'
-  | 'labs'
->;
-const PeopleCard: React.FC<PeopleCardProps> = ({
+const PeopleCard: React.FC<UserListItem> = ({
   id,
   alumniSinceDate,
   displayName,

--- a/packages/react-components/src/organisms/__tests__/DashboardRecommendedUsers.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/DashboardRecommendedUsers.test.tsx
@@ -1,5 +1,5 @@
 import { render } from '@testing-library/react';
-import { createUserResponse } from '@asap-hub/fixtures';
+import { createUserAlgoliaResponse } from '@asap-hub/fixtures';
 import DashboardRecommendedUsers from '../DashboardRecommendedUsers';
 
 it('renders the dashboard recommended users', () => {
@@ -7,15 +7,15 @@ it('renders the dashboard recommended users', () => {
     <DashboardRecommendedUsers
       recommendedUsers={[
         {
-          ...createUserResponse(undefined, 0),
+          ...createUserAlgoliaResponse(undefined, 0),
           displayName: 'John Doe',
         },
         {
-          ...createUserResponse(undefined, 1),
+          ...createUserAlgoliaResponse(undefined, 1),
           displayName: 'Octavian Ratiu',
         },
         {
-          ...createUserResponse(undefined, 2),
+          ...createUserAlgoliaResponse(undefined, 2),
           id: '345',
           displayName: 'User 3',
         },
@@ -32,20 +32,20 @@ it('renders the recommended user', () => {
     <DashboardRecommendedUsers
       recommendedUsers={[
         {
-          ...createUserResponse(),
+          ...createUserAlgoliaResponse(),
           id: 'user-1',
           firstName: 'Test',
           lastName: 'User',
           displayName: 'Test User',
-          expertiseAndResourceTags: ['Tag 1'],
+          _tags: ['Tag 1'],
           avatarUrl:
             'https://www.gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50?f=y',
           teams: [
             { id: 'team-1', displayName: 'Team 1', role: 'Key Personnel' },
           ],
         },
-        createUserResponse(undefined, 1),
-        createUserResponse(undefined, 2),
+        createUserAlgoliaResponse(undefined, 1),
+        createUserAlgoliaResponse(undefined, 2),
       ]}
     />,
   );

--- a/packages/react-components/src/templates/DashboardPageBody.tsx
+++ b/packages/react-components/src/templates/DashboardPageBody.tsx
@@ -14,6 +14,8 @@ import {
   NewsResponse,
   GuideDataObject,
   EventResponse,
+  UserListItem,
+  WithAlgoliaTags,
 } from '@asap-hub/model';
 import {
   NewsSection,
@@ -62,7 +64,7 @@ type DashboardPageBodyProps = Pick<
     roles: TeamRole[];
     guides: GuideDataObject[];
     recentSharedOutputs?: ListResearchOutputResponse;
-    recommendedUsers: UserResponse[];
+    recommendedUsers: WithAlgoliaTags<UserListItem>[];
   };
 
 const publishRoles: TeamRole[] = ['ASAP Staff', 'Project Manager'];

--- a/packages/react-components/src/templates/TagsPageBody.tsx
+++ b/packages/react-components/src/templates/TagsPageBody.tsx
@@ -5,7 +5,7 @@ import {
   TagSearchResponse,
   TeamListItemResponse,
   TutorialsResponse,
-  UserResponse,
+  UserListItem,
   WorkingGroupResponse,
 } from '@asap-hub/model';
 import { css } from '@emotion/react';
@@ -59,7 +59,7 @@ const EntityCard: React.FC<TagsPageBodyProps['results'][number]> = ({
   }
 
   if (type === 'user') {
-    return <PeopleCard {...(data as UserResponse)} />;
+    return <PeopleCard {...(data as UserListItem)} />;
   }
 
   if (type === 'event') {

--- a/packages/react-components/src/templates/__tests__/DashboardPageBody.test.tsx
+++ b/packages/react-components/src/templates/__tests__/DashboardPageBody.test.tsx
@@ -4,7 +4,7 @@ import { GuideDataObject } from '@asap-hub/model';
 import {
   createListEventResponse,
   createListResearchOutputResponse,
-  createListUserResponse,
+  createUserListAlgoliaResponse,
   createResearchOutputResponse,
 } from '@asap-hub/fixtures';
 import DashboardPageBody from '../DashboardPageBody';
@@ -33,7 +33,7 @@ const props: ComponentProps<typeof DashboardPageBody> = {
   dismissedGettingStarted: false,
   upcomingEvents: undefined,
   recentSharedOutputs: createListResearchOutputResponse(5),
-  recommendedUsers: createListUserResponse(3).items,
+  recommendedUsers: createUserListAlgoliaResponse(3).items,
 };
 
 it('renders guides', () => {

--- a/packages/server-common/src/handlers/utils.ts
+++ b/packages/server-common/src/handlers/utils.ts
@@ -26,7 +26,8 @@ export const createProcessingFunction =
     type: Type,
     logger: Logger,
     filterFunction: (item: T['data']) => boolean = () => true,
-    addTagsFunction?: (item: T['data']) => T['data'] & { _tags: string[] },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    addTagsFunction?: (item: any) => SavePayload['data'],
   ) =>
   async (found: ListResponse<T['data']>) => {
     logger.info(


### PR DESCRIPTION
This PR reduces the user data sent to the frontend by algolia by reducing the data stored in algolia with the `toAlgoliaUserItem` method on `packages/model/src/user.ts`. Note that the data sent to algolia is exactly the data needed in `PeopleCard`. This `toAlgoliaUserItem` is applied to the handlers that index user on algolia.

##### Before
<img width="1440" alt="Screenshot 2023-12-07 at 10 38 19" src="https://github.com/yldio/asap-hub/assets/16595804/66103f7e-2751-4ea2-9a07-c2bcbafbd786">

##### After
<img width="1440" alt="Screenshot 2023-12-07 at 10 37 39" src="https://github.com/yldio/asap-hub/assets/16595804/6f2488e5-76bc-4181-a0bc-c4e2c545742c">


