### PR TITLE
ASAP-346 Fix algolia index in dedicated environment PR

### DIFF
--- a/.github/actions/cache-build/action.yml
+++ b/.github/actions/cache-build/action.yml
@@ -10,10 +10,16 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/cache@v3
+    - name: Setup
+      id: setup
+      uses: ./.github/actions/setup-environment
+      with:
+        environment-name: ${{ inputs.environment-name }}
+    - name: Cache
+      uses: actions/cache@v3
       with:
         path: |
           apps/**/build*
           apps/**/dist*
           packages/**/build*
-        key: ${{ inputs.cache-prefix }}-${{ inputs.environment-name }}-${{ github.sha }}
+        key: ${{ inputs.cache-prefix }}-${{ inputs.environment-name }}-${{ github.sha }}-${{ steps.setup.outputs.crn-algolia-index }}-${{ steps.setup.outputs.gp2-algolia-index }}


### PR DESCRIPTION
The issue with the build not being uploaded with the right algolia index is that we have the `Cache build output` step in `reusable-build` that was restoring an old build although we had a new build in the previous step.

The reason is that we use as key:

```
key: ${{ inputs.cache-prefix }}-${{ inputs.environment-name }}-${{ github.sha }}
```

that looks like

```
frontend-output-Branch-6bb10f742f8b2b087441b7943ab7d7b14fea4901
```

and this `github.sha` doesn't change when we just add a label like `crn-create-environment` or `gp2-create-environment` but don't push a new commit. So in this case, we restore an old build.

---

What was happening in the actions:

1. Pushed a commit without labels -> New sha -> Cache not restored
<img width="1437" alt="Screenshot 2024-02-29 at 11 57 15" src="https://github.com/yldio/asap-hub/assets/16595804/d0a7f2d8-ed96-44cb-b6c8-7e5a71846d61">

2. Added a label without pushing a new commit -> triggered the pipeline but sha didn't change -> Cache restored
<img width="1434" alt="Screenshot 2024-02-29 at 11 57 27" src="https://github.com/yldio/asap-hub/assets/16595804/7418ce22-2d97-4ba7-ba3e-d0e9f584ba22">
