### PR TITLE
ASAP-294 Update working group header/footer

### DIFF
--- a/apps/crn-frontend/src/network/working-groups/About.tsx
+++ b/apps/crn-frontend/src/network/working-groups/About.tsx
@@ -3,15 +3,18 @@ import { WorkingGroupAbout } from '@asap-hub/react-components';
 import { WorkingGroupResponse } from '@asap-hub/model';
 
 interface AboutProps {
+  showCollaborationCard: boolean;
   workingGroup: WorkingGroupResponse;
   membersListElementId: string;
 }
 const About: React.FC<AboutProps> = ({
+  showCollaborationCard,
   workingGroup,
   membersListElementId,
 }) => (
   <WorkingGroupAbout
     {...workingGroup}
+    showCollaborationCard={showCollaborationCard}
     membersListElementId={membersListElementId}
   />
 );

--- a/apps/crn-frontend/src/network/working-groups/WorkingGroupProfile.tsx
+++ b/apps/crn-frontend/src/network/working-groups/WorkingGroupProfile.tsx
@@ -162,6 +162,9 @@ const WorkingGroupProfile: FC<WorkingGroupProfileProps> = ({ currentTime }) => {
             <ProfileSwitch
               About={() => (
                 <About
+                  showCollaborationCard={
+                    !canShareResearchOutput && !workingGroup.complete
+                  }
                   membersListElementId={membersListElementId}
                   workingGroup={workingGroup}
                 />

--- a/apps/crn-frontend/src/network/working-groups/__tests__/WorkingGroupProfile.test.tsx
+++ b/apps/crn-frontend/src/network/working-groups/__tests__/WorkingGroupProfile.test.tsx
@@ -81,9 +81,12 @@ const renderWorkingGroupProfile = async (
       network({}).workingGroups({}).workingGroup({ workingGroupId }).$,
     ],
   }),
+  workingGroupOverrides = {},
 ) => {
   mockGetWorkingGroup.mockImplementation(async (id) =>
-    id === workingGroupResponse.id ? workingGroupResponse : undefined,
+    id === workingGroupResponse.id
+      ? { ...workingGroupResponse, ...workingGroupOverrides }
+      : undefined,
   );
 
   render(
@@ -181,6 +184,79 @@ describe('the share outputs page', () => {
     );
     expect(screen.queryByText('About')).toBeInTheDocument();
     expect(screen.queryByText(/share an output/i)).toBeNull();
+  });
+});
+
+describe('collaboration card', () => {
+  it('is not rendered when user is the pm of the team', async () => {
+    const history = createMemoryHistory({
+      initialEntries: [
+        network({}).workingGroups({}).workingGroup({ workingGroupId }).$,
+      ],
+    });
+
+    await renderWorkingGroupProfile(
+      {
+        ...createUserResponse({}, 1),
+        workingGroups: [
+          {
+            id: workingGroupId,
+            role: 'Project Manager',
+            active: true,
+            name: 'test',
+          },
+        ],
+      },
+      history,
+    );
+    expect(
+      screen.queryByText(
+        'Would you like to collaborate with this Working Group?',
+      ),
+    ).not.toBeInTheDocument();
+  });
+
+  it('is not rendered when user is not the pm of the team but the working group is complete', async () => {
+    const history = createMemoryHistory({
+      initialEntries: [
+        network({}).workingGroups({}).workingGroup({ workingGroupId }).$,
+      ],
+    });
+
+    await renderWorkingGroupProfile(
+      {
+        ...createUserResponse({}, 1),
+        workingGroups: [],
+      },
+      history,
+      { complete: true },
+    );
+    expect(
+      screen.queryByText(
+        'Would you like to collaborate with this Working Group?',
+      ),
+    ).not.toBeInTheDocument();
+  });
+
+  it('is rendered when user is not the pm of the team', async () => {
+    const history = createMemoryHistory({
+      initialEntries: [
+        network({}).workingGroups({}).workingGroup({ workingGroupId }).$,
+      ],
+    });
+
+    await renderWorkingGroupProfile(
+      {
+        ...createUserResponse({}, 1),
+        workingGroups: [],
+      },
+      history,
+    );
+    expect(
+      screen.getByText(
+        'Would you like to collaborate with this Working Group?',
+      ),
+    ).toBeVisible();
   });
 });
 

--- a/apps/storybook/src/WorkingGroupPage.stories.tsx
+++ b/apps/storybook/src/WorkingGroupPage.stories.tsx
@@ -32,6 +32,7 @@ export const Normal = () => {
 
   const props: ComponentProps<typeof WorkingGroupPage> &
     ComponentProps<typeof WorkingGroupAbout> = {
+    showCollaborationCard: true,
     membersListElementId,
     id: 'id',
     pointOfContact: undefined,

--- a/packages/react-components/src/templates/WorkingGroupAbout.tsx
+++ b/packages/react-components/src/templates/WorkingGroupAbout.tsx
@@ -97,21 +97,23 @@ const WorkingGroupAbout: React.FC<WorkingGroupAboutProps> = ({
         isComplete={complete}
       />
     </section>
-    <Card accent="green">
-      <div css={getInTouchStyles}>
-        <div css={{ display: 'flex', flexDirection: 'column' }}>
-          <Subtitle noMargin>Have additional questions?</Subtitle>
-          <div>The project manager is here to help.</div>
+    {!complete && (
+      <Card accent="green">
+        <div css={getInTouchStyles}>
+          <div css={{ display: 'flex', flexDirection: 'column' }}>
+            <Subtitle noMargin>Have additional questions?</Subtitle>
+            <div>The project manager is here to help.</div>
+          </div>
+          {pointOfContact && (
+            <CtaContactSection
+              href={createMailTo(pointOfContact.user.email)}
+              buttonText={'Contact PM'}
+              displayCopy
+            />
+          )}
         </div>
-        {pointOfContact && (
-          <CtaContactSection
-            href={createMailTo(pointOfContact.user.email)}
-            buttonText={'Contact PM'}
-            displayCopy
-          />
-        )}
-      </div>
-    </Card>
+      </Card>
+    )}
   </div>
 );
 

--- a/packages/react-components/src/templates/WorkingGroupAbout.tsx
+++ b/packages/react-components/src/templates/WorkingGroupAbout.tsx
@@ -8,6 +8,7 @@ import { DeliverablesCard, WorkingGroupMembers, RichText } from '../organisms';
 import { perRem, smallDesktopScreen } from '../pixels';
 
 type WorkingGroupAboutProps = {
+  readonly showCollaborationCard: boolean;
   readonly membersListElementId: string;
 } & Pick<
   WorkingGroupResponse,
@@ -41,6 +42,7 @@ const getInTouchStyles = css({
 });
 
 const WorkingGroupAbout: React.FC<WorkingGroupAboutProps> = ({
+  showCollaborationCard,
   membersListElementId,
   description,
   deliverables,
@@ -70,7 +72,7 @@ const WorkingGroupAbout: React.FC<WorkingGroupAboutProps> = ({
         <TagList tags={tags} />
       </Card>
     )}
-    {!complete && (
+    {showCollaborationCard && (
       <Card accent="green">
         <Headline3>
           <span css={{ color: charcoal.rgb }}>

--- a/packages/react-components/src/templates/WorkingGroupPageHeader.tsx
+++ b/packages/react-components/src/templates/WorkingGroupPageHeader.tsx
@@ -195,7 +195,7 @@ const WorkingGroupPageHeader: React.FC<WorkingGroupPageHeaderProps> = ({
               .about({}).$
           }#${membersListElementId}`}
         />
-        {pointOfContact && !canShareResearchOutput && !complete && (
+        {pointOfContact && !complete && (
           <div css={pointOfContactStyles}>
             <div css={{ display: 'flex', flexGrow: 1 }}>
               <Link

--- a/packages/react-components/src/templates/__tests__/WorkingGroupAbout.test.tsx
+++ b/packages/react-components/src/templates/__tests__/WorkingGroupAbout.test.tsx
@@ -5,6 +5,7 @@ import { ComponentProps } from 'react';
 import WorkingGroupAbout from '../WorkingGroupAbout';
 
 const baseProps: ComponentProps<typeof WorkingGroupAbout> = {
+  showCollaborationCard: true,
   membersListElementId: '',
   description: '',
   pointOfContact: undefined,
@@ -42,14 +43,14 @@ it('renders a list of deliverables', () => {
   expect(getByText('In Progress')).toBeVisible();
 });
 
-it('renders collaboration invite if not completed', () => {
+it('renders collaboration invite if showCollaborationCard is true', () => {
   const { getByText, queryByText, rerender } = render(
-    <WorkingGroupAbout {...baseProps} />,
+    <WorkingGroupAbout {...baseProps} showCollaborationCard={true} />,
   );
   expect(
     getByText('Would you like to collaborate with this Working Group?'),
   ).toBeVisible();
-  rerender(<WorkingGroupAbout {...baseProps} complete={true} />);
+  rerender(<WorkingGroupAbout {...baseProps} showCollaborationCard={false} />);
   expect(
     queryByText('Would you like to collaborate with this Working Group?'),
   ).not.toBeInTheDocument();
@@ -72,6 +73,7 @@ it('does not render CTA when pointOfContact is provided but working group is com
     <WorkingGroupAbout
       {...baseProps}
       pointOfContact={createWorkingGroupPointOfContact()}
+      showCollaborationCard={false}
       complete
     />,
   );

--- a/packages/react-components/src/templates/__tests__/WorkingGroupAbout.test.tsx
+++ b/packages/react-components/src/templates/__tests__/WorkingGroupAbout.test.tsx
@@ -67,6 +67,17 @@ it('renders CTA when pointOfContact is provided', () => {
   expect(queryAllByText('Contact PM')).toHaveLength(0);
 });
 
+it('does not render CTA when pointOfContact is provided but working group is complete', () => {
+  const { queryAllByText } = render(
+    <WorkingGroupAbout
+      {...baseProps}
+      pointOfContact={createWorkingGroupPointOfContact()}
+      complete
+    />,
+  );
+  expect(queryAllByText('Contact PM')).toHaveLength(0);
+});
+
 it('renders a list of tags', () => {
   const { getByRole } = render(
     <WorkingGroupAbout {...baseProps} tags={['Tag One', 'Tag Two']} />,

--- a/packages/react-components/src/templates/__tests__/WorkingGroupPageHeader.test.tsx
+++ b/packages/react-components/src/templates/__tests__/WorkingGroupPageHeader.test.tsx
@@ -43,6 +43,17 @@ it('renders CTA when pointOfContact is provided', () => {
   expect(queryAllByText('Contact PM')).toHaveLength(0);
 });
 
+it('does not render CTA when pointOfContact is provided but working group is complete', () => {
+  const { queryAllByText } = render(
+    <WorkingGroupHeader
+      {...baseProps}
+      pointOfContact={createWorkingGroupPointOfContact()}
+      complete
+    />,
+  );
+  expect(queryAllByText('Contact PM')).toHaveLength(0);
+});
+
 it('copy button copies pointOfContact email', () => {
   Object.assign(navigator, {
     clipboard: {


### PR DESCRIPTION
Jira ticket: https://asaphub.atlassian.net/browse/ASAP-294

---

This PR

- Adds the contact button + copy email to the header of internal working groups as per requirement
![Screenshot 2024-03-07 at 12 48 30](https://github.com/yldio/asap-hub/assets/16595804/8bcc708b-93c8-4596-924b-bbb9e04bd8c5)


- Removes the footer for completed working groups
![Screenshot 2024-03-07 at 12 50 03](https://github.com/yldio/asap-hub/assets/16595804/0a5e5abb-8f9b-42aa-8a89-ec38996ea3c0)

