### PR TITLE
[ASAP-373]- analytics productivity sort

### DIFF
--- a/apps/asap-cli/src/scripts/algolia/set-analytics-settings.ts
+++ b/apps/asap-cli/src/scripts/algolia/set-analytics-settings.ts
@@ -40,6 +40,29 @@ export const setAlgoliaAnalyticsSettings = async ({
     `${indexName}_ig_current_membership_desc`,
     `${indexName}_ig_previous_membership_asc`,
     `${indexName}_ig_previous_membership_desc`,
+
+    `${indexName}_user_desc`,
+    `${indexName}_user_asap_output_asc`,
+    `${indexName}_user_asap_output_desc`,
+    `${indexName}_user_asap_public_output_asc`,
+    `${indexName}_user_asap_public_output_desc`,
+    `${indexName}_user_ratio_asc`,
+    `${indexName}_user_ratio_desc`,
+    `${indexName}_user_role_asc`,
+    `${indexName}_user_role_desc`,
+    `${indexName}_user_team_asc`,
+    `${indexName}_user_team_desc`,
+
+    `${indexName}_team_article_asc`,
+    `${indexName}_team_article_desc`,
+    `${indexName}_team_bioinformatics_asc`,
+    `${indexName}_team_bioinformatics_desc`,
+    `${indexName}_team_dataset_asc`,
+    `${indexName}_team_dataset_desc`,
+    `${indexName}_team_lab_resource_asc`,
+    `${indexName}_team_lab_resource_desc`,
+    `${indexName}_team_protocol_asc`,
+    `${indexName}_team_protocol_desc`,
   ];
   await index.setSettings({ ...indexSchema, replicas }).wait();
 

--- a/apps/crn-frontend/src/analytics/productivity/TeamProductivity.tsx
+++ b/apps/crn-frontend/src/analytics/productivity/TeamProductivity.tsx
@@ -1,4 +1,10 @@
+import {
+  SortTeamProductivity,
+  teamProductivityInitialSortingDirection,
+  TeamProductivitySortingDirection,
+} from '@asap-hub/model';
 import { TeamProductivityTable } from '@asap-hub/react-components';
+import { useState } from 'react';
 import { useAnalytics, usePagination, usePaginationParams } from '../../hooks';
 import {
   useAnalyticsTeamProductivity,
@@ -8,11 +14,17 @@ import {
 const TeamProductivity = () => {
   const { currentPage, pageSize } = usePaginationParams();
   const { timeRange } = useAnalytics();
+  const [sort, setSort] = useState<SortTeamProductivity>('team_asc');
+  const [sortingDirection, setSortingDirection] =
+    useState<TeamProductivitySortingDirection>(
+      teamProductivityInitialSortingDirection,
+    );
 
   const { items: data, total } = useAnalyticsTeamProductivity({
     currentPage,
     pageSize,
     timeRange,
+    sort,
   });
 
   const performance = useTeamProductivityPerformance(timeRange);
@@ -23,6 +35,10 @@ const TeamProductivity = () => {
     <TeamProductivityTable
       data={data}
       performance={performance}
+      sort={sort}
+      setSort={setSort}
+      sortingDirection={sortingDirection}
+      setSortingDirection={setSortingDirection}
       currentPageIndex={currentPage}
       numberOfPages={numberOfPages}
       renderPageHref={renderPageHref}

--- a/apps/crn-frontend/src/analytics/productivity/UserProductivity.tsx
+++ b/apps/crn-frontend/src/analytics/productivity/UserProductivity.tsx
@@ -1,4 +1,10 @@
+import {
+  SortUserProductivity,
+  userProductivityInitialSortingDirection,
+  UserProductivitySortingDirection,
+} from '@asap-hub/model';
 import { UserProductivityTable } from '@asap-hub/react-components';
+import { useState } from 'react';
 import { useAnalytics, usePagination, usePaginationParams } from '../../hooks';
 import {
   useAnalyticsUserProductivity,
@@ -8,11 +14,17 @@ import {
 const UserProductivity = () => {
   const { currentPage, pageSize } = usePaginationParams();
   const { timeRange } = useAnalytics();
+  const [sort, setSort] = useState<SortUserProductivity>('user_asc');
+  const [sortingDirection, setSortingDirection] =
+    useState<UserProductivitySortingDirection>(
+      userProductivityInitialSortingDirection,
+    );
 
   const { items: data, total } = useAnalyticsUserProductivity({
     currentPage,
     pageSize,
     timeRange,
+    sort,
   });
 
   const performance = useUserProductivityPerformance(timeRange);
@@ -23,6 +35,10 @@ const UserProductivity = () => {
     <UserProductivityTable
       data={data}
       performance={performance}
+      sort={sort}
+      setSort={setSort}
+      sortingDirection={sortingDirection}
+      setSortingDirection={setSortingDirection}
       currentPageIndex={currentPage}
       numberOfPages={numberOfPages}
       renderPageHref={renderPageHref}

--- a/apps/crn-frontend/src/analytics/productivity/__tests__/Productivity.test.tsx
+++ b/apps/crn-frontend/src/analytics/productivity/__tests__/Productivity.test.tsx
@@ -4,6 +4,7 @@ import {
   userProductivityPerformance,
 } from '@asap-hub/fixtures';
 import {
+  SortUserProductivity,
   TeamProductivityAlgoliaResponse,
   UserProductivityAlgoliaResponse,
 } from '@asap-hub/model';
@@ -61,6 +62,7 @@ const defaultOptions: ProductivityListOptions = {
   pageSize: 10,
   currentPage: 0,
   timeRange: '30d',
+  sort: 'team_asc',
 };
 
 const userProductivityResponse: UserProductivityAlgoliaResponse = {
@@ -119,6 +121,10 @@ const renderPage = async (path: string) => {
 };
 
 describe('user productivity', () => {
+  const userOptions = {
+    ...defaultOptions,
+    sort: 'user_asc' as SortUserProductivity,
+  };
   it('renders with user data', async () => {
     mockGetUserProductivity.mockResolvedValue({ items: [], total: 0 });
     await renderPage(
@@ -129,10 +135,10 @@ describe('user productivity', () => {
 
   it('renders data for different time ranges', async () => {
     when(mockGetUserProductivity)
-      .calledWith(expect.anything(), defaultOptions)
+      .calledWith(expect.anything(), userOptions)
       .mockResolvedValue({ items: [userProductivityResponse], total: 1 });
     when(mockGetUserProductivity)
-      .calledWith(expect.anything(), { ...defaultOptions, timeRange: '90d' })
+      .calledWith(expect.anything(), { ...userOptions, timeRange: '90d' })
       .mockResolvedValue({
         items: [
           {

--- a/apps/crn-frontend/src/analytics/productivity/__tests__/TeamProductivity.test.tsx
+++ b/apps/crn-frontend/src/analytics/productivity/__tests__/TeamProductivity.test.tsx
@@ -65,6 +65,7 @@ const renderPage = async () => {
             currentPage: 0,
             pageSize: 10,
             timeRange: '30d',
+            sort: 'team_asc'
           }),
         );
       }}

--- a/apps/crn-frontend/src/analytics/productivity/__tests__/TeamProductivity.test.tsx
+++ b/apps/crn-frontend/src/analytics/productivity/__tests__/TeamProductivity.test.tsx
@@ -1,10 +1,15 @@
 import {
+  AlgoliaSearchClient,
+  algoliaSearchClientFactory,
+} from '@asap-hub/algolia';
+import {
   Auth0Provider,
   WhenReady,
 } from '@asap-hub/crn-frontend/src/auth/test-utils';
 import { teamProductivityPerformance } from '@asap-hub/fixtures';
 import { ListTeamProductivityAlgoliaResponse } from '@asap-hub/model';
 import { render, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { Suspense } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { RecoilRoot } from 'recoil';
@@ -12,6 +17,13 @@ import { RecoilRoot } from 'recoil';
 import { getTeamProductivity, getTeamProductivityPerformance } from '../api';
 import { analyticsTeamProductivityState } from '../state';
 import TeamProductivity from '../TeamProductivity';
+
+jest.mock('@asap-hub/algolia', () => ({
+  ...jest.requireActual('@asap-hub/algolia'),
+  algoliaSearchClientFactory: jest
+    .fn()
+    .mockReturnValue({} as AlgoliaSearchClient<'crn'>),
+}));
 
 jest.mock('../api');
 
@@ -26,6 +38,11 @@ const mockGetTeamProductivity = getTeamProductivity as jest.MockedFunction<
 const mockGetTeamProductivityPerformance =
   getTeamProductivityPerformance as jest.MockedFunction<
     typeof getTeamProductivityPerformance
+  >;
+
+const mockAlgoliaSearchClientFactory =
+  algoliaSearchClientFactory as jest.MockedFunction<
+    typeof algoliaSearchClientFactory
   >;
 
 const data: ListTeamProductivityAlgoliaResponse = {
@@ -107,4 +124,31 @@ it('renders the team productivity data', async () => {
   expect(getAllByTitle('Below Average').length).toEqual(12);
   expect(getAllByTitle('Average').length).toEqual(7);
   expect(getAllByTitle('Above Average').length).toEqual(6);
+});
+
+it('calls algolia client with the right index name', async () => {
+  mockGetTeamProductivity.mockResolvedValue(data);
+  mockGetTeamProductivityPerformance.mockResolvedValue(
+    teamProductivityPerformance,
+  );
+
+  const { getByTitle } = await renderPage();
+
+  await waitFor(() => {
+    expect(mockAlgoliaSearchClientFactory).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        algoliaIndex: expect.not.stringContaining('_team_desc'),
+      }),
+    );
+  });
+
+  userEvent.click(getByTitle('Active Alphabetical Ascending Sort Icon'));
+
+  await waitFor(() => {
+    expect(mockAlgoliaSearchClientFactory).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        algoliaIndex: expect.stringContaining('_team_desc'),
+      }),
+    );
+  });
 });

--- a/apps/crn-frontend/src/analytics/productivity/__tests__/TeamProductivity.test.tsx
+++ b/apps/crn-frontend/src/analytics/productivity/__tests__/TeamProductivity.test.tsx
@@ -65,7 +65,7 @@ const renderPage = async () => {
             currentPage: 0,
             pageSize: 10,
             timeRange: '30d',
-            sort: 'team_asc'
+            sort: 'team_asc',
           }),
         );
       }}

--- a/apps/crn-frontend/src/analytics/productivity/__tests__/UserProductivity.test.tsx
+++ b/apps/crn-frontend/src/analytics/productivity/__tests__/UserProductivity.test.tsx
@@ -74,6 +74,7 @@ const renderPage = async () => {
             currentPage: 0,
             pageSize: 10,
             timeRange: '30d',
+            sort: 'user_asc',
           }),
         );
       }}

--- a/apps/crn-frontend/src/analytics/productivity/__tests__/UserProductivity.test.tsx
+++ b/apps/crn-frontend/src/analytics/productivity/__tests__/UserProductivity.test.tsx
@@ -1,4 +1,8 @@
 import {
+  AlgoliaSearchClient,
+  algoliaSearchClientFactory,
+} from '@asap-hub/algolia';
+import {
   Auth0Provider,
   WhenReady,
 } from '@asap-hub/crn-frontend/src/auth/test-utils';
@@ -8,6 +12,7 @@ import {
   UserProductivityAlgoliaResponse,
 } from '@asap-hub/model';
 import { render, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { Suspense } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { RecoilRoot } from 'recoil';
@@ -15,6 +20,13 @@ import { RecoilRoot } from 'recoil';
 import { getUserProductivity, getUserProductivityPerformance } from '../api';
 import { analyticsUserProductivityState } from '../state';
 import UserProductivity from '../UserProductivity';
+
+jest.mock('@asap-hub/algolia', () => ({
+  ...jest.requireActual('@asap-hub/algolia'),
+  algoliaSearchClientFactory: jest
+    .fn()
+    .mockReturnValue({} as AlgoliaSearchClient<'crn'>),
+}));
 
 jest.mock('../api');
 
@@ -29,6 +41,11 @@ const mockGetUserProductivity = getUserProductivity as jest.MockedFunction<
 const mockGetUserProductivityPerformance =
   getUserProductivityPerformance as jest.MockedFunction<
     typeof getUserProductivityPerformance
+  >;
+
+const mockAlgoliaSearchClientFactory =
+  algoliaSearchClientFactory as jest.MockedFunction<
+    typeof algoliaSearchClientFactory
   >;
 
 const userTeam: UserProductivityAlgoliaResponse['teams'][number] = {
@@ -117,4 +134,31 @@ it('renders the user productivity data', async () => {
   expect(getAllByTitle('Below Average').length).toEqual(3);
   expect(getAllByTitle('Average').length).toEqual(9);
   expect(getAllByTitle('Above Average').length).toEqual(3);
+});
+
+it('calls algolia client with the right index name', async () => {
+  mockGetUserProductivity.mockResolvedValue(userProductivity);
+  mockGetUserProductivityPerformance.mockResolvedValue(
+    userProductivityPerformance,
+  );
+
+  const { getByTitle } = await renderPage();
+
+  await waitFor(() => {
+    expect(mockAlgoliaSearchClientFactory).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        algoliaIndex: expect.not.stringContaining('_user_desc'),
+      }),
+    );
+  });
+
+  userEvent.click(getByTitle('User Active Alphabetical Ascending Sort Icon'));
+
+  await waitFor(() => {
+    expect(mockAlgoliaSearchClientFactory).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        algoliaIndex: expect.stringContaining('_user_desc'),
+      }),
+    );
+  });
 });

--- a/apps/crn-frontend/src/analytics/productivity/__tests__/api.test.tsx
+++ b/apps/crn-frontend/src/analytics/productivity/__tests__/api.test.tsx
@@ -45,6 +45,7 @@ const defaultOptions: ProductivityListOptions = {
   pageSize: null,
   currentPage: null,
   timeRange: '30d',
+  sort: 'user_asc',
 };
 
 const userProductivityResponse: UserProductivityAlgoliaResponse = {
@@ -147,10 +148,10 @@ describe('getTeamProductivity', () => {
   });
 
   it('returns successfully fetched team productivity', async () => {
-    const teamProductivity = await getTeamProductivity(
-      algoliaSearchClient,
-      defaultOptions,
-    );
+    const teamProductivity = await getTeamProductivity(algoliaSearchClient, {
+      ...defaultOptions,
+      sort: 'team_asc',
+    });
     expect(teamProductivity).toEqual(
       expect.objectContaining({
         items: [
@@ -175,6 +176,7 @@ describe('getTeamProductivity', () => {
     await getTeamProductivity(algoliaSearchClient, {
       ...defaultOptions,
       timeRange,
+      sort: 'team_asc',
     });
 
     expect(search).toHaveBeenCalledWith(

--- a/apps/crn-frontend/src/analytics/productivity/api.ts
+++ b/apps/crn-frontend/src/analytics/productivity/api.ts
@@ -4,6 +4,8 @@ import {
   ListTeamProductivityAlgoliaResponse,
   ListUserProductivityAlgoliaResponse,
   TeamProductivityPerformance,
+  SortTeamProductivity,
+  SortUserProductivity,
   TimeRangeOption,
   UserProductivityPerformance,
 } from '@asap-hub/model';
@@ -13,6 +15,7 @@ export type ProductivityListOptions = Pick<
   'currentPage' | 'pageSize'
 > & {
   timeRange: TimeRangeOption;
+  sort: SortUserProductivity | SortTeamProductivity;
 };
 
 export const getUserProductivity = async (

--- a/apps/crn-frontend/src/analytics/productivity/state.ts
+++ b/apps/crn-frontend/src/analytics/productivity/state.ts
@@ -87,7 +87,13 @@ export const analyticsUserProductivityState = selectorFamily<
 export const useAnalyticsUserProductivity = (
   options: ProductivityListOptions,
 ) => {
-  const algoliaClient = useAnalyticsAlgolia(ANALYTICS_ALGOLIA_INDEX);
+  const indexName =
+    options.sort === 'user_asc'
+      ? ANALYTICS_ALGOLIA_INDEX
+      : `${ANALYTICS_ALGOLIA_INDEX}_user_${options.sort.replace('user_', '')}`;
+
+  const algoliaClient = useAnalyticsAlgolia(indexName);
+
   const [userProductivity, setUserProductivity] = useRecoilState(
     analyticsUserProductivityState(options),
   );
@@ -212,7 +218,12 @@ export const analyticsTeamProductivityState = selectorFamily<
 export const useAnalyticsTeamProductivity = (
   options: ProductivityListOptions,
 ) => {
-  const algoliaClient = useAnalyticsAlgolia(ANALYTICS_ALGOLIA_INDEX);
+  const indexName =
+    options.sort === 'team_asc'
+      ? ANALYTICS_ALGOLIA_INDEX
+      : `${ANALYTICS_ALGOLIA_INDEX}_team_${options.sort.replace('team_', '')}`;
+  const algoliaClient = useAnalyticsAlgolia(indexName);
+
   const [teamProductivity, setTeamProductivity] = useRecoilState(
     analyticsTeamProductivityState(options),
   );

--- a/packages/algolia/schema/crn-analytics/team_article_asc-schema.json
+++ b/packages/algolia/schema/crn-analytics/team_article_asc-schema.json
@@ -1,0 +1,13 @@
+{
+  "ranking": [
+    "asc(Article)",
+    "typo",
+    "geo",
+    "words",
+    "filters",
+    "proximity",
+    "attribute",
+    "exact",
+    "custom"
+  ]
+}

--- a/packages/algolia/schema/crn-analytics/team_article_desc-schema.json
+++ b/packages/algolia/schema/crn-analytics/team_article_desc-schema.json
@@ -1,0 +1,13 @@
+{
+  "ranking": [
+    "desc(Article)",
+    "typo",
+    "geo",
+    "words",
+    "filters",
+    "proximity",
+    "attribute",
+    "exact",
+    "custom"
+  ]
+}

--- a/packages/algolia/schema/crn-analytics/team_bioinformatics_asc-schema.json
+++ b/packages/algolia/schema/crn-analytics/team_bioinformatics_asc-schema.json
@@ -1,0 +1,13 @@
+{
+  "ranking": [
+    "asc(Bioinformatics)",
+    "typo",
+    "geo",
+    "words",
+    "filters",
+    "proximity",
+    "attribute",
+    "exact",
+    "custom"
+  ]
+}

--- a/packages/algolia/schema/crn-analytics/team_bioinformatics_desc-schema.json
+++ b/packages/algolia/schema/crn-analytics/team_bioinformatics_desc-schema.json
@@ -1,0 +1,13 @@
+{
+  "ranking": [
+    "desc(Bioinformatics)",
+    "typo",
+    "geo",
+    "words",
+    "filters",
+    "proximity",
+    "attribute",
+    "exact",
+    "custom"
+  ]
+}

--- a/packages/algolia/schema/crn-analytics/team_dataset_asc-schema.json
+++ b/packages/algolia/schema/crn-analytics/team_dataset_asc-schema.json
@@ -1,0 +1,13 @@
+{
+  "ranking": [
+    "asc(Dataset)",
+    "typo",
+    "geo",
+    "words",
+    "filters",
+    "proximity",
+    "attribute",
+    "exact",
+    "custom"
+  ]
+}

--- a/packages/algolia/schema/crn-analytics/team_dataset_desc-schema.json
+++ b/packages/algolia/schema/crn-analytics/team_dataset_desc-schema.json
@@ -1,0 +1,13 @@
+{
+  "ranking": [
+    "desc(Dataset)",
+    "typo",
+    "geo",
+    "words",
+    "filters",
+    "proximity",
+    "attribute",
+    "exact",
+    "custom"
+  ]
+}

--- a/packages/algolia/schema/crn-analytics/team_desc-schema.json
+++ b/packages/algolia/schema/crn-analytics/team_desc-schema.json
@@ -1,3 +1,3 @@
 {
-  "customRanking": ["desc(displayName)"]
+  "customRanking": ["desc(displayName)", "desc(name)"]
 }

--- a/packages/algolia/schema/crn-analytics/team_lab_resource_asc-schema.json
+++ b/packages/algolia/schema/crn-analytics/team_lab_resource_asc-schema.json
@@ -1,0 +1,13 @@
+{
+  "ranking": [
+    "asc(Lab Resource)",
+    "typo",
+    "geo",
+    "words",
+    "filters",
+    "proximity",
+    "attribute",
+    "exact",
+    "custom"
+  ]
+}

--- a/packages/algolia/schema/crn-analytics/team_lab_resource_desc-schema.json
+++ b/packages/algolia/schema/crn-analytics/team_lab_resource_desc-schema.json
@@ -1,0 +1,13 @@
+{
+  "ranking": [
+    "desc(Lab Resource)",
+    "typo",
+    "geo",
+    "words",
+    "filters",
+    "proximity",
+    "attribute",
+    "exact",
+    "custom"
+  ]
+}

--- a/packages/algolia/schema/crn-analytics/team_protocol_asc-schema.json
+++ b/packages/algolia/schema/crn-analytics/team_protocol_asc-schema.json
@@ -1,0 +1,13 @@
+{
+  "ranking": [
+    "asc(Protocol)",
+    "typo",
+    "geo",
+    "words",
+    "filters",
+    "proximity",
+    "attribute",
+    "exact",
+    "custom"
+  ]
+}

--- a/packages/algolia/schema/crn-analytics/team_protocol_desc-schema.json
+++ b/packages/algolia/schema/crn-analytics/team_protocol_desc-schema.json
@@ -1,0 +1,13 @@
+{
+  "ranking": [
+    "desc(Protocol)",
+    "typo",
+    "geo",
+    "words",
+    "filters",
+    "proximity",
+    "attribute",
+    "exact",
+    "custom"
+  ]
+}

--- a/packages/algolia/schema/crn-analytics/user_asap_output_asc-schema.json
+++ b/packages/algolia/schema/crn-analytics/user_asap_output_asc-schema.json
@@ -1,0 +1,13 @@
+{
+  "ranking": [
+    "asc(asapOutput)",
+    "typo",
+    "geo",
+    "words",
+    "filters",
+    "proximity",
+    "attribute",
+    "exact",
+    "custom"
+  ]
+}

--- a/packages/algolia/schema/crn-analytics/user_asap_output_desc-schema.json
+++ b/packages/algolia/schema/crn-analytics/user_asap_output_desc-schema.json
@@ -1,0 +1,13 @@
+{
+  "ranking": [
+    "desc(asapOutput)",
+    "typo",
+    "geo",
+    "words",
+    "filters",
+    "proximity",
+    "attribute",
+    "exact",
+    "custom"
+  ]
+}

--- a/packages/algolia/schema/crn-analytics/user_asap_public_output_asc-schema.json
+++ b/packages/algolia/schema/crn-analytics/user_asap_public_output_asc-schema.json
@@ -1,0 +1,13 @@
+{
+  "ranking": [
+    "asc(asapPublicOutput)",
+    "typo",
+    "geo",
+    "words",
+    "filters",
+    "proximity",
+    "attribute",
+    "exact",
+    "custom"
+  ]
+}

--- a/packages/algolia/schema/crn-analytics/user_asap_public_output_desc-schema.json
+++ b/packages/algolia/schema/crn-analytics/user_asap_public_output_desc-schema.json
@@ -1,0 +1,13 @@
+{
+  "ranking": [
+    "desc(asapPublicOutput)",
+    "typo",
+    "geo",
+    "words",
+    "filters",
+    "proximity",
+    "attribute",
+    "exact",
+    "custom"
+  ]
+}

--- a/packages/algolia/schema/crn-analytics/user_desc-schema.json
+++ b/packages/algolia/schema/crn-analytics/user_desc-schema.json
@@ -1,0 +1,3 @@
+{
+  "customRanking": ["desc(name)"]
+}

--- a/packages/algolia/schema/crn-analytics/user_ratio_asc-schema.json
+++ b/packages/algolia/schema/crn-analytics/user_ratio_asc-schema.json
@@ -1,0 +1,13 @@
+{
+  "ranking": [
+    "asc(ratio)",
+    "typo",
+    "geo",
+    "words",
+    "filters",
+    "proximity",
+    "attribute",
+    "exact",
+    "custom"
+  ]
+}

--- a/packages/algolia/schema/crn-analytics/user_ratio_desc-schema.json
+++ b/packages/algolia/schema/crn-analytics/user_ratio_desc-schema.json
@@ -1,0 +1,13 @@
+{
+  "ranking": [
+    "desc(ratio)",
+    "typo",
+    "geo",
+    "words",
+    "filters",
+    "proximity",
+    "attribute",
+    "exact",
+    "custom"
+  ]
+}

--- a/packages/algolia/schema/crn-analytics/user_role_asc-schema.json
+++ b/packages/algolia/schema/crn-analytics/user_role_asc-schema.json
@@ -1,0 +1,3 @@
+{
+  "customRanking": ["asc(teams.role)"]
+}

--- a/packages/algolia/schema/crn-analytics/user_role_asc-schema.json
+++ b/packages/algolia/schema/crn-analytics/user_role_asc-schema.json
@@ -1,3 +1,3 @@
 {
-  "customRanking": ["asc(teams.role)"]
+  "customRanking": ["asc(role)"]
 }

--- a/packages/algolia/schema/crn-analytics/user_role_desc-schema.json
+++ b/packages/algolia/schema/crn-analytics/user_role_desc-schema.json
@@ -1,0 +1,3 @@
+{
+  "customRanking": ["desc(teams.role)"]
+}

--- a/packages/algolia/schema/crn-analytics/user_role_desc-schema.json
+++ b/packages/algolia/schema/crn-analytics/user_role_desc-schema.json
@@ -1,3 +1,3 @@
 {
-  "customRanking": ["desc(teams.role)"]
+  "customRanking": ["desc(role)"]
 }

--- a/packages/algolia/schema/crn-analytics/user_team_asc-schema.json
+++ b/packages/algolia/schema/crn-analytics/user_team_asc-schema.json
@@ -1,3 +1,3 @@
 {
-  "customRanking": ["asc(teams.team)"]
+  "customRanking": ["asc(team)"]
 }

--- a/packages/algolia/schema/crn-analytics/user_team_asc-schema.json
+++ b/packages/algolia/schema/crn-analytics/user_team_asc-schema.json
@@ -1,0 +1,3 @@
+{
+  "customRanking": ["asc(teams.team)"]
+}

--- a/packages/algolia/schema/crn-analytics/user_team_desc-schema.json
+++ b/packages/algolia/schema/crn-analytics/user_team_desc-schema.json
@@ -1,0 +1,3 @@
+{
+  "customRanking": ["desc(teams.team)"]
+}

--- a/packages/algolia/schema/crn-analytics/user_team_desc-schema.json
+++ b/packages/algolia/schema/crn-analytics/user_team_desc-schema.json
@@ -1,3 +1,3 @@
 {
-  "customRanking": ["desc(teams.team)"]
+  "customRanking": ["desc(team)"]
 }

--- a/packages/model/src/analytics.ts
+++ b/packages/model/src/analytics.ts
@@ -105,6 +105,76 @@ export type AnalyticsTeamLeadershipResponse = AnalyticsTeamLeadershipDataObject;
 export type ListAnalyticsTeamLeadershipResponse =
   ListResponse<AnalyticsTeamLeadershipResponse>;
 
+export type SortUserProductivity =
+  | 'user_asc'
+  | 'user_desc'
+  | 'team_asc'
+  | 'team_desc'
+  | 'role_asc'
+  | 'role_desc'
+  | 'asap_output_asc'
+  | 'asap_output_desc'
+  | 'asap_public_output_asc'
+  | 'asap_public_output_desc'
+  | 'ratio_asc'
+  | 'ratio_desc';
+
+export type SortTeamProductivity =
+  | 'team_asc'
+  | 'team_desc'
+  | 'article_asc'
+  | 'article_desc'
+  | 'bioinformatics_asc'
+  | 'bioinformatics_desc'
+  | 'dataset_asc'
+  | 'dataset_desc'
+  | 'lab_resource_asc'
+  | 'lab_resource_desc'
+  | 'protocol_asc'
+  | 'protocol_desc';
+
+export type UserProductivityFields =
+  | 'user'
+  | 'team'
+  | 'role'
+  | 'asapOutput'
+  | 'asapPublicOutput'
+  | 'ratio';
+
+export type TeamProductivityFields =
+  | 'team'
+  | 'article'
+  | 'bioinformatics'
+  | 'dataset'
+  | 'labResource'
+  | 'protocol';
+
+export type TeamProductivitySortingDirection = {
+  [key in TeamProductivityFields]: SortingDirection;
+};
+
+export type UserProductivitySortingDirection = {
+  [key in UserProductivityFields]: SortingDirection;
+};
+
+export const userProductivityInitialSortingDirection = {
+  user: ascending,
+  team: ascending,
+  role: ascending,
+  asapOutput: descending,
+  asapPublicOutput: descending,
+  ratio: descending,
+};
+
+export const teamProductivityInitialSortingDirection = {
+  team: ascending,
+  article: descending,
+  bioinformatics: descending,
+  dataset: descending,
+  labResource: descending,
+  protocol: descending,
+};
+
 export type UserProductivityTeam = {
   team: string;
   id: string;

--- a/packages/react-components/src/icons/alphabetical-sorting.tsx
+++ b/packages/react-components/src/icons/alphabetical-sorting.tsx
@@ -3,19 +3,21 @@
 interface AlphabeticalSortingIconProps {
   readonly active?: boolean;
   readonly ascending?: boolean;
+  readonly description?: string;
 }
 
 const AlphabeticalSortingIcon: React.FC<AlphabeticalSortingIconProps> = ({
   active = false,
   ascending = false,
+  description = '',
 }) => {
   const title = active
     ? ascending
-      ? 'Active Alphabetical Ascending Sort Icon'
-      : 'Active Alphabetical Descending Sort Icon'
+      ? `${description} Active Alphabetical Ascending Sort Icon`
+      : `${description} Active Alphabetical Descending Sort Icon`
     : ascending
-      ? 'Inactive Alphabetical Ascending Sort Icon'
-      : 'Inactive Alphabetical Descending Sort Icon';
+      ? `${description} Inactive Alphabetical Ascending Sort Icon`
+      : `${description} Inactive Alphabetical Descending Sort Icon`;
   const fill = active ? '#00202C' : '#C2C9CE';
   const d = ascending
     ? 'M6.141 3.75L5.976 4.242L4.524 8.25H4.5V8.29725L3.7965 10.242L3.75 10.359V11.25H5.25V10.617L5.5545 9.75H7.9455L8.25 10.617V11.25H9.75V10.359L9.70275 10.242L9 8.2965V8.25H8.9775L7.5225 4.242L7.3605 3.75H6.13875H6.141ZM16.5 3.75V17.766L14.5545 15.8205L13.5 16.875L16.71 20.1097L17.25 20.625L17.79 20.109L21 16.875L19.9455 15.8205L18 17.7653V3.75H16.5ZM6.75 6.492L7.383 8.25H6.117L6.75 6.492ZM3.75 12.75V14.25H7.92225L3.96 18.21L3.75 18.4455V20.25H9.75V18.75H5.57775L9.53925 14.79L9.74925 14.5545V12.75H3.75Z'

--- a/packages/react-components/src/organisms/TeamProductivityTable.tsx
+++ b/packages/react-components/src/organisms/TeamProductivityTable.tsx
@@ -130,15 +130,15 @@ const TeamProductivityTable: React.FC<TeamProductivityTableProps> = ({
 
   return (
     <>
-    <CaptionCard>
-      <>
-        <CaptionItem label="Article" {...performance.article} />
-        <CaptionItem label="Lab Resources" {...performance.labResource} />
-        <CaptionItem label="Bioinformatics" {...performance.bioinformatics} />
-        <CaptionItem label="Protocols" {...performance.protocol} />
-        <CaptionItem label="Datasets" {...performance.dataset} />
-      </>
-    </CaptionCard>
+      <CaptionCard>
+        <>
+          <CaptionItem label="Article" {...performance.article} />
+          <CaptionItem label="Lab Resources" {...performance.labResource} />
+          <CaptionItem label="Bioinformatics" {...performance.bioinformatics} />
+          <CaptionItem label="Protocols" {...performance.protocol} />
+          <CaptionItem label="Datasets" {...performance.dataset} />
+        </>
+      </CaptionCard>
       <Card padding={false}>
         <div css={container}>
           <div css={[rowStyles, gridTitleStyles]}>
@@ -304,32 +304,35 @@ const TeamProductivityTable: React.FC<TeamProductivityTableProps> = ({
               </p>
               <span css={[titleStyles, rowTitleStyles]}>Articles</span>
               <p css={rowValueStyles}>
-              {row.Article}{' '}
-              {getPerformanceIcon(row.Article, performance.article)}
-            </p>
+                {row.Article}{' '}
+                {getPerformanceIcon(row.Article, performance.article)}
+              </p>
               <span css={[titleStyles, rowTitleStyles]}>Bioinformatics</span>
               <p css={rowValueStyles}>
-              {row.Bioinformatics}{' '}
-              {getPerformanceIcon(
-                row.Bioinformatics,
-                performance.bioinformatics,
-              )}
-            </p>
+                {row.Bioinformatics}{' '}
+                {getPerformanceIcon(
+                  row.Bioinformatics,
+                  performance.bioinformatics,
+                )}
+              </p>
               <span css={[titleStyles, rowTitleStyles]}>Datasets</span>
               <p css={rowValueStyles}>
-              {row.Dataset}{' '}
-              {getPerformanceIcon(row.Dataset, performance.dataset)}
-            </p>
+                {row.Dataset}{' '}
+                {getPerformanceIcon(row.Dataset, performance.dataset)}
+              </p>
               <span css={[titleStyles, rowTitleStyles]}>Lab Resources</span>
               <p css={rowValueStyles}>
-              {row['Lab Resource']}{' '}
-              {getPerformanceIcon(row['Lab Resource'], performance.labResource)}
-            </p>
+                {row['Lab Resource']}{' '}
+                {getPerformanceIcon(
+                  row['Lab Resource'],
+                  performance.labResource,
+                )}
+              </p>
               <span css={[titleStyles, rowTitleStyles]}>Protocols</span>
               <p css={rowValueStyles}>
-              {row.Protocol}{' '}
-              {getPerformanceIcon(row.Protocol, performance.protocol)}
-            </p>
+                {row.Protocol}{' '}
+                {getPerformanceIcon(row.Protocol, performance.protocol)}
+              </p>
             </div>
           ))}
         </div>

--- a/packages/react-components/src/organisms/TeamProductivityTable.tsx
+++ b/packages/react-components/src/organisms/TeamProductivityTable.tsx
@@ -297,10 +297,10 @@ const TeamProductivityTable: React.FC<TeamProductivityTableProps> = ({
               <span css={[titleStyles, rowTitleStyles]}>Team</span>
               <p css={iconStyles}>
                 <Link href={network({}).teams({}).team({ teamId: row.id }).$}>
-                {row.name}
-              </Link>
+                  {row.name}
+                </Link>
 
-              {row.isInactive && <InactiveBadgeIcon />}
+                {row.isInactive && <InactiveBadgeIcon />}
               </p>
               <span css={[titleStyles, rowTitleStyles]}>Articles</span>
               <p css={rowValueStyles}>

--- a/packages/react-components/src/organisms/TeamProductivityTable.tsx
+++ b/packages/react-components/src/organisms/TeamProductivityTable.tsx
@@ -1,6 +1,9 @@
 import {
+  SortTeamProductivity,
+  teamProductivityInitialSortingDirection,
   TeamProductivityPerformance,
   TeamProductivityResponse,
+  TeamProductivitySortingDirection,
 } from '@asap-hub/model';
 import { network } from '@asap-hub/routing';
 import { css } from '@emotion/react';
@@ -10,7 +13,11 @@ import { CaptionCard, CaptionItem, PageControls } from '..';
 import { Card, Link } from '../atoms';
 import { borderRadius } from '../card';
 import { charcoal, neutral200, steel } from '../colors';
-import { InactiveBadgeIcon } from '../icons';
+import {
+  AlphabeticalSortingIcon,
+  InactiveBadgeIcon,
+  NumericalSortingIcon,
+} from '../icons';
 import { rem, tabletScreen } from '../pixels';
 import { getPerformanceIcon } from '../utils';
 
@@ -59,7 +66,13 @@ const rowStyles = css({
   },
 });
 
-const titleStyles = css({ fontWeight: 'bold', color: charcoal.rgb });
+const titleStyles = css({
+  display: 'flex',
+  alignItems: 'center',
+  fontWeight: 'bold',
+  color: charcoal.rgb,
+  gap: rem(8),
+});
 
 const rowValueStyles = css({
   display: 'flex',
@@ -78,17 +91,45 @@ const pageControlsStyles = css({
   paddingBottom: rem(36),
 });
 
+const buttonStyles = css({
+  width: rem(24),
+  margin: 0,
+  padding: 0,
+  border: 'none',
+  backgroundColor: 'unset',
+  cursor: 'pointer',
+  alignSelf: 'center',
+});
+
 type TeamProductivityTableProps = ComponentProps<typeof PageControls> & {
   data: TeamProductivityResponse[];
   performance: TeamProductivityPerformance;
+  sort: SortTeamProductivity;
+  setSort: React.Dispatch<React.SetStateAction<SortTeamProductivity>>;
+  sortingDirection: TeamProductivitySortingDirection;
+  setSortingDirection: React.Dispatch<
+    React.SetStateAction<TeamProductivitySortingDirection>
+  >;
 };
 
 const TeamProductivityTable: React.FC<TeamProductivityTableProps> = ({
   data,
   performance,
+  sort,
+  setSort,
+  sortingDirection,
+  setSortingDirection,
   ...pageControlProps
-}) => (
-  <>
+}) => {
+  const isTeamSortActive = sort.includes('team');
+  const isArticleSortActive = sort.includes('article');
+  const isBioinformaticsSortActive = sort.includes('bioinformatics');
+  const isDatasetSortActive = sort.includes('dataset');
+  const isLabResourceSortActive = sort.includes('lab_resource');
+  const isProtocolSortActive = sort.includes('protocol');
+
+  return (
+    <>
     <CaptionCard>
       <>
         <CaptionItem label="Article" {...performance.article} />
@@ -98,62 +139,206 @@ const TeamProductivityTable: React.FC<TeamProductivityTableProps> = ({
         <CaptionItem label="Datasets" {...performance.dataset} />
       </>
     </CaptionCard>
-    <Card padding={false}>
-      <div css={container}>
-        <div css={[rowStyles, gridTitleStyles]}>
-          <span css={titleStyles}>Team</span>
-          <span css={titleStyles}>Articles</span>
-          <span css={titleStyles}>Bioinformatics</span>
-          <span css={titleStyles}>Datasets</span>
-          <span css={titleStyles}>Lab Resources</span>
-          <span css={titleStyles}>Protocols</span>
-        </div>
-        {data.map((row) => (
-          <div key={row.id} css={[rowStyles]}>
-            <span css={[titleStyles, rowTitleStyles]}>Team</span>
-            <p css={iconStyles}>
-              <Link href={network({}).teams({}).team({ teamId: row.id }).$}>
+      <Card padding={false}>
+        <div css={container}>
+          <div css={[rowStyles, gridTitleStyles]}>
+            <span css={titleStyles}>
+              Team
+              <button
+                css={buttonStyles}
+                onClick={() => {
+                  const newDirection = isTeamSortActive
+                    ? sortingDirection.team === 'asc'
+                      ? 'desc'
+                      : 'asc'
+                    : 'asc';
+
+                  setSort(`team_${newDirection}`);
+                  setSortingDirection({
+                    ...teamProductivityInitialSortingDirection,
+                    team: newDirection,
+                  });
+                }}
+              >
+                <AlphabeticalSortingIcon
+                  active={isTeamSortActive}
+                  ascending={sortingDirection.team === 'asc'}
+                />
+              </button>
+            </span>
+            <span css={titleStyles}>
+              Articles
+              <button
+                css={buttonStyles}
+                onClick={() => {
+                  const newDirection = isArticleSortActive
+                    ? sortingDirection.article === 'asc'
+                      ? 'desc'
+                      : 'asc'
+                    : 'desc';
+
+                  setSort(`article_${newDirection}`);
+                  setSortingDirection({
+                    ...teamProductivityInitialSortingDirection,
+                    article: newDirection,
+                  });
+                }}
+              >
+                <NumericalSortingIcon
+                  active={isArticleSortActive}
+                  ascending={sortingDirection.article === 'asc'}
+                  description={'Article'}
+                />
+              </button>
+            </span>
+            <span css={titleStyles}>
+              Bioinformatics
+              <button
+                css={buttonStyles}
+                onClick={() => {
+                  const newDirection = isBioinformaticsSortActive
+                    ? sortingDirection.bioinformatics === 'asc'
+                      ? 'desc'
+                      : 'asc'
+                    : 'desc';
+
+                  setSort(`bioinformatics_${newDirection}`);
+                  setSortingDirection({
+                    ...teamProductivityInitialSortingDirection,
+                    bioinformatics: newDirection,
+                  });
+                }}
+              >
+                <NumericalSortingIcon
+                  active={isBioinformaticsSortActive}
+                  ascending={sortingDirection.bioinformatics === 'asc'}
+                  description={'Bioinformatics'}
+                />
+              </button>
+            </span>
+            <span css={titleStyles}>
+              Datasets
+              <button
+                css={buttonStyles}
+                onClick={() => {
+                  const newDirection = isDatasetSortActive
+                    ? sortingDirection.dataset === 'asc'
+                      ? 'desc'
+                      : 'asc'
+                    : 'desc';
+
+                  setSort(`dataset_${newDirection}`);
+                  setSortingDirection({
+                    ...teamProductivityInitialSortingDirection,
+                    dataset: newDirection,
+                  });
+                }}
+              >
+                <NumericalSortingIcon
+                  active={isDatasetSortActive}
+                  ascending={sortingDirection.dataset === 'asc'}
+                  description={'Dataset'}
+                />
+              </button>
+            </span>
+            <span css={titleStyles}>
+              Lab Resources
+              <button
+                css={buttonStyles}
+                onClick={() => {
+                  const newDirection = isLabResourceSortActive
+                    ? sortingDirection.labResource === 'asc'
+                      ? 'desc'
+                      : 'asc'
+                    : 'desc';
+
+                  setSort(`lab_resource_${newDirection}`);
+                  setSortingDirection({
+                    ...teamProductivityInitialSortingDirection,
+                    labResource: newDirection,
+                  });
+                }}
+              >
+                <NumericalSortingIcon
+                  active={isLabResourceSortActive}
+                  ascending={sortingDirection.labResource === 'asc'}
+                  description={'Lab Resource'}
+                />
+              </button>
+            </span>
+            <span css={titleStyles}>
+              Protocols
+              <button
+                css={buttonStyles}
+                onClick={() => {
+                  const newDirection = isProtocolSortActive
+                    ? sortingDirection.protocol === 'asc'
+                      ? 'desc'
+                      : 'asc'
+                    : 'desc';
+
+                  setSort(`protocol_${newDirection}`);
+                  setSortingDirection({
+                    ...teamProductivityInitialSortingDirection,
+                    protocol: newDirection,
+                  });
+                }}
+              >
+                <NumericalSortingIcon
+                  active={isProtocolSortActive}
+                  ascending={sortingDirection.protocol === 'asc'}
+                  description={'Protocol'}
+                />
+              </button>
+            </span>
+          </div>
+          {data.map((row) => (
+            <div key={row.id} css={[rowStyles]}>
+              <span css={[titleStyles, rowTitleStyles]}>Team</span>
+              <p css={iconStyles}>
+                <Link href={network({}).teams({}).team({ teamId: row.id }).$}>
                 {row.name}
               </Link>
 
               {row.isInactive && <InactiveBadgeIcon />}
-            </p>
-            <span css={[titleStyles, rowTitleStyles]}>Articles</span>
-            <p css={rowValueStyles}>
+              </p>
+              <span css={[titleStyles, rowTitleStyles]}>Articles</span>
+              <p css={rowValueStyles}>
               {row.Article}{' '}
               {getPerformanceIcon(row.Article, performance.article)}
             </p>
-            <span css={[titleStyles, rowTitleStyles]}>Bioinformatics</span>
-            <p css={rowValueStyles}>
+              <span css={[titleStyles, rowTitleStyles]}>Bioinformatics</span>
+              <p css={rowValueStyles}>
               {row.Bioinformatics}{' '}
               {getPerformanceIcon(
                 row.Bioinformatics,
                 performance.bioinformatics,
               )}
             </p>
-            <span css={[titleStyles, rowTitleStyles]}>Datasets</span>
-            <p css={rowValueStyles}>
+              <span css={[titleStyles, rowTitleStyles]}>Datasets</span>
+              <p css={rowValueStyles}>
               {row.Dataset}{' '}
               {getPerformanceIcon(row.Dataset, performance.dataset)}
             </p>
-            <span css={[titleStyles, rowTitleStyles]}>Lab Resources</span>
-            <p css={rowValueStyles}>
+              <span css={[titleStyles, rowTitleStyles]}>Lab Resources</span>
+              <p css={rowValueStyles}>
               {row['Lab Resource']}{' '}
               {getPerformanceIcon(row['Lab Resource'], performance.labResource)}
             </p>
-            <span css={[titleStyles, rowTitleStyles]}>Protocols</span>
-            <p css={rowValueStyles}>
+              <span css={[titleStyles, rowTitleStyles]}>Protocols</span>
+              <p css={rowValueStyles}>
               {row.Protocol}{' '}
               {getPerformanceIcon(row.Protocol, performance.protocol)}
             </p>
-          </div>
-        ))}
-      </div>
-    </Card>
-    <section css={pageControlsStyles}>
-      <PageControls {...pageControlProps} />
-    </section>
-  </>
-);
+            </div>
+          ))}
+        </div>
+      </Card>
+      <section css={pageControlsStyles}>
+        <PageControls {...pageControlProps} />
+      </section>
+    </>
+  );
+};
 
 export default TeamProductivityTable;

--- a/packages/react-components/src/organisms/UserProductivityTable.tsx
+++ b/packages/react-components/src/organisms/UserProductivityTable.tsx
@@ -1,6 +1,9 @@
 import {
+  SortUserProductivity,
+  userProductivityInitialSortingDirection,
   UserProductivityPerformance,
   UserProductivityResponse,
+  UserProductivitySortingDirection,
 } from '@asap-hub/model';
 import { network } from '@asap-hub/routing';
 import { css } from '@emotion/react';
@@ -10,7 +13,12 @@ import { CaptionCard, CaptionItem, PageControls } from '..';
 import { Card, Link } from '../atoms';
 import { borderRadius } from '../card';
 import { charcoal, lead, neutral200, steel } from '../colors';
-import { alumniBadgeIcon, InactiveBadgeIcon } from '../icons';
+import {
+  AlphabeticalSortingIcon,
+  alumniBadgeIcon,
+  InactiveBadgeIcon,
+  NumericalSortingIcon,
+} from '../icons';
 import { rem, tabletScreen } from '../pixels';
 import { getPerformanceIcon } from '../utils';
 
@@ -59,7 +67,14 @@ const rowStyles = css({
   },
 });
 
-const titleStyles = css({ fontWeight: 'bold', color: charcoal.rgb });
+const titleStyles = css({
+  display: 'flex',
+  alignItems: 'center',
+  fontWeight: 'bold',
+  color: charcoal.rgb,
+  gap: rem(8),
+});
+
 
 const rowValueStyles = css({
   display: 'flex',
@@ -93,6 +108,16 @@ const pageControlsStyles = css({
   justifySelf: 'center',
   paddingTop: rem(36),
   paddingBottom: rem(36),
+});
+
+const buttonStyles = css({
+  width: rem(24),
+  margin: 0,
+  padding: 0,
+  border: 'none',
+  backgroundColor: 'unset',
+  cursor: 'pointer',
+  alignSelf: 'center',
 });
 
 const displayTeams = (items: UserProductivityResponse['teams']) => {
@@ -132,14 +157,32 @@ const displayRoles = (items: UserProductivityResponse['teams']) => {
 type UserProductivityTableProps = ComponentProps<typeof PageControls> & {
   data: UserProductivityResponse[];
   performance: UserProductivityPerformance;
+  sort: SortUserProductivity;
+  setSort: React.Dispatch<React.SetStateAction<SortUserProductivity>>;
+  sortingDirection: UserProductivitySortingDirection;
+  setSortingDirection: React.Dispatch<
+    React.SetStateAction<UserProductivitySortingDirection>
+  >;
 };
 
 const UserProductivityTable: React.FC<UserProductivityTableProps> = ({
   data,
   performance,
+  sort,
+  setSort,
+  sortingDirection,
+  setSortingDirection,
   ...pageControlProps
-}) => (
-  <>
+}) => {
+  const isUserSortActive = sort.includes('user');
+  const isTeamSortActive = sort.includes('team');
+  const isRoleSortActive = sort.includes('role');
+  const isAsapOutputSortActive = sort.includes('asap_output');
+  const isAsapPublicOutputSortActive = sort.includes('asap_public_output');
+  const isRatioSortActive = sort.includes('ratio');
+
+  return (
+    <>
     <CaptionCard>
       <>
         <CaptionItem label="ASAP Output" {...performance.asapOutput} />
@@ -150,55 +193,202 @@ const UserProductivityTable: React.FC<UserProductivityTableProps> = ({
         <CaptionItem label="Ratio" {...performance.ratio} />
       </>
     </CaptionCard>
-    <Card padding={false}>
-      <div css={container}>
-        <div css={[rowStyles, gridTitleStyles]}>
-          <span css={titleStyles}>User</span>
-          <span css={titleStyles}>Team</span>
-          <span css={titleStyles}>Role</span>
-          <span css={titleStyles}>ASAP Output</span>
-          <span css={titleStyles}>ASAP Public Output</span>
-          <span css={titleStyles}>Ratio</span>
-        </div>
-        {data.map((row) => (
-          <div key={row.id} css={[rowStyles]}>
-            <span css={[titleStyles, rowTitleStyles]}>User</span>
-            <p css={iconStyles}>
-              <Link href={network({}).users({}).user({ userId: row.id }).$}>
+      <Card padding={false}>
+        <div css={container}>
+          <div css={[rowStyles, gridTitleStyles]}>
+            <span css={titleStyles}>
+              User
+              <button
+                css={buttonStyles}
+                onClick={() => {
+                  const newDirection = isUserSortActive
+                    ? sortingDirection.user === 'asc'
+                      ? 'desc'
+                      : 'asc'
+                    : 'asc';
+
+                  setSort(`user_${newDirection}`);
+                  setSortingDirection({
+                    ...userProductivityInitialSortingDirection,
+                    user: newDirection,
+                  });
+                }}
+              >
+                <AlphabeticalSortingIcon
+                  active={isUserSortActive}
+                  ascending={sortingDirection.user === 'asc'}
+                  description={'User'}
+                />
+              </button>
+            </span>
+            <span css={titleStyles}>
+              Team
+              <button
+                css={buttonStyles}
+                onClick={() => {
+                  const newDirection = isTeamSortActive
+                    ? sortingDirection.team === 'asc'
+                      ? 'desc'
+                      : 'asc'
+                    : 'asc';
+
+                  setSort(`team_${newDirection}`);
+                  setSortingDirection({
+                    ...userProductivityInitialSortingDirection,
+                    team: newDirection,
+                  });
+                }}
+              >
+                <AlphabeticalSortingIcon
+                  active={isTeamSortActive}
+                  ascending={sortingDirection.team === 'asc'}
+                  description={'Team'}
+                />
+              </button>
+            </span>
+            <span css={titleStyles}>
+              Role
+              <button
+                css={buttonStyles}
+                onClick={() => {
+                  const newDirection = isRoleSortActive
+                    ? sortingDirection.role === 'asc'
+                      ? 'desc'
+                      : 'asc'
+                    : 'asc';
+
+                  setSort(`role_${newDirection}`);
+                  setSortingDirection({
+                    ...userProductivityInitialSortingDirection,
+                    role: newDirection,
+                  });
+                }}
+              >
+                <AlphabeticalSortingIcon
+                  active={isRoleSortActive}
+                  ascending={sortingDirection.role === 'asc'}
+                  description={'Role'}
+                />
+              </button>
+            </span>
+            <span css={titleStyles}>
+              ASAP Output
+              <button
+                css={buttonStyles}
+                onClick={() => {
+                  const newDirection = isAsapOutputSortActive
+                    ? sortingDirection.asapOutput === 'asc'
+                      ? 'desc'
+                      : 'asc'
+                    : 'desc';
+
+                  setSort(`asap_output_${newDirection}`);
+                  setSortingDirection({
+                    ...userProductivityInitialSortingDirection,
+                    asapOutput: newDirection,
+                  });
+                }}
+              >
+                <NumericalSortingIcon
+                  active={isAsapOutputSortActive}
+                  ascending={sortingDirection.asapOutput === 'asc'}
+                  description={'ASAP Output'}
+                />
+              </button>
+            </span>
+            <span css={titleStyles}>
+              ASAP Public Output
+              <button
+                css={buttonStyles}
+                onClick={() => {
+                  const newDirection = isAsapPublicOutputSortActive
+                    ? sortingDirection.asapPublicOutput === 'asc'
+                      ? 'desc'
+                      : 'asc'
+                    : 'desc';
+
+                  setSort(`asap_public_output_${newDirection}`);
+                  setSortingDirection({
+                    ...userProductivityInitialSortingDirection,
+                    asapPublicOutput: newDirection,
+                  });
+                }}
+              >
+                <NumericalSortingIcon
+                  active={isAsapPublicOutputSortActive}
+                  ascending={sortingDirection.asapPublicOutput === 'asc'}
+                  description={'ASAP Public Output'}
+                />
+              </button>
+            </span>
+            <span css={titleStyles}>
+              Ratio
+              <button
+                css={buttonStyles}
+                onClick={() => {
+                  const newDirection = isRatioSortActive
+                    ? sortingDirection.ratio === 'asc'
+                      ? 'desc'
+                      : 'asc'
+                    : 'desc';
+
+                  setSort(`ratio_${newDirection}`);
+                  setSortingDirection({
+                    ...userProductivityInitialSortingDirection,
+                    ratio: newDirection,
+                  });
+                }}
+              >
+                <NumericalSortingIcon
+                  active={isRatioSortActive}
+                  ascending={sortingDirection.ratio === 'asc'}
+                  description={'Ratio'}
+                />
+              </button>
+            </span>
+          </div>
+          {data.map((row) => (
+            <div key={row.id} css={[rowStyles]}>
+              <span css={[titleStyles, rowTitleStyles]}>User</span>
+              <p css={iconStyles}>
+                <Link href={network({}).users({}).user({ userId: row.id }).$}>
                 {row.name}
               </Link>
               {row.isAlumni && alumniBadgeIcon}
-            </p>
-            <span css={[titleStyles, rowTitleStyles]}>Team</span>
-            <p>{displayTeams(row.teams)}</p>
-            <span css={[titleStyles, rowTitleStyles]}>Role</span>
-            <p>{displayRoles(row.teams)}</p>
-            <span css={[titleStyles, rowTitleStyles]}>ASAP Output</span>
-            <p css={rowValueStyles}>
+              </p>
+              <span css={[titleStyles, rowTitleStyles]}>Team</span>
+              <p>{displayTeams(row.teams)}</p>
+              <span css={[titleStyles, rowTitleStyles]}>Role</span>
+              <p>{displayRoles(row.teams)}</p>
+              <span css={[titleStyles, rowTitleStyles]}>ASAP Output</span>
+              <p css={rowValueStyles}>
               {row.asapOutput}{' '}
               {getPerformanceIcon(row.asapOutput, performance.asapOutput)}
             </p>
-            <span css={[titleStyles, rowTitleStyles]}>ASAP Public Output</span>
-            <p css={rowValueStyles}>
+              <span css={[titleStyles, rowTitleStyles]}>
+                ASAP Public Output
+              </span>
+              <p css={rowValueStyles}>
               {row.asapPublicOutput}{' '}
               {getPerformanceIcon(
                 row.asapPublicOutput,
                 performance.asapPublicOutput,
               )}
             </p>
-            <span css={[titleStyles, rowTitleStyles]}>Ratio</span>
-            <p css={rowValueStyles}>
+              <span css={[titleStyles, rowTitleStyles]}>Ratio</span>
+              <p css={rowValueStyles}>
               {row.ratio}{' '}
               {getPerformanceIcon(parseFloat(row.ratio), performance.ratio)}
             </p>
-          </div>
-        ))}
-      </div>
-    </Card>
-    <section css={pageControlsStyles}>
-      <PageControls {...pageControlProps} />
-    </section>
-  </>
-);
+            </div>
+          ))}
+        </div>
+      </Card>
+      <section css={pageControlsStyles}>
+        <PageControls {...pageControlProps} />
+      </section>
+    </>
+  );
+};
 
 export default UserProductivityTable;

--- a/packages/react-components/src/organisms/UserProductivityTable.tsx
+++ b/packages/react-components/src/organisms/UserProductivityTable.tsx
@@ -75,7 +75,6 @@ const titleStyles = css({
   gap: rem(8),
 });
 
-
 const rowValueStyles = css({
   display: 'flex',
   gap: rem(6),
@@ -183,16 +182,16 @@ const UserProductivityTable: React.FC<UserProductivityTableProps> = ({
 
   return (
     <>
-    <CaptionCard>
-      <>
-        <CaptionItem label="ASAP Output" {...performance.asapOutput} />
-        <CaptionItem
-          label="ASAP Public Output"
-          {...performance.asapPublicOutput}
-        />
-        <CaptionItem label="Ratio" {...performance.ratio} />
-      </>
-    </CaptionCard>
+      <CaptionCard>
+        <>
+          <CaptionItem label="ASAP Output" {...performance.asapOutput} />
+          <CaptionItem
+            label="ASAP Public Output"
+            {...performance.asapPublicOutput}
+          />
+          <CaptionItem label="Ratio" {...performance.ratio} />
+        </>
+      </CaptionCard>
       <Card padding={false}>
         <div css={container}>
           <div css={[rowStyles, gridTitleStyles]}>
@@ -362,24 +361,24 @@ const UserProductivityTable: React.FC<UserProductivityTableProps> = ({
               <p>{displayRoles(row.teams)}</p>
               <span css={[titleStyles, rowTitleStyles]}>ASAP Output</span>
               <p css={rowValueStyles}>
-              {row.asapOutput}{' '}
-              {getPerformanceIcon(row.asapOutput, performance.asapOutput)}
-            </p>
+                {row.asapOutput}{' '}
+                {getPerformanceIcon(row.asapOutput, performance.asapOutput)}
+              </p>
               <span css={[titleStyles, rowTitleStyles]}>
                 ASAP Public Output
               </span>
               <p css={rowValueStyles}>
-              {row.asapPublicOutput}{' '}
-              {getPerformanceIcon(
-                row.asapPublicOutput,
-                performance.asapPublicOutput,
-              )}
-            </p>
+                {row.asapPublicOutput}{' '}
+                {getPerformanceIcon(
+                  row.asapPublicOutput,
+                  performance.asapPublicOutput,
+                )}
+              </p>
               <span css={[titleStyles, rowTitleStyles]}>Ratio</span>
               <p css={rowValueStyles}>
-              {row.ratio}{' '}
-              {getPerformanceIcon(parseFloat(row.ratio), performance.ratio)}
-            </p>
+                {row.ratio}{' '}
+                {getPerformanceIcon(parseFloat(row.ratio), performance.ratio)}
+              </p>
             </div>
           ))}
         </div>

--- a/packages/react-components/src/organisms/UserProductivityTable.tsx
+++ b/packages/react-components/src/organisms/UserProductivityTable.tsx
@@ -351,9 +351,9 @@ const UserProductivityTable: React.FC<UserProductivityTableProps> = ({
               <span css={[titleStyles, rowTitleStyles]}>User</span>
               <p css={iconStyles}>
                 <Link href={network({}).users({}).user({ userId: row.id }).$}>
-                {row.name}
-              </Link>
-              {row.isAlumni && alumniBadgeIcon}
+                  {row.name}
+                </Link>
+                {row.isAlumni && alumniBadgeIcon}
               </p>
               <span css={[titleStyles, rowTitleStyles]}>Team</span>
               <p>{displayTeams(row.teams)}</p>

--- a/packages/react-components/src/organisms/__tests__/TeamProductivityTable.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/TeamProductivityTable.test.tsx
@@ -1,6 +1,11 @@
 import { teamProductivityPerformance } from '@asap-hub/fixtures';
-import { TeamProductivityResponse } from '@asap-hub/model';
+import {
+  SortTeamProductivity,
+  teamProductivityInitialSortingDirection,
+  TeamProductivityResponse,
+} from '@asap-hub/model';
 import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { ComponentProps } from 'react';
 import TeamProductivityTable from '../TeamProductivityTable';
 
@@ -15,6 +20,10 @@ describe('TeamProductivityTable', () => {
     ...pageControlsProps,
     performance: teamProductivityPerformance,
     data: [],
+    sort: 'team_asc' as SortTeamProductivity,
+    setSort: jest.fn(),
+    sortingDirection: teamProductivityInitialSortingDirection,
+    setSortingDirection: jest.fn(),
   };
 
   const teamProductivity: TeamProductivityResponse = {
@@ -63,4 +72,50 @@ describe('TeamProductivityTable', () => {
     );
     expect(getByTitle('Inactive Team')).toBeInTheDocument();
   });
+
+  it.each`
+    sort                     | sortingDirection                                                          | iconTitle                                                   | newSort                  | newSortingDirection
+    ${'team_asc'}            | ${{ ...teamProductivityInitialSortingDirection, team: 'asc' }}            | ${'Active Alphabetical Ascending Sort Icon'}                | ${'team_desc'}           | ${{ ...teamProductivityInitialSortingDirection, team: 'desc' }}
+    ${'team_desc'}           | ${{ ...teamProductivityInitialSortingDirection, team: 'desc' }}           | ${'Active Alphabetical Descending Sort Icon'}               | ${'team_asc'}            | ${{ ...teamProductivityInitialSortingDirection, team: 'asc' }}
+    ${'article_asc'}         | ${{ ...teamProductivityInitialSortingDirection, article: 'asc' }}         | ${'Inactive Alphabetical Ascending Sort Icon'}              | ${'team_asc'}            | ${{ ...teamProductivityInitialSortingDirection, team: 'asc' }}
+    ${'team_desc'}           | ${{ ...teamProductivityInitialSortingDirection, article: 'desc' }}        | ${'Article Inactive Numerical Descending Sort Icon'}        | ${'article_desc'}        | ${{ ...teamProductivityInitialSortingDirection, article: 'desc' }}
+    ${'article_asc'}         | ${{ ...teamProductivityInitialSortingDirection, article: 'asc' }}         | ${'Article Active Numerical Ascending Sort Icon'}           | ${'article_desc'}        | ${{ ...teamProductivityInitialSortingDirection, article: 'desc' }}
+    ${'article_desc'}        | ${{ ...teamProductivityInitialSortingDirection, article: 'desc' }}        | ${'Article Active Numerical Descending Sort Icon'}          | ${'article_asc'}         | ${{ ...teamProductivityInitialSortingDirection, article: 'asc' }}
+    ${'team_desc'}           | ${{ ...teamProductivityInitialSortingDirection, bioinformatics: 'desc' }} | ${'Bioinformatics Inactive Numerical Descending Sort Icon'} | ${'bioinformatics_desc'} | ${{ ...teamProductivityInitialSortingDirection, bioinformatics: 'desc' }}
+    ${'bioinformatics_asc'}  | ${{ ...teamProductivityInitialSortingDirection, bioinformatics: 'asc' }}  | ${'Bioinformatics Active Numerical Ascending Sort Icon'}    | ${'bioinformatics_desc'} | ${{ ...teamProductivityInitialSortingDirection, bioinformatics: 'desc' }}
+    ${'bioinformatics_desc'} | ${{ ...teamProductivityInitialSortingDirection, bioinformatics: 'desc' }} | ${'Bioinformatics Active Numerical Descending Sort Icon'}   | ${'bioinformatics_asc'}  | ${{ ...teamProductivityInitialSortingDirection, bioinformatics: 'asc' }}
+    ${'team_desc'}           | ${{ ...teamProductivityInitialSortingDirection, dataset: 'desc' }}        | ${'Dataset Inactive Numerical Descending Sort Icon'}        | ${'dataset_desc'}        | ${{ ...teamProductivityInitialSortingDirection, dataset: 'desc' }}
+    ${'dataset_asc'}         | ${{ ...teamProductivityInitialSortingDirection, dataset: 'asc' }}         | ${'Dataset Active Numerical Ascending Sort Icon'}           | ${'dataset_desc'}        | ${{ ...teamProductivityInitialSortingDirection, dataset: 'desc' }}
+    ${'dataset_desc'}        | ${{ ...teamProductivityInitialSortingDirection, dataset: 'desc' }}        | ${'Dataset Active Numerical Descending Sort Icon'}          | ${'dataset_asc'}         | ${{ ...teamProductivityInitialSortingDirection, dataset: 'asc' }}
+    ${'team_desc'}           | ${{ ...teamProductivityInitialSortingDirection, labResource: 'desc' }}    | ${'Lab Resource Inactive Numerical Descending Sort Icon'}   | ${'lab_resource_desc'}   | ${{ ...teamProductivityInitialSortingDirection, labResource: 'desc' }}
+    ${'lab_resource_asc'}    | ${{ ...teamProductivityInitialSortingDirection, labResource: 'asc' }}     | ${'Lab Resource Active Numerical Ascending Sort Icon'}      | ${'lab_resource_desc'}   | ${{ ...teamProductivityInitialSortingDirection, labResource: 'desc' }}
+    ${'lab_resource_desc'}   | ${{ ...teamProductivityInitialSortingDirection, labResource: 'desc' }}    | ${'Lab Resource Active Numerical Descending Sort Icon'}     | ${'lab_resource_asc'}    | ${{ ...teamProductivityInitialSortingDirection, labResource: 'asc' }}
+    ${'team_desc'}           | ${{ ...teamProductivityInitialSortingDirection, protocol: 'desc' }}       | ${'Protocol Inactive Numerical Descending Sort Icon'}       | ${'protocol_desc'}       | ${{ ...teamProductivityInitialSortingDirection, protocol: 'desc' }}
+    ${'protocol_asc'}        | ${{ ...teamProductivityInitialSortingDirection, protocol: 'asc' }}        | ${'Protocol Active Numerical Ascending Sort Icon'}          | ${'protocol_desc'}       | ${{ ...teamProductivityInitialSortingDirection, protocol: 'desc' }}
+    ${'protocol_desc'}       | ${{ ...teamProductivityInitialSortingDirection, protocol: 'desc' }}       | ${'Protocol Active Numerical Descending Sort Icon'}         | ${'protocol_asc'}        | ${{ ...teamProductivityInitialSortingDirection, protocol: 'asc' }}
+  `(
+    'when sort is $sort and user clicks on $iconTitle, the new sort becomes $newSort and the sorting direction $newSortingDirection',
+    ({ sort, sortingDirection, iconTitle, newSort, newSortingDirection }) => {
+      const setSort = jest.fn();
+
+      const setSortingDirection = jest.fn();
+      const { getByTitle } = render(
+        <TeamProductivityTable
+          data={[teamProductivity]}
+          sort={sort}
+          setSort={setSort}
+          sortingDirection={sortingDirection}
+          setSortingDirection={setSortingDirection}
+          {...pageControlsProps}
+        />,
+      );
+
+      const sortIcon = getByTitle(iconTitle);
+      expect(sortIcon).toBeInTheDocument();
+
+      userEvent.click(sortIcon);
+      expect(setSort).toHaveBeenCalledWith(newSort);
+      expect(setSortingDirection).toHaveBeenCalledWith(newSortingDirection);
+    },
+  );
 });

--- a/packages/react-components/src/organisms/__tests__/TeamProductivityTable.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/TeamProductivityTable.test.tsx
@@ -102,6 +102,7 @@ describe('TeamProductivityTable', () => {
       const { getByTitle } = render(
         <TeamProductivityTable
           data={[teamProductivity]}
+          performance={teamProductivityPerformance}
           sort={sort}
           setSort={setSort}
           sortingDirection={sortingDirection}

--- a/packages/react-components/src/organisms/__tests__/UserProductivityTable.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/UserProductivityTable.test.tsx
@@ -1,6 +1,12 @@
 import { userProductivityPerformance } from '@asap-hub/fixtures';
-import { TeamRole, UserProductivityResponse } from '@asap-hub/model';
+import {
+  SortUserProductivity,
+  TeamRole,
+  userProductivityInitialSortingDirection,
+  UserProductivityResponse,
+} from '@asap-hub/model';
 import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { ComponentProps } from 'react';
 import UserProductivityTable from '../UserProductivityTable';
 
@@ -15,6 +21,10 @@ describe('UserProductivityTable', () => {
     ...pageControlsProps,
     performance: userProductivityPerformance,
     data: [],
+    sort: 'user_asc' as SortUserProductivity,
+    setSort: jest.fn(),
+    sortingDirection: userProductivityInitialSortingDirection,
+    setSortingDirection: jest.fn(),
   };
 
   const userTeam: UserProductivityResponse['teams'][number] = {
@@ -113,7 +123,7 @@ describe('UserProductivityTable', () => {
     expect(getByText('Multiple roles')).toBeInTheDocument();
   });
 
-  it('display no team', () => {
+  it('displays no team', () => {
     const data: UserProductivityResponse[] = [
       {
         ...user,
@@ -126,7 +136,7 @@ describe('UserProductivityTable', () => {
     expect(getByText('No team')).toBeInTheDocument();
   });
 
-  it('display no role', () => {
+  it('displays no role', () => {
     const data: UserProductivityResponse[] = [
       {
         ...user,
@@ -138,4 +148,49 @@ describe('UserProductivityTable', () => {
     );
     expect(getByText('No role')).toBeInTheDocument();
   });
+
+  it.each`
+    sort                         | sortingDirection                                                            | iconTitle                                                       | newSort                      | newSortingDirection
+    ${'user_asc'}                | ${{ ...userProductivityInitialSortingDirection, user: 'asc' }}              | ${'User Active Alphabetical Ascending Sort Icon'}               | ${'user_desc'}               | ${{ ...userProductivityInitialSortingDirection, user: 'desc' }}
+    ${'user_desc'}               | ${{ ...userProductivityInitialSortingDirection, user: 'desc' }}             | ${'User Active Alphabetical Descending Sort Icon'}              | ${'user_asc'}                | ${{ ...userProductivityInitialSortingDirection, user: 'asc' }}
+    ${'role_asc'}                | ${{ ...userProductivityInitialSortingDirection, role: 'asc' }}              | ${'User Inactive Alphabetical Ascending Sort Icon'}             | ${'user_asc'}                | ${{ ...userProductivityInitialSortingDirection, user: 'asc' }}
+    ${'user_desc'}               | ${{ ...userProductivityInitialSortingDirection, role: 'asc' }}              | ${'Role Inactive Alphabetical Ascending Sort Icon'}             | ${'role_asc'}                | ${{ ...userProductivityInitialSortingDirection, role: 'asc' }}
+    ${'role_asc'}                | ${{ ...userProductivityInitialSortingDirection, role: 'asc' }}              | ${'Role Active Alphabetical Ascending Sort Icon'}               | ${'role_desc'}               | ${{ ...userProductivityInitialSortingDirection, role: 'desc' }}
+    ${'role_desc'}               | ${{ ...userProductivityInitialSortingDirection, role: 'desc' }}             | ${'Role Active Alphabetical Descending Sort Icon'}              | ${'role_asc'}                | ${{ ...userProductivityInitialSortingDirection, role: 'asc' }}
+    ${'user_desc'}               | ${{ ...userProductivityInitialSortingDirection, team: 'asc' }}              | ${'Team Inactive Alphabetical Ascending Sort Icon'}             | ${'team_asc'}                | ${{ ...userProductivityInitialSortingDirection, team: 'asc' }}
+    ${'team_asc'}                | ${{ ...userProductivityInitialSortingDirection, team: 'asc' }}              | ${'Team Active Alphabetical Ascending Sort Icon'}               | ${'team_desc'}               | ${{ ...userProductivityInitialSortingDirection, team: 'desc' }}
+    ${'team_desc'}               | ${{ ...userProductivityInitialSortingDirection, team: 'desc' }}             | ${'Team Active Alphabetical Descending Sort Icon'}              | ${'team_asc'}                | ${{ ...userProductivityInitialSortingDirection, team: 'asc' }}
+    ${'user_desc'}               | ${{ ...userProductivityInitialSortingDirection, asapOutput: 'desc' }}       | ${'ASAP Output Inactive Numerical Descending Sort Icon'}        | ${'asap_output_desc'}        | ${{ ...userProductivityInitialSortingDirection, asapOutput: 'desc' }}
+    ${'asap_output_asc'}         | ${{ ...userProductivityInitialSortingDirection, asapOutput: 'asc' }}        | ${'ASAP Output Active Numerical Ascending Sort Icon'}           | ${'asap_output_desc'}        | ${{ ...userProductivityInitialSortingDirection, asapOutput: 'desc' }}
+    ${'asap_output_desc'}        | ${{ ...userProductivityInitialSortingDirection, asapOutput: 'desc' }}       | ${'ASAP Output Active Numerical Descending Sort Icon'}          | ${'asap_output_asc'}         | ${{ ...userProductivityInitialSortingDirection, asapOutput: 'asc' }}
+    ${'user_desc'}               | ${{ ...userProductivityInitialSortingDirection, asapPublicOutput: 'desc' }} | ${'ASAP Public Output Inactive Numerical Descending Sort Icon'} | ${'asap_public_output_desc'} | ${{ ...userProductivityInitialSortingDirection, asapPublicOutput: 'desc' }}
+    ${'asap_public_output_asc'}  | ${{ ...userProductivityInitialSortingDirection, asapPublicOutput: 'asc' }}  | ${'ASAP Public Output Active Numerical Ascending Sort Icon'}    | ${'asap_public_output_desc'} | ${{ ...userProductivityInitialSortingDirection, asapPublicOutput: 'desc' }}
+    ${'asap_public_output_desc'} | ${{ ...userProductivityInitialSortingDirection, asapPublicOutput: 'desc' }} | ${'ASAP Public Output Active Numerical Descending Sort Icon'}   | ${'asap_public_output_asc'}  | ${{ ...userProductivityInitialSortingDirection, asapPublicOutput: 'asc' }}
+    ${'user_desc'}               | ${{ ...userProductivityInitialSortingDirection, ratio: 'desc' }}            | ${'Ratio Inactive Numerical Descending Sort Icon'}              | ${'ratio_desc'}              | ${{ ...userProductivityInitialSortingDirection, ratio: 'desc' }}
+    ${'ratio_asc'}               | ${{ ...userProductivityInitialSortingDirection, ratio: 'asc' }}             | ${'Ratio Active Numerical Ascending Sort Icon'}                 | ${'ratio_desc'}              | ${{ ...userProductivityInitialSortingDirection, ratio: 'desc' }}
+    ${'ratio_desc'}              | ${{ ...userProductivityInitialSortingDirection, ratio: 'desc' }}            | ${'Ratio Active Numerical Descending Sort Icon'}                | ${'ratio_asc'}               | ${{ ...userProductivityInitialSortingDirection, ratio: 'asc' }}
+  `(
+    'when sort is $sort and user clicks on $iconTitle, the new sort becomes $newSort and the sorting direction $newSortingDirection',
+    ({ sort, sortingDirection, iconTitle, newSort, newSortingDirection }) => {
+      const setSort = jest.fn();
+      const setSortingDirection = jest.fn();
+      const { getByTitle } = render(
+        <UserProductivityTable
+          data={[user]}
+          sort={sort}
+          setSort={setSort}
+          sortingDirection={sortingDirection}
+          setSortingDirection={setSortingDirection}
+          {...pageControlsProps}
+        />,
+      );
+
+      const sortIcon = getByTitle(iconTitle);
+      expect(sortIcon).toBeInTheDocument();
+
+      userEvent.click(sortIcon);
+      expect(setSort).toHaveBeenCalledWith(newSort);
+      expect(setSortingDirection).toHaveBeenCalledWith(newSortingDirection);
+    },
+  );
 });

--- a/packages/react-components/src/organisms/__tests__/UserProductivityTable.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/UserProductivityTable.test.tsx
@@ -177,6 +177,7 @@ describe('UserProductivityTable', () => {
       const { getByTitle } = render(
         <UserProductivityTable
           data={[user]}
+          performance={userProductivityPerformance}
           sort={sort}
           setSort={setSort}
           sortingDirection={sortingDirection}

--- a/packages/react-components/src/templates/AnalyticsProductivityPageBody.tsx
+++ b/packages/react-components/src/templates/AnalyticsProductivityPageBody.tsx
@@ -18,7 +18,7 @@ const metricOptionList = Object.keys(metricOptions).map((value) => ({
   label: metricOptions[value as MetricOption],
 }));
 
-type LeadershipAndMembershipAnalyticsProps = Pick<
+type ProductivityAnalyticsProps = Pick<
   ComponentProps<typeof AnalyticsControls>,
   'timeRange' | 'currentPage'
 > & {
@@ -40,9 +40,12 @@ const controlsStyles = css({
   flexDirection: 'row-reverse',
 });
 
-const AnalyticsProductivityPageBody: React.FC<
-  LeadershipAndMembershipAnalyticsProps
-> = ({ metric, setMetric, timeRange, currentPage, children }) => (
+const AnalyticsProductivityPageBody: React.FC<ProductivityAnalyticsProps> = ({
+  metric,
+  setMetric,
+  timeRange, currentPage,
+  children,
+}) => (
   <article>
     <div css={metricDropdownStyles}>
       <Subtitle>Metric</Subtitle>

--- a/packages/react-components/src/templates/AnalyticsProductivityPageBody.tsx
+++ b/packages/react-components/src/templates/AnalyticsProductivityPageBody.tsx
@@ -43,7 +43,8 @@ const controlsStyles = css({
 const AnalyticsProductivityPageBody: React.FC<ProductivityAnalyticsProps> = ({
   metric,
   setMetric,
-  timeRange, currentPage,
+  timeRange,
+  currentPage,
   children,
 }) => (
   <article>


### PR DESCRIPTION
ref: https://asaphub.atlassian.net/browse/ASAP-373
This pr covers points 1 & 2 in the requirements (Display sort icons on both team and user productivity pages as per designs & Enable sort by the selected column)

Indices have been added for some of the user productivity & team productivity columns.

On the Team & Role columns (User Productivity table), we have the 'Multiple Teams'/'Multiple Roles'  & 'No team'/'No role' values which we don't store in Algolia. It makes the results a bit weird as the actual team name or lack of is used for sorting and not what is seen in the table (see images below). I've updated the export script to add team & role fields with similar data as what we display in the table and use them to sort those columns.
<img width="919" alt="Screenshot 2024-05-30 at 12 21 20" src="https://github.com/yldio/asap-hub/assets/25244556/a76aa42e-1872-46a5-80fa-d922a59417b9">

<img width="919" alt="Screenshot 2024-05-30 at 12 22 00" src="https://github.com/yldio/asap-hub/assets/25244556/eba55747-e9a3-46a5-8296-badf50fa4dff">



The ascending & descending icons for the numerical columns are different from the designs. I'll confirm with João when he's back but I assume the icons in the design are outdated.