### PR TITLE
update analytics sync action & workflow

### DIFF
--- a/.github/actions/algolia-import-entity/action.yml
+++ b/.github/actions/algolia-import-entity/action.yml
@@ -44,7 +44,7 @@ runs:
         crn_entities=(events external-authors interest-groups news research-outputs teams tutorials users working-groups)
         gp2_entities=(events external-users news outputs projects users working-groups)
 
-        ["${{ inputs.app }}" == "crn"] && entities=crn_entities || entities=gp2_entities
+        ["${{ inputs.app }}" == "crn"] && entities=("${crn_entities[@]}") || entities=("${gp2_entities[@]}")
 
         if [[ "$ENTITY" == "all" ]]; then
           for entity in "${entities[@]}"; do yarn export:entity:${{ inputs.app }} $entity -f $entity.json

--- a/.github/actions/algolia-import-entity/action.yml
+++ b/.github/actions/algolia-import-entity/action.yml
@@ -41,8 +41,18 @@ runs:
     - name: Import Entity
       shell: bash
       run: |
-        yarn export:entity:${{ inputs.app }} $ENTITY -f $ENTITY.json
-        jq -c '.[]' $ENTITY.json | algolia objects import $ALGOLIA_INDEX -F -
+        crn-entities=(events external-authors interest-groups news research-outputs teams tutorials users working-groups)
+        gp2-entities=(events external-users news outputs projects users working-groups)
+
+        ["${{ inputs.app }}" == "crn"] && entities=crn-entities || entities=gp2-entities
+
+        if [[ "$ENTITY" == "all" ]]; then
+          for entity in "${entities[@]}"; do yarn export:entity:${{ inputs.app }} $entity -f $entity.json
+          jq -c '.[]' $entity.json | algolia objects import $ALGOLIA_INDEX -F -; done
+        else
+          yarn export:entity:${{ inputs.app }} $ENTITY -f $ENTITY.json
+          jq -c '.[]' $ENTITY.json | algolia objects import $ALGOLIA_INDEX -F -
+        fi
       env:
         ALGOLIA_APPLICATION_ID: ${{ inputs.algolia-app-id }}
         ALGOLIA_ADMIN_API_KEY: ${{ inputs.algolia-api-key }}

--- a/.github/actions/algolia-import-entity/action.yml
+++ b/.github/actions/algolia-import-entity/action.yml
@@ -41,8 +41,8 @@ runs:
     - name: Import Entity
       shell: bash
       run: |
-        crn_entities=(events external-authors interest-groups news research-outputs teams tutorials users working-groups)
-        gp2_entities=(events external-users news outputs projects users working-groups)
+        crn_entities=(event external-author interest-group news research-output team tutorial user working-group)
+        gp2_entities=(event external-user news output project user working-group)
 
         ["${{ inputs.app }}" == "crn"] && entities=("${crn_entities[@]}") || entities=("${gp2_entities[@]}")
 

--- a/.github/actions/algolia-import-entity/action.yml
+++ b/.github/actions/algolia-import-entity/action.yml
@@ -44,7 +44,7 @@ runs:
         crn_entities=(event external-author interest-group news research-output team tutorial user working-group)
         gp2_entities=(event external-user news output project user working-group)
 
-        ["${{ inputs.app }}" == "crn"] && entities=("${crn_entities[@]}") || entities=("${gp2_entities[@]}")
+        [ "${{ inputs.app }}" == "crn" ] && entities=("${crn_entities[@]}") || entities=("${gp2_entities[@]}")
 
         if [[ "$ENTITY" == "all" ]]; then
           for entity in "${entities[@]}"; do yarn export:entity:${{ inputs.app }} $entity -f $entity.json

--- a/.github/actions/algolia-import-entity/action.yml
+++ b/.github/actions/algolia-import-entity/action.yml
@@ -41,10 +41,10 @@ runs:
     - name: Import Entity
       shell: bash
       run: |
-        crn-entities=(events external-authors interest-groups news research-outputs teams tutorials users working-groups)
-        gp2-entities=(events external-users news outputs projects users working-groups)
+        crn_entities=(events external-authors interest-groups news research-outputs teams tutorials users working-groups)
+        gp2_entities=(events external-users news outputs projects users working-groups)
 
-        ["${{ inputs.app }}" == "crn"] && entities=crn-entities || entities=gp2-entities
+        ["${{ inputs.app }}" == "crn"] && entities=crn_entities || entities=gp2_entities
 
         if [[ "$ENTITY" == "all" ]]; then
           for entity in "${entities[@]}"; do yarn export:entity:${{ inputs.app }} $entity -f $entity.json

--- a/.github/actions/algolia-import-entity/action.yml
+++ b/.github/actions/algolia-import-entity/action.yml
@@ -47,8 +47,8 @@ runs:
         [ "${{ inputs.app }}" == "crn" ] && entities=("${crn_entities[@]}") || entities=("${gp2_entities[@]}")
 
         if [[ "$ENTITY" == "all" ]]; then
-          for entity in "${entities[@]}"; do yarn export:entity:${{ inputs.app }} $entity -f $entity.json
-          jq -c '.[]' $entity.json | algolia objects import $ALGOLIA_INDEX -F -; done
+          for iteratedEntity in "${entities[@]}"; do yarn export:entity:${{ inputs.app }} $iteratedEntity -f $iteratedEntity.json
+          jq -c '.[]' $iteratedEntity.json | algolia objects import $ALGOLIA_INDEX -F -; done
         else
           yarn export:entity:${{ inputs.app }} $ENTITY -f $ENTITY.json
           jq -c '.[]' $ENTITY.json | algolia objects import $ALGOLIA_INDEX -F -

--- a/.github/actions/algolia-import-metric/action.yml
+++ b/.github/actions/algolia-import-metric/action.yml
@@ -41,8 +41,8 @@ runs:
         metrics=(team-leadership team-productivity user-productivity)
 
         if [[ "$METRIC" == "all" ]]; then
-          for metric in "${metrics[@]}"; do yarn export:analytics $metric -f $metric.json
-          jq -c '.[]' $metric.json | algolia objects import $ALGOLIA_INDEX -F -; done
+          for iteratedMetric in "${metrics[@]}"; do yarn export:analytics $iteratedMetric -f $iteratedMetric.json
+          jq -c '.[]' $iteratedMetric.json | algolia objects import $ALGOLIA_INDEX -F -; done
         else
           yarn export:analytics $METRIC -f $METRIC.json
           jq -c '.[]' $METRIC.json | algolia objects import $ALGOLIA_INDEX -F -

--- a/.github/actions/algolia-import-metric/action.yml
+++ b/.github/actions/algolia-import-metric/action.yml
@@ -38,8 +38,15 @@ runs:
     - name: Import Metric
       shell: bash
       run: |
-        yarn export:analytics $METRIC -f $METRIC.json
-        jq -c '.[]' $METRIC.json | algolia objects import $ALGOLIA_INDEX -F -
+        metrics=(team-leadership team-productivity user-productivity)
+
+        if [[ "$METRIC" == "all" ]]; then
+          for metric in "${metrics[@]}"; do yarn export:analytics $metric -f $metric.json
+          jq -c '.[]' $metric.json | algolia objects import $ALGOLIA_INDEX -F -; done
+        else
+          yarn export:analytics $METRIC -f $METRIC.json
+          jq -c '.[]' $METRIC.json | algolia objects import $ALGOLIA_INDEX -F -
+        fi
       env:
         ALGOLIA_APPLICATION_ID: ${{ inputs.algolia-app-id }}
         ALGOLIA_ADMIN_API_KEY: ${{ inputs.algolia-api-key }}

--- a/.github/workflows/reusable-crn-algolia-sync.yml
+++ b/.github/workflows/reusable-crn-algolia-sync.yml
@@ -100,7 +100,7 @@ jobs:
           ALGOLIA_API_KEY: ${{ steps.algolia-keys.outputs.algolia-api-key }}
           ALGOLIA_APP_ID: ${{ steps.algolia-keys.outputs.algolia-app-id }}
           ALGOLIA_INDEX_TEMP: '${{ steps.setup.outputs.crn-algolia-index }}_${{ github.run_id }}_temp'
-          ENTITY_TYPE: ${{ (inputs.entity == 'users' && 'user') || (inputs.entity == 'research-outputs' && 'research-output') || (inputs.entity == 'external-authors' && 'external-author') || (inputs.entity == 'events' && 'event') }}
+          ENTITY_TYPE: ${{ (inputs.entity == 'users' && 'user') || (inputs.entity == 'research-outputs' && 'research-output') || (inputs.entity == 'external-authors' && 'external-author') || (inputs.entity == 'events' && 'event') || (inputs.entity == 'interest-groups' && 'interest-group') || (inputs.entity == 'news' && 'news') || (inputs.entity == 'teams' && 'team') || (inputs.entity == 'tutorials' && 'tutorial') || (inputs.entity == 'working-groups' && 'working-group') }}
       - name: Import Entities
         uses: ./.github/actions/algolia-import-entity
         with:
@@ -108,7 +108,7 @@ jobs:
           algolia-app-id: ${{ steps.algolia-keys.outputs.algolia-app-id }}
           algolia-index: '${{ steps.setup.outputs.crn-algolia-index }}_${{github.run_id}}_temp'
           app: 'crn'
-          entity-type: ${{ inputs.entity }}
+          entity-type: ${{ (inputs.entity == 'all' && 'all') || (inputs.entity == 'users' && 'user') || (inputs.entity == 'research-outputs' && 'research-output') || (inputs.entity == 'external-authors' && 'external-author') || (inputs.entity == 'events' && 'event') || (inputs.entity == 'interest-groups' && 'interest-group') || (inputs.entity == 'news' && 'news') || (inputs.entity == 'teams' && 'team') || (inputs.entity == 'tutorials' && 'tutorial') || (inputs.entity == 'working-groups' && 'working-group') }}
           contentful-env: ${{ inputs.contentful-environment-id }}
           contentful-access-token: ${{ secrets.CRN_CONTENTFUL_ACCESS_TOKEN }}
           contentful-management-token: ${{ secrets.CONTENTFUL_MANAGEMENT_TOKEN }}

--- a/.github/workflows/reusable-crn-algolia-sync.yml
+++ b/.github/workflows/reusable-crn-algolia-sync.yml
@@ -97,7 +97,7 @@ jobs:
         uses: kanga333/variable-mapper@master
         id: get-entity-type
         with:
-          key: "${{inputs.entity}}"
+          key: '${{inputs.entity}}'
           map: |
             {
               "all": {

--- a/.github/workflows/reusable-crn-algolia-sync.yml
+++ b/.github/workflows/reusable-crn-algolia-sync.yml
@@ -101,119 +101,14 @@ jobs:
           ALGOLIA_APP_ID: ${{ steps.algolia-keys.outputs.algolia-app-id }}
           ALGOLIA_INDEX_TEMP: '${{ steps.setup.outputs.crn-algolia-index }}_${{ github.run_id }}_temp'
           ENTITY_TYPE: ${{ (inputs.entity == 'users' && 'user') || (inputs.entity == 'research-outputs' && 'research-output') || (inputs.entity == 'external-authors' && 'external-author') || (inputs.entity == 'events' && 'event') }}
-      - name: Import Research Outputs (ROs | ALL)
-        if: ${{ inputs.entity == 'research-outputs' || inputs.entity == 'all'}}
+      - name: Import Entities
         uses: ./.github/actions/algolia-import-entity
         with:
           algolia-api-key: ${{ steps.algolia-keys.outputs.algolia-api-key }}
           algolia-app-id: ${{ steps.algolia-keys.outputs.algolia-app-id }}
           algolia-index: '${{ steps.setup.outputs.crn-algolia-index }}_${{github.run_id}}_temp'
           app: 'crn'
-          entity-type: 'research-output'
-          contentful-env: ${{ inputs.contentful-environment-id }}
-          contentful-access-token: ${{ secrets.CRN_CONTENTFUL_ACCESS_TOKEN }}
-          contentful-management-token: ${{ secrets.CONTENTFUL_MANAGEMENT_TOKEN }}
-          contentful-space-id: ${{ steps.setup.outputs.crn-contentful-space-id }}
-      - name: Import Users (USERs | ALL)
-        if: ${{ inputs.entity == 'users' || inputs.entity == 'all'}}
-        uses: ./.github/actions/algolia-import-entity
-        with:
-          algolia-api-key: ${{ steps.algolia-keys.outputs.algolia-api-key }}
-          algolia-app-id: ${{ steps.algolia-keys.outputs.algolia-app-id }}
-          algolia-index: '${{ steps.setup.outputs.crn-algolia-index }}_${{github.run_id}}_temp'
-          app: 'crn'
-          entity-type: 'user'
-          contentful-env: ${{ inputs.contentful-environment-id }}
-          contentful-access-token: ${{ secrets.CRN_CONTENTFUL_ACCESS_TOKEN }}
-          contentful-management-token: ${{ secrets.CONTENTFUL_MANAGEMENT_TOKEN }}
-          contentful-space-id: ${{ steps.setup.outputs.crn-contentful-space-id }}
-      - name: Import External Authors (EXTERNAL_AUTHORS | ALL)
-        if: ${{ inputs.entity == 'external-authors' || inputs.entity == 'all'}}
-        uses: ./.github/actions/algolia-import-entity
-        with:
-          algolia-api-key: ${{ steps.algolia-keys.outputs.algolia-api-key }}
-          algolia-app-id: ${{ steps.algolia-keys.outputs.algolia-app-id }}
-          algolia-index: '${{ steps.setup.outputs.crn-algolia-index }}_${{github.run_id}}_temp'
-          app: 'crn'
-          entity-type: 'external-author'
-          contentful-env: ${{ inputs.contentful-environment-id }}
-          contentful-access-token: ${{ secrets.CRN_CONTENTFUL_ACCESS_TOKEN }}
-          contentful-management-token: ${{ secrets.CONTENTFUL_MANAGEMENT_TOKEN }}
-          contentful-space-id: ${{ steps.setup.outputs.crn-contentful-space-id }}
-      - name: Import Events (EVENTS | ALL)
-        if: ${{ inputs.entity == 'events' || inputs.entity == 'all'}}
-        uses: ./.github/actions/algolia-import-entity
-        with:
-          algolia-api-key: ${{ steps.algolia-keys.outputs.algolia-api-key }}
-          algolia-app-id: ${{ steps.algolia-keys.outputs.algolia-app-id }}
-          algolia-index: '${{ steps.setup.outputs.crn-algolia-index }}_${{github.run_id}}_temp'
-          app: 'crn'
-          entity-type: 'event'
-          contentful-env: ${{ inputs.contentful-environment-id }}
-          contentful-access-token: ${{ secrets.CRN_CONTENTFUL_ACCESS_TOKEN }}
-          contentful-management-token: ${{ secrets.CONTENTFUL_MANAGEMENT_TOKEN }}
-          contentful-space-id: ${{ steps.setup.outputs.crn-contentful-space-id }}
-      - name: Import Teams (TEAMS | ALL)
-        if: ${{ inputs.entity == 'teams' || inputs.entity == 'all'}}
-        uses: ./.github/actions/algolia-import-entity
-        with:
-          algolia-api-key: ${{ steps.algolia-keys.outputs.algolia-api-key }}
-          algolia-app-id: ${{ steps.algolia-keys.outputs.algolia-app-id }}
-          algolia-index: '${{ steps.setup.outputs.crn-algolia-index }}_${{github.run_id}}_temp'
-          app: 'crn'
-          entity-type: 'team'
-          contentful-env: ${{ inputs.contentful-environment-id }}
-          contentful-access-token: ${{ secrets.CRN_CONTENTFUL_ACCESS_TOKEN }}
-          contentful-management-token: ${{ secrets.CONTENTFUL_MANAGEMENT_TOKEN }}
-          contentful-space-id: ${{ steps.setup.outputs.crn-contentful-space-id }}
-      - name: Import WorkingGroups (WORKING_GROUPS | ALL)
-        if: ${{ inputs.entity == 'working-groups' || inputs.entity == 'all'}}
-        uses: ./.github/actions/algolia-import-entity
-        with:
-          algolia-api-key: ${{ steps.algolia-keys.outputs.algolia-api-key }}
-          algolia-app-id: ${{ steps.algolia-keys.outputs.algolia-app-id }}
-          algolia-index: '${{ steps.setup.outputs.crn-algolia-index }}_${{github.run_id}}_temp'
-          app: 'crn'
-          entity-type: 'working-group'
-          contentful-env: ${{ inputs.contentful-environment-id }}
-          contentful-access-token: ${{ secrets.CRN_CONTENTFUL_ACCESS_TOKEN }}
-          contentful-management-token: ${{ secrets.CONTENTFUL_MANAGEMENT_TOKEN }}
-          contentful-space-id: ${{ steps.setup.outputs.crn-contentful-space-id }}
-      - name: Import InterestGroups (INTEREST_GROUPS | ALL)
-        if: ${{ inputs.entity == 'interest-groups' || inputs.entity == 'all'}}
-        uses: ./.github/actions/algolia-import-entity
-        with:
-          algolia-api-key: ${{ steps.algolia-keys.outputs.algolia-api-key }}
-          algolia-app-id: ${{ steps.algolia-keys.outputs.algolia-app-id }}
-          algolia-index: '${{ steps.setup.outputs.crn-algolia-index }}_${{github.run_id}}_temp'
-          app: 'crn'
-          entity-type: 'interest-group'
-          contentful-env: ${{ inputs.contentful-environment-id }}
-          contentful-access-token: ${{ secrets.CRN_CONTENTFUL_ACCESS_TOKEN }}
-          contentful-management-token: ${{ secrets.CONTENTFUL_MANAGEMENT_TOKEN }}
-          contentful-space-id: ${{ steps.setup.outputs.crn-contentful-space-id }}
-      - name: Import Tutorials (TUTORIALS | ALL)
-        if: ${{ inputs.entity == 'tutorials' || inputs.entity == 'all'}}
-        uses: ./.github/actions/algolia-import-entity
-        with:
-          algolia-api-key: ${{ steps.algolia-keys.outputs.algolia-api-key }}
-          algolia-app-id: ${{ steps.algolia-keys.outputs.algolia-app-id }}
-          algolia-index: '${{ steps.setup.outputs.crn-algolia-index }}_${{github.run_id}}_temp'
-          app: 'crn'
-          entity-type: 'tutorial'
-          contentful-env: ${{ inputs.contentful-environment-id }}
-          contentful-access-token: ${{ secrets.CRN_CONTENTFUL_ACCESS_TOKEN }}
-          contentful-management-token: ${{ secrets.CONTENTFUL_MANAGEMENT_TOKEN }}
-          contentful-space-id: ${{ steps.setup.outputs.crn-contentful-space-id }}
-      - name: Import News (NEWS | ALL)
-        if: ${{ inputs.entity == 'news' || inputs.entity == 'all'}}
-        uses: ./.github/actions/algolia-import-entity
-        with:
-          algolia-api-key: ${{ steps.algolia-keys.outputs.algolia-api-key }}
-          algolia-app-id: ${{ steps.algolia-keys.outputs.algolia-app-id }}
-          algolia-index: '${{ steps.setup.outputs.crn-algolia-index }}_${{github.run_id}}_temp'
-          app: 'crn'
-          entity-type: 'news'
+          entity-type: ${{ inputs.entity }}
           contentful-env: ${{ inputs.contentful-environment-id }}
           contentful-access-token: ${{ secrets.CRN_CONTENTFUL_ACCESS_TOKEN }}
           contentful-management-token: ${{ secrets.CONTENTFUL_MANAGEMENT_TOKEN }}

--- a/.github/workflows/reusable-crn-algolia-sync.yml
+++ b/.github/workflows/reusable-crn-algolia-sync.yml
@@ -93,6 +93,45 @@ jobs:
           ALGOLIA_INDEX_TEMP: '${{ steps.setup.outputs.crn-algolia-index }}_${{ github.run_id }}_temp'
           # Do not copy the records if all entities are being synced
           SCOPE: ${{ inputs.entity == 'all' && '-s settings,synonyms' || '' }}
+      - name: Get entity type
+        uses: kanga333/variable-mapper@master
+        id: get-entity-type
+        with:
+          key: "${{inputs.entity}}"
+          map: |
+            {
+              "all": {
+                "entity_type": "all"
+              },
+              "events": {
+                "entity_type": "event"
+              },
+              "external-authors": {
+                "entity_type": "external-author"
+              },
+              "interest-groups": {
+                "entity_type": "interest-group"
+              },
+              "news": {
+                "entity_type": "news"
+              },
+              "research-outputs": {
+                "entity_type": "research-output"
+              },
+              "teams": {
+                "entity_type": "team"
+              },
+              "tutorials": {
+                "entity_type": "tutorial"
+              },
+              "users": {
+                "entity_type": "user"
+              },
+              "working-groups": {
+                "entity_type": "working-group"
+              }
+            }
+          export_to: output
       - name: Remove the entity data (ENTITY)
         if: ${{ inputs.entity != 'all'}}
         run: yarn algolia:remove-records -a $ALGOLIA_APP_ID -k $ALGOLIA_API_KEY -n $ALGOLIA_INDEX_TEMP -e $ENTITY_TYPE
@@ -100,7 +139,7 @@ jobs:
           ALGOLIA_API_KEY: ${{ steps.algolia-keys.outputs.algolia-api-key }}
           ALGOLIA_APP_ID: ${{ steps.algolia-keys.outputs.algolia-app-id }}
           ALGOLIA_INDEX_TEMP: '${{ steps.setup.outputs.crn-algolia-index }}_${{ github.run_id }}_temp'
-          ENTITY_TYPE: ${{ (inputs.entity == 'users' && 'user') || (inputs.entity == 'research-outputs' && 'research-output') || (inputs.entity == 'external-authors' && 'external-author') || (inputs.entity == 'events' && 'event') || (inputs.entity == 'interest-groups' && 'interest-group') || (inputs.entity == 'news' && 'news') || (inputs.entity == 'teams' && 'team') || (inputs.entity == 'tutorials' && 'tutorial') || (inputs.entity == 'working-groups' && 'working-group') }}
+          ENTITY_TYPE: ${{ steps.get-entity-type.outputs.entity_type }}
       - name: Import Entities
         uses: ./.github/actions/algolia-import-entity
         with:
@@ -108,7 +147,7 @@ jobs:
           algolia-app-id: ${{ steps.algolia-keys.outputs.algolia-app-id }}
           algolia-index: '${{ steps.setup.outputs.crn-algolia-index }}_${{github.run_id}}_temp'
           app: 'crn'
-          entity-type: ${{ (inputs.entity == 'all' && 'all') || (inputs.entity == 'users' && 'user') || (inputs.entity == 'research-outputs' && 'research-output') || (inputs.entity == 'external-authors' && 'external-author') || (inputs.entity == 'events' && 'event') || (inputs.entity == 'interest-groups' && 'interest-group') || (inputs.entity == 'news' && 'news') || (inputs.entity == 'teams' && 'team') || (inputs.entity == 'tutorials' && 'tutorial') || (inputs.entity == 'working-groups' && 'working-group') }}
+          entity-type: ${{ steps.get-entity-type.outputs.entity_type }}
           contentful-env: ${{ inputs.contentful-environment-id }}
           contentful-access-token: ${{ secrets.CRN_CONTENTFUL_ACCESS_TOKEN }}
           contentful-management-token: ${{ secrets.CONTENTFUL_MANAGEMENT_TOKEN }}

--- a/.github/workflows/reusable-crn-algolia-sync.yml
+++ b/.github/workflows/reusable-crn-algolia-sync.yml
@@ -93,45 +93,6 @@ jobs:
           ALGOLIA_INDEX_TEMP: '${{ steps.setup.outputs.crn-algolia-index }}_${{ github.run_id }}_temp'
           # Do not copy the records if all entities are being synced
           SCOPE: ${{ inputs.entity == 'all' && '-s settings,synonyms' || '' }}
-      - name: Get entity type
-        uses: kanga333/variable-mapper@master
-        id: get-entity-type
-        with:
-          key: '${{inputs.entity}}'
-          map: |
-            {
-              "all": {
-                "entity_type": "all"
-              },
-              "events": {
-                "entity_type": "event"
-              },
-              "external-authors": {
-                "entity_type": "external-author"
-              },
-              "interest-groups": {
-                "entity_type": "interest-group"
-              },
-              "news": {
-                "entity_type": "news"
-              },
-              "research-outputs": {
-                "entity_type": "research-output"
-              },
-              "teams": {
-                "entity_type": "team"
-              },
-              "tutorials": {
-                "entity_type": "tutorial"
-              },
-              "users": {
-                "entity_type": "user"
-              },
-              "working-groups": {
-                "entity_type": "working-group"
-              }
-            }
-          export_to: output
       - name: Remove the entity data (ENTITY)
         if: ${{ inputs.entity != 'all'}}
         run: yarn algolia:remove-records -a $ALGOLIA_APP_ID -k $ALGOLIA_API_KEY -n $ALGOLIA_INDEX_TEMP -e $ENTITY_TYPE
@@ -139,7 +100,7 @@ jobs:
           ALGOLIA_API_KEY: ${{ steps.algolia-keys.outputs.algolia-api-key }}
           ALGOLIA_APP_ID: ${{ steps.algolia-keys.outputs.algolia-app-id }}
           ALGOLIA_INDEX_TEMP: '${{ steps.setup.outputs.crn-algolia-index }}_${{ github.run_id }}_temp'
-          ENTITY_TYPE: ${{ steps.get-entity-type.outputs.entity_type }}
+          ENTITY_TYPE: ${{ (inputs.entity == 'users' && 'user') || (inputs.entity == 'research-outputs' && 'research-output') || (inputs.entity == 'external-authors' && 'external-author') || (inputs.entity == 'events' && 'event') || (inputs.entity == 'interest-groups' && 'interest-group') || (inputs.entity == 'news' && 'news') || (inputs.entity == 'teams' && 'team') || (inputs.entity == 'tutorials' && 'tutorial') || (inputs.entity == 'working-groups' && 'working-group') }}
       - name: Import Entities
         uses: ./.github/actions/algolia-import-entity
         with:
@@ -147,7 +108,7 @@ jobs:
           algolia-app-id: ${{ steps.algolia-keys.outputs.algolia-app-id }}
           algolia-index: '${{ steps.setup.outputs.crn-algolia-index }}_${{github.run_id}}_temp'
           app: 'crn'
-          entity-type: ${{ steps.get-entity-type.outputs.entity_type }}
+          entity-type: ${{ (inputs.entity == 'all' && 'all') || (inputs.entity == 'users' && 'user') || (inputs.entity == 'research-outputs' && 'research-output') || (inputs.entity == 'external-authors' && 'external-author') || (inputs.entity == 'events' && 'event') || (inputs.entity == 'interest-groups' && 'interest-group') || (inputs.entity == 'news' && 'news') || (inputs.entity == 'teams' && 'team') || (inputs.entity == 'tutorials' && 'tutorial') || (inputs.entity == 'working-groups' && 'working-group') }}
           contentful-env: ${{ inputs.contentful-environment-id }}
           contentful-access-token: ${{ secrets.CRN_CONTENTFUL_ACCESS_TOKEN }}
           contentful-management-token: ${{ secrets.CONTENTFUL_MANAGEMENT_TOKEN }}

--- a/.github/workflows/reusable-crn-analytics-algolia-sync.yml
+++ b/.github/workflows/reusable-crn-analytics-algolia-sync.yml
@@ -100,8 +100,7 @@ jobs:
           ALGOLIA_APP_ID: ${{ steps.algolia-keys.outputs.algolia-app-id }}
           ALGOLIA_INDEX_TEMP: '${{ steps.setup.outputs.crn-analytics-algolia-index }}_${{ github.run_id }}_temp'
           ENTITY_TYPE: ${{ (inputs.metric == 'team-leadership' && 'team-leadership') || (inputs.metric == 'team-productivity' && 'team-productivity') || (inputs.metric == 'user-productivity' && 'user-productivity')}}
-      - name: Import team-leadership
-        if: ${{ inputs.metric == 'team-leadership' || inputs.metric == 'all'}}
+      - name: Import metrics
         uses: ./.github/actions/algolia-import-metric
         with:
           algolia-api-key: ${{ steps.algolia-keys.outputs.algolia-api-key }}
@@ -111,31 +110,7 @@ jobs:
           contentful-access-token: ${{ secrets.CRN_CONTENTFUL_ACCESS_TOKEN }}
           contentful-management-token: ${{ secrets.CONTENTFUL_MANAGEMENT_TOKEN }}
           contentful-space-id: ${{ steps.setup.outputs.crn-contentful-space-id }}
-          metric: 'team-leadership'
-      - name: Import team-productivity
-        if: ${{ inputs.metric == 'team-productivity' || inputs.metric == 'all'}}
-        uses: ./.github/actions/algolia-import-metric
-        with:
-          algolia-api-key: ${{ steps.algolia-keys.outputs.algolia-api-key }}
-          algolia-app-id: ${{ steps.algolia-keys.outputs.algolia-app-id }}
-          algolia-index: '${{ steps.setup.outputs.crn-analytics-algolia-index }}_${{github.run_id}}_temp'
-          contentful-env: ${{ inputs.contentful-environment-id }}
-          contentful-access-token: ${{ secrets.CRN_CONTENTFUL_ACCESS_TOKEN }}
-          contentful-management-token: ${{ secrets.CONTENTFUL_MANAGEMENT_TOKEN }}
-          contentful-space-id: ${{ steps.setup.outputs.crn-contentful-space-id }}
-          metric: 'team-productivity'
-      - name: Import user-productivity
-        if: ${{ inputs.metric == 'user-productivity' || inputs.metric == 'all'}}
-        uses: ./.github/actions/algolia-import-metric
-        with:
-          algolia-api-key: ${{ steps.algolia-keys.outputs.algolia-api-key }}
-          algolia-app-id: ${{ steps.algolia-keys.outputs.algolia-app-id }}
-          algolia-index: '${{ steps.setup.outputs.crn-analytics-algolia-index }}_${{github.run_id}}_temp'
-          contentful-env: ${{ inputs.contentful-environment-id }}
-          contentful-access-token: ${{ secrets.CRN_CONTENTFUL_ACCESS_TOKEN }}
-          contentful-management-token: ${{ secrets.CONTENTFUL_MANAGEMENT_TOKEN }}
-          contentful-space-id: ${{ steps.setup.outputs.crn-contentful-space-id }}
-          metric: 'user-productivity'
+          metric: ${{ inputs.metric }}
       - name: Override index with the temp one
         run: yarn algolia:move-index -a $ALGOLIA_APP_ID -k $ALGOLIA_API_KEY -n $ALGOLIA_INDEX_TEMP -i $ALGOLIA_INDEX
         env:

--- a/.github/workflows/reusable-crn-analytics-algolia-sync.yml
+++ b/.github/workflows/reusable-crn-analytics-algolia-sync.yml
@@ -100,7 +100,7 @@ jobs:
           ALGOLIA_APP_ID: ${{ steps.algolia-keys.outputs.algolia-app-id }}
           ALGOLIA_INDEX_TEMP: '${{ steps.setup.outputs.crn-analytics-algolia-index }}_${{ github.run_id }}_temp'
           ENTITY_TYPE: ${{ (inputs.metric == 'team-leadership' && 'team-leadership') || (inputs.metric == 'team-productivity' && 'team-productivity') || (inputs.metric == 'user-productivity' && 'user-productivity')}}
-      - name: Import metrics
+      - name: Import Metrics
         uses: ./.github/actions/algolia-import-metric
         with:
           algolia-api-key: ${{ steps.algolia-keys.outputs.algolia-api-key }}

--- a/.github/workflows/reusable-gp2-algolia-sync.yml
+++ b/.github/workflows/reusable-gp2-algolia-sync.yml
@@ -100,7 +100,7 @@ jobs:
           ALGOLIA_API_KEY: ${{ steps.algolia-keys.outputs.algolia-api-key }}
           ALGOLIA_APP_ID: ${{ steps.algolia-keys.outputs.algolia-app-id }}
           ALGOLIA_INDEX_TEMP: '${{ steps.setup.outputs.gp2-algolia-index }}_${{github.run_id}}_temp'
-          ENTITY_TYPE: ${{ (inputs.entity == 'outputs' && 'output') || (inputs.entity == 'projects' && 'project') || (inputs.entity == 'events' && 'event') || (inputs.entity == 'users' && 'user') || (inputs.entity == 'news' && 'news') || (inputs.entity == 'external-users' && 'external-user') }}
+          ENTITY_TYPE: ${{ (inputs.entity == 'outputs' && 'output') || (inputs.entity == 'projects' && 'project') || (inputs.entity == 'events' && 'event') || (inputs.entity == 'users' && 'user') || (inputs.entity == 'news' && 'news') || (inputs.entity == 'external-users' && 'external-user') || (inputs.entity == 'working-groups' && 'working-group') }}
       - name: Import Entities
         uses: ./.github/actions/algolia-import-entity
         with:
@@ -108,7 +108,7 @@ jobs:
           algolia-app-id: ${{ steps.algolia-keys.outputs.algolia-app-id }}
           algolia-index: '${{ steps.setup.outputs.gp2-algolia-index }}_${{github.run_id}}_temp'
           app: 'gp2'
-          entity-type: ${{ inputs.entity }}
+          entity-type: ${{ (inputs.entity == 'all' && 'all') || (inputs.entity == 'outputs' && 'output') || (inputs.entity == 'projects' && 'project') || (inputs.entity == 'events' && 'event') || (inputs.entity == 'users' && 'user') || (inputs.entity == 'news' && 'news') || (inputs.entity == 'external-users' && 'external-user') || (inputs.entity == 'working-groups' && 'working-group') }}
           contentful-env: ${{ inputs.contentful-environment-id }}
           contentful-access-token: ${{ secrets.GP2_CONTENTFUL_ACCESS_TOKEN }}
           contentful-management-token: ${{ secrets.CONTENTFUL_MANAGEMENT_TOKEN }}

--- a/.github/workflows/reusable-gp2-algolia-sync.yml
+++ b/.github/workflows/reusable-gp2-algolia-sync.yml
@@ -101,99 +101,14 @@ jobs:
           ALGOLIA_APP_ID: ${{ steps.algolia-keys.outputs.algolia-app-id }}
           ALGOLIA_INDEX_TEMP: '${{ steps.setup.outputs.gp2-algolia-index }}_${{github.run_id}}_temp'
           ENTITY_TYPE: ${{ (inputs.entity == 'outputs' && 'output') || (inputs.entity == 'projects' && 'project') || (inputs.entity == 'events' && 'event') || (inputs.entity == 'users' && 'user') || (inputs.entity == 'news' && 'news') || (inputs.entity == 'external-users' && 'external-user') }}
-      - name: Import Outputs (OUTPUTS | ALL)
-        if: ${{ inputs.entity == 'outputs' || inputs.entity == 'all'}}
+      - name: Import Entities
         uses: ./.github/actions/algolia-import-entity
         with:
           algolia-api-key: ${{ steps.algolia-keys.outputs.algolia-api-key }}
           algolia-app-id: ${{ steps.algolia-keys.outputs.algolia-app-id }}
           algolia-index: '${{ steps.setup.outputs.gp2-algolia-index }}_${{github.run_id}}_temp'
           app: 'gp2'
-          entity-type: 'output'
-          contentful-env: ${{ inputs.contentful-environment-id }}
-          contentful-access-token: ${{ secrets.GP2_CONTENTFUL_ACCESS_TOKEN }}
-          contentful-management-token: ${{ secrets.CONTENTFUL_MANAGEMENT_TOKEN }}
-          contentful-space-id: ${{ steps.setup.outputs.gp2-contentful-space-id }}
-          data-store: 'contentful'
-      - name: Import Projects (PROJECTS | ALL)
-        if: ${{ inputs.entity == 'projects' || inputs.entity == 'all'}}
-        uses: ./.github/actions/algolia-import-entity
-        with:
-          algolia-api-key: ${{ steps.algolia-keys.outputs.algolia-api-key }}
-          algolia-app-id: ${{ steps.algolia-keys.outputs.algolia-app-id }}
-          algolia-index: '${{ steps.setup.outputs.gp2-algolia-index }}_${{github.run_id}}_temp'
-          app: 'gp2'
-          entity-type: 'project'
-          contentful-env: ${{ inputs.contentful-environment-id }}
-          contentful-access-token: ${{ secrets.GP2_CONTENTFUL_ACCESS_TOKEN }}
-          contentful-management-token: ${{ secrets.CONTENTFUL_MANAGEMENT_TOKEN }}
-          contentful-space-id: ${{ steps.setup.outputs.gp2-contentful-space-id }}
-          data-store: 'contentful'
-      - name: Import Events (EVENTS | ALL)
-        if: ${{ inputs.entity == 'events' || inputs.entity == 'all'}}
-        uses: ./.github/actions/algolia-import-entity
-        with:
-          algolia-api-key: ${{ steps.algolia-keys.outputs.algolia-api-key }}
-          algolia-app-id: ${{ steps.algolia-keys.outputs.algolia-app-id }}
-          algolia-index: '${{ steps.setup.outputs.gp2-algolia-index }}_${{github.run_id}}_temp'
-          app: 'gp2'
-          entity-type: 'event'
-          contentful-env: ${{ inputs.contentful-environment-id }}
-          contentful-access-token: ${{ secrets.GP2_CONTENTFUL_ACCESS_TOKEN }}
-          contentful-management-token: ${{ secrets.CONTENTFUL_MANAGEMENT_TOKEN }}
-          contentful-space-id: ${{ steps.setup.outputs.gp2-contentful-space-id }}
-          data-store: 'contentful'
-      - name: Import Users (USERS | ALL)
-        if: ${{ inputs.entity == 'users' || inputs.entity == 'all'}}
-        uses: ./.github/actions/algolia-import-entity
-        with:
-          algolia-api-key: ${{ steps.algolia-keys.outputs.algolia-api-key }}
-          algolia-app-id: ${{ steps.algolia-keys.outputs.algolia-app-id }}
-          algolia-index: '${{ steps.setup.outputs.gp2-algolia-index }}_${{github.run_id}}_temp'
-          app: 'gp2'
-          entity-type: 'user'
-          contentful-env: ${{ inputs.contentful-environment-id }}
-          contentful-access-token: ${{ secrets.GP2_CONTENTFUL_ACCESS_TOKEN }}
-          contentful-management-token: ${{ secrets.CONTENTFUL_MANAGEMENT_TOKEN }}
-          contentful-space-id: ${{ steps.setup.outputs.gp2-contentful-space-id }}
-          data-store: 'contentful'
-      - name: Import News (NEWS | ALL)
-        if: ${{ inputs.entity == 'news' || inputs.entity == 'all'}}
-        uses: ./.github/actions/algolia-import-entity
-        with:
-          algolia-api-key: ${{ steps.algolia-keys.outputs.algolia-api-key }}
-          algolia-app-id: ${{ steps.algolia-keys.outputs.algolia-app-id }}
-          algolia-index: '${{ steps.setup.outputs.gp2-algolia-index }}_${{github.run_id}}_temp'
-          app: 'gp2'
-          entity-type: 'news'
-          contentful-env: ${{ inputs.contentful-environment-id }}
-          contentful-access-token: ${{ secrets.GP2_CONTENTFUL_ACCESS_TOKEN }}
-          contentful-management-token: ${{ secrets.CONTENTFUL_MANAGEMENT_TOKEN }}
-          contentful-space-id: ${{ steps.setup.outputs.gp2-contentful-space-id }}
-          data-store: 'contentful'
-      - name: Import External Users (EXTERNAL-USERS | ALL)
-        if: ${{ inputs.entity == 'external-users' || inputs.entity == 'all'}}
-        uses: ./.github/actions/algolia-import-entity
-        with:
-          algolia-api-key: ${{ steps.algolia-keys.outputs.algolia-api-key }}
-          algolia-app-id: ${{ steps.algolia-keys.outputs.algolia-app-id }}
-          algolia-index: '${{ steps.setup.outputs.gp2-algolia-index }}_${{github.run_id}}_temp'
-          app: 'gp2'
-          entity-type: 'external-user'
-          contentful-env: ${{ inputs.contentful-environment-id }}
-          contentful-access-token: ${{ secrets.GP2_CONTENTFUL_ACCESS_TOKEN }}
-          contentful-management-token: ${{ secrets.CONTENTFUL_MANAGEMENT_TOKEN }}
-          contentful-space-id: ${{ steps.setup.outputs.gp2-contentful-space-id }}
-          data-store: 'contentful'
-      - name: Import Working Gropus (WORKING-GROUPS | ALL)
-        if: ${{ inputs.entity == 'working-groups' || inputs.entity == 'all'}}
-        uses: ./.github/actions/algolia-import-entity
-        with:
-          algolia-api-key: ${{ steps.algolia-keys.outputs.algolia-api-key }}
-          algolia-app-id: ${{ steps.algolia-keys.outputs.algolia-app-id }}
-          algolia-index: '${{ steps.setup.outputs.gp2-algolia-index }}_${{github.run_id}}_temp'
-          app: 'gp2'
-          entity-type: 'working-group'
+          entity-type: ${{ inputs.entity }}
           contentful-env: ${{ inputs.contentful-environment-id }}
           contentful-access-token: ${{ secrets.GP2_CONTENTFUL_ACCESS_TOKEN }}
           contentful-management-token: ${{ secrets.CONTENTFUL_MANAGEMENT_TOKEN }}

--- a/.github/workflows/reusable-gp2-algolia-sync.yml
+++ b/.github/workflows/reusable-gp2-algolia-sync.yml
@@ -113,7 +113,6 @@ jobs:
           contentful-access-token: ${{ secrets.GP2_CONTENTFUL_ACCESS_TOKEN }}
           contentful-management-token: ${{ secrets.CONTENTFUL_MANAGEMENT_TOKEN }}
           contentful-space-id: ${{ steps.setup.outputs.gp2-contentful-space-id }}
-          data-store: 'contentful'
       - name: Override index with the temp one
         run: yarn algolia:move-index -a $ALGOLIA_APP_ID -k $ALGOLIA_API_KEY -n $ALGOLIA_INDEX_TEMP -i $ALGOLIA_INDEX
         env:


### PR DESCRIPTION
The aim of this pr is to modify the `sync_index` jobs for analytics and entities so that we don't repeat code as the import steps are basically the same except the metric/entity-type inputs.

- modify `algolia-import-entity` and `algolia-import-metric` actions to import into algolia all metrics/entity-types when the input is 'all' otherwise import for the specific metric/entity-type provided
- update the corresponding reusable workflows

Tests
CRN Algolia Entity Sync  
For All entities
<img width="1213" alt="Screenshot 2024-05-09 at 17 06 25" src="https://github.com/yldio/asap-hub/assets/25244556/6e44a792-afe7-42fc-9e33-03ea49f058a8">

For Team Entity
<img width="1213" alt="Screenshot 2024-05-09 at 17 06 43" src="https://github.com/yldio/asap-hub/assets/25244556/8f54c4c6-019c-46b7-b642-3c25b5318ef8">


GP2 Algolia Entity Sync
For All Entities
<img width="1213" alt="Screenshot 2024-05-09 at 17 16 43" src="https://github.com/yldio/asap-hub/assets/25244556/c9b119a2-c08f-4bff-9562-7fcd1d843b7f">

For Project Entity
<img width="1213" alt="Screenshot 2024-05-09 at 17 17 17" src="https://github.com/yldio/asap-hub/assets/25244556/c612a9a3-5cb8-4a3d-b37c-cb496455bdd0">

We don't use the data-store input so I've taken that out as well
<img width="849" alt="Screenshot 2024-05-09 at 17 34 10" src="https://github.com/yldio/asap-hub/assets/25244556/a676fd6f-7742-4e0a-8a4f-98df3f12034f">

CRN Algolia Metrics Sync
For All Metrics
<img width="1213" alt="Screenshot 2024-05-09 at 17 32 57" src="https://github.com/yldio/asap-hub/assets/25244556/f4b1589d-00a3-4d1a-8bcd-4c2f5ee37375">


For Team Productivity Metric
<img width="1213" alt="Screenshot 2024-05-09 at 17 28 20" src="https://github.com/yldio/asap-hub/assets/25244556/035a8ff3-bdaa-44dd-8d13-264de126e8e6">


