### PR TITLE
Hide tech support text in Tutorials page

### DIFF
--- a/packages/react-components/src/organisms/HelpSection.tsx
+++ b/packages/react-components/src/organisms/HelpSection.tsx
@@ -10,16 +10,23 @@ const bottomStyles = css({
   gridRowGap: rem(12),
 });
 
-const HelpSection: React.FC = () => (
+type HelpSectionProps = {
+  hideTechSupportText?: boolean;
+};
+const HelpSection: React.FC<HelpSectionProps> = ({
+  hideTechSupportText = false,
+}) => (
   <section css={bottomStyles}>
     <CtaCard href={mailToGrants()} buttonText="Contact grants team" displayCopy>
       <strong>Need help with a grant-related matter?</strong>
       <br /> The grants team is here to help.
     </CtaCard>
-    <Paragraph accent="lead">
-      If you're facing a technical issue with the Hub, our team is happy to
-      help! <Link href={mailToSupport()}>Contact tech support</Link>.
-    </Paragraph>
+    {!hideTechSupportText && (
+      <Paragraph accent="lead">
+        If you're facing a technical issue with the Hub, our team is happy to
+        help! <Link href={mailToSupport()}>Contact tech support</Link>.
+      </Paragraph>
+    )}
   </section>
 );
 

--- a/packages/react-components/src/templates/TutorialDetailsPage.tsx
+++ b/packages/react-components/src/templates/TutorialDetailsPage.tsx
@@ -87,7 +87,7 @@ const TutorialDetailsPage: React.FC<TutorialDetailsPageProps> = ({
         {hasAdditionalInformation && (
           <TutorialAdditionalInformationCard {...props} />
         )}
-        <HelpSection />
+        <HelpSection hideTechSupportText />
       </div>
     </div>
   );


### PR DESCRIPTION
This PR hides this text
<img width="1242" alt="Screenshot 2024-03-11 at 12 12 25" src="https://github.com/yldio/asap-hub/assets/16595804/96c62b94-a658-4adf-8e0e-6ab73d847c07">

in Tutorials page as requested here https://asaphub.atlassian.net/browse/ASAP-298?focusedCommentId=11597