### PR TITLE
ASAP-353 Poll user data conditionally

### DIFF
--- a/apps/crn-server/src/controllers/user.controller.ts
+++ b/apps/crn-server/src/controllers/user.controller.ts
@@ -139,10 +139,16 @@ export default class UserController {
     }
     const existingConnections =
       user.connections?.filter(({ code }) => code !== welcomeCode) || [];
-    return this.update(user.id, {
-      email: user.email,
-      connections: [...existingConnections, { code: userId }],
-    });
+    return this.update(
+      user.id,
+      {
+        email: user.email,
+        connections: [...existingConnections, { code: userId }],
+      },
+      {
+        polling: false,
+      },
+    );
   }
 
   async syncOrcidProfile(
@@ -174,7 +180,10 @@ export default class UserController {
       logger.warn(error, 'Failed to sync ORCID profile');
     }
 
-    return this.update(user.id, updateToUser, { suppressConflict: true });
+    return this.update(user.id, updateToUser, {
+      suppressConflict: true,
+      polling: false,
+    });
   }
   private async queryByCode(code: string) {
     return this.userDataProvider.fetch({

--- a/apps/crn-server/src/controllers/user.controller.ts
+++ b/apps/crn-server/src/controllers/user.controller.ts
@@ -34,12 +34,15 @@ export default class UserController {
   async update(
     id: string,
     update: UserUpdateRequest,
-    { suppressConflict = false } = {},
+    { suppressConflict = false, polling = true } = {},
   ): Promise<UserResponse> {
     if (update.tagIds) {
       await this.validateUser(update.tagIds);
     }
-    await this.userDataProvider.update(id, update, { suppressConflict });
+    await this.userDataProvider.update(id, update, {
+      suppressConflict,
+      polling,
+    });
     return this.fetchById(id);
   }
 

--- a/apps/crn-server/src/data-providers/contentful/user.data-provider.ts
+++ b/apps/crn-server/src/data-providers/contentful/user.data-provider.ts
@@ -193,7 +193,7 @@ export class UserContentfulDataProvider implements UserDataProvider {
   async update(
     id: string,
     data: UserUpdateDataObject,
-    { suppressConflict = false } = {},
+    { suppressConflict = false, polling = true } = {},
   ): Promise<void> {
     const pollForUpdate = async (publishedVersion: number | undefined) => {
       const fetchUserById = () => this.fetchUserById(id);
@@ -215,7 +215,7 @@ export class UserContentfulDataProvider implements UserDataProvider {
       ...fields,
       ...(data.tagIds ? { researchTags: getLinkEntities(data.tagIds) } : {}),
     });
-    if (!result) {
+    if (!result || !polling) {
       return;
     }
     await pollForUpdate(result.sys.publishedVersion);

--- a/apps/crn-server/src/data-providers/types/users.data-provider.types.ts
+++ b/apps/crn-server/src/data-providers/types/users.data-provider.types.ts
@@ -14,5 +14,5 @@ export type UserDataProvider = DataProvider<
   UserCreateDataObject,
   null,
   UserUpdateDataObject,
-  { suppressConflict?: boolean }
+  { suppressConflict?: boolean; polling?: boolean }
 >;

--- a/apps/crn-server/test/controllers/user.controller.test.ts
+++ b/apps/crn-server/test/controllers/user.controller.test.ts
@@ -316,7 +316,7 @@ describe('Users controller', () => {
           email: user.email,
           connections: [{ code: 'user-id' }],
         },
-        { suppressConflict: false, polling: true },
+        { suppressConflict: false, polling: false },
       );
       expect(result).toEqual({
         ...getUserResponse(),
@@ -347,7 +347,7 @@ describe('Users controller', () => {
             },
           ]),
         },
-        { suppressConflict: false, polling: true },
+        { suppressConflict: false, polling: false },
       );
     });
 
@@ -426,7 +426,7 @@ describe('Users controller', () => {
           orcidLastModifiedDate: '2020-07-14T01:36:15.911Z',
           orcidWorks: orcidFixtures.orcidWorksDeserialisedExpectation,
         }),
-        { suppressConflict: true, polling: true },
+        { suppressConflict: true, polling: false },
       );
     });
 
@@ -452,7 +452,7 @@ describe('Users controller', () => {
           orcidLastModifiedDate: '2020-07-14T01:36:15.911Z',
           orcidWorks: orcidFixtures.orcidWorksDeserialisedExpectation,
         }),
-        { suppressConflict: true, polling: true },
+        { suppressConflict: true, polling: false },
       );
       expect(result).toEqual({ ...getUserResponse(), orcid });
     });
@@ -479,7 +479,7 @@ describe('Users controller', () => {
           email: user.email,
           orcidLastSyncDate: expect.any(String),
         },
-        { suppressConflict: true, polling: true },
+        { suppressConflict: true, polling: false },
       );
       expect(result).toEqual({ ...getUserResponse(), orcid });
     });
@@ -505,7 +505,7 @@ describe('Users controller', () => {
           email: user.email,
           orcidLastSyncDate: expect.any(String),
         },
-        { suppressConflict: true, polling: true },
+        { suppressConflict: true, polling: false },
       );
     });
 
@@ -539,7 +539,7 @@ describe('Users controller', () => {
             orcidFixtures.orcidWorksResponse['last-modified-date']!.value,
           ).toISOString(),
         }),
-        { suppressConflict: true, polling: true },
+        { suppressConflict: true, polling: false },
       );
     });
   });

--- a/apps/crn-server/test/controllers/user.controller.test.ts
+++ b/apps/crn-server/test/controllers/user.controller.test.ts
@@ -224,7 +224,7 @@ describe('Users controller', () => {
       expect(userDataProviderMock.update).toHaveBeenCalledWith(
         'user-id',
         {},
-        { suppressConflict: false },
+        { suppressConflict: false, polling: true },
       );
     });
 
@@ -248,6 +248,21 @@ describe('Users controller', () => {
         }),
       );
     });
+
+    test('Should call data provider with options', async () => {
+      const result = await userController.update(
+        'user-id',
+        {},
+        { suppressConflict: true, polling: false },
+      );
+
+      expect(result).toEqual(getUserResponse());
+      expect(userDataProviderMock.update).toHaveBeenCalledWith(
+        'user-id',
+        {},
+        { suppressConflict: true, polling: false },
+      );
+    });
   });
 
   describe('updateAvatar', () => {
@@ -269,7 +284,7 @@ describe('Users controller', () => {
         {
           avatar: '42',
         },
-        { suppressConflict: false },
+        { suppressConflict: false, polling: true },
       );
       expect(assetDataProviderMock.create).toHaveBeenCalledWith({
         id: 'user-id',
@@ -301,7 +316,7 @@ describe('Users controller', () => {
           email: user.email,
           connections: [{ code: 'user-id' }],
         },
-        { suppressConflict: false },
+        { suppressConflict: false, polling: true },
       );
       expect(result).toEqual({
         ...getUserResponse(),
@@ -332,7 +347,7 @@ describe('Users controller', () => {
             },
           ]),
         },
-        { suppressConflict: false },
+        { suppressConflict: false, polling: true },
       );
     });
 
@@ -411,7 +426,7 @@ describe('Users controller', () => {
           orcidLastModifiedDate: '2020-07-14T01:36:15.911Z',
           orcidWorks: orcidFixtures.orcidWorksDeserialisedExpectation,
         }),
-        { suppressConflict: true },
+        { suppressConflict: true, polling: true },
       );
     });
 
@@ -437,7 +452,7 @@ describe('Users controller', () => {
           orcidLastModifiedDate: '2020-07-14T01:36:15.911Z',
           orcidWorks: orcidFixtures.orcidWorksDeserialisedExpectation,
         }),
-        { suppressConflict: true },
+        { suppressConflict: true, polling: true },
       );
       expect(result).toEqual({ ...getUserResponse(), orcid });
     });
@@ -464,7 +479,7 @@ describe('Users controller', () => {
           email: user.email,
           orcidLastSyncDate: expect.any(String),
         },
-        { suppressConflict: true },
+        { suppressConflict: true, polling: true },
       );
       expect(result).toEqual({ ...getUserResponse(), orcid });
     });
@@ -490,7 +505,7 @@ describe('Users controller', () => {
           email: user.email,
           orcidLastSyncDate: expect.any(String),
         },
-        { suppressConflict: true },
+        { suppressConflict: true, polling: true },
       );
     });
 
@@ -524,7 +539,7 @@ describe('Users controller', () => {
             orcidFixtures.orcidWorksResponse['last-modified-date']!.value,
           ).toISOString(),
         }),
-        { suppressConflict: true },
+        { suppressConflict: true, polling: true },
       );
     });
   });

--- a/apps/crn-server/test/data-providers/contentful/users.data-provider.test.ts
+++ b/apps/crn-server/test/data-providers/contentful/users.data-provider.test.ts
@@ -759,6 +759,29 @@ describe('User data provider', () => {
         },
       });
     });
+
+    describe('polling', () => {
+      test('it is true by default when no options is passed, thus it makes a graphql request', async () => {
+        await userDataProvider.update('123', {
+          firstName: 'Colin',
+        });
+
+        expect(contentfulGraphqlClientMock.request).toHaveBeenCalled();
+      });
+
+      test('does not call graphql request when polling is passed as false', async () => {
+        await userDataProvider.update(
+          '123',
+          {
+            firstName: 'Colin',
+          },
+          { polling: false },
+        );
+
+        expect(contentfulGraphqlClientMock.request).not.toHaveBeenCalled();
+      });
+    });
+
     describe('suppressConflict false', () => {
       test('fetches entry from contentful and passes to `patchAndPublish`', async () => {
         await userDataProvider.update('123', {

--- a/apps/crn-server/test/handlers/user/cronjob-sync-orcid.test.ts
+++ b/apps/crn-server/test/handlers/user/cronjob-sync-orcid.test.ts
@@ -46,7 +46,7 @@ describe('Cronjob - Sync Users ORCID', () => {
           fixtures.ORCIDWorksDeserialisedExpectation,
         ),
       }),
-      { suppressConflict: true },
+      { suppressConflict: true, polling: false },
     );
   });
 });

--- a/apps/crn-server/test/handlers/webhooks/webhook-connect-by-code.test.ts
+++ b/apps/crn-server/test/handlers/webhooks/webhook-connect-by-code.test.ts
@@ -124,7 +124,7 @@ describe('POST /webhook/users/connections - success', () => {
         connections: [{ code: 'oauth-connection-code' }],
         email: 'test@example.com',
       },
-      { suppressConflict: false },
+      { suppressConflict: false, polling: false },
     );
   });
 

--- a/packages/server-common/src/handlers/user/sync-active-campaign-contact-factory.ts
+++ b/packages/server-common/src/handlers/user/sync-active-campaign-contact-factory.ts
@@ -26,6 +26,7 @@ export interface UserController {
   update(
     id: string,
     update: UserUpdateRequest | gp2.UserUpdateRequest,
+    options?: { suppressConflict?: boolean; polling?: boolean } | null,
   ): Promise<gp2.UserResponse | UserResponse>;
 }
 
@@ -138,10 +139,14 @@ export const syncUserActiveCampaignData = async (
       if (contactResponse?.contact.cdate && contactResponse?.contact.id) {
         await updateContactLists(contactResponse.contact.id, isAlumni);
 
-        await userController.update(user.id, {
-          activeCampaignCreatedAt: new Date(contactResponse.contact.cdate),
-          activeCampaignId: contactResponse.contact.id,
-        });
+        await userController.update(
+          user.id,
+          {
+            activeCampaignCreatedAt: new Date(contactResponse.contact.cdate),
+            activeCampaignId: contactResponse.contact.id,
+          },
+          { polling: false },
+        );
       }
 
       log.info(`Contact ${user.id} created`);
@@ -194,9 +199,13 @@ export const syncUserActiveCampaignData = async (
     await updateContactLists(contactId, isAlumni);
 
     if (!user.activeCampaignId) {
-      await userController.update(user.id, {
-        activeCampaignId: contactId,
-      });
+      await userController.update(
+        user.id,
+        {
+          activeCampaignId: contactId,
+        },
+        { polling: false },
+      );
     }
 
     log.info(

--- a/packages/server-common/test/handlers/user/sync-active-campaign-contact-factory.test.ts
+++ b/packages/server-common/test/handlers/user/sync-active-campaign-contact-factory.test.ts
@@ -141,10 +141,14 @@ describe('Sync ActiveCampaign Contact Factory', () => {
       activeCampaignId,
       'crn-list-id',
     );
-    expect(userController.update).toHaveBeenCalledWith(user.id, {
-      activeCampaignCreatedAt: new Date(date),
-      activeCampaignId,
-    });
+    expect(userController.update).toHaveBeenCalledWith(
+      user.id,
+      {
+        activeCampaignCreatedAt: new Date(date),
+        activeCampaignId,
+      },
+      { polling: false },
+    );
     expect(logger.info).toHaveBeenCalledWith('Contact user-id-1 created');
   });
 


### PR DESCRIPTION
This PR adds an option `polling` to user data provider update method. We don't always need to fetch the last version of the entry, only when we're displaying data in the frontend. So we can pass this flag as `false` to webhooks, for example.