### PR TITLE
feat: ASAP-416 Add throttling configuration to public API

### DIFF
--- a/apps/gp2-server/serverless.ts
+++ b/apps/gp2-server/serverless.ts
@@ -1014,6 +1014,18 @@ const serverlessConfig: AWS = {
           ],
         },
       },
+      HttpApiStage: {
+        Type: 'AWS::ApiGatewayV2::Stage',
+        DependsOn: ['HttpApiRouteGetPublicProxyVar'],
+        Properties: {
+          RouteSettings: {
+            'GET /public/{proxy+}': {
+              ThrottlingBurstLimit: 30,
+              ThrottlingRateLimit: 100,
+            },
+          },
+        },
+      },
       FrontendBucket: {
         Type: 'AWS::S3::Bucket',
         DeletionPolicy: 'Delete',


### PR DESCRIPTION
Adds CloudFormation throttling settings to Stage resource that affect the specific /public/ route of the API Gateway

