### PR TITLE
add projects and working groups filter to people page

### DIFF
--- a/packages/algolia/schema/gp2/algolia-reverse-timestamp-schema.json
+++ b/packages/algolia/schema/gp2/algolia-reverse-timestamp-schema.json
@@ -28,6 +28,7 @@
     "id",
     "lastName",
     "project.title",
+    "projects.title",
     "speakers.externalUser.name",
     "speakers.team.displayName",
     "speakers.user.displayName",
@@ -40,6 +41,7 @@
     "region",
     "contributingCohorts.name",
     "workingGroup.title",
+    "workingGroups.title",
     "projectIds",
     "workingGroupIds"
   ]

--- a/packages/algolia/schema/gp2/algolia-schema.json
+++ b/packages/algolia/schema/gp2/algolia-schema.json
@@ -13,6 +13,7 @@
     "id",
     "lastName",
     "project.title",
+    "projects.title",
     "speakers.externalUser.name",
     "speakers.team.displayName",
     "speakers.user.displayName",
@@ -25,6 +26,7 @@
     "region",
     "contributingCohorts.name",
     "workingGroup.title",
+    "workingGroups.title",
     "projectIds",
     "workingGroupIds"
   ],


### PR DESCRIPTION
The workingGroup.title & project.title attributes are used for events while workingGroups.title & projects.title are for people.

events:
<img width="884" alt="Screenshot 2024-01-29 at 15 25 09" src="https://github.com/yldio/asap-hub/assets/25244556/4d70958c-ab97-4bdc-88b9-5cc01c8f301d">

people:
<img width="884" alt="Screenshot 2024-01-29 at 15 26 57" src="https://github.com/yldio/asap-hub/assets/25244556/796d706b-89f3-4ab0-a3b3-f8dfc7fabe0a">
