### PR TITLE
fix: finding news by tags

### DIFF
--- a/apps/gp2-server/src/handlers/news/algolia-index-handler.ts
+++ b/apps/gp2-server/src/handlers/news/algolia-index-handler.ts
@@ -25,8 +25,13 @@ export const indexNewsHandler =
         const news = await newsController.fetchById(id);
         log.debug(`Fetched news ${news.id}`);
 
+        const data = {
+          ...news,
+          _tags: news.tags,
+        };
+
         await algoliaClient.save({
-          data: news,
+          data,
           type: 'news',
         });
 

--- a/apps/gp2-server/test/handlers/news/algolia-index-handler.test.ts
+++ b/apps/gp2-server/test/handlers/news/algolia-index-handler.test.ts
@@ -24,7 +24,7 @@ describe('News index handler', () => {
     await indexHandler(publishedEvent('42'));
 
     expect(algoliaSearchClientMock.save).toHaveBeenCalledWith({
-      data: newsResponse,
+      data: { ...newsResponse, _tags: newsResponse.tags },
       type: 'news',
     });
   });


### PR DESCRIPTION
This is a fix for https://github.com/yldio/asap-hub/pull/4218

---

The issue is that we were not sending `_tags` to algolia in the handler, only on the on-demand action.
I've tested adding tags to news in `gp2-4231` contentful environment and checking that they appear on https://4231.gp2.asap.science/tags?entityType=news 