### PR TITLE
fix: Turbo typecheck depedency issue

### DIFF
--- a/apps/gp2-frontend/src/events/Event.tsx
+++ b/apps/gp2-frontend/src/events/Event.tsx
@@ -23,6 +23,7 @@ const Event: React.FC = () => {
           descriptionOutput="Find all outputs that contributed to this event."
           tags={event.tags.map((t) => t.name)}
           relatedResearch={event.relatedOutputs}
+          relatedTutorials={[]}
           getIconForDocumentType={getIconForDocumentType}
           tableTitles={['Type of Output', 'Output Name', 'Source Type']}
           getSourceIcon={getSourceIcon}

--- a/turbo.json
+++ b/turbo.json
@@ -13,7 +13,7 @@
       "cache": false
     },
     "typecheck": {
-      "dependsOn": ["//#build:typecheck:tsc"]
+      "dependsOn": ["//#build:typecheck:tsc", "^typecheck"]
     },
     "build": {
       "dependsOn": ["typecheck", "build:babel", "//#build:typecheck:tsc"],


### PR DESCRIPTION
* makes the typecheck job depend on related dependency jobs (so that the packages are built first)
* fixes the bug introduced because of the missing dependency in turbo