### PR TITLE
ASAP-447 Create L&M replica indexes

### DIFF
--- a/.github/workflows/reusable-deployment.yml
+++ b/.github/workflows/reusable-deployment.yml
@@ -204,7 +204,7 @@ jobs:
       - name: Synchronize Schema
         run: |
           yarn algolia:set-settings -a $ALGOLIA_APP_ID -k $ALGOLIA_API_KEY -n $ALGOLIA_INDEX -p crn
-          yarn algolia:set-settings -a $ALGOLIA_APP_ID -k $ALGOLIA_API_KEY -n $ALGOLIA_ANALYTICS_INDEX -p crn-analytics
+          yarn algolia:set-analytics-settings -a $ALGOLIA_APP_ID -k $ALGOLIA_API_KEY -n $ALGOLIA_ANALYTICS_INDEX -p crn-analytics
         env:
           ALGOLIA_API_KEY: ${{ steps.algolia-keys.outputs.algolia-api-key }}
           ALGOLIA_APP_ID: ${{ steps.algolia-keys.outputs.algolia-app-id }}

--- a/.github/workflows/reusable-deployment.yml
+++ b/.github/workflows/reusable-deployment.yml
@@ -204,7 +204,7 @@ jobs:
       - name: Synchronize Schema
         run: |
           yarn algolia:set-settings -a $ALGOLIA_APP_ID -k $ALGOLIA_API_KEY -n $ALGOLIA_INDEX -p crn
-          yarn algolia:set-analytics-settings -a $ALGOLIA_APP_ID -k $ALGOLIA_API_KEY -n $ALGOLIA_ANALYTICS_INDEX -p crn-analytics
+          yarn algolia:set-analytics-settings -a $ALGOLIA_APP_ID -k $ALGOLIA_API_KEY -n $ALGOLIA_ANALYTICS_INDEX
         env:
           ALGOLIA_API_KEY: ${{ steps.algolia-keys.outputs.algolia-api-key }}
           ALGOLIA_APP_ID: ${{ steps.algolia-keys.outputs.algolia-app-id }}

--- a/apps/asap-cli/package.json
+++ b/apps/asap-cli/package.json
@@ -19,6 +19,7 @@
     "typecheck": "tsc"
   },
   "dependencies": {
+    "@algolia/client-search": "4.22.1",
     "@asap-hub/algolia": "workspace:*",
     "@asap-hub/errors": "workspace:*",
     "@asap-hub/message-templates": "workspace:*",

--- a/apps/asap-cli/package.json
+++ b/apps/asap-cli/package.json
@@ -13,6 +13,7 @@
     "algolia:move-index": "ts-node --transpile-only src/cli.ts algolia:move-index",
     "algolia:remove-records": "ts-node --transpile-only src/cli.ts algolia:remove-records",
     "algolia:set-settings": "ts-node --transpile-only src/cli.ts algolia:set-settings",
+    "algolia:set-analytics-settings": "ts-node --transpile-only src/cli.ts algolia:set-analytics-settings",
     "build:babel": "../../scripts/build-babel.sh build",
     "watch:babel": "../../scripts/build-babel.sh watch",
     "typecheck": "tsc"

--- a/apps/asap-cli/src/cli.ts
+++ b/apps/asap-cli/src/cli.ts
@@ -17,124 +17,126 @@ import {
   setAlgoliaSettings,
 } from './scripts/algolia';
 
+const stringType = 'string' as 'string';
+const trueType = true as true;
+
+const appIdOption = {
+  alias: 'a',
+  type: stringType,
+  description: 'The App ID',
+  demandOption: trueType,
+};
+
+const apikeyOption = {
+  alias: 'k',
+  type: stringType,
+  description: 'The API key',
+  demandOption: trueType,
+};
+
+const indexOption = {
+  alias: 'n',
+  type: stringType,
+  description: 'Name of the index to remove',
+  demandOption: trueType,
+};
+
+const appNameOption = {
+  alias: 'p',
+  description: 'Name of App - crn or gp2',
+  type: stringType,
+  choices: ['crn', 'gp2'],
+  demandOption: trueType,
+};
+
+type BaseArguments = {
+  appid: string;
+  apikey: string;
+};
+
+interface DeleteIndexArguments extends BaseArguments {
+  index: string;
+}
+
+interface ClearIndexArguments extends BaseArguments {
+  index: string;
+}
+
+interface MoveIndexArguments extends BaseArguments {
+  indexfrom: string;
+  indexto: string;
+}
+
+interface RemoveRecordsArguments extends BaseArguments {
+  index: string;
+  entityType: string;
+}
+
+interface GetSettingsArguments extends BaseArguments {
+  index: string;
+  appName: string;
+}
+
+interface SetSettingsArguments extends BaseArguments {
+  index: string;
+  appName: string;
+}
+interface SetAnalyticsSettings extends BaseArguments {
+  index: string;
+}
+
 // eslint-disable-next-line no-unused-expressions, @typescript-eslint/no-floating-promises
 yargs(hideBin(process.argv))
-  .command({
+  .command<DeleteIndexArguments>({
     command: 'algolia:delete-index',
     describe: 'deletes the index',
     builder: (cli) =>
       cli
-        .option('appid', {
-          alias: 'a',
-          type: 'string',
-          description: 'The App ID',
-          demandOption: true,
-        })
-        .option('apikey', {
-          alias: 'k',
-          type: 'string',
-          description: 'The API key',
-          demandOption: true,
-        })
-        .option('index', {
-          alias: 'n',
-          type: 'string',
-          description: 'Name of the index to remove',
-          demandOption: true,
-        }),
-    handler: async ({
-      index,
-      appid,
-      apikey,
-    }: {
-      index: string;
-      appid: string;
-      apikey: string;
-    }) =>
+        .option('appid', appIdOption)
+        .option('apikey', apikeyOption)
+        .option('index', indexOption),
+    handler: async ({ index, appid, apikey }) =>
       deleteAlgoliaIndex({
         algoliaAppId: appid,
         algoliaCiApiKey: apikey,
         indexName: index,
       }),
   })
-  .command({
+  .command<ClearIndexArguments>({
     command: 'algolia:clear-index',
     describe: 'clears the index',
     builder: (cli) =>
       cli
-        .option('appid', {
-          alias: 'a',
-          type: 'string',
-          description: 'The App ID',
-          demandOption: true,
-        })
-        .option('apikey', {
-          alias: 'k',
-          type: 'string',
-          description: 'The API key',
-          demandOption: true,
-        })
-        .option('index', {
-          alias: 'n',
-          type: 'string',
-          description: 'Name of the index to remove',
-          demandOption: true,
-        }),
-    handler: async ({
-      index,
-      appid,
-      apikey,
-    }: {
-      index: string;
-      appid: string;
-      apikey: string;
-    }) =>
+        .option('appid', appIdOption)
+        .option('apikey', apikeyOption)
+        .option('index', indexOption),
+    handler: async ({ index, appid, apikey }) =>
       clearAlgoliaIndex({
         algoliaAppId: appid,
         algoliaCiApiKey: apikey,
         indexName: index,
       }),
   })
-  .command({
+  .command<MoveIndexArguments>({
     command: 'algolia:move-index',
     describe: 'move the index',
     builder: (cli) =>
       cli
-        .option('appid', {
-          alias: 'a',
-          type: 'string',
-          description: 'The App ID',
-          demandOption: true,
-        })
-        .option('apikey', {
-          alias: 'k',
-          type: 'string',
-          description: 'The API key',
-          demandOption: true,
-        })
+        .option('appid', appIdOption)
+        .option('apikey', apikeyOption)
         .option('indexfrom', {
           alias: 'n',
-          type: 'string',
+          type: stringType,
           description: 'Name of the index to move from',
-          demandOption: true,
+          demandOption: trueType,
         })
         .option('indexto', {
           alias: 'i',
-          type: 'string',
+          type: stringType,
           description: 'Name of the index to move to',
-          demandOption: true,
+          demandOption: trueType,
         }),
-    handler: async ({
-      indexfrom,
-      indexto,
-      appid,
-      apikey,
-    }: {
-      indexfrom: string;
-      indexto: string;
-      appid: string;
-      apikey: string;
-    }) =>
+    handler: async ({ indexfrom, indexto, appid, apikey }) =>
       moveAlgoliaIndex({
         algoliaAppId: appid,
         algoliaCiApiKey: apikey,
@@ -142,46 +144,21 @@ yargs(hideBin(process.argv))
         indexNameTo: indexto,
       }),
   })
-  .command({
+  .command<RemoveRecordsArguments>({
     command: 'algolia:remove-records',
     describe: 'removes all the records by the entity type',
     builder: (cli) =>
       cli
-        .option('appid', {
-          alias: 'a',
-          type: 'string',
-          description: 'The App ID',
-          demandOption: true,
-        })
-        .option('apikey', {
-          alias: 'k',
-          type: 'string',
-          description: 'The API key',
-          demandOption: true,
-        })
-        .option('index', {
-          alias: 'n',
-          type: 'string',
-          description: 'Name of the index to remove',
-          demandOption: true,
-        })
+        .option('appid', appIdOption)
+        .option('apikey', apikeyOption)
+        .option('index', indexOption)
         .option('entityType', {
           alias: 'e',
-          type: 'string',
+          type: stringType,
           description: 'Entity meta type',
-          demandOption: true,
+          demandOption: trueType,
         }),
-    handler: async ({
-      index,
-      appid,
-      apikey,
-      entityType,
-    }: {
-      index: string;
-      appid: string;
-      apikey: string;
-      entityType: string;
-    }) =>
+    handler: async ({ index, appid, apikey, entityType }) =>
       removeAlgoliaRecords({
         algoliaAppId: appid,
         algoliaCiApiKey: apikey,
@@ -189,47 +166,16 @@ yargs(hideBin(process.argv))
         entityType,
       }),
   })
-  .command({
+  .command<GetSettingsArguments>({
     command: 'algolia:get-settings',
     describe: 'gets the settings for an Algolia index',
     builder: (cli) =>
       cli
-        .option('appid', {
-          alias: 'a',
-          type: 'string',
-          description: 'The App ID',
-          demandOption: true,
-        })
-        .option('apikey', {
-          alias: 'k',
-          type: 'string',
-          description: 'The API key',
-          demandOption: true,
-        })
-        .option('index', {
-          alias: 'n',
-          type: 'string',
-          description: 'Name of the index',
-          demandOption: true,
-        })
-        .option('appName', {
-          alias: 'p',
-          description: 'Name of App - crn or gp2',
-          type: 'string',
-          choices: ['crn', 'gp2'],
-          demandOption: true,
-        }),
-    handler: async ({
-      index,
-      appid,
-      apikey,
-      appName,
-    }: {
-      index: string;
-      appid: string;
-      apikey: string;
-      appName: string;
-    }) =>
+        .option('appid', appIdOption)
+        .option('apikey', apikeyOption)
+        .option('index', indexOption)
+        .option('appName', appNameOption),
+    handler: async ({ index, appid, apikey, appName }) =>
       getAlgoliaSettings({
         algoliaAppId: appid,
         algoliaCiApiKey: apikey,
@@ -237,47 +183,16 @@ yargs(hideBin(process.argv))
         appName,
       }),
   })
-  .command({
+  .command<SetSettingsArguments>({
     command: 'algolia:set-settings',
     describe: 'sets the settings for an Algolia index',
     builder: (cli) =>
       cli
-        .option('appid', {
-          alias: 'a',
-          type: 'string',
-          description: 'The App ID',
-          demandOption: true,
-        })
-        .option('apikey', {
-          alias: 'k',
-          type: 'string',
-          description: 'The API key',
-          demandOption: true,
-        })
-        .option('index', {
-          alias: 'n',
-          type: 'string',
-          description: 'Name of the index',
-          demandOption: true,
-        })
-        .option('appName', {
-          alias: 'p',
-          description: 'Name of App - crn, gp2 or crn-analytics',
-          type: 'string',
-          choices: ['crn', 'gp2', 'crn-analytics'],
-          demandOption: true,
-        }),
-    handler: async ({
-      index,
-      appid,
-      apikey,
-      appName,
-    }: {
-      index: string;
-      appid: string;
-      apikey: string;
-      appName: string;
-    }) =>
+        .option('appid', appIdOption)
+        .option('apikey', apikeyOption)
+        .option('index', indexOption)
+        .option('appName', appNameOption),
+    handler: async ({ index, appid, apikey, appName }) =>
       setAlgoliaSettings({
         algoliaAppId: appid,
         algoliaCiApiKey: apikey,
@@ -285,38 +200,15 @@ yargs(hideBin(process.argv))
         appName,
       }),
   })
-  .command({
+  .command<SetAnalyticsSettings>({
     command: 'algolia:set-analytics-settings',
     describe: 'sets the settings for an Algolia analytics index',
     builder: (cli) =>
       cli
-        .option('appid', {
-          alias: 'a',
-          type: 'string',
-          description: 'The App ID',
-          demandOption: true,
-        })
-        .option('apikey', {
-          alias: 'k',
-          type: 'string',
-          description: 'The API key',
-          demandOption: true,
-        })
-        .option('index', {
-          alias: 'n',
-          type: 'string',
-          description: 'Name of the index',
-          demandOption: true,
-        }),
-    handler: async ({
-      index,
-      appid,
-      apikey,
-    }: {
-      index: string;
-      appid: string;
-      apikey: string;
-    }) =>
+        .option('appid', appIdOption)
+        .option('apikey', apikeyOption)
+        .option('index', indexOption),
+    handler: async ({ index, appid, apikey }) =>
       setAlgoliaAnalyticsSettings({
         algoliaAppId: appid,
         algoliaCiApiKey: apikey,

--- a/apps/asap-cli/src/cli.ts
+++ b/apps/asap-cli/src/cli.ts
@@ -17,8 +17,8 @@ import {
   setAlgoliaSettings,
 } from './scripts/algolia';
 
-const stringType = 'string' as 'string';
-const trueType = true as true;
+const stringType = 'string' as const;
+const trueType = true as const;
 
 const appIdOption = {
   alias: 'a',

--- a/apps/asap-cli/src/cli.ts
+++ b/apps/asap-cli/src/cli.ts
@@ -13,6 +13,7 @@ import {
   getAlgoliaSettings,
   moveAlgoliaIndex,
   removeAlgoliaRecords,
+  setAlgoliaAnalyticsSettings,
   setAlgoliaSettings,
 } from './scripts/algolia';
 
@@ -282,6 +283,44 @@ yargs(hideBin(process.argv))
         algoliaCiApiKey: apikey,
         indexName: index,
         appName,
+      }),
+  })
+  .command({
+    command: 'algolia:set-analytics-settings',
+    describe: 'sets the settings for an Algolia analytics index',
+    builder: (cli) =>
+      cli
+        .option('appid', {
+          alias: 'a',
+          type: 'string',
+          description: 'The App ID',
+          demandOption: true,
+        })
+        .option('apikey', {
+          alias: 'k',
+          type: 'string',
+          description: 'The API key',
+          demandOption: true,
+        })
+        .option('index', {
+          alias: 'n',
+          type: 'string',
+          description: 'Name of the index',
+          demandOption: true,
+        }),
+    handler: async ({
+      index,
+      appid,
+      apikey,
+    }: {
+      index: string;
+      appid: string;
+      apikey: string;
+    }) =>
+      setAlgoliaAnalyticsSettings({
+        algoliaAppId: appid,
+        algoliaCiApiKey: apikey,
+        indexName: index,
       }),
   })
   .demandCommand(1)

--- a/apps/asap-cli/src/scripts/algolia/index.ts
+++ b/apps/asap-cli/src/scripts/algolia/index.ts
@@ -4,3 +4,4 @@ export * from './get-settings';
 export * from './move-index';
 export * from './remove-records';
 export * from './set-settings';
+export * from './set-analytics-settings';

--- a/apps/asap-cli/src/scripts/algolia/set-analytics-settings.ts
+++ b/apps/asap-cli/src/scripts/algolia/set-analytics-settings.ts
@@ -1,0 +1,63 @@
+/* istanbul ignore file */
+import algoliasearch from 'algoliasearch';
+import fs from 'fs/promises';
+import { resolve } from 'path';
+
+export type SetAlgoliaAnalyticsSettings = {
+  algoliaAppId: string;
+  algoliaCiApiKey: string;
+  indexName: string;
+};
+
+export const setAlgoliaAnalyticsSettings = async ({
+  algoliaAppId,
+  algoliaCiApiKey,
+  indexName,
+}: SetAlgoliaAnalyticsSettings): Promise<void> => {
+  const path = resolve(
+    __dirname,
+    `../../../../../packages/algolia/schema/crn-analytics`,
+  );
+  const client = algoliasearch(algoliaAppId, algoliaCiApiKey);
+
+  const index = client.initIndex(indexName);
+  const indexSchemaRaw = await fs.readFile(
+    `${path}/algolia-schema.json`,
+    'utf8',
+  );
+  const indexSchema = JSON.parse(indexSchemaRaw);
+
+  const replicas = [
+    `${indexName}_team_desc`,
+
+    `${indexName}_wg_current_leadership_asc`,
+    `${indexName}_wg_current_leadership_desc`,
+    `${indexName}_wg_previous_leadership_asc`,
+    `${indexName}_wg_previous_leadership_desc`,
+    `${indexName}_wg_current_membership_asc`,
+    `${indexName}_wg_current_membership_desc`,
+    `${indexName}_wg_previous_membership_asc`,
+    `${indexName}_wg_previous_membership_desc`,
+
+    `${indexName}_ig_current_leadership_asc`,
+    `${indexName}_ig_current_leadership_desc`,
+    `${indexName}_ig_previous_leadership_asc`,
+    `${indexName}_ig_previous_leadership_desc`,
+    `${indexName}_ig_current_membership_asc`,
+    `${indexName}_ig_current_membership_desc`,
+    `${indexName}_ig_previous_membership_asc`,
+    `${indexName}_ig_previous_membership_desc`,
+  ];
+  await index.setSettings({ ...indexSchema, replicas }).wait();
+
+  replicas.forEach(async (replica) => {
+    const replicaIndex = client.initIndex(replica);
+    const replicaNameSuffix = replica.replace(`${indexName}_`, '');
+    const replicaIndexSchemaRaw = await fs.readFile(
+      `${path}/${replicaNameSuffix}-schema.json`,
+      'utf8',
+    );
+    const replicaIndexSchema = JSON.parse(replicaIndexSchemaRaw);
+    await replicaIndex.setSettings(replicaIndexSchema);
+  });
+};

--- a/apps/asap-cli/src/scripts/algolia/set-analytics-settings.ts
+++ b/apps/asap-cli/src/scripts/algolia/set-analytics-settings.ts
@@ -1,7 +1,6 @@
 /* istanbul ignore file */
-import algoliasearch from 'algoliasearch';
 import fs from 'fs/promises';
-import { resolve } from 'path';
+import { getIndexSchema } from './set-settings';
 
 export type SetAlgoliaAnalyticsSettings = {
   algoliaAppId: string;
@@ -14,18 +13,12 @@ export const setAlgoliaAnalyticsSettings = async ({
   algoliaCiApiKey,
   indexName,
 }: SetAlgoliaAnalyticsSettings): Promise<void> => {
-  const path = resolve(
-    __dirname,
-    `../../../../../packages/algolia/schema/crn-analytics`,
-  );
-  const client = algoliasearch(algoliaAppId, algoliaCiApiKey);
-
-  const index = client.initIndex(indexName);
-  const indexSchemaRaw = await fs.readFile(
-    `${path}/algolia-schema.json`,
-    'utf8',
-  );
-  const indexSchema = JSON.parse(indexSchemaRaw);
+  const { path, client, index, indexSchema } = await getIndexSchema({
+    algoliaAppId,
+    algoliaCiApiKey,
+    indexName,
+    appName: 'crn-analytics',
+  });
 
   const replicas = [
     `${indexName}_team_desc`,

--- a/apps/asap-cli/src/scripts/algolia/set-settings.ts
+++ b/apps/asap-cli/src/scripts/algolia/set-settings.ts
@@ -1,5 +1,6 @@
 /* istanbul ignore file */
-import algoliasearch from 'algoliasearch';
+import { Settings } from '@algolia/client-search';
+import algoliasearch, { SearchClient, SearchIndex } from 'algoliasearch';
 import fs from 'fs/promises';
 import { resolve } from 'path';
 
@@ -10,12 +11,17 @@ export type SetAlgoliaSettings = {
   appName: string;
 };
 
-export const setAlgoliaSettings = async ({
+export const getIndexSchema = async ({
   algoliaAppId,
   algoliaCiApiKey,
   indexName,
   appName,
-}: SetAlgoliaSettings): Promise<void> => {
+}: SetAlgoliaSettings): Promise<{
+  path: string;
+  client: SearchClient;
+  index: SearchIndex;
+  indexSchema: Settings;
+}> => {
   const path = resolve(
     __dirname,
     `../../../../../packages/algolia/schema/${appName}`,
@@ -28,6 +34,27 @@ export const setAlgoliaSettings = async ({
     'utf8',
   );
   const indexSchema = JSON.parse(indexSchemaRaw);
+
+  return {
+    path,
+    client,
+    index,
+    indexSchema,
+  };
+};
+
+export const setAlgoliaSettings = async ({
+  algoliaAppId,
+  algoliaCiApiKey,
+  indexName,
+  appName,
+}: SetAlgoliaSettings): Promise<void> => {
+  const { path, client, index, indexSchema } = await getIndexSchema({
+    algoliaAppId,
+    algoliaCiApiKey,
+    indexName,
+    appName,
+  });
 
   const replicaIndexName = `${indexName}-reverse-timestamp`;
   await index

--- a/apps/asap-cli/src/scripts/algolia/set-settings.ts
+++ b/apps/asap-cli/src/scripts/algolia/set-settings.ts
@@ -16,8 +16,6 @@ export const setAlgoliaSettings = async ({
   indexName,
   appName,
 }: SetAlgoliaSettings): Promise<void> => {
-  const isAnalyticsIndex = appName.includes('analytics');
-
   const path = resolve(
     __dirname,
     `../../../../../packages/algolia/schema/${appName}`,
@@ -31,56 +29,20 @@ export const setAlgoliaSettings = async ({
   );
   const indexSchema = JSON.parse(indexSchemaRaw);
 
-  if (isAnalyticsIndex) {
-    const replicas = [
-      `${indexName}_team_desc`,
+  const replicaIndexName = `${indexName}-reverse-timestamp`;
+  await index
+    .setSettings({
+      ...indexSchema,
+      replicas: [replicaIndexName],
+    })
+    .wait();
 
-      `${indexName}_wg_current_leadership_asc`,
-      `${indexName}_wg_current_leadership_desc`,
-      `${indexName}_wg_previous_leadership_asc`,
-      `${indexName}_wg_previous_leadership_desc`,
-      `${indexName}_wg_current_membership_asc`,
-      `${indexName}_wg_current_membership_desc`,
-      `${indexName}_wg_previous_membership_asc`,
-      `${indexName}_wg_previous_membership_desc`,
+  const replicaIndex = client.initIndex(replicaIndexName);
+  const replicaIndexSchemaRaw = await fs.readFile(
+    `${path}/algolia-reverse-timestamp-schema.json`,
+    'utf8',
+  );
 
-      `${indexName}_ig_current_leadership_asc`,
-      `${indexName}_ig_current_leadership_desc`,
-      `${indexName}_ig_previous_leadership_asc`,
-      `${indexName}_ig_previous_leadership_desc`,
-      `${indexName}_ig_current_membership_asc`,
-      `${indexName}_ig_current_membership_desc`,
-      `${indexName}_ig_previous_membership_asc`,
-      `${indexName}_ig_previous_membership_desc`,
-    ];
-    await index.setSettings({ ...indexSchema, replicas }).wait();
-
-    replicas.forEach(async (replica) => {
-      const replicaIndex = client.initIndex(replica);
-      const replicaNameSuffix = replica.replace(`${indexName}_`, '');
-      const replicaIndexSchemaRaw = await fs.readFile(
-        `${path}/${replicaNameSuffix}-schema.json`,
-        'utf8',
-      );
-      const replicaIndexSchema = JSON.parse(replicaIndexSchemaRaw);
-      await replicaIndex.setSettings(replicaIndexSchema);
-    });
-  } else {
-    const replicaIndexName = `${indexName}-reverse-timestamp`;
-    await index
-      .setSettings({
-        ...indexSchema,
-        replicas: [replicaIndexName],
-      })
-      .wait();
-
-    const replicaIndex = client.initIndex(replicaIndexName);
-    const replicaIndexSchemaRaw = await fs.readFile(
-      `${path}/algolia-reverse-timestamp-schema.json`,
-      'utf8',
-    );
-
-    const replicaIndexSchema = JSON.parse(replicaIndexSchemaRaw);
-    await replicaIndex.setSettings(replicaIndexSchema);
-  }
+  const replicaIndexSchema = JSON.parse(replicaIndexSchemaRaw);
+  await replicaIndex.setSettings(replicaIndexSchema);
 };

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "algolia:move-index": "yarn workspace @asap-hub/asap-cli algolia:move-index",
     "algolia:remove-records": "yarn workspace @asap-hub/asap-cli algolia:remove-records",
     "algolia:set-settings": "yarn workspace @asap-hub/asap-cli algolia:set-settings",
+    "algolia:set-analytics-settings": "yarn workspace @asap-hub/asap-cli algolia:set-analytics-settings",
     "build": "yarn turbo build --filter='!@asap-hub/contentful-app-*'",
     "build:babel": "turbo build:babel",
     "build:frontend": "yarn turbo build --filter='!@asap-hub/contentful-app-*' --only",

--- a/packages/algolia/schema/crn-analytics/ig_current_leadership_asc-schema.json
+++ b/packages/algolia/schema/crn-analytics/ig_current_leadership_asc-schema.json
@@ -1,0 +1,13 @@
+{
+  "ranking": [
+    "asc(interestGroupLeadershipRoleCount)",
+    "typo",
+    "geo",
+    "words",
+    "filters",
+    "proximity",
+    "attribute",
+    "exact",
+    "custom"
+  ]
+}

--- a/packages/algolia/schema/crn-analytics/ig_current_leadership_desc-schema.json
+++ b/packages/algolia/schema/crn-analytics/ig_current_leadership_desc-schema.json
@@ -1,0 +1,13 @@
+{
+  "ranking": [
+    "desc(interestGroupLeadershipRoleCount)",
+    "typo",
+    "geo",
+    "words",
+    "filters",
+    "proximity",
+    "attribute",
+    "exact",
+    "custom"
+  ]
+}

--- a/packages/algolia/schema/crn-analytics/ig_current_membership_asc-schema.json
+++ b/packages/algolia/schema/crn-analytics/ig_current_membership_asc-schema.json
@@ -1,0 +1,13 @@
+{
+  "ranking": [
+    "asc(interestGroupMemberCount)",
+    "typo",
+    "geo",
+    "words",
+    "filters",
+    "proximity",
+    "attribute",
+    "exact",
+    "custom"
+  ]
+}

--- a/packages/algolia/schema/crn-analytics/ig_current_membership_desc-schema.json
+++ b/packages/algolia/schema/crn-analytics/ig_current_membership_desc-schema.json
@@ -1,0 +1,13 @@
+{
+  "ranking": [
+    "desc(interestGroupMemberCount)",
+    "typo",
+    "geo",
+    "words",
+    "filters",
+    "proximity",
+    "attribute",
+    "exact",
+    "custom"
+  ]
+}

--- a/packages/algolia/schema/crn-analytics/ig_previous_leadership_asc-schema.json
+++ b/packages/algolia/schema/crn-analytics/ig_previous_leadership_asc-schema.json
@@ -1,0 +1,13 @@
+{
+  "ranking": [
+    "asc(interestGroupPreviousLeadershipRoleCount)",
+    "typo",
+    "geo",
+    "words",
+    "filters",
+    "proximity",
+    "attribute",
+    "exact",
+    "custom"
+  ]
+}

--- a/packages/algolia/schema/crn-analytics/ig_previous_leadership_desc-schema.json
+++ b/packages/algolia/schema/crn-analytics/ig_previous_leadership_desc-schema.json
@@ -1,0 +1,13 @@
+{
+  "ranking": [
+    "desc(interestGroupPreviousLeadershipRoleCount)",
+    "typo",
+    "geo",
+    "words",
+    "filters",
+    "proximity",
+    "attribute",
+    "exact",
+    "custom"
+  ]
+}

--- a/packages/algolia/schema/crn-analytics/ig_previous_membership_asc-schema.json
+++ b/packages/algolia/schema/crn-analytics/ig_previous_membership_asc-schema.json
@@ -1,0 +1,13 @@
+{
+  "ranking": [
+    "asc(interestGroupPreviousMemberCount)",
+    "typo",
+    "geo",
+    "words",
+    "filters",
+    "proximity",
+    "attribute",
+    "exact",
+    "custom"
+  ]
+}

--- a/packages/algolia/schema/crn-analytics/ig_previous_membership_desc-schema.json
+++ b/packages/algolia/schema/crn-analytics/ig_previous_membership_desc-schema.json
@@ -1,0 +1,13 @@
+{
+  "ranking": [
+    "desc(interestGroupPreviousMemberCount)",
+    "typo",
+    "geo",
+    "words",
+    "filters",
+    "proximity",
+    "attribute",
+    "exact",
+    "custom"
+  ]
+}

--- a/packages/algolia/schema/crn-analytics/team_desc-schema.json
+++ b/packages/algolia/schema/crn-analytics/team_desc-schema.json
@@ -1,0 +1,3 @@
+{
+  "customRanking": ["desc(displayName)"]
+}

--- a/packages/algolia/schema/crn-analytics/wg_current_leadership_asc-schema.json
+++ b/packages/algolia/schema/crn-analytics/wg_current_leadership_asc-schema.json
@@ -1,0 +1,13 @@
+{
+  "ranking": [
+    "asc(workingGroupLeadershipRoleCount)",
+    "typo",
+    "geo",
+    "words",
+    "filters",
+    "proximity",
+    "attribute",
+    "exact",
+    "custom"
+  ]
+}

--- a/packages/algolia/schema/crn-analytics/wg_current_leadership_desc-schema.json
+++ b/packages/algolia/schema/crn-analytics/wg_current_leadership_desc-schema.json
@@ -1,0 +1,13 @@
+{
+  "ranking": [
+    "desc(workingGroupLeadershipRoleCount)",
+    "typo",
+    "geo",
+    "words",
+    "filters",
+    "proximity",
+    "attribute",
+    "exact",
+    "custom"
+  ]
+}

--- a/packages/algolia/schema/crn-analytics/wg_current_membership_asc-schema.json
+++ b/packages/algolia/schema/crn-analytics/wg_current_membership_asc-schema.json
@@ -1,0 +1,13 @@
+{
+  "ranking": [
+    "asc(workingGroupMemberCount)",
+    "typo",
+    "geo",
+    "words",
+    "filters",
+    "proximity",
+    "attribute",
+    "exact",
+    "custom"
+  ]
+}

--- a/packages/algolia/schema/crn-analytics/wg_current_membership_desc-schema.json
+++ b/packages/algolia/schema/crn-analytics/wg_current_membership_desc-schema.json
@@ -1,0 +1,13 @@
+{
+  "ranking": [
+    "desc(workingGroupMemberCount)",
+    "typo",
+    "geo",
+    "words",
+    "filters",
+    "proximity",
+    "attribute",
+    "exact",
+    "custom"
+  ]
+}

--- a/packages/algolia/schema/crn-analytics/wg_previous_leadership_asc-schema.json
+++ b/packages/algolia/schema/crn-analytics/wg_previous_leadership_asc-schema.json
@@ -1,0 +1,13 @@
+{
+  "ranking": [
+    "asc(workingGroupPreviousLeadershipRoleCount)",
+    "typo",
+    "geo",
+    "words",
+    "filters",
+    "proximity",
+    "attribute",
+    "exact",
+    "custom"
+  ]
+}

--- a/packages/algolia/schema/crn-analytics/wg_previous_leadership_desc-schema.json
+++ b/packages/algolia/schema/crn-analytics/wg_previous_leadership_desc-schema.json
@@ -1,0 +1,13 @@
+{
+  "ranking": [
+    "desc(workingGroupPreviousLeadershipRoleCount)",
+    "typo",
+    "geo",
+    "words",
+    "filters",
+    "proximity",
+    "attribute",
+    "exact",
+    "custom"
+  ]
+}

--- a/packages/algolia/schema/crn-analytics/wg_previous_membership_asc-schema.json
+++ b/packages/algolia/schema/crn-analytics/wg_previous_membership_asc-schema.json
@@ -1,0 +1,13 @@
+{
+  "ranking": [
+    "asc(workingGroupPreviousMemberCount)",
+    "typo",
+    "geo",
+    "words",
+    "filters",
+    "proximity",
+    "attribute",
+    "exact",
+    "custom"
+  ]
+}

--- a/packages/algolia/schema/crn-analytics/wg_previous_membership_desc-schema.json
+++ b/packages/algolia/schema/crn-analytics/wg_previous_membership_desc-schema.json
@@ -1,0 +1,13 @@
+{
+  "ranking": [
+    "desc(workingGroupPreviousMemberCount)",
+    "typo",
+    "geo",
+    "words",
+    "filters",
+    "proximity",
+    "attribute",
+    "exact",
+    "custom"
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -275,6 +275,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@asap-hub/asap-cli@workspace:apps/asap-cli"
   dependencies:
+    "@algolia/client-search": 4.22.1
     "@asap-hub/algolia": "workspace:*"
     "@asap-hub/errors": "workspace:*"
     "@asap-hub/message-templates": "workspace:*"


### PR DESCRIPTION
This PR changes the algolia `set-settings` to create all the replica indexes necessary to sort the Leadership & Membership data. 

![Screenshot 2024-04-26 at 07 35 37 (2)](https://github.com/yldio/asap-hub/assets/16595804/9edbe4fb-ff6b-4826-9981-1e5a842e431e)
