### PR TITLE
feat: ASAP-210 Prepare workflow for merge queue

### DIFF
--- a/.github/workflows/on-push-branch.yml
+++ b/.github/workflows/on-push-branch.yml
@@ -1,8 +1,9 @@
 name: Pipeline branch
 concurrency:
-  group: ${{ github.head_ref }}
+  group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 on:
+  merge_group:
   pull_request:
     types: [opened, synchronize, labeled]
     branches:


### PR DESCRIPTION
This PR will enable us to use merge queues in github. The changes include:
* adding merge-group trigger for the existing on-push-branch workflow so that it gets triggered when the PR reaches the queue
* adding a fix to concurrency group since head_ref is missing when triggered by merge-group