### PR TITLE
ASAP-361 Adjust parameters to reduce revision errors

### DIFF
--- a/packages/contentful/src/utils/poll-content.ts
+++ b/packages/contentful/src/utils/poll-content.ts
@@ -65,7 +65,12 @@ const pollContentful = async <T extends EntrySkeletonType<FieldsType, string>>(
         }
       }
     },
-    { minTimeout: 200, maxRetryTime: 8_000 },
+    {
+      minTimeout: 200,
+      maxRetryTime: 60_000,
+      factor: 2,
+      randomize: false,
+    },
   );
 
 export const pollContentfulDeliveryApi = async <

--- a/packages/contentful/test/utils/poll-content.test.ts
+++ b/packages/contentful/test/utils/poll-content.test.ts
@@ -22,11 +22,15 @@ describe('pollContentfulGql', () => {
       .fn()
       .mockResolvedValueOnce(userDataWithPublishedVersion1)
       .mockResolvedValueOnce(userDataWithPublishedVersion1)
+      .mockResolvedValueOnce(userDataWithPublishedVersion1)
+      .mockResolvedValueOnce(userDataWithPublishedVersion1)
+      .mockResolvedValueOnce(userDataWithPublishedVersion1)
+      .mockResolvedValueOnce(userDataWithPublishedVersion1)
       .mockResolvedValueOnce(userDataWithPublishedVersion2);
 
     await pollContentfulGql(2, fetchData, 'users');
-    expect(fetchData).toHaveBeenCalledTimes(3);
-  });
+    expect(fetchData).toHaveBeenCalledTimes(7);
+  }, 120_000);
 
   test('throws if polling query does not return a value', async () => {
     const fetchData = jest.fn().mockResolvedValueOnce({
@@ -55,12 +59,18 @@ describe('pollContentfulDeliveryApi', () => {
       .fn()
       .mockResolvedValueOnce(entryDataWithPublishedCounter1)
       .mockResolvedValueOnce(entryDataWithPublishedCounter1)
+      .mockResolvedValueOnce(entryDataWithPublishedCounter1)
+      .mockResolvedValueOnce(entryDataWithPublishedCounter1)
+      .mockResolvedValueOnce(entryDataWithPublishedCounter1)
+      .mockResolvedValueOnce(entryDataWithPublishedCounter1)
+      .mockResolvedValueOnce(entryDataWithPublishedCounter1)
+      .mockResolvedValueOnce(entryDataWithPublishedCounter1)
       .mockResolvedValueOnce(entryDataWithPublishedCounter2);
 
     const response = await pollContentfulDeliveryApi(fetchEntry, 2);
-    expect(fetchEntry).toHaveBeenCalledTimes(3);
+    expect(fetchEntry).toHaveBeenCalledTimes(9);
     expect(response).toEqual(entryDataWithPublishedCounter2);
-  });
+  }, 120_000);
 
   test('throws if polling query does not return a value', async () => {
     const fetchEntry = jest.fn().mockResolvedValueOnce(null);


### PR DESCRIPTION
### Why do we have a polling script?

From https://www.contentful.com/faq/webhooks/#if-i-received-a-publish-event-why-do-i-get-an-old-version-in-the-cda
<img width="904" alt="Screenshot 2024-03-21 at 10 38 41" src="https://github.com/yldio/asap-hub/assets/16595804/898a23d2-3e8e-4481-8b06-d9d3361ce3fd">


### Retry parameters

The `retry` had `maxRetryTime` as 8s. So we would try to fetch fresh data during only 8 seconds. More about parameters here https://github.com/vercel/async-retry?tab=readme-ov-file#api.

Running it locally, it would give us most of times 5 trials

![Screenshot 2024-03-21 at 10 28 33](https://github.com/yldio/asap-hub/assets/16595804/ecd117c6-fd4b-4ba6-ba32-3975d358feb0)

which might be not enough if the cache is taking a long time to be purged. 

This is not happening so frequently, though. From Sentry it seems that we had a peak over March 6th ~ 8th but it is not happening so often now

![Screenshot 2024-03-21 at 10 29 27](https://github.com/yldio/asap-hub/assets/16595804/4e1bd238-1730-4763-bd8f-0ea296c1f5c4)

Link to sentry: https://yld.sentry.io/issues/5038500144/?referrer=slack&notification_uuid=9aa914de-ff4c-414b-a453-a4b8c950514c&environment=production&alert_rule_id=14694571&alert_type=issue

### Proposed solution

The `maxRetryTime` was increased to 1 minute. The parameter `randomize` was set to false, so now, the delay between attempts will always increase by a factor of 2, so we have more time between attempts than before.