### PR TITLE
ASAP-376 Connecting Frontend with Algolia Data

### DIFF
--- a/apps/crn-frontend/src/analytics/productivity/Productivity.tsx
+++ b/apps/crn-frontend/src/analytics/productivity/Productivity.tsx
@@ -1,13 +1,15 @@
 import { AnalyticsProductivityPageBody } from '@asap-hub/react-components';
 import { analytics } from '@asap-hub/routing';
 import { useHistory, useParams } from 'react-router-dom';
-import { useAnalytics } from '../../hooks';
+import { useAnalytics, usePaginationParams } from '../../hooks';
 
 import TeamProductivity from './TeamProductivity';
 import UserProductivity from './UserProductivity';
 
 const Productivity = () => {
   const history = useHistory();
+  const { currentPage } = usePaginationParams();
+
   const { metric } = useParams<{ metric: 'user' | 'team' }>();
   const setMetric = (newMetric: 'user' | 'team') =>
     history.push(
@@ -21,6 +23,7 @@ const Productivity = () => {
       metric={metric}
       setMetric={setMetric}
       timeRange={timeRange}
+      currentPage={currentPage}
     >
       {metric === 'user' ? <UserProductivity /> : <TeamProductivity />}
     </AnalyticsProductivityPageBody>

--- a/apps/crn-frontend/src/analytics/productivity/TeamProductivity.tsx
+++ b/apps/crn-frontend/src/analytics/productivity/TeamProductivity.tsx
@@ -1,6 +1,9 @@
 import { TeamProductivityTable } from '@asap-hub/react-components';
 import { useAnalytics, usePagination, usePaginationParams } from '../../hooks';
-import { useAnalyticsTeamProductivity } from './state';
+import {
+  useAnalyticsTeamProductivity,
+  useTeamProductivityPerformance,
+} from './state';
 
 const TeamProductivity = () => {
   const { currentPage, pageSize } = usePaginationParams();
@@ -12,11 +15,14 @@ const TeamProductivity = () => {
     timeRange,
   });
 
+  const performance = useTeamProductivityPerformance(timeRange);
+
   const { numberOfPages, renderPageHref } = usePagination(total, pageSize);
 
   return (
     <TeamProductivityTable
       data={data}
+      performance={performance}
       currentPageIndex={currentPage}
       numberOfPages={numberOfPages}
       renderPageHref={renderPageHref}

--- a/apps/crn-frontend/src/analytics/productivity/UserProductivity.tsx
+++ b/apps/crn-frontend/src/analytics/productivity/UserProductivity.tsx
@@ -1,6 +1,9 @@
 import { UserProductivityTable } from '@asap-hub/react-components';
 import { useAnalytics, usePagination, usePaginationParams } from '../../hooks';
-import { useAnalyticsUserProductivity } from './state';
+import {
+  useAnalyticsUserProductivity,
+  useUserProductivityPerformance,
+} from './state';
 
 const UserProductivity = () => {
   const { currentPage, pageSize } = usePaginationParams();
@@ -12,11 +15,14 @@ const UserProductivity = () => {
     timeRange,
   });
 
+  const performance = useUserProductivityPerformance(timeRange);
+
   const { numberOfPages, renderPageHref } = usePagination(total, pageSize);
 
   return (
     <UserProductivityTable
       data={data}
+      performance={performance}
       currentPageIndex={currentPage}
       numberOfPages={numberOfPages}
       renderPageHref={renderPageHref}

--- a/apps/crn-frontend/src/analytics/productivity/__tests__/Productivity.test.tsx
+++ b/apps/crn-frontend/src/analytics/productivity/__tests__/Productivity.test.tsx
@@ -1,5 +1,9 @@
 import { mockConsoleError } from '@asap-hub/dom-test-utils';
 import {
+  teamProductivityPerformance,
+  userProductivityPerformance,
+} from '@asap-hub/fixtures';
+import {
   TeamProductivityAlgoliaResponse,
   UserProductivityAlgoliaResponse,
 } from '@asap-hub/model';
@@ -14,7 +18,9 @@ import { RecoilRoot } from 'recoil';
 import { Auth0Provider, WhenReady } from '../../../auth/test-utils';
 import {
   getTeamProductivity,
+  getTeamProductivityPerformance,
   getUserProductivity,
+  getUserProductivityPerformance,
   ProductivityListOptions,
 } from '../api';
 import Productivity from '../Productivity';
@@ -30,9 +36,26 @@ const mockGetTeamProductivity = getTeamProductivity as jest.MockedFunction<
   typeof getTeamProductivity
 >;
 
+const mockGetTeamProductivityPerformance =
+  getTeamProductivityPerformance as jest.MockedFunction<
+    typeof getTeamProductivityPerformance
+  >;
+
 const mockGetUserProductivity = getUserProductivity as jest.MockedFunction<
   typeof getUserProductivity
 >;
+
+const mockGetUserProductivityPerformance =
+  getUserProductivityPerformance as jest.MockedFunction<
+    typeof getUserProductivityPerformance
+  >;
+
+mockGetTeamProductivityPerformance.mockResolvedValue(
+  teamProductivityPerformance,
+);
+mockGetUserProductivityPerformance.mockResolvedValue(
+  userProductivityPerformance,
+);
 
 const defaultOptions: ProductivityListOptions = {
   pageSize: 10,

--- a/apps/crn-frontend/src/analytics/productivity/__tests__/TeamProductivity.test.tsx
+++ b/apps/crn-frontend/src/analytics/productivity/__tests__/TeamProductivity.test.tsx
@@ -2,13 +2,14 @@ import {
   Auth0Provider,
   WhenReady,
 } from '@asap-hub/crn-frontend/src/auth/test-utils';
+import { teamProductivityPerformance } from '@asap-hub/fixtures';
 import { ListTeamProductivityAlgoliaResponse } from '@asap-hub/model';
 import { render, waitFor } from '@testing-library/react';
 import { Suspense } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { RecoilRoot } from 'recoil';
 
-import { getTeamProductivity } from '../api';
+import { getTeamProductivity, getTeamProductivityPerformance } from '../api';
 import { analyticsTeamProductivityState } from '../state';
 import TeamProductivity from '../TeamProductivity';
 
@@ -21,6 +22,11 @@ afterEach(() => {
 const mockGetTeamProductivity = getTeamProductivity as jest.MockedFunction<
   typeof getTeamProductivity
 >;
+
+const mockGetTeamProductivityPerformance =
+  getTeamProductivityPerformance as jest.MockedFunction<
+    typeof getTeamProductivityPerformance
+  >;
 
 const data: ListTeamProductivityAlgoliaResponse = {
   total: 2,
@@ -84,8 +90,11 @@ const renderPage = async () => {
 
 it('renders the team productivity data', async () => {
   mockGetTeamProductivity.mockResolvedValueOnce(data);
+  mockGetTeamProductivityPerformance.mockResolvedValueOnce(
+    teamProductivityPerformance,
+  );
 
-  const { container, getAllByText } = await renderPage();
+  const { container, getAllByText, getAllByTitle } = await renderPage();
   expect(container).toHaveTextContent('Team Alessi');
   expect(container).toHaveTextContent('Team De Camilli');
   expect(getAllByText('0')).toHaveLength(3);
@@ -94,4 +103,7 @@ it('renders the team productivity data', async () => {
   expect(getAllByText('3')).toHaveLength(1);
   expect(getAllByText('4')).toHaveLength(1);
   expect(getAllByText('5')).toHaveLength(1);
+  expect(getAllByTitle('Below Average').length).toEqual(12);
+  expect(getAllByTitle('Average').length).toEqual(7);
+  expect(getAllByTitle('Above Average').length).toEqual(6);
 });

--- a/apps/crn-frontend/src/analytics/productivity/__tests__/UserProductivity.test.tsx
+++ b/apps/crn-frontend/src/analytics/productivity/__tests__/UserProductivity.test.tsx
@@ -2,6 +2,7 @@ import {
   Auth0Provider,
   WhenReady,
 } from '@asap-hub/crn-frontend/src/auth/test-utils';
+import { userProductivityPerformance } from '@asap-hub/fixtures';
 import {
   ListUserProductivityAlgoliaResponse,
   UserProductivityAlgoliaResponse,
@@ -11,7 +12,7 @@ import { Suspense } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { RecoilRoot } from 'recoil';
 
-import { getUserProductivity } from '../api';
+import { getUserProductivity, getUserProductivityPerformance } from '../api';
 import { analyticsUserProductivityState } from '../state';
 import UserProductivity from '../UserProductivity';
 
@@ -25,6 +26,11 @@ const mockGetUserProductivity = getUserProductivity as jest.MockedFunction<
   typeof getUserProductivity
 >;
 
+const mockGetUserProductivityPerformance =
+  getUserProductivityPerformance as jest.MockedFunction<
+    typeof getUserProductivityPerformance
+  >;
+
 const userTeam: UserProductivityAlgoliaResponse['teams'][number] = {
   team: 'Team A',
   isTeamInactive: false,
@@ -32,7 +38,7 @@ const userTeam: UserProductivityAlgoliaResponse['teams'][number] = {
   role: 'Collaborating PI',
 };
 
-const data: ListUserProductivityAlgoliaResponse = {
+const userProductivity: ListUserProductivityAlgoliaResponse = {
   total: 2,
   items: [
     {
@@ -91,9 +97,12 @@ const renderPage = async () => {
 };
 
 it('renders the user productivity data', async () => {
-  mockGetUserProductivity.mockResolvedValueOnce(data);
+  mockGetUserProductivity.mockResolvedValueOnce(userProductivity);
+  mockGetUserProductivityPerformance.mockResolvedValueOnce(
+    userProductivityPerformance,
+  );
 
-  const { container, getAllByText } = await renderPage();
+  const { container, getAllByText, getAllByTitle } = await renderPage();
   expect(container).toHaveTextContent('Ted Mosby');
   expect(container).toHaveTextContent('Collaborating PI');
   expect(container).toHaveTextContent('Robin Scherbatsky');
@@ -103,4 +112,7 @@ it('renders the user productivity data', async () => {
   expect(getAllByText('4')).toHaveLength(1);
   expect(getAllByText('0.33')).toHaveLength(1);
   expect(getAllByText('0.25')).toHaveLength(1);
+  expect(getAllByTitle('Below Average').length).toEqual(3);
+  expect(getAllByTitle('Average').length).toEqual(9);
+  expect(getAllByTitle('Above Average').length).toEqual(3);
 });

--- a/apps/crn-frontend/src/analytics/productivity/api.ts
+++ b/apps/crn-frontend/src/analytics/productivity/api.ts
@@ -3,7 +3,9 @@ import { GetListOptions } from '@asap-hub/frontend-utils';
 import {
   ListTeamProductivityAlgoliaResponse,
   ListUserProductivityAlgoliaResponse,
+  TeamProductivityPerformance,
   TimeRangeOption,
+  UserProductivityPerformance,
 } from '@asap-hub/model';
 
 export type ProductivityListOptions = Pick<
@@ -30,6 +32,36 @@ export const getUserProductivity = async (
     algoliaIndexName: result.index,
     algoliaQueryId: result.queryID,
   };
+};
+
+export const getUserProductivityPerformance = async (
+  algoliaClient: AlgoliaClient<'analytics'>,
+  timeRange: TimeRangeOption,
+): Promise<UserProductivityPerformance | undefined> => {
+  const rangeFilter = `__meta.range:"${timeRange || '30d'}"`;
+  const result = await algoliaClient.search(
+    ['user-productivity-performance'],
+    '',
+    {
+      filters: rangeFilter,
+    },
+  );
+  return result.hits[0];
+};
+
+export const getTeamProductivityPerformance = async (
+  algoliaClient: AlgoliaClient<'analytics'>,
+  timeRange: TimeRangeOption,
+): Promise<TeamProductivityPerformance | undefined> => {
+  const rangeFilter = `__meta.range:"${timeRange || '30d'}"`;
+  const result = await algoliaClient.search(
+    ['team-productivity-performance'],
+    '',
+    {
+      filters: rangeFilter,
+    },
+  );
+  return result.hits[0];
 };
 
 export const getTeamProductivity = async (

--- a/apps/crn-frontend/src/analytics/productivity/state.ts
+++ b/apps/crn-frontend/src/analytics/productivity/state.ts
@@ -2,7 +2,10 @@ import {
   ListTeamProductivityAlgoliaResponse,
   ListUserProductivityAlgoliaResponse,
   TeamProductivityAlgoliaResponse,
+  TeamProductivityPerformance,
+  TimeRangeOption,
   UserProductivityAlgoliaResponse,
+  UserProductivityPerformance,
 } from '@asap-hub/model';
 import {
   atomFamily,
@@ -14,7 +17,9 @@ import { ANALYTICS_ALGOLIA_INDEX } from '../../config';
 import { useAnalyticsAlgolia } from '../../hooks/algolia';
 import {
   getTeamProductivity,
+  getTeamProductivityPerformance,
   getUserProductivity,
+  getUserProductivityPerformance,
   ProductivityListOptions,
 } from './api';
 
@@ -95,6 +100,52 @@ export const useAnalyticsUserProductivity = (
     throw userProductivity;
   }
   return userProductivity;
+};
+
+export const userProductivityPerformanceState = atomFamily<
+  UserProductivityPerformance | undefined,
+  string
+>({
+  key: 'analyticsUserProductivityPerformance',
+  default: undefined,
+});
+
+export const useUserProductivityPerformance = (timeRange: TimeRangeOption) => {
+  const algoliaClient = useAnalyticsAlgolia(ANALYTICS_ALGOLIA_INDEX);
+  const [userProductivityPerformance, setUserProductivityPerformance] =
+    useRecoilState(userProductivityPerformanceState(timeRange));
+  if (userProductivityPerformance === undefined) {
+    throw getUserProductivityPerformance(algoliaClient.client, timeRange)
+      .then(setUserProductivityPerformance)
+      .catch(setUserProductivityPerformance);
+  }
+  if (userProductivityPerformance instanceof Error) {
+    throw userProductivityPerformance;
+  }
+  return userProductivityPerformance;
+};
+
+export const teamProductivityPerformanceState = atomFamily<
+  TeamProductivityPerformance | undefined,
+  string
+>({
+  key: 'analyticsTeamProductivityPerformance',
+  default: undefined,
+});
+
+export const useTeamProductivityPerformance = (timeRange: TimeRangeOption) => {
+  const algoliaClient = useAnalyticsAlgolia(ANALYTICS_ALGOLIA_INDEX);
+  const [teamProductivityPerformance, setTeamProductivityPerformance] =
+    useRecoilState(teamProductivityPerformanceState(timeRange));
+  if (teamProductivityPerformance === undefined) {
+    throw getTeamProductivityPerformance(algoliaClient.client, timeRange)
+      .then(setTeamProductivityPerformance)
+      .catch(setTeamProductivityPerformance);
+  }
+  if (teamProductivityPerformance instanceof Error) {
+    throw teamProductivityPerformance;
+  }
+  return teamProductivityPerformance;
 };
 
 const analyticsTeamProductivityIndexState = atomFamily<

--- a/packages/algolia/src/analytics/types.ts
+++ b/packages/algolia/src/analytics/types.ts
@@ -1,3 +1,5 @@
 export const TEAM_LEADERSHIP = 'team-leadership';
 export const TEAM_PRODUCTIVITY = 'team-productivity';
 export const USER_PRODUCTIVITY = 'user-productivity';
+export const USER_PRODUCTIVITY_PERFORMANCE = 'user-productivity-performance';
+export const TEAM_PRODUCTIVITY_PERFORMANCE = 'team-productivity-performance';

--- a/packages/algolia/src/client.ts
+++ b/packages/algolia/src/client.ts
@@ -4,6 +4,7 @@ import {
   SearchResponse,
 } from '@algolia/client-search';
 import {
+  AnalyticsTeamLeadershipResponse,
   EventResponse,
   ExternalAuthorResponse,
   gp2 as gp2Model,
@@ -11,21 +12,24 @@ import {
   NewsResponse,
   ResearchOutputResponse,
   TeamListItemResponse,
+  TeamProductivityPerformance,
+  TeamProductivityResponse,
+  TimeRangeOption,
   TutorialsResponse,
   UserListItemResponse,
+  UserProductivityPerformance,
+  UserProductivityResponse,
   UserResponse,
   WithMeta,
   WorkingGroupResponse,
-  AnalyticsTeamLeadershipResponse,
-  UserProductivityResponse,
-  TeamProductivityResponse,
-  TimeRangeOption,
 } from '@asap-hub/model';
 import { SearchIndex } from 'algoliasearch';
 import {
   TEAM_LEADERSHIP,
   TEAM_PRODUCTIVITY,
+  TEAM_PRODUCTIVITY_PERFORMANCE,
   USER_PRODUCTIVITY,
+  USER_PRODUCTIVITY_PERFORMANCE,
 } from './analytics';
 import {
   EVENT_ENTITY_TYPE,
@@ -108,6 +112,8 @@ export type EntityResponses = {
     [TEAM_LEADERSHIP]: AnalyticsTeamLeadershipResponse;
     [TEAM_PRODUCTIVITY]: TeamProductivityResponse;
     [USER_PRODUCTIVITY]: UserProductivityResponse;
+    [USER_PRODUCTIVITY_PERFORMANCE]: UserProductivityPerformance;
+    [TEAM_PRODUCTIVITY_PERFORMANCE]: TeamProductivityPerformance;
   };
 };
 export type SavePayload = Payload | GP2Payload;

--- a/packages/fixtures/src/analytics.ts
+++ b/packages/fixtures/src/analytics.ts
@@ -1,0 +1,74 @@
+import {
+  TeamProductivityPerformance,
+  UserProductivityPerformance,
+} from '@asap-hub/model';
+
+export const userProductivityPerformance: UserProductivityPerformance = {
+  asapOutput: {
+    belowAverageMin: 0,
+    belowAverageMax: 1,
+    averageMin: 2,
+    averageMax: 4,
+    aboveAverageMin: 5,
+    aboveAverageMax: 7,
+  },
+  asapPublicOutput: {
+    belowAverageMin: 0,
+    belowAverageMax: 0,
+    averageMin: 1,
+    averageMax: 2,
+    aboveAverageMin: 3,
+    aboveAverageMax: 4,
+  },
+  ratio: {
+    belowAverageMin: 0,
+    belowAverageMax: 0.14,
+    averageMin: 0.15,
+    averageMax: 0.8,
+    aboveAverageMin: 0.81,
+    aboveAverageMax: 1,
+  },
+};
+
+export const teamProductivityPerformance: TeamProductivityPerformance = {
+  article: {
+    belowAverageMin: 0,
+    belowAverageMax: 2,
+    averageMin: 3,
+    averageMax: 19,
+    aboveAverageMin: 20,
+    aboveAverageMax: 20,
+  },
+  bioinformatics: {
+    belowAverageMin: 0,
+    belowAverageMax: 4,
+    averageMin: 5,
+    averageMax: 9,
+    aboveAverageMin: 10,
+    aboveAverageMax: 13,
+  },
+  dataset: {
+    belowAverageMin: 0,
+    belowAverageMax: 3,
+    averageMin: 4,
+    averageMax: 9,
+    aboveAverageMin: 10,
+    aboveAverageMax: 12,
+  },
+  labResource: {
+    belowAverageMin: 0,
+    belowAverageMax: 2,
+    averageMin: 3,
+    averageMax: 5,
+    aboveAverageMin: 6,
+    aboveAverageMax: 8,
+  },
+  protocol: {
+    belowAverageMin: 0,
+    belowAverageMax: 0,
+    averageMin: 1,
+    averageMax: 2,
+    aboveAverageMin: 3,
+    aboveAverageMax: 3,
+  },
+};

--- a/packages/fixtures/src/index.ts
+++ b/packages/fixtures/src/index.ts
@@ -1,4 +1,5 @@
 export * from './auth';
+export * from './analytics';
 export * from './calendars';
 export * from './dashboard';
 export * from './discover';

--- a/packages/model/src/analytics.ts
+++ b/packages/model/src/analytics.ts
@@ -10,6 +10,20 @@ export type PerformanceMetrics = {
   aboveAverageMax: number;
 };
 
+export type UserProductivityPerformance = {
+  asapOutput: PerformanceMetrics;
+  asapPublicOutput: PerformanceMetrics;
+  ratio: PerformanceMetrics;
+};
+
+export type TeamProductivityPerformance = {
+  article: PerformanceMetrics;
+  bioinformatics: PerformanceMetrics;
+  dataset: PerformanceMetrics;
+  labResource: PerformanceMetrics;
+  protocol: PerformanceMetrics;
+};
+
 export type SortLeadershipAndMembership =
   | 'team_asc'
   | 'team_desc'

--- a/packages/react-components/src/molecules/AnalyticsControls.tsx
+++ b/packages/react-components/src/molecules/AnalyticsControls.tsx
@@ -36,9 +36,11 @@ const timeRangeOptions: Record<TimeRangeOption, string> = {
 interface AnalyticsControlsProps {
   readonly timeRange: TimeRangeOption;
   readonly href: string;
+  readonly currentPage: number;
 }
 const AnalyticsControls: React.FC<AnalyticsControlsProps> = ({
   timeRange,
+  currentPage,
   href,
 }) => (
   <span css={containerStyles}>
@@ -56,7 +58,7 @@ const AnalyticsControls: React.FC<AnalyticsControlsProps> = ({
     >
       {Object.keys(timeRangeOptions).map((key) => ({
         item: <>{timeRangeOptions[key as TimeRangeOption]}</>,
-        href: `${href}?range=${key}`,
+        href: `${href}?range=${key}&currentPage=${currentPage}`,
       }))}
     </DropdownButton>
   </span>

--- a/packages/react-components/src/molecules/CaptionItem.tsx
+++ b/packages/react-components/src/molecules/CaptionItem.tsx
@@ -47,6 +47,8 @@ const CaptionItem: React.FC<CaptionItemProps> = ({
   const belowAverageCaption =
     belowAverageMax < 0 ? `- - -` : `${belowAverageMin} - ${belowAverageMax}`;
 
+  const averageMinPositive = averageMin < 0 ? 0 : averageMin;
+
   return (
     <div css={containerStyles}>
       <Subtitle noMargin>{label}:</Subtitle>
@@ -55,7 +57,9 @@ const CaptionItem: React.FC<CaptionItemProps> = ({
         {belowAverageIcon}
       </div>
       <div css={dataContainerStyles}>
-        <span css={dataTextStyles}>{`${averageMin} - ${averageMax}`}</span>
+        <span
+          css={dataTextStyles}
+        >{`${averageMinPositive} - ${averageMax}`}</span>
         {averageIcon}
       </div>
       <div css={dataContainerStyles}>

--- a/packages/react-components/src/molecules/__tests__/CaptionItem.test.tsx
+++ b/packages/react-components/src/molecules/__tests__/CaptionItem.test.tsx
@@ -23,13 +23,34 @@ it('renders label, values and icons', () => {
   expect(screen.getByTitle('Above Average')).toBeInTheDocument();
 });
 
-it('render below average without numbers when belowAverageMax is negative', () => {
+it('renders below average without numbers when belowAverageMax is negative', () => {
   render(
     <CaptionItem
       label="ASAP Public Output"
       belowAverageMin={0}
       belowAverageMax={-1}
       averageMin={0}
+      averageMax={2}
+      aboveAverageMin={4}
+      aboveAverageMax={6}
+    />,
+  );
+  expect(screen.getByText('ASAP Public Output:')).toBeVisible();
+  expect(screen.getByText('- - -')).toBeVisible();
+  expect(screen.getByTitle('Below Average')).toBeInTheDocument();
+  expect(screen.getByText('0 - 2')).toBeVisible();
+  expect(screen.getByTitle('Average')).toBeInTheDocument();
+  expect(screen.getByText('4 - 6')).toBeVisible();
+  expect(screen.getByTitle('Above Average')).toBeInTheDocument();
+});
+
+it('renders average min as zero when it is negative', () => {
+  render(
+    <CaptionItem
+      label="ASAP Public Output"
+      belowAverageMin={-3}
+      belowAverageMax={-2}
+      averageMin={-1}
       averageMax={2}
       aboveAverageMin={4}
       aboveAverageMax={6}

--- a/packages/react-components/src/organisms/TeamProductivityTable.tsx
+++ b/packages/react-components/src/organisms/TeamProductivityTable.tsx
@@ -1,13 +1,17 @@
-import { TeamProductivityResponse } from '@asap-hub/model';
+import {
+  TeamProductivityPerformance,
+  TeamProductivityResponse,
+} from '@asap-hub/model';
 import { css } from '@emotion/react';
 import { ComponentProps } from 'react';
-import { PageControls } from '..';
+import { CaptionCard, CaptionItem, PageControls } from '..';
 
 import { Card } from '../atoms';
 import { borderRadius } from '../card';
 import { charcoal, neutral200, steel } from '../colors';
 import { InactiveBadgeIcon } from '../icons';
 import { rem, tabletScreen } from '../pixels';
+import { getPerformanceIcon } from '../utils';
 
 const container = css({
   display: 'grid',
@@ -56,6 +60,12 @@ const rowStyles = css({
 
 const titleStyles = css({ fontWeight: 'bold', color: charcoal.rgb });
 
+const rowValueStyles = css({
+  display: 'flex',
+  gap: rem(6),
+  fontWeight: 400,
+});
+
 const iconStyles = css({
   display: 'flex',
   gap: rem(3),
@@ -69,13 +79,24 @@ const pageControlsStyles = css({
 
 type TeamProductivityTableProps = ComponentProps<typeof PageControls> & {
   data: TeamProductivityResponse[];
+  performance: TeamProductivityPerformance;
 };
 
 const TeamProductivityTable: React.FC<TeamProductivityTableProps> = ({
   data,
+  performance,
   ...pageControlProps
 }) => (
   <>
+    <CaptionCard>
+      <>
+        <CaptionItem label="Article" {...performance.article} />
+        <CaptionItem label="Lab Resources" {...performance.labResource} />
+        <CaptionItem label="Bioinformatics" {...performance.bioinformatics} />
+        <CaptionItem label="Protocols" {...performance.protocol} />
+        <CaptionItem label="Datasets" {...performance.dataset} />
+      </>
+    </CaptionCard>
     <Card padding={false}>
       <div css={container}>
         <div css={[rowStyles, gridTitleStyles]}>
@@ -93,15 +114,33 @@ const TeamProductivityTable: React.FC<TeamProductivityTableProps> = ({
               {row.name} {row.isInactive && <InactiveBadgeIcon />}
             </p>
             <span css={[titleStyles, rowTitleStyles]}>Articles</span>
-            <p>{row.Article}</p>
+            <p css={rowValueStyles}>
+              {row.Article}{' '}
+              {getPerformanceIcon(row.Article, performance.article)}
+            </p>
             <span css={[titleStyles, rowTitleStyles]}>Bioinformatics</span>
-            <p>{row.Bioinformatics}</p>
+            <p css={rowValueStyles}>
+              {row.Bioinformatics}{' '}
+              {getPerformanceIcon(
+                row.Bioinformatics,
+                performance.bioinformatics,
+              )}
+            </p>
             <span css={[titleStyles, rowTitleStyles]}>Datasets</span>
-            <p>{row.Dataset}</p>
+            <p css={rowValueStyles}>
+              {row.Dataset}{' '}
+              {getPerformanceIcon(row.Dataset, performance.dataset)}
+            </p>
             <span css={[titleStyles, rowTitleStyles]}>Lab Resources</span>
-            <p>{row['Lab Resource']}</p>
+            <p css={rowValueStyles}>
+              {row['Lab Resource']}{' '}
+              {getPerformanceIcon(row['Lab Resource'], performance.labResource)}
+            </p>
             <span css={[titleStyles, rowTitleStyles]}>Protocols</span>
-            <p>{row.Protocol}</p>
+            <p css={rowValueStyles}>
+              {row.Protocol}{' '}
+              {getPerformanceIcon(row.Protocol, performance.protocol)}
+            </p>
           </div>
         ))}
       </div>

--- a/packages/react-components/src/organisms/UserProductivityTable.tsx
+++ b/packages/react-components/src/organisms/UserProductivityTable.tsx
@@ -1,13 +1,17 @@
-import { UserProductivityResponse } from '@asap-hub/model';
+import {
+  UserProductivityPerformance,
+  UserProductivityResponse,
+} from '@asap-hub/model';
 import { css } from '@emotion/react';
 import { ComponentProps } from 'react';
-import { PageControls } from '..';
+import { CaptionCard, CaptionItem, PageControls } from '..';
 
 import { Card } from '../atoms';
 import { borderRadius } from '../card';
 import { charcoal, lead, neutral200, steel } from '../colors';
 import { alumniBadgeIcon, InactiveBadgeIcon } from '../icons';
 import { rem, tabletScreen } from '../pixels';
+import { getPerformanceIcon } from '../utils';
 
 const container = css({
   display: 'grid',
@@ -55,6 +59,13 @@ const rowStyles = css({
 });
 
 const titleStyles = css({ fontWeight: 'bold', color: charcoal.rgb });
+
+const rowValueStyles = css({
+  display: 'flex',
+  gap: rem(6),
+  fontWeight: 400,
+});
+
 const counterStyle = css({
   display: 'inline-flex',
   color: lead.rgb,
@@ -119,13 +130,25 @@ const displayRoles = (items: UserProductivityResponse['teams']) => {
 
 type UserProductivityTableProps = ComponentProps<typeof PageControls> & {
   data: UserProductivityResponse[];
+  performance: UserProductivityPerformance;
 };
 
 const UserProductivityTable: React.FC<UserProductivityTableProps> = ({
   data,
+  performance,
   ...pageControlProps
 }) => (
   <>
+    <CaptionCard>
+      <>
+        <CaptionItem label="ASAP Output" {...performance.asapOutput} />
+        <CaptionItem
+          label="ASAP Public Output"
+          {...performance.asapPublicOutput}
+        />
+        <CaptionItem label="Ratio" {...performance.ratio} />
+      </>
+    </CaptionCard>
     <Card padding={false}>
       <div css={container}>
         <div css={[rowStyles, gridTitleStyles]}>
@@ -147,11 +170,23 @@ const UserProductivityTable: React.FC<UserProductivityTableProps> = ({
             <span css={[titleStyles, rowTitleStyles]}>Role</span>
             <p>{displayRoles(row.teams)}</p>
             <span css={[titleStyles, rowTitleStyles]}>ASAP Output</span>
-            <p>{row.asapOutput}</p>
+            <p css={rowValueStyles}>
+              {row.asapOutput}{' '}
+              {getPerformanceIcon(row.asapOutput, performance.asapOutput)}
+            </p>
             <span css={[titleStyles, rowTitleStyles]}>ASAP Public Output</span>
-            <p>{row.asapPublicOutput}</p>
+            <p css={rowValueStyles}>
+              {row.asapPublicOutput}{' '}
+              {getPerformanceIcon(
+                row.asapPublicOutput,
+                performance.asapPublicOutput,
+              )}
+            </p>
             <span css={[titleStyles, rowTitleStyles]}>Ratio</span>
-            <p>{row.ratio}</p>
+            <p css={rowValueStyles}>
+              {row.ratio}{' '}
+              {getPerformanceIcon(parseFloat(row.ratio), performance.ratio)}
+            </p>
           </div>
         ))}
       </div>

--- a/packages/react-components/src/organisms/__tests__/TeamProductivityTable.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/TeamProductivityTable.test.tsx
@@ -1,5 +1,7 @@
+import { teamProductivityPerformance } from '@asap-hub/fixtures';
 import { TeamProductivityResponse } from '@asap-hub/model';
 import { render } from '@testing-library/react';
+import { ComponentProps } from 'react';
 import TeamProductivityTable from '../TeamProductivityTable';
 
 describe('TeamProductivityTable', () => {
@@ -9,23 +11,44 @@ describe('TeamProductivityTable', () => {
     renderPageHref: () => '',
   };
 
+  const defaultProps: ComponentProps<typeof TeamProductivityTable> = {
+    ...pageControlsProps,
+    performance: teamProductivityPerformance,
+    data: [],
+  };
+
   const teamProductivity: TeamProductivityResponse = {
     id: '1',
     name: 'Test Team',
     isInactive: false,
-    Article: 1,
-    Bioinformatics: 2,
-    Dataset: 3,
-    'Lab Resource': 4,
-    Protocol: 5,
+    Article: 9,
+    Bioinformatics: 7,
+    Dataset: 5,
+    'Lab Resource': 1,
+    Protocol: 3,
   };
 
   it('renders data', () => {
     const data = [teamProductivity];
     const { getByText } = render(
-      <TeamProductivityTable data={data} {...pageControlsProps} />,
+      <TeamProductivityTable {...defaultProps} data={data} />,
     );
     expect(getByText('Test Team')).toBeInTheDocument();
+  });
+
+  it('displays the caption and icon in row values', () => {
+    const data = [teamProductivity];
+    const { getByText, getAllByTitle } = render(
+      <TeamProductivityTable {...defaultProps} data={data} />,
+    );
+    expect(getByText('Article:')).toBeVisible();
+    expect(getByText('Bioinformatics:')).toBeVisible();
+    expect(getByText('Datasets:')).toBeVisible();
+    expect(getByText('Lab Resources:')).toBeVisible();
+    expect(getByText('Protocols:')).toBeVisible();
+    expect(getAllByTitle('Below Average').length).toEqual(6);
+    expect(getAllByTitle('Average').length).toEqual(8);
+    expect(getAllByTitle('Above Average').length).toEqual(6);
   });
 
   it('renders inactive badge', () => {
@@ -36,7 +59,7 @@ describe('TeamProductivityTable', () => {
       },
     ];
     const { getByTitle } = render(
-      <TeamProductivityTable data={data} {...pageControlsProps} />,
+      <TeamProductivityTable {...defaultProps} data={data} />,
     );
     expect(getByTitle('Inactive Team')).toBeInTheDocument();
   });

--- a/packages/react-components/src/organisms/__tests__/UserProductivityTable.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/UserProductivityTable.test.tsx
@@ -1,5 +1,7 @@
+import { userProductivityPerformance } from '@asap-hub/fixtures';
 import { TeamRole, UserProductivityResponse } from '@asap-hub/model';
 import { render } from '@testing-library/react';
+import { ComponentProps } from 'react';
 import UserProductivityTable from '../UserProductivityTable';
 
 describe('UserProductivityTable', () => {
@@ -7,6 +9,12 @@ describe('UserProductivityTable', () => {
     numberOfPages: 1,
     currentPageIndex: 0,
     renderPageHref: () => '',
+  };
+
+  const defaultProps: ComponentProps<typeof UserProductivityTable> = {
+    ...pageControlsProps,
+    performance: userProductivityPerformance,
+    data: [],
   };
 
   const userTeam: UserProductivityResponse['teams'][number] = {
@@ -22,15 +30,28 @@ describe('UserProductivityTable', () => {
     teams: [userTeam],
     asapOutput: 1,
     asapPublicOutput: 2,
-    ratio: '0.50',
+    ratio: '0.10',
   };
 
   it('renders data', () => {
     const data = [user];
     const { getByText } = render(
-      <UserProductivityTable data={data} {...pageControlsProps} />,
+      <UserProductivityTable {...defaultProps} data={data} />,
     );
     expect(getByText('Test User')).toBeInTheDocument();
+  });
+
+  it('displays the caption and icon in row values', () => {
+    const data = [user];
+    const { getByText, getAllByTitle } = render(
+      <UserProductivityTable {...defaultProps} data={data} />,
+    );
+    expect(getByText('ASAP Output:')).toBeVisible();
+    expect(getByText('ASAP Public Output:')).toBeVisible();
+    expect(getByText('Ratio:')).toBeVisible();
+    expect(getAllByTitle('Below Average').length).toEqual(5);
+    expect(getAllByTitle('Average').length).toEqual(4);
+    expect(getAllByTitle('Above Average').length).toEqual(3);
   });
 
   it('displays alumni badge', () => {
@@ -41,7 +62,7 @@ describe('UserProductivityTable', () => {
       },
     ];
     const { getByTitle } = render(
-      <UserProductivityTable data={data} {...pageControlsProps} />,
+      <UserProductivityTable {...defaultProps} data={data} />,
     );
     expect(getByTitle('Alumni Member')).toBeInTheDocument();
   });
@@ -54,7 +75,7 @@ describe('UserProductivityTable', () => {
       },
     ];
     const { getByTitle } = render(
-      <UserProductivityTable data={data} {...pageControlsProps} />,
+      <UserProductivityTable {...defaultProps} data={data} />,
     );
     expect(getByTitle('Inactive Team')).toBeInTheDocument();
   });
@@ -70,7 +91,7 @@ describe('UserProductivityTable', () => {
       },
     ];
     const { getByText } = render(
-      <UserProductivityTable data={data} {...pageControlsProps} />,
+      <UserProductivityTable {...defaultProps} data={data} />,
     );
     expect(getByText('Multiple teams')).toBeInTheDocument();
   });
@@ -86,7 +107,7 @@ describe('UserProductivityTable', () => {
       },
     ];
     const { getByText } = render(
-      <UserProductivityTable data={data} {...pageControlsProps} />,
+      <UserProductivityTable {...defaultProps} data={data} />,
     );
     expect(getByText('Multiple roles')).toBeInTheDocument();
   });
@@ -99,7 +120,7 @@ describe('UserProductivityTable', () => {
       },
     ];
     const { getByText } = render(
-      <UserProductivityTable data={data} {...pageControlsProps} />,
+      <UserProductivityTable {...defaultProps} data={data} />,
     );
     expect(getByText('No team')).toBeInTheDocument();
   });
@@ -112,7 +133,7 @@ describe('UserProductivityTable', () => {
       },
     ];
     const { getByText } = render(
-      <UserProductivityTable data={data} {...pageControlsProps} />,
+      <UserProductivityTable {...defaultProps} data={data} />,
     );
     expect(getByText('No role')).toBeInTheDocument();
   });

--- a/packages/react-components/src/templates/AnalyticsProductivityPageBody.tsx
+++ b/packages/react-components/src/templates/AnalyticsProductivityPageBody.tsx
@@ -20,7 +20,7 @@ const metricOptionList = Object.keys(metricOptions).map((value) => ({
 
 type LeadershipAndMembershipAnalyticsProps = Pick<
   ComponentProps<typeof AnalyticsControls>,
-  'timeRange'
+  'timeRange' | 'currentPage'
 > & {
   metric: MetricOption;
   setMetric: (option: MetricOption) => void;
@@ -42,7 +42,7 @@ const controlsStyles = css({
 
 const AnalyticsProductivityPageBody: React.FC<
   LeadershipAndMembershipAnalyticsProps
-> = ({ metric, setMetric, timeRange, children }) => (
+> = ({ metric, setMetric, timeRange, currentPage, children }) => (
   <article>
     <div css={metricDropdownStyles}>
       <Subtitle>Metric</Subtitle>
@@ -55,6 +55,7 @@ const AnalyticsProductivityPageBody: React.FC<
     </div>
     <div css={controlsStyles}>
       <AnalyticsControls
+        currentPage={currentPage}
         timeRange={timeRange}
         href={analytics({}).productivity({}).metric({ metric }).$}
       />

--- a/packages/react-components/src/templates/__tests__/AnalyticsProductivityPageBody.test.tsx
+++ b/packages/react-components/src/templates/__tests__/AnalyticsProductivityPageBody.test.tsx
@@ -7,6 +7,7 @@ describe('AnalyticsProductivityPageBody', () => {
     setMetric: () => null,
     metric: 'user',
     timeRange: '30d',
+    currentPage: 5,
     children: <span>table</span>,
   };
   it('renders user tab', () => {

--- a/packages/react-components/src/utils/analytics.ts
+++ b/packages/react-components/src/utils/analytics.ts
@@ -1,0 +1,20 @@
+import { PerformanceMetrics } from '@asap-hub/model';
+import { aboveAverageIcon, averageIcon, belowAverageIcon } from '../icons';
+
+export const getPerformanceIcon = (
+  value: number,
+  performanceMetrics: PerformanceMetrics,
+) => {
+  if (value <= performanceMetrics.belowAverageMax) {
+    return belowAverageIcon;
+  }
+
+  if (
+    value >= performanceMetrics.averageMin &&
+    value <= performanceMetrics.averageMax
+  ) {
+    return averageIcon;
+  }
+
+  return aboveAverageIcon;
+};

--- a/packages/react-components/src/utils/index.ts
+++ b/packages/react-components/src/utils/index.ts
@@ -1,3 +1,4 @@
+export * from './analytics';
 export * from './common';
 export * from './text';
 export * from './events';


### PR DESCRIPTION
This PR connects the frontend with Algolia to display the performance in the User and Team Productivity pages.

---

JIRA ticket: https://asaphub.atlassian.net/browse/ASAP-376

For more context:

Front PR: [ASAP-376 Analytics Below/Average/Above icons and components](https://github.com/yldio/asap-hub/commit/935e42317ea9e0527dc302eca0ffcca1c9371fae)
Algolia PR: [ASAP-376 Process Productivity Metrics](https://github.com/yldio/asap-hub/commit/e4d5d2bbfc7025cccf155e0bbcaa23bc4db86a7d)

---

![Screenshot 2024-05-28 at 09 23 57](https://github.com/yldio/asap-hub/assets/16595804/59f9408d-6bc5-4d2e-9b65-00cc2c3614fe)
