### PR TITLE
fix: Revert skeleton loading state for Dashboard

### DIFF
--- a/apps/crn-frontend/src/dashboard/Dashboard.tsx
+++ b/apps/crn-frontend/src/dashboard/Dashboard.tsx
@@ -1,7 +1,7 @@
 import { usePrefetchCalendars } from '@asap-hub/crn-frontend/src/events/calendar/state';
 import { CARD_VIEW_PAGE_SIZE } from '@asap-hub/crn-frontend/src/hooks';
 import { usePrefetchTeams } from '@asap-hub/crn-frontend/src/network/teams/state';
-import { SkeletonBodyFrame as Frame } from '@asap-hub/frontend-utils';
+import { Frame } from '@asap-hub/frontend-utils';
 import { ConfirmModal, DashboardPage } from '@asap-hub/react-components';
 import {
   useCurrentUserCRN,


### PR DESCRIPTION
This reverts commit 49da63c4804cd1f19d884862e01e1cb87101e6f1.
