### PR TITLE
ASAP-272 Fix tooltip width

### DIFF
--- a/packages/gp2-components/src/organisms/EmailSection.tsx
+++ b/packages/gp2-components/src/organisms/EmailSection.tsx
@@ -26,7 +26,7 @@ const containerStyles = css({
 const itemStyles = css({
   display: 'grid',
   columnGap: rem(16),
-  gridTemplateColumns: `1fr ${rem(32)} 1fr`,
+  gridTemplateColumns: `1fr ${rem(38)} 1fr`,
   alignItems: 'center',
 });
 

--- a/packages/react-components/src/atoms/Tooltip.tsx
+++ b/packages/react-components/src/atoms/Tooltip.tsx
@@ -11,8 +11,7 @@ const positionerStyles = css({
   position: 'relative',
   height: 0,
   [`@media (max-width: ${tabletScreen.width - 1}px)`]: {
-    position: 'absolute',
-    left: 0,
+    position: 'relative',
     width: '100%',
   },
 });
@@ -26,21 +25,22 @@ const tooltipStyles = css({
   display: 'grid',
   gridTemplateRows: `auto ${triangleHeight / perRem}em`,
 
-  clipPath: `polygon(
-    0 0,
-    0 calc(100% - ${triangleHeight / perRem}em),
-    calc(50% - ${4.5 / perRem}em) calc(100% - ${triangleHeight / perRem}em),
-    50% 100%,
-    calc(50% + ${4.5 / perRem}em) calc(100% - ${triangleHeight / perRem}em),
-    100% calc(100% - ${triangleHeight / perRem}em),
-    100% 0
-  )`,
+  '::before': {
+    content: '""',
+    display: 'block',
+    width: 0,
+    height: 0,
+    position: 'absolute',
+    borderLeft: `${triangleHeight}px solid transparent`,
+    borderRight: `${triangleHeight}px solid transparent`,
+    borderTop: `${triangleHeight}px solid #000`,
+    bottom: 0,
+    right: '50%',
+    marginRight: `-${triangleHeight / 2}px`,
+  },
 
   [`@media (max-width: ${tabletScreen.width - 1}px)`]: {
-    width: '100vw',
-    transform: 'none',
-    left: 0,
-    clipPath: 'none',
+    width: 'max-content',
   },
 });
 const bubbleStyles = css({
@@ -57,12 +57,6 @@ const bubbleStyles = css({
     maxWidth: '100%',
     marginLeft: `${12 / perRem}em`,
     marginRight: `${12 / perRem}em`,
-  },
-});
-
-const presentationStyles = css({
-  [`@media (max-width: ${tabletScreen.width - 1}px)`]: {
-    display: 'none',
   },
 });
 
@@ -90,7 +84,6 @@ const Tooltip: React.FC<TooltipProps> = ({
       <span role="tooltip" css={bubbleStyles}>
         {children}
       </span>
-      <span role="presentation" css={[themes.dark, presentationStyles]} />
     </span>
   </span>
 );


### PR DESCRIPTION
Before - **wrong** width **without** arrow down            |  After - correct width **wtih** arrow down
:-------------------------:|:-------------------------:
![tooltip-0](https://github.com/yldio/asap-hub/assets/16595804/365604ef-71b6-426b-b771-f794e3e0ae87) | ![tooltip-1](https://github.com/yldio/asap-hub/assets/16595804/db7ad330-697c-4e66-be81-feba330282a4)



---


Before - **wrong** button width in GP2           |  After - **correct** button width in GP2
:-------------------------:|:-------------------------:
![gp2-0](https://github.com/yldio/asap-hub/assets/16595804/c9076d32-c1b0-4aa7-b7c4-2816a606a22c) |  ![gp2-1](https://github.com/yldio/asap-hub/assets/16595804/cf7f458e-cc83-41a1-93ca-f0fbf719b435)
