### PR TITLE
ASAP-400 (GP2) Make it possible to save user without orcid

### DIFF
--- a/packages/fixtures/src/gp2/users.ts
+++ b/packages/fixtures/src/gp2/users.ts
@@ -62,7 +62,7 @@ export const mockedUser: gp2.UserResponse = {
     googleScholar: 'https://wwww.scholar.google.com',
     orcid: '0000-0001-5993-0331',
     researchGate: 'https://www.researchid.com/rid/',
-    researcherId: 'E-4548-2018',
+    researcherId: 'https://researcherid.com/rid/E-4548-2018',
     blog: 'https://www.blogger.com',
     twitter: 'https://twitter.com',
     linkedIn: 'https://www.linkedin.com',

--- a/packages/gp2-components/src/organisms/KeyInformationModal.tsx
+++ b/packages/gp2-components/src/organisms/KeyInformationModal.tsx
@@ -156,8 +156,7 @@ const KeyInformationModal: React.FC<KeyInformationModalProps> = ({
             },
             {},
           ),
-
-          orcid: newOrcid,
+          ...(newOrcid ? { orcid: newOrcid } : {}),
         });
       }}
       backHref={backHref}

--- a/packages/gp2-components/src/organisms/__tests__/KeyInformationModal.test.tsx
+++ b/packages/gp2-components/src/organisms/__tests__/KeyInformationModal.test.tsx
@@ -111,6 +111,45 @@ describe('KeyInformationModal', () => {
     expect(screen.getByText(/Please add your city/i)).toBeVisible();
   });
 
+  it('does not call onSave with orcid when orcid is not provided', async () => {
+    const onSave = jest.fn();
+    renderKeyInformation({
+      onSave,
+      social: {
+        ...defaultProps.social,
+        orcid: undefined,
+      },
+    });
+    const saveButton = getSaveButton();
+    userEvent.click(saveButton);
+    const {
+      firstName,
+      lastName,
+      degrees,
+      positions,
+      country,
+      stateOrProvince,
+      city,
+      region,
+      social,
+    } = defaultProps;
+    const { orcid, ...socialWithoutOrcid } = social!;
+    expect(onSave).toHaveBeenCalledWith({
+      firstName,
+      middleName: '',
+      lastName,
+      nickname: '',
+      degrees,
+      positions,
+      country,
+      stateOrProvince,
+      city,
+      region,
+      social: socialWithoutOrcid,
+    });
+    await waitFor(() => expect(saveButton).toBeEnabled());
+  }, 60000);
+
   it('calls onSave with the updated fields', async () => {
     const firstName = 'Gonçalo';
     const middleName = 'Matias';


### PR DESCRIPTION
This bug was introduced in this PR https://github.com/yldio/asap-hub/pull/4160. 

The issue was that before the bug was introduced we were not sending `orcid` if its value is not truthy. 
![-before](https://github.com/yldio/asap-hub/assets/16595804/4d715f30-30e6-4552-a6c3-9e7abfb46a00)


After the bug was introduced, we were always sending `orcid` and when it doesn't have a value, it's initialized as `''` so it was giving a 400 error in the BE.
![-after](https://github.com/yldio/asap-hub/assets/16595804/dff3ab37-bee6-4b12-9a63-f7f4d92e3512)

BE error in gp2.dev
<img width="1440" alt="Screenshot 2024-04-10 at 12 00 59" src="https://github.com/yldio/asap-hub/assets/16595804/82a535a9-8a73-4f68-8aef-c4bd7246400f">

So this PR makes the `orcid` field to be sent only when it's value is truthy as it was before the bug was introduced.


