### PR TITLE
Asap 262 update view export buttons

### DIFF
--- a/apps/crn-frontend/src/network/teams/__tests__/Outputs.test.tsx
+++ b/apps/crn-frontend/src/network/teams/__tests__/Outputs.test.tsx
@@ -197,7 +197,7 @@ it('triggers export with the same parameters and custom file name', async () => 
     }),
   );
 
-  userEvent.click(getByText(/export/i));
+  userEvent.click(getByText(/csv/i));
   expect(mockCreateCsvFileStream).toHaveBeenLastCalledWith(
     expect.stringMatching(/SharedOutputs_Team_ExampleTeam123_\d+\.csv/),
     expect.anything(),
@@ -232,7 +232,7 @@ it('triggers draft research output export with custom file name', async () => {
     true,
   );
 
-  userEvent.click(getByText(/export as csv/i));
+  userEvent.click(getByText(/csv/i));
   await waitFor(() =>
     expect(mockGetDraftResearchOutputs).toHaveBeenCalledWith(
       {

--- a/apps/crn-frontend/src/network/users/__tests__/Outputs.test.tsx
+++ b/apps/crn-frontend/src/network/users/__tests__/Outputs.test.tsx
@@ -185,7 +185,7 @@ it('triggers export with the same parameters and custom filename', async () => {
     }),
   );
 
-  userEvent.click(getByText(/export/i));
+  userEvent.click(getByText(/csv/i));
   expect(mockCreateCsvFileStream).toHaveBeenLastCalledWith(
     expect.stringMatching(/SharedOutputs_JohnSmith_\d+\.csv/),
     expect.anything(),

--- a/apps/crn-frontend/src/network/working-groups/__tests__/Outputs.test.tsx
+++ b/apps/crn-frontend/src/network/working-groups/__tests__/Outputs.test.tsx
@@ -175,7 +175,7 @@ it('triggers research output export with custom file name', async () => {
     title: 'WorkingGroup123',
   });
 
-  userEvent.click(getByText(/export as csv/i));
+  userEvent.click(getByText(/csv/i));
   await waitFor(() =>
     expect(mockGetResearchOutputs).toHaveBeenCalledWith(expect.anything(), {
       searchQuery: '',
@@ -210,7 +210,7 @@ it('triggers draft research output export with custom file name', async () => {
     true,
   );
 
-  userEvent.click(getByText(/export as csv/i));
+  userEvent.click(getByText(/csv/i));
   await waitFor(() =>
     expect(mockGetDraftResearchOutputs).toHaveBeenCalledWith(
       {

--- a/apps/crn-frontend/src/shared-research/__tests__/ResearchOutputList.test.tsx
+++ b/apps/crn-frontend/src/shared-research/__tests__/ResearchOutputList.test.tsx
@@ -87,7 +87,7 @@ it('triggers and export with the same parameters', async () => {
     createResearchOutputListAlgoliaResponse(2),
   );
   const { getByText } = await renderResearchOutputList('example');
-  userEvent.click(getByText(/export/i));
+  userEvent.click(getByText(/csv/i));
   expect(mockCreateCsvFileStream).toHaveBeenCalledWith(
     expect.stringMatching(/SharedOutputs_\d+\.csv/),
     expect.anything(),

--- a/apps/gp2-frontend/src/outputs/OutputList.tsx
+++ b/apps/gp2-frontend/src/outputs/OutputList.tsx
@@ -5,7 +5,6 @@ import {
   OutputCard,
 } from '@asap-hub/gp2-components';
 import { ResultList, SearchAndFilter } from '@asap-hub/react-components';
-import { useCurrentUserGP2 } from '@asap-hub/react-context';
 import { ComponentProps } from 'react';
 import { useAlgolia } from '../hooks/algolia';
 import { usePagination, usePaginationParams } from '../hooks/pagination';
@@ -26,8 +25,6 @@ const OutputList: React.FC<OutputListProps> = ({
   authorId,
 }) => {
   const { currentPage, pageSize } = usePaginationParams();
-  const currentUser = useCurrentUserGP2();
-  const isAdministrator = currentUser?.role === 'Administrator';
 
   const { client } = useAlgolia();
 
@@ -64,7 +61,6 @@ const OutputList: React.FC<OutputListProps> = ({
       currentPageIndex={currentPage}
       renderPageHref={renderPageHref}
       exportResults={exportOutputs}
-      isAdministrator={isAdministrator}
     >
       {items.map((output) => (
         <OutputCard key={output.id} {...output} />

--- a/apps/gp2-frontend/src/tags/ResultList.tsx
+++ b/apps/gp2-frontend/src/tags/ResultList.tsx
@@ -10,7 +10,6 @@ import {
   EventCard,
   ResultList as ResultListComponent,
 } from '@asap-hub/react-components';
-import { useCurrentUserGP2 } from '@asap-hub/react-context';
 import { eventMapper } from '../events/EventsList';
 import { usePagination, usePaginationParams } from '../hooks/pagination';
 import { useTagSearchResults } from './state';
@@ -21,8 +20,6 @@ export type ResultListProps = {
 };
 const ResultList: React.FC<ResultListProps> = ({ filters = new Set() }) => {
   const { currentPage, pageSize } = usePaginationParams();
-  const currentUser = useCurrentUserGP2();
-  const isAdministrator = currentUser?.role === 'Administrator';
 
   const { tags } = useSearch();
   const { items, total } = useTagSearchResults({
@@ -39,7 +36,6 @@ const ResultList: React.FC<ResultListProps> = ({ filters = new Set() }) => {
       numberOfPages={numberOfPages}
       currentPageIndex={currentPage}
       renderPageHref={renderPageHref}
-      isAdministrator={isAdministrator}
     >
       {items.map((result) => {
         // eslint-disable-next-line no-underscore-dangle

--- a/packages/react-components/src/molecules/ListControls.tsx
+++ b/packages/react-components/src/molecules/ListControls.tsx
@@ -1,43 +1,24 @@
-import { Link } from 'react-router-dom';
+import { dropdownChevronIcon } from '../icons';
+import DropdownButton from './DropdownButton';
 import { css } from '@emotion/react';
-
-import { charcoal, fern, lead } from '../colors';
-import { perRem, lineHeight } from '../pixels';
-import { cardViewIcon, listViewIcon } from '../icons';
+import { rem, tabletScreen } from '../pixels';
 
 const containerStyles = css({
-  display: 'grid',
-  gridAutoFlow: 'column',
-  columnGap: '24px',
-  width: 'fit-content',
-  margin: `${12 / perRem}em 0`,
-});
-
-const linkStyles = css({
-  color: charcoal.rgb,
-  textDecoration: 'none',
-  outline: 'none',
-});
-
-const textStyles = css({
-  margin: 0,
   display: 'flex',
-  fontSize: `${18 / perRem}em`,
-  svg: {
-    stroke: lead.rgb,
+  alignItems: 'center',
+  gap: rem(15),
+  'span + svg': {
+    width: '11px',
   },
-});
-const iconStyles = css({
-  display: 'inline-block',
-  width: `${lineHeight / perRem}em`,
-  height: `${lineHeight / perRem}em`,
-  paddingRight: `${14 / perRem}em`,
-});
+  button: {
+    padding: `${rem(8)} ${rem(24)}`,
+  },
 
-const activeStyles = css({
-  fontWeight: 'bold',
-  svg: {
-    stroke: fern.rgb,
+  [`@media (max-width: ${tabletScreen.min}px)`]: {
+    flexDirection: 'column',
+    alignItems: 'flex-start',
+    marginTop: rem(24),
+    width: '100%',
   },
 });
 
@@ -50,21 +31,30 @@ const ListControls: React.FC<ListControlsProps> = ({
   isListView,
   listViewHref,
   cardViewHref,
-}) => (
-  <div css={containerStyles}>
-    <Link to={cardViewHref} css={linkStyles}>
-      <p css={[textStyles, !isListView && activeStyles]}>
-        <span css={iconStyles}>{cardViewIcon}</span>
-        Card View
-      </p>
-    </Link>
-    <Link to={listViewHref} css={linkStyles}>
-      <p css={[textStyles, isListView && activeStyles]}>
-        <span css={iconStyles}>{listViewIcon}</span>
-        List View
-      </p>
-    </Link>
-  </div>
-);
+}) => {
+  return (
+    <span css={containerStyles}>
+      <strong>View as:</strong>
+      <DropdownButton
+        noMargin
+        buttonChildren={() => (
+          <>
+            <span>{isListView ? 'List' : 'Card'}</span>
+            {dropdownChevronIcon}
+          </>
+        )}
+      >
+        {{
+          item: <>List</>,
+          href: listViewHref,
+        }}
+        {{
+          item: <>Card</>,
+          href: cardViewHref,
+        }}
+      </DropdownButton>
+    </span>
+  );
+};
 
 export default ListControls;

--- a/packages/react-components/src/molecules/ListControls.tsx
+++ b/packages/react-components/src/molecules/ListControls.tsx
@@ -39,7 +39,9 @@ const ListControls: React.FC<ListControlsProps> = ({
       noMargin
       buttonChildren={() => (
         <>
-          <span css={{ marginRight: rem(10) }}>{isListView ? 'List' : 'Card'}</span>
+          <span css={{ marginRight: rem(10) }}>
+            {isListView ? 'List' : 'Card'}
+          </span>
           {dropdownChevronIcon}
         </>
       )}

--- a/packages/react-components/src/molecules/ListControls.tsx
+++ b/packages/react-components/src/molecules/ListControls.tsx
@@ -9,9 +9,10 @@ const containerStyles = css({
   gap: rem(15),
   'span + svg': {
     width: '11px',
+    marginRight: '10px',
   },
   button: {
-    padding: `${rem(8)} ${rem(24)}`,
+    padding: `${rem(8)} ${rem(16)}`,
   },
 
   [`@media (max-width: ${tabletScreen.min}px)`]: {
@@ -38,7 +39,7 @@ const ListControls: React.FC<ListControlsProps> = ({
       noMargin
       buttonChildren={() => (
         <>
-          <span>{isListView ? 'List' : 'Card'}</span>
+          <span css={{ marginRight: rem(10) }}>{isListView ? 'List' : 'Card'}</span>
           {dropdownChevronIcon}
         </>
       )}

--- a/packages/react-components/src/molecules/ListControls.tsx
+++ b/packages/react-components/src/molecules/ListControls.tsx
@@ -1,6 +1,6 @@
+import { css } from '@emotion/react';
 import { dropdownChevronIcon } from '../icons';
 import DropdownButton from './DropdownButton';
-import { css } from '@emotion/react';
 import { rem, tabletScreen } from '../pixels';
 
 const containerStyles = css({
@@ -31,30 +31,28 @@ const ListControls: React.FC<ListControlsProps> = ({
   isListView,
   listViewHref,
   cardViewHref,
-}) => {
-  return (
-    <span css={containerStyles}>
-      <strong>View as:</strong>
-      <DropdownButton
-        noMargin
-        buttonChildren={() => (
-          <>
-            <span>{isListView ? 'List' : 'Card'}</span>
-            {dropdownChevronIcon}
-          </>
-        )}
-      >
-        {{
-          item: <>List</>,
-          href: listViewHref,
-        }}
-        {{
-          item: <>Card</>,
-          href: cardViewHref,
-        }}
-      </DropdownButton>
-    </span>
-  );
-};
+}) => (
+  <span css={containerStyles}>
+    <strong>View as:</strong>
+    <DropdownButton
+      noMargin
+      buttonChildren={() => (
+        <>
+          <span>{isListView ? 'List' : 'Card'}</span>
+          {dropdownChevronIcon}
+        </>
+      )}
+    >
+      {{
+        item: <>List</>,
+        href: listViewHref,
+      }}
+      {{
+        item: <>Card</>,
+        href: cardViewHref,
+      }}
+    </DropdownButton>
+  </span>
+);
 
 export default ListControls;

--- a/packages/react-components/src/molecules/__tests__/ListControls.test.tsx
+++ b/packages/react-components/src/molecules/__tests__/ListControls.test.tsx
@@ -1,10 +1,10 @@
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 
 import ListControls from '../ListControls';
 
 it('passes through links', () => {
-  const { getByTitle } = render(
+  const { getAllByText, getByText, getByRole } = render(
     <ListControls
       cardViewHref="/card?123"
       listViewHref="/list?321"
@@ -12,12 +12,16 @@ it('passes through links', () => {
     />,
     { wrapper: MemoryRouter },
   );
-  expect(getByTitle(/list/i).closest('a')).toHaveAttribute('href', '/list?321');
-  expect(getByTitle(/card/i).closest('a')).toHaveAttribute('href', '/card?123');
+  fireEvent.click(getByRole('button'));
+  expect(getByText(/list/i).closest('a')).toHaveAttribute('href', '/list?321');
+  expect(getAllByText(/card/i)[1]!.closest('a')).toHaveAttribute(
+    'href',
+    '/card?123',
+  );
 });
 
 it('indicates which option is selected', () => {
-  const { getByText, rerender } = render(
+  const { getByRole, rerender } = render(
     <ListControls
       cardViewHref="/card?123"
       listViewHref="/list?321"
@@ -25,12 +29,7 @@ it('indicates which option is selected', () => {
     />,
     { wrapper: MemoryRouter },
   );
-  expect(
-    getComputedStyle(getByText(/card/i, { selector: 'p' })).fontWeight,
-  ).toBe('bold');
-  expect(
-    getComputedStyle(getByText(/list/i, { selector: 'p' })).fontWeight,
-  ).toBe('');
+  expect(getByRole('button').closest('span')).toHaveTextContent(/card/i);
   rerender(
     <ListControls
       cardViewHref="/card?123"
@@ -38,10 +37,5 @@ it('indicates which option is selected', () => {
       isListView={true}
     />,
   );
-  expect(
-    getComputedStyle(getByText(/card/i, { selector: 'p' })).fontWeight,
-  ).toBe('');
-  expect(
-    getComputedStyle(getByText(/list/i, { selector: 'p' })).fontWeight,
-  ).toBe('bold');
+  expect(getByRole('button').closest('span')).toHaveTextContent(/list/i);
 });

--- a/packages/react-components/src/organisms/ResultList.tsx
+++ b/packages/react-components/src/organisms/ResultList.tsx
@@ -27,8 +27,6 @@ const headerNoResultsStyles = css({
   },
 });
 
-const exportStyles = css({ marginLeft: `${24 / perRem}em` });
-
 const exportSectionStyles = css({
   display: 'flex',
   alignItems: 'center',
@@ -54,7 +52,7 @@ const exportButton = css({
     },
 });
 
-const resultsParagraphStyles = css({
+const resultsHeaderStyles = css({
   display: 'flex',
   justifyContent: 'space-between',
   width: '100%',
@@ -63,6 +61,17 @@ const resultsParagraphStyles = css({
   [`@media (max-width: ${tabletScreen.min}px)`]: {
     flexDirection: 'column',
     alignItems: 'flex-start',
+  },
+});
+
+const viewOptionsStyles = css({
+  display: 'flex',
+  gap: `${33 / perRem}em`,
+  [`@media (max-width: ${tabletScreen.min}px)`]: {
+    flexDirection: 'column',
+    alignItems: 'flex-start',
+    width: '100%',
+    gap: 0,
   },
 });
 
@@ -108,7 +117,6 @@ type ResultListProps = ComponentProps<typeof PageControls> & {
   readonly noResultsComponent?: React.ReactNode;
   readonly children: React.ReactNode;
   readonly algoliaIndexName?: string;
-  readonly isAdministrator?: boolean;
 };
 const ResultList: React.FC<ResultListProps> = ({
   icon,
@@ -120,7 +128,6 @@ const ResultList: React.FC<ResultListProps> = ({
   children,
   noResultsComponent,
   algoliaIndexName,
-  isAdministrator,
   ...pageControlsProps
 }) => {
   const toast = useContext(ToastContext);
@@ -135,19 +142,21 @@ const ResultList: React.FC<ResultListProps> = ({
         css={[headerStyles, numberOfItems === 0 && headerNoResultsStyles]}
       >
         {numberOfItems > 0 && (
-          <Paragraph
-            styles={
-              exportResults && isAdministrator
-                ? resultsParagraphStyles
-                : undefined
-            }
-          >
+          <div css={exportResults && resultsHeaderStyles}>
             <strong>
               {numberOfItems} result{numberOfItems === 1 || 's'} found
             </strong>
 
-            {exportResults &&
-              (isAdministrator ? (
+            <span css={viewOptionsStyles}>
+              {cardViewHref && listViewHref && (
+                <ListControls
+                  isListView={isListView}
+                  cardViewHref={cardViewHref}
+                  listViewHref={listViewHref}
+                />
+              )}
+
+              {exportResults && (
                 <span css={exportSectionStyles}>
                   <strong>Export as:</strong>
                   <Button
@@ -165,30 +174,9 @@ const ResultList: React.FC<ResultListProps> = ({
                     CSV
                   </Button>
                 </span>
-              ) : (
-                <span css={exportStyles}>
-                  <Button
-                    linkStyle
-                    onClick={() =>
-                      exportResults().catch(() =>
-                        toast(
-                          'There was an issue exporting to CSV. Please try again.',
-                        ),
-                      )
-                    }
-                  >
-                    Export as CSV
-                  </Button>
-                </span>
-              ))}
-          </Paragraph>
-        )}
-        {cardViewHref && listViewHref && (
-          <ListControls
-            isListView={isListView}
-            cardViewHref={cardViewHref}
-            listViewHref={listViewHref}
-          />
+              )}
+            </span>
+          </div>
         )}
       </header>
       {numberOfItems > 0 ? (

--- a/packages/react-components/src/organisms/__tests__/ResultList.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/ResultList.test.tsx
@@ -69,26 +69,9 @@ it('renders page controls', () => {
   );
 });
 
-it('renders export link', () => {
+it('renders export as csv button', () => {
   const { rerender } = render(
     <ResultList {...props} exportResults={undefined}>
-      cards
-    </ResultList>,
-  );
-  expect(screen.queryByText(/export/i)).toBeNull();
-  const mockExport = jest.fn(() => Promise.resolve());
-  rerender(
-    <ResultList {...props} exportResults={mockExport}>
-      cards
-    </ResultList>,
-  );
-  userEvent.click(screen.getByText(/export/i));
-  expect(mockExport).toHaveBeenCalled();
-});
-
-it('renders export csv as admin', () => {
-  const { rerender } = render(
-    <ResultList {...props} exportResults={undefined} isAdministrator>
       cards
     </ResultList>,
   );
@@ -96,7 +79,7 @@ it('renders export csv as admin', () => {
   expect(screen.queryByText(/csv/i)).toBeNull();
   const mockExport = jest.fn(() => Promise.resolve());
   rerender(
-    <ResultList {...props} exportResults={mockExport} isAdministrator>
+    <ResultList {...props} exportResults={mockExport}>
       cards
     </ResultList>,
   );
@@ -105,26 +88,27 @@ it('renders export csv as admin', () => {
   expect(mockExport).toHaveBeenCalled();
 });
 
-it('triggers an error toast when export fails', async () => {
-  const mockToast = jest.fn();
-  const mockExport = jest.fn(() => Promise.reject());
-  render(
-    <ToastContext.Provider value={mockToast}>
-      <ResultList {...props} exportResults={mockExport} isAdministrator>
-        cards
-      </ResultList>
-    </ToastContext.Provider>,
+it('renders view as dropdown when view and card links are available', () => {
+  const { rerender } = render(
+    <ResultList {...props} exportResults={undefined}>
+      cards
+    </ResultList>,
   );
-  userEvent.click(screen.getByText(/csv/i));
-  expect(mockExport).toHaveBeenCalled();
-  await waitFor(() =>
-    expect(mockToast).toHaveBeenCalledWith(
-      expect.stringMatching(/issue exporting/i),
-    ),
+  expect(screen.queryByText(/view as:/i)).toBeNull();
+  rerender(
+    <ResultList
+      {...props}
+      exportResults={undefined}
+      listViewHref="/list"
+      cardViewHref="/card"
+    >
+      cards
+    </ResultList>,
   );
+  expect(screen.getByText(/view as:/i)).toBeVisible();
 });
 
-it('triggers an error toast when export link fails', async () => {
+it('triggers an error toast when export fails', async () => {
   const mockToast = jest.fn();
   const mockExport = jest.fn(() => Promise.reject());
   render(
@@ -134,7 +118,7 @@ it('triggers an error toast when export link fails', async () => {
       </ResultList>
     </ToastContext.Provider>,
   );
-  userEvent.click(screen.getByText(/export as csv/i));
+  userEvent.click(screen.getByText(/csv/i));
   expect(mockExport).toHaveBeenCalled();
   await waitFor(() =>
     expect(mockToast).toHaveBeenCalledWith(

--- a/packages/react-components/src/organisms/__tests__/ResultList.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/ResultList.test.tsx
@@ -88,7 +88,7 @@ it('renders export as csv button', () => {
   expect(mockExport).toHaveBeenCalled();
 });
 
-it('renders view as dropdown when view and card links are available', () => {
+it('renders view as dropdown when list and card links are available', () => {
   const { rerender } = render(
     <ResultList {...props} exportResults={undefined}>
       cards

--- a/packages/react-components/src/templates/__tests__/SharedResearchList.test.tsx
+++ b/packages/react-components/src/templates/__tests__/SharedResearchList.test.tsx
@@ -16,36 +16,27 @@ const props: Omit<ComponentProps<typeof SharedResearchList>, 'children'> = {
 };
 
 it('renders multiple shared outputs cards in card view', () => {
-  const { queryAllByRole, getByText } = render(
+  const { queryAllByRole, getByRole } = render(
     <SharedResearchList {...props} isListView={false} />,
     {
       wrapper: StaticRouter,
     },
   );
-  expect(
-    getComputedStyle(getByText(/card/i, { selector: 'p' })).fontWeight,
-  ).toBe('bold');
-  expect(
-    getComputedStyle(getByText(/list/i, { selector: 'p' })).fontWeight,
-  ).toBe('');
+  expect(getByRole('button').closest('span')).toHaveTextContent(/card/i);
   expect(
     queryAllByRole('heading').map(({ textContent }) => textContent),
   ).toEqual(['Output 1', 'Output 2']);
 });
 
 it('renders multiple research outputs in list view', () => {
-  const { queryAllByRole, getByText } = render(
+  const { queryAllByRole, getByRole } = render(
     <SharedResearchList {...props} isListView />,
     {
       wrapper: StaticRouter,
     },
   );
-  expect(
-    getComputedStyle(getByText(/card/i, { selector: 'p' })).fontWeight,
-  ).toBe('');
-  expect(
-    getComputedStyle(getByText(/list/i, { selector: 'p' })).fontWeight,
-  ).toBe('bold');
+
+  expect(getByRole('button').closest('span')).toHaveTextContent(/list/i);
   expect(
     queryAllByRole('heading').map(({ textContent }) => textContent),
   ).toEqual(['Output 1', 'Output 2']);


### PR DESCRIPTION
ref: https://asaphub.atlassian.net/jira/software/c/projects/ASAP/boards/13?selectedIssue=ASAP-262

The isAdministrator prop was being used in the ResultList component to display different UIs for the 'Export as CSV' section. This is no longer needed and so has been removed. It also caused a bug in gp2 where the 'Export as CSV' section was rendered differently depending on whether the user was an admin or not.

<img width="1327" alt="Screenshot 2024-01-04 at 16 48 00" src="https://github.com/yldio/asap-hub/assets/25244556/9692d997-545e-42d8-931a-4a617a53106a">
<img width="1327" alt="Screenshot 2024-01-04 at 16 55 53" src="https://github.com/yldio/asap-hub/assets/25244556/ee6e8254-b552-4841-9cbb-9847fac98f0a">
