### PR TITLE
feat: Rearrange PR CI job order to speed up deployment

### DIFF
--- a/.github/workflows/on-push-branch.yml
+++ b/.github/workflows/on-push-branch.yml
@@ -102,7 +102,7 @@ jobs:
       GP2_CONTENTFUL_ACCESS_TOKEN: ${{ secrets.GP2_CONTENTFUL_ACCESS_TOKEN }}
 
   deployment:
-    needs: [setup, test, build-analysis, create-environment]
+    needs: [setup, build, create-environment]
     uses: ./.github/workflows/reusable-deployment.yml
     with:
       environment-name: Branch


### PR DESCRIPTION
Changes the order of jobs by removing some dependencies so that the deployment can happen without tests passing which should speed it up