### PR TITLE
[ASAP-373] - productivity search

### DIFF
--- a/apps/crn-frontend/src/analytics/leadership/Leadership.tsx
+++ b/apps/crn-frontend/src/analytics/leadership/Leadership.tsx
@@ -100,7 +100,11 @@ const Leadership: FC<Record<string, never>> = () => {
       tags={tags}
       setTags={setTags}
       loadTags={async (tagQuery) => {
-        const searchedTags = await client.searchForTagValues([], tagQuery, {});
+        const searchedTags = await client.searchForTagValues(
+          ['team-leadership'],
+          tagQuery,
+          {},
+        );
         return searchedTags.facetHits.map(({ value }) => ({
           label: value,
           value,

--- a/apps/crn-frontend/src/analytics/leadership/__tests__/Leadership.test.tsx
+++ b/apps/crn-frontend/src/analytics/leadership/__tests__/Leadership.test.tsx
@@ -147,7 +147,11 @@ describe('search', () => {
     userEvent.type(searchBox, 'test123');
     expect(searchBox.value).toEqual('test123');
     await waitFor(() =>
-      expect(mockSearchForTagValues).toHaveBeenCalledWith([], 'test123', {}),
+      expect(mockSearchForTagValues).toHaveBeenCalledWith(
+        ['team-leadership'],
+        'test123',
+        {},
+      ),
     );
   });
   it('Will search algolia using selected team', async () => {

--- a/apps/crn-frontend/src/analytics/productivity/Productivity.tsx
+++ b/apps/crn-frontend/src/analytics/productivity/Productivity.tsx
@@ -1,7 +1,8 @@
 import { AnalyticsProductivityPageBody } from '@asap-hub/react-components';
 import { analytics } from '@asap-hub/routing';
 import { useHistory, useParams } from 'react-router-dom';
-import { useAnalytics, usePaginationParams } from '../../hooks';
+import { useAnalytics, usePaginationParams, useSearch } from '../../hooks';
+import { useAnalyticsAlgolia } from '../../hooks/algolia';
 
 import TeamProductivity from './TeamProductivity';
 import UserProductivity from './UserProductivity';
@@ -17,6 +18,8 @@ const Productivity = () => {
     );
 
   const { timeRange } = useAnalytics();
+  const { tags, setTags } = useSearch();
+  const { client } = useAnalyticsAlgolia();
 
   return (
     <AnalyticsProductivityPageBody
@@ -24,8 +27,21 @@ const Productivity = () => {
       setMetric={setMetric}
       timeRange={timeRange}
       currentPage={currentPage}
+      tags={tags}
+      setTags={setTags}
+      loadTags={async (tagQuery) => {
+        const searchedTags = await client.searchForTagValues([], tagQuery, {});
+        return searchedTags.facetHits.map(({ value }) => ({
+          label: value,
+          value,
+        }));
+      }}
     >
-      {metric === 'user' ? <UserProductivity /> : <TeamProductivity />}
+      {metric === 'user' ? (
+        <UserProductivity tags={tags} />
+      ) : (
+        <TeamProductivity tags={tags} />
+      )}
     </AnalyticsProductivityPageBody>
   );
 };

--- a/apps/crn-frontend/src/analytics/productivity/Productivity.tsx
+++ b/apps/crn-frontend/src/analytics/productivity/Productivity.tsx
@@ -21,6 +21,9 @@ const Productivity = () => {
   const { tags, setTags } = useSearch();
   const { client } = useAnalyticsAlgolia();
 
+  const entityType =
+    metric === 'user' ? 'user-productivity' : 'team-productivity';
+
   return (
     <AnalyticsProductivityPageBody
       metric={metric}
@@ -30,7 +33,11 @@ const Productivity = () => {
       tags={tags}
       setTags={setTags}
       loadTags={async (tagQuery) => {
-        const searchedTags = await client.searchForTagValues([], tagQuery, {});
+        const searchedTags = await client.searchForTagValues(
+          [entityType],
+          tagQuery,
+          {},
+        );
         return searchedTags.facetHits.map(({ value }) => ({
           label: value,
           value,

--- a/apps/crn-frontend/src/analytics/productivity/TeamProductivity.tsx
+++ b/apps/crn-frontend/src/analytics/productivity/TeamProductivity.tsx
@@ -10,8 +10,9 @@ import {
   useAnalyticsTeamProductivity,
   useTeamProductivityPerformance,
 } from './state';
+import { ProductivityProps } from './UserProductivity';
 
-const TeamProductivity = () => {
+const TeamProductivity: React.FC<ProductivityProps> = ({ tags }) => {
   const { currentPage, pageSize } = usePaginationParams();
   const { timeRange } = useAnalytics();
   const [sort, setSort] = useState<SortTeamProductivity>('team_asc');
@@ -23,8 +24,9 @@ const TeamProductivity = () => {
   const { items: data, total } = useAnalyticsTeamProductivity({
     currentPage,
     pageSize,
-    timeRange,
     sort,
+    tags,
+    timeRange,
   });
 
   const performance = useTeamProductivityPerformance(timeRange);

--- a/apps/crn-frontend/src/analytics/productivity/UserProductivity.tsx
+++ b/apps/crn-frontend/src/analytics/productivity/UserProductivity.tsx
@@ -11,7 +11,11 @@ import {
   useUserProductivityPerformance,
 } from './state';
 
-const UserProductivity = () => {
+export type ProductivityProps = {
+  tags: string[];
+};
+
+const UserProductivity: React.FC<ProductivityProps> = ({ tags }) => {
   const { currentPage, pageSize } = usePaginationParams();
   const { timeRange } = useAnalytics();
   const [sort, setSort] = useState<SortUserProductivity>('user_asc');
@@ -23,8 +27,9 @@ const UserProductivity = () => {
   const { items: data, total } = useAnalyticsUserProductivity({
     currentPage,
     pageSize,
-    timeRange,
     sort,
+    tags,
+    timeRange,
   });
 
   const performance = useUserProductivityPerformance(timeRange);

--- a/apps/crn-frontend/src/analytics/productivity/__tests__/Productivity.test.tsx
+++ b/apps/crn-frontend/src/analytics/productivity/__tests__/Productivity.test.tsx
@@ -279,7 +279,11 @@ describe('search', () => {
     userEvent.type(searchBox, 'test123');
     expect(searchBox.value).toEqual('test123');
     await waitFor(() =>
-      expect(mockSearchForTagValues).toHaveBeenCalledWith([], 'test123', {}),
+      expect(mockSearchForTagValues).toHaveBeenCalledWith(
+        ['team-productivity'],
+        'test123',
+        {},
+      ),
     );
   });
 });

--- a/apps/crn-frontend/src/analytics/productivity/__tests__/Productivity.test.tsx
+++ b/apps/crn-frontend/src/analytics/productivity/__tests__/Productivity.test.tsx
@@ -63,6 +63,7 @@ const defaultOptions: ProductivityListOptions = {
   currentPage: 0,
   timeRange: '30d',
   sort: 'team_asc',
+  tags: [],
 };
 
 const userProductivityResponse: UserProductivityAlgoliaResponse = {
@@ -187,7 +188,7 @@ describe('team productivity', () => {
     await renderPage(
       analytics({}).productivity({}).metric({ metric: 'user' }).$,
     );
-    const input = screen.getByRole('textbox', { hidden: false });
+    const input = screen.getAllByRole('textbox', { hidden: false })[0]!;
     userEvent.click(input);
     userEvent.click(screen.getByText(label));
 

--- a/apps/crn-frontend/src/analytics/productivity/__tests__/Productivity.test.tsx
+++ b/apps/crn-frontend/src/analytics/productivity/__tests__/Productivity.test.tsx
@@ -1,3 +1,4 @@
+import { AlgoliaSearchClient } from '@asap-hub/algolia';
 import { mockConsoleError } from '@asap-hub/dom-test-utils';
 import {
   teamProductivityPerformance,
@@ -9,7 +10,7 @@ import {
   UserProductivityAlgoliaResponse,
 } from '@asap-hub/model';
 import { analytics } from '@asap-hub/routing';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { when } from 'jest-when';
 import { Suspense } from 'react';
@@ -17,6 +18,7 @@ import { MemoryRouter, Route } from 'react-router-dom';
 import { RecoilRoot } from 'recoil';
 
 import { Auth0Provider, WhenReady } from '../../../auth/test-utils';
+import { useAnalyticsAlgolia } from '../../../hooks/algolia';
 import {
   getTeamProductivity,
   getTeamProductivityPerformance,
@@ -27,6 +29,11 @@ import {
 import Productivity from '../Productivity';
 
 jest.mock('../api');
+
+jest.mock('../../../hooks/algolia', () => ({
+  useAnalyticsAlgolia: jest.fn(),
+}));
+
 mockConsoleError();
 
 afterEach(() => {
@@ -57,6 +64,24 @@ mockGetTeamProductivityPerformance.mockResolvedValue(
 mockGetUserProductivityPerformance.mockResolvedValue(
   userProductivityPerformance,
 );
+
+const mockSearchForTagValues = jest.fn() as jest.MockedFunction<
+  AlgoliaSearchClient<'analytics'>['searchForTagValues']
+>;
+
+const mockUseAnalyticsAlgolia = useAnalyticsAlgolia as jest.MockedFunction<
+  typeof useAnalyticsAlgolia
+>;
+
+beforeEach(() => {
+  const mockAlgoliaClient = {
+    searchForTagValues: mockSearchForTagValues,
+  };
+
+  mockUseAnalyticsAlgolia.mockReturnValue({
+    client: mockAlgoliaClient as unknown as AlgoliaSearchClient<'analytics'>,
+  });
+});
 
 const defaultOptions: ProductivityListOptions = {
   pageSize: 10,
@@ -236,5 +261,25 @@ describe('team productivity', () => {
 
     expect(screen.getByText('50')).toBeVisible();
     expect(screen.queryByText('60')).not.toBeInTheDocument();
+  });
+});
+
+describe('search', () => {
+  const getSearchBox = () => {
+    const searchContainer = screen.getByRole('search') as HTMLElement;
+    return within(searchContainer).getByRole('textbox') as HTMLInputElement;
+  };
+  it('allows typing in search queries', async () => {
+    mockGetTeamProductivity.mockResolvedValue({ items: [], total: 0 });
+    await renderPage(
+      analytics({}).productivity({}).metric({ metric: 'team' }).$,
+    );
+    const searchBox = getSearchBox();
+
+    userEvent.type(searchBox, 'test123');
+    expect(searchBox.value).toEqual('test123');
+    await waitFor(() =>
+      expect(mockSearchForTagValues).toHaveBeenCalledWith([], 'test123', {}),
+    );
   });
 });

--- a/apps/crn-frontend/src/analytics/productivity/__tests__/TeamProductivity.test.tsx
+++ b/apps/crn-frontend/src/analytics/productivity/__tests__/TeamProductivity.test.tsx
@@ -83,6 +83,7 @@ const renderPage = async () => {
             pageSize: 10,
             timeRange: '30d',
             sort: 'team_asc',
+            tags: [],
           }),
         );
       }}
@@ -91,7 +92,7 @@ const renderPage = async () => {
         <Auth0Provider user={{}}>
           <WhenReady>
             <MemoryRouter initialEntries={['/analytics']}>
-              <TeamProductivity />
+              <TeamProductivity tags={[]} />
             </MemoryRouter>
           </WhenReady>
         </Auth0Provider>

--- a/apps/crn-frontend/src/analytics/productivity/__tests__/UserProductivity.test.tsx
+++ b/apps/crn-frontend/src/analytics/productivity/__tests__/UserProductivity.test.tsx
@@ -92,6 +92,7 @@ const renderPage = async () => {
             pageSize: 10,
             timeRange: '30d',
             sort: 'user_asc',
+            tags: [],
           }),
         );
       }}
@@ -100,7 +101,7 @@ const renderPage = async () => {
         <Auth0Provider user={{}}>
           <WhenReady>
             <MemoryRouter initialEntries={['/analytics']}>
-              <UserProductivity />
+              <UserProductivity tags={[]} />
             </MemoryRouter>
           </WhenReady>
         </Auth0Provider>

--- a/apps/crn-frontend/src/analytics/productivity/__tests__/api.test.tsx
+++ b/apps/crn-frontend/src/analytics/productivity/__tests__/api.test.tsx
@@ -46,6 +46,7 @@ const defaultOptions: ProductivityListOptions = {
   currentPage: null,
   timeRange: '30d',
   sort: 'user_asc',
+  tags: [],
 };
 
 const userProductivityResponse: UserProductivityAlgoliaResponse = {
@@ -131,6 +132,20 @@ describe('getUserProductivity', () => {
       }),
     );
   });
+
+  it('should pass the search query to Algolia', async () => {
+    await getUserProductivity(algoliaSearchClient, {
+      ...defaultOptions,
+      tags: ['Alessi'],
+    });
+    expect(search).toHaveBeenCalledWith(
+      ['user-productivity'],
+      '',
+      expect.objectContaining({
+        tagFilters: [['Alessi']],
+      }),
+    );
+  });
 });
 
 describe('getTeamProductivity', () => {
@@ -184,6 +199,20 @@ describe('getTeamProductivity', () => {
       '',
       expect.objectContaining({
         filters: `__meta.range:"${timeRange}"`,
+      }),
+    );
+  });
+
+  it('should pass the search query to Algolia', async () => {
+    await getTeamProductivity(algoliaSearchClient, {
+      ...defaultOptions,
+      tags: ['Alessi'],
+    });
+    expect(search).toHaveBeenCalledWith(
+      ['team-productivity'],
+      '',
+      expect.objectContaining({
+        tagFilters: [['Alessi']],
       }),
     );
   });

--- a/apps/crn-frontend/src/analytics/productivity/api.ts
+++ b/apps/crn-frontend/src/analytics/productivity/api.ts
@@ -1,5 +1,4 @@
 import { AlgoliaClient } from '@asap-hub/algolia';
-import { GetListOptions } from '@asap-hub/frontend-utils';
 import {
   ListTeamProductivityAlgoliaResponse,
   ListUserProductivityAlgoliaResponse,
@@ -9,10 +8,11 @@ import {
   TimeRangeOption,
   UserProductivityPerformance,
 } from '@asap-hub/model';
+import { AnalyticsSearchOptions } from '../leadership/api';
 
 export type ProductivityListOptions = Pick<
-  GetListOptions,
-  'currentPage' | 'pageSize'
+  AnalyticsSearchOptions,
+  'currentPage' | 'pageSize' | 'tags'
 > & {
   timeRange: TimeRangeOption;
   sort: SortUserProductivity | SortTeamProductivity;
@@ -22,9 +22,10 @@ export const getUserProductivity = async (
   algoliaClient: AlgoliaClient<'analytics'>,
   options: ProductivityListOptions,
 ): Promise<ListUserProductivityAlgoliaResponse | undefined> => {
-  const { currentPage, pageSize, timeRange } = options;
+  const { currentPage, pageSize, timeRange, tags } = options;
   const rangeFilter = `__meta.range:"${timeRange || '30d'}"`;
   const result = await algoliaClient.search(['user-productivity'], '', {
+    tagFilters: [tags],
     filters: rangeFilter,
     page: currentPage ?? undefined,
     hitsPerPage: pageSize ?? undefined,
@@ -71,9 +72,10 @@ export const getTeamProductivity = async (
   algoliaClient: AlgoliaClient<'analytics'>,
   options: ProductivityListOptions,
 ): Promise<ListTeamProductivityAlgoliaResponse | undefined> => {
-  const { currentPage, pageSize, timeRange } = options;
+  const { currentPage, pageSize, timeRange, tags } = options;
   const rangeFilter = `__meta.range:"${timeRange || '30d'}"`;
   const result = await algoliaClient.search(['team-productivity'], '', {
+    tagFilters: [tags],
     filters: rangeFilter,
     page: currentPage ?? undefined,
     hitsPerPage: pageSize ?? undefined,

--- a/apps/crn-frontend/src/hooks/algolia.ts
+++ b/apps/crn-frontend/src/hooks/algolia.ts
@@ -6,7 +6,11 @@ import {
 import { User } from '@asap-hub/auth';
 import { useCurrentUserCRN } from '@asap-hub/react-context';
 import { useEffect, useState } from 'react';
-import { ALGOLIA_APP_ID, ALGOLIA_INDEX } from '../config';
+import {
+  ALGOLIA_APP_ID,
+  ALGOLIA_INDEX,
+  ANALYTICS_ALGOLIA_INDEX,
+} from '../config';
 
 export type AlgoliaHook<App extends Apps> = {
   client: AlgoliaClient<App>;
@@ -49,8 +53,8 @@ export const useAlgolia = () => {
   return algolia;
 };
 
-export const useAnalyticsAlgolia = (index: string) => {
+export const useAnalyticsAlgolia = (index?: string) => {
   const user = useCurrentUserCRN();
 
-  return initAlgolia<'analytics'>(user, index);
+  return initAlgolia<'analytics'>(user, index ?? ANALYTICS_ALGOLIA_INDEX);
 };

--- a/apps/crn-server/scripts/export-analytics.ts
+++ b/apps/crn-server/scripts/export-analytics.ts
@@ -2,8 +2,10 @@ import { AnalyticsData } from '@asap-hub/algolia';
 import {
   AnalyticsTeamLeadershipResponse,
   ListResponse,
+  TeamProductivityResponse,
   TimeRangeOption,
   timeRanges,
+  UserProductivityResponse,
   UserProductivityTeam,
 } from '@asap-hub/model';
 import { promises as fs } from 'fs';
@@ -128,10 +130,18 @@ const transformRecords = (
 };
 
 const getRecordTags = (record: AnalyticsData, type: Metric): string[] => {
+  let tag = '';
   switch (type) {
     case 'team-leadership':
-      const teamName = (record as AnalyticsTeamLeadershipResponse).displayName;
-      return teamName ? [teamName] : [];
+      tag = (record as AnalyticsTeamLeadershipResponse).displayName;
+      return tag ? [tag] : [];
+    case 'user-productivity':
+      const { name, teams } = record as UserProductivityResponse;
+      const teamNames = teams.map((team) => team.team);
+      return name ? [name].concat(teamNames) : teamNames;
+    case 'team-productivity':
+      tag = (record as TeamProductivityResponse).name;
+      return tag ? [tag] : [];
     default:
       return [];
   }

--- a/packages/react-components/src/molecules/AnalyticsControls.tsx
+++ b/packages/react-components/src/molecules/AnalyticsControls.tsx
@@ -114,57 +114,65 @@ const AnalyticsControls: React.FC<AnalyticsControlsProps> = ({
   exportResults,
   currentPage,
   href,
-}) => (
-  <>
-    {metricOption && (
-      <div css={searchContainerStyles}>
-        <Subtitle>{searchTexts[metricOption].label}:</Subtitle>
-        <span role="search" css={searchStyles}>
-          <MultiSelect
-            noMargin
-            leftIndicator={searchIcon}
-            noOptionsMessage={() => 'No results found'}
-            loadOptions={loadTags}
-            onChange={(items) => setTags(items.map(({ value }) => value))}
-            values={tags.map((tag) => ({
-              label: tag,
-              value: tag,
-            }))}
-            key={`${tags.join('')}`}
-            placeholder={searchTexts[metricOption].placeholder}
-          />
-        </span>
-      </div>
-    )}
-    <span css={containerStyles}>
-      {timeRange && (
-        <span css={viewContainerStyles}>
-          <strong>View:</strong>
-          <DropdownButton
-            noMargin
-            buttonChildren={() => (
-              <>
-                <span css={{ marginRight: rem(10) }}>
-                  {timeRangeOptions[timeRange]}
-                </span>
-                {dropdownChevronIcon}
-              </>
-            )}
-          >
-            {Object.keys(timeRangeOptions).map((key) => ({
-              item: <>{timeRangeOptions[key as TimeRangeOption]}</>,
-              href: `${href}?range=${key}&currentPage=${currentPage}`,
-            }))}
-          </DropdownButton>
-        </span>
+}) => {
+  const searchParams = new URLSearchParams(window.location.search);
+  searchParams.delete('range');
+  searchParams.delete('currentPage');
+  const tagsQueryString = searchParams.has('tag')
+    ? '&' + searchParams.toString()
+    : '';
+  return (
+    <>
+      {metricOption && (
+        <div css={searchContainerStyles}>
+          <Subtitle>{searchTexts[metricOption].label}:</Subtitle>
+          <span role="search" css={searchStyles}>
+            <MultiSelect
+              noMargin
+              leftIndicator={searchIcon}
+              noOptionsMessage={() => 'No results found'}
+              loadOptions={loadTags}
+              onChange={(items) => setTags(items.map(({ value }) => value))}
+              values={tags.map((tag) => ({
+                label: tag,
+                value: tag,
+              }))}
+              key={`${tags.join('')}`}
+              placeholder={searchTexts[metricOption].placeholder}
+            />
+          </span>
+        </div>
       )}
-      {exportResults && (
-        <span css={exportContainerStyles}>
-          <ExportButton exportResults={exportResults} />
-        </span>
-      )}
-    </span>
-  </>
-);
+      <span css={containerStyles}>
+        {timeRange && (
+          <span css={viewContainerStyles}>
+            <strong>View:</strong>
+            <DropdownButton
+              noMargin
+              buttonChildren={() => (
+                <>
+                  <span css={{ marginRight: rem(10) }}>
+                    {timeRangeOptions[timeRange]}
+                  </span>
+                  {dropdownChevronIcon}
+                </>
+              )}
+            >
+              {Object.keys(timeRangeOptions).map((key) => ({
+                item: <>{timeRangeOptions[key as TimeRangeOption]}</>,
+                href: `${href}?range=${key}&currentPage=${currentPage}${tagsQueryString}`,
+              }))}
+            </DropdownButton>
+          </span>
+        )}
+        {exportResults && (
+          <span css={exportContainerStyles}>
+            <ExportButton exportResults={exportResults} />
+          </span>
+        )}
+      </span>
+    </>
+  );
+};
 
 export default AnalyticsControls;

--- a/packages/react-components/src/molecules/AnalyticsControls.tsx
+++ b/packages/react-components/src/molecules/AnalyticsControls.tsx
@@ -119,7 +119,7 @@ const AnalyticsControls: React.FC<AnalyticsControlsProps> = ({
   searchParams.delete('range');
   searchParams.delete('currentPage');
   const tagsQueryString = searchParams.has('tag')
-    ? '&' + searchParams.toString()
+    ? `&${searchParams.toString()}`
     : '';
   return (
     <>

--- a/packages/react-components/src/molecules/AnalyticsControls.tsx
+++ b/packages/react-components/src/molecules/AnalyticsControls.tsx
@@ -4,8 +4,36 @@ import { TimeRangeOption } from '@asap-hub/model';
 import { dropdownChevronIcon } from '../icons';
 import DropdownButton from './DropdownButton';
 import { rem, tabletScreen } from '../pixels';
+import { MultiSelect, Subtitle } from '../atoms';
+import { noop, searchIcon } from '..';
+import { ComponentProps } from 'react';
+import ExportButton from './ExportButton';
 
+export type MetricOption = 'user' | 'team';
 const containerStyles = css({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'flex-end',
+
+  gap: rem(33),
+  'span + svg': {
+    width: '11px',
+    marginRight: '10px',
+  },
+  paddingBottom: rem(33),
+  button: {
+    padding: `${rem(8)} ${rem(16)}`,
+  },
+
+  [`@media (max-width: ${tabletScreen.min}px)`]: {
+    flexDirection: 'column',
+    alignItems: 'flex-start',
+    marginTop: rem(24),
+    width: '100%',
+  },
+});
+
+const viewContainerStyles = css({
   display: 'flex',
   alignItems: 'center',
   gap: rem(15),
@@ -25,6 +53,29 @@ const containerStyles = css({
   },
 });
 
+const searchContainerStyles = css({
+  display: 'flex',
+  gap: rem(18),
+  alignItems: 'center',
+  paddingBottom: rem(24),
+});
+
+const searchStyles = css({
+  flexGrow: 1,
+});
+
+const exportContainerStyles = css({
+  display: 'flex',
+  justifyContent: 'right',
+  gap: rem(33),
+  [`@media (max-width: ${tabletScreen.min}px)`]: {
+    flexDirection: 'column',
+    alignItems: 'flex-start',
+    width: '100%',
+    gap: 0,
+  },
+});
+
 const timeRangeOptions: Record<TimeRangeOption, string> = {
   '30d': 'Last 30 days',
   '90d': 'Last 90 days',
@@ -32,36 +83,87 @@ const timeRangeOptions: Record<TimeRangeOption, string> = {
   'last-year': 'Last 12 months',
   all: 'Since Hub Launch (2020)',
 };
+const searchTexts = {
+  user: {
+    label: 'Users & Teams',
+    placeholder: 'Enter user and/or team names...',
+  },
+  team: {
+    label: 'Teams',
+    placeholder: 'Enter team names...',
+  },
+};
 
 interface AnalyticsControlsProps {
-  readonly timeRange: TimeRangeOption;
-  readonly href: string;
-  readonly currentPage: number;
+  readonly timeRange?: TimeRangeOption;
+  readonly metricOption?: MetricOption; //metric is optional for now since we haven't added search to the collaboration page
+  readonly tags: string[];
+  readonly loadTags: ComponentProps<typeof MultiSelect>['loadOptions'];
+  readonly setTags: (tags: string[]) => void;
+  readonly href?: string;
+  readonly currentPage?: number;
+  readonly exportResults?: () => Promise<void>;
 }
 const AnalyticsControls: React.FC<AnalyticsControlsProps> = ({
   timeRange,
+  metricOption,
+  tags,
+  setTags,
+  loadTags = noop,
+  exportResults,
   currentPage,
   href,
 }) => (
-  <span css={containerStyles}>
-    <strong>View as:</strong>
-    <DropdownButton
-      noMargin
-      buttonChildren={() => (
-        <>
-          <span css={{ marginRight: rem(10) }}>
-            {timeRangeOptions[timeRange]}
-          </span>
-          {dropdownChevronIcon}
-        </>
+  <>
+    {metricOption && (
+      <div css={searchContainerStyles}>
+        <Subtitle>{searchTexts[metricOption].label}:</Subtitle>
+        <span role="search" css={searchStyles}>
+          <MultiSelect
+            noMargin
+            leftIndicator={searchIcon}
+            noOptionsMessage={() => 'No results found'}
+            loadOptions={loadTags}
+            onChange={(items) => setTags(items.map(({ value }) => value))}
+            values={tags.map((tag) => ({
+              label: tag,
+              value: tag,
+            }))}
+            key={`${tags.join('')}`}
+            placeholder={searchTexts[metricOption].placeholder}
+          />
+        </span>
+      </div>
+    )}
+    <span css={containerStyles}>
+      {timeRange && (
+        <span css={viewContainerStyles}>
+          <strong>View:</strong>
+          <DropdownButton
+            noMargin
+            buttonChildren={() => (
+              <>
+                <span css={{ marginRight: rem(10) }}>
+                  {timeRangeOptions[timeRange]}
+                </span>
+                {dropdownChevronIcon}
+              </>
+            )}
+          >
+            {Object.keys(timeRangeOptions).map((key) => ({
+              item: <>{timeRangeOptions[key as TimeRangeOption]}</>,
+              href: `${href}?range=${key}&currentPage=${currentPage}`,
+            }))}
+          </DropdownButton>
+        </span>
       )}
-    >
-      {Object.keys(timeRangeOptions).map((key) => ({
-        item: <>{timeRangeOptions[key as TimeRangeOption]}</>,
-        href: `${href}?range=${key}&currentPage=${currentPage}`,
-      }))}
-    </DropdownButton>
-  </span>
+      {exportResults && (
+        <span css={exportContainerStyles}>
+          <ExportButton exportResults={exportResults} />
+        </span>
+      )}
+    </span>
+  </>
 );
 
 export default AnalyticsControls;

--- a/packages/react-components/src/molecules/AnalyticsControls.tsx
+++ b/packages/react-components/src/molecules/AnalyticsControls.tsx
@@ -137,7 +137,7 @@ const AnalyticsControls: React.FC<AnalyticsControlsProps> = ({
                 label: tag,
                 value: tag,
               }))}
-              key={`${tags.join('')}`}
+              key={`${tags.join('')},${metricOption}`}
               placeholder={searchTexts[metricOption].placeholder}
             />
           </span>

--- a/packages/react-components/src/molecules/AnalyticsControls.tsx
+++ b/packages/react-components/src/molecules/AnalyticsControls.tsx
@@ -1,12 +1,12 @@
 import { css } from '@emotion/react';
 import { TimeRangeOption } from '@asap-hub/model';
+import { ComponentProps } from 'react';
 
 import { dropdownChevronIcon } from '../icons';
 import DropdownButton from './DropdownButton';
 import { rem, tabletScreen } from '../pixels';
 import { MultiSelect, Subtitle } from '../atoms';
 import { noop, searchIcon } from '..';
-import { ComponentProps } from 'react';
 import ExportButton from './ExportButton';
 
 export type MetricOption = 'user' | 'team';
@@ -96,7 +96,8 @@ const searchTexts = {
 
 interface AnalyticsControlsProps {
   readonly timeRange?: TimeRangeOption;
-  readonly metricOption?: MetricOption; //metric is optional for now since we haven't added search to the collaboration page
+  // metric is optional for now since we haven't added search to the collaboration page
+  readonly metricOption?: MetricOption;
   readonly tags: string[];
   readonly loadTags: ComponentProps<typeof MultiSelect>['loadOptions'];
   readonly setTags: (tags: string[]) => void;

--- a/packages/react-components/src/molecules/AnalyticsControls.tsx
+++ b/packages/react-components/src/molecules/AnalyticsControls.tsx
@@ -99,8 +99,8 @@ interface AnalyticsControlsProps {
   // metric is optional for now since we haven't added search to the collaboration page
   readonly metricOption?: MetricOption;
   readonly tags: string[];
-  readonly loadTags: ComponentProps<typeof MultiSelect>['loadOptions'];
-  readonly setTags: (tags: string[]) => void;
+  readonly loadTags?: ComponentProps<typeof MultiSelect>['loadOptions'];
+  readonly setTags?: (tags: string[]) => void;
   readonly href?: string;
   readonly currentPage?: number;
   readonly exportResults?: () => Promise<void>;
@@ -109,7 +109,7 @@ const AnalyticsControls: React.FC<AnalyticsControlsProps> = ({
   timeRange,
   metricOption,
   tags,
-  setTags,
+  setTags = noop,
   loadTags = noop,
   exportResults,
   currentPage,

--- a/packages/react-components/src/molecules/__tests__/AnalyticsControls.test.tsx
+++ b/packages/react-components/src/molecules/__tests__/AnalyticsControls.test.tsx
@@ -44,4 +44,12 @@ describe('AnalyticsControls', () => {
     );
     expect(getByText(/export as:/i)).toBeVisible();
   });
+
+  it('maintains tag search when changing time range', () => {
+    delete (window as Partial<Window>).location;
+    window.location = { search: '?range=30d&tag=TestTag' } as Location;
+
+    const { getByText } = render(<AnalyticsControls {...defaultProps} timeRange={'30d'} />);
+    expect(getByText('Last 90 days').closest('a')!.href).toContain('tag=TestTag');
+  });
 });

--- a/packages/react-components/src/molecules/__tests__/AnalyticsControls.test.tsx
+++ b/packages/react-components/src/molecules/__tests__/AnalyticsControls.test.tsx
@@ -49,7 +49,11 @@ describe('AnalyticsControls', () => {
     delete (window as Partial<Window>).location;
     window.location = { search: '?range=30d&tag=TestTag' } as Location;
 
-    const { getByText } = render(<AnalyticsControls {...defaultProps} timeRange={'30d'} />);
-    expect(getByText('Last 90 days').closest('a')!.href).toContain('tag=TestTag');
+    const { getByText } = render(
+      <AnalyticsControls {...defaultProps} timeRange={'30d'} />,
+    );
+    expect(getByText('Last 90 days').closest('a')!.href).toContain(
+      'tag=TestTag',
+    );
   });
 });

--- a/packages/react-components/src/molecules/__tests__/AnalyticsControls.test.tsx
+++ b/packages/react-components/src/molecules/__tests__/AnalyticsControls.test.tsx
@@ -1,0 +1,47 @@
+import { render } from '@testing-library/react';
+import { ComponentProps } from 'react';
+
+import AnalyticsControls from '../AnalyticsControls';
+
+describe('AnalyticsControls', () => {
+  const defaultProps: ComponentProps<typeof AnalyticsControls> = {
+    currentPage: 0,
+    tags: [],
+    setTags: jest.fn(),
+    loadTags: jest.fn().mockResolvedValue([]),
+  };
+
+  it('renders range selection dropdown if time range provided', () => {
+    const { container, queryByRole, getByRole, rerender } = render(
+      <AnalyticsControls {...defaultProps} />,
+    );
+    expect(queryByRole('button', { name: /chevron down/i })).toBeNull();
+
+    rerender(<AnalyticsControls {...defaultProps} timeRange={'30d'} />);
+    expect(getByRole('button', { name: /chevron down/i })).toBeVisible();
+    expect(container).toHaveTextContent('Last 30 days');
+  });
+
+  it('renders search box if metricOption is provided', () => {
+    const { getByRole, queryByRole, rerender } = render(
+      <AnalyticsControls {...defaultProps} />,
+    );
+
+    expect(queryByRole('search')).toBeNull();
+
+    rerender(<AnalyticsControls {...defaultProps} metricOption={'user'} />);
+    expect(getByRole('search')).toBeVisible();
+  });
+
+  it('renders export csv button if exportResults is provided', () => {
+    const { rerender, queryByText, getByText } = render(
+      <AnalyticsControls {...defaultProps} />,
+    );
+    expect(queryByText(/export as:/i)).toBeNull();
+    const mockExport = jest.fn(() => Promise.resolve());
+    rerender(
+      <AnalyticsControls {...defaultProps} exportResults={mockExport} />,
+    );
+    expect(getByText(/export as:/i)).toBeVisible();
+  });
+});

--- a/packages/react-components/src/templates/AnalyticsCollaborationPageBody.tsx
+++ b/packages/react-components/src/templates/AnalyticsCollaborationPageBody.tsx
@@ -4,7 +4,8 @@ import { ComponentProps } from 'react';
 
 import { Dropdown, Headline3, Paragraph, Subtitle } from '../atoms';
 import { AnalyticsControls } from '../molecules';
-import { perRem, rem } from '../pixels';
+import { perRem } from '../pixels';
+import { noop } from '../utils';
 
 type MetricOption = 'user' | 'team';
 type TypeOption = 'within-team' | 'across-teams';
@@ -72,12 +73,6 @@ const tableHeaderStyles = css({
   paddingBottom: `${24 / perRem}em`,
 });
 
-const controlsStyles = css({
-  display: 'flex',
-  flexDirection: 'row-reverse',
-  marginBottom: rem(32),
-});
-
 const AnalyticsCollaborationPageBody: React.FC<CollaborationAnalyticsProps> = ({
   metric,
   type,
@@ -112,16 +107,16 @@ const AnalyticsCollaborationPageBody: React.FC<CollaborationAnalyticsProps> = ({
         <Headline3>{header}</Headline3>
         <Paragraph>{description}.</Paragraph>
       </div>
-      <div css={controlsStyles}>
-        <AnalyticsControls
-          currentPage={currentPage}
-          timeRange={timeRange}
-          href={
-            analytics({}).collaboration({}).collaborationPath({ metric, type })
-              .$
-          }
-        />
-      </div>
+      <AnalyticsControls
+        currentPage={currentPage}
+        loadTags={noop}
+        tags={[]}
+        setTags={noop}
+        timeRange={timeRange}
+        href={
+          analytics({}).collaboration({}).collaborationPath({ metric, type }).$
+        }
+      />
       {children}
     </article>
   );

--- a/packages/react-components/src/templates/AnalyticsCollaborationPageBody.tsx
+++ b/packages/react-components/src/templates/AnalyticsCollaborationPageBody.tsx
@@ -5,7 +5,6 @@ import { ComponentProps } from 'react';
 import { Dropdown, Headline3, Paragraph, Subtitle } from '../atoms';
 import { AnalyticsControls } from '../molecules';
 import { perRem } from '../pixels';
-import { noop } from '../utils';
 
 type MetricOption = 'user' | 'team';
 type TypeOption = 'within-team' | 'across-teams';
@@ -109,9 +108,7 @@ const AnalyticsCollaborationPageBody: React.FC<CollaborationAnalyticsProps> = ({
       </div>
       <AnalyticsControls
         currentPage={currentPage}
-        loadTags={noop}
         tags={[]}
-        setTags={noop}
         timeRange={timeRange}
         href={
           analytics({}).collaboration({}).collaborationPath({ metric, type }).$

--- a/packages/react-components/src/templates/AnalyticsLeadershipPageBody.tsx
+++ b/packages/react-components/src/templates/AnalyticsLeadershipPageBody.tsx
@@ -4,7 +4,7 @@ import {
 } from '@asap-hub/model';
 import { css } from '@emotion/react';
 import { ComponentProps } from 'react';
-import { noop, PageControls, searchIcon } from '..';
+import { noop, PageControls } from '..';
 import {
   Dropdown,
   Headline3,
@@ -12,9 +12,9 @@ import {
   Paragraph,
   Subtitle,
 } from '../atoms';
-import { ExportButton } from '../molecules';
+import { AnalyticsControls } from '../molecules';
 import { LeadershipMembershipTable } from '../organisms';
-import { rem, tabletScreen } from '../pixels';
+import { rem } from '../pixels';
 
 type MetricOption = 'working-group' | 'interest-group';
 type MetricData = {
@@ -68,29 +68,6 @@ const pageControlsStyles = css({
   paddingBottom: rem(36),
 });
 
-const searchContainerStyles = css({
-  display: 'flex',
-  gap: rem(18),
-  alignItems: 'center',
-  paddingBottom: rem(33),
-});
-
-const searchStyles = css({
-  flexGrow: 1,
-});
-const exportContainerStyles = css({
-  display: 'flex',
-  justifyContent: 'right',
-  gap: rem(33),
-  paddingBottom: rem(33),
-  [`@media (max-width: ${tabletScreen.min}px)`]: {
-    flexDirection: 'column',
-    alignItems: 'flex-start',
-    width: '100%',
-    gap: 0,
-  },
-});
-
 const LeadershipPageBody: React.FC<LeadershipAndMembershipAnalyticsProps> = ({
   tags,
   setTags,
@@ -115,9 +92,6 @@ const LeadershipPageBody: React.FC<LeadershipAndMembershipAnalyticsProps> = ({
         required
       />
     </div>
-    <span css={exportContainerStyles}>
-      <ExportButton exportResults={exportResults} />
-    </span>
     <div css={tableHeaderStyles}>
       <Headline3>{metricOptions[metric]}</Headline3>
       <Paragraph>
@@ -125,24 +99,13 @@ const LeadershipPageBody: React.FC<LeadershipAndMembershipAnalyticsProps> = ({
         membership role within a Working Group.
       </Paragraph>
     </div>
-    <div css={searchContainerStyles}>
-      <Subtitle>Teams:</Subtitle>
-      <span role="search" css={searchStyles}>
-        <MultiSelect
-          noMargin
-          leftIndicator={searchIcon}
-          noOptionsMessage={() => 'No results found'}
-          loadOptions={loadTags}
-          onChange={(items) => setTags(items.map(({ value }) => value))}
-          values={tags.map((tag) => ({
-            label: tag,
-            value: tag,
-          }))}
-          key={`${tags.join('')}`} // Force re-render to refresh default options. (https://github.com/JedWatson/react-select/discussions/5389)
-          placeholder="Enter team names..."
-        />
-      </span>
-    </div>
+    <AnalyticsControls
+      metricOption={'team'}
+      tags={tags}
+      loadTags={loadTags}
+      setTags={setTags}
+      exportResults={exportResults}
+    />
     <LeadershipMembershipTable
       metric={metric}
       data={data}

--- a/packages/react-components/src/templates/AnalyticsProductivityPageBody.tsx
+++ b/packages/react-components/src/templates/AnalyticsProductivityPageBody.tsx
@@ -3,10 +3,10 @@ import { css } from '@emotion/react';
 import { analytics } from '@asap-hub/routing';
 
 import { Dropdown, Headline3, Paragraph, Subtitle } from '../atoms';
-import AnalyticsControls from '../molecules/AnalyticsControls';
-import { perRem } from '../pixels';
-
-type MetricOption = 'user' | 'team';
+import AnalyticsControls, {
+  MetricOption,
+} from '../molecules/AnalyticsControls';
+import { rem } from '../pixels';
 
 const metricOptions: Record<MetricOption, string> = {
   user: 'User Productivity',
@@ -20,7 +20,7 @@ const metricOptionList = Object.keys(metricOptions).map((value) => ({
 
 type ProductivityAnalyticsProps = Pick<
   ComponentProps<typeof AnalyticsControls>,
-  'timeRange' | 'currentPage'
+  'timeRange' | 'currentPage' | 'tags' | 'loadTags' | 'setTags'
 > & {
   metric: MetricOption;
   setMetric: (option: MetricOption) => void;
@@ -28,22 +28,20 @@ type ProductivityAnalyticsProps = Pick<
 };
 
 const metricDropdownStyles = css({
-  marginBottom: `${48 / perRem}em`,
+  marginBottom: rem(48),
 });
 
 const tableHeaderStyles = css({
-  paddingBottom: `${24 / perRem}em`,
-});
-
-const controlsStyles = css({
-  display: 'flex',
-  flexDirection: 'row-reverse',
+  paddingBottom: rem(24),
 });
 
 const AnalyticsProductivityPageBody: React.FC<ProductivityAnalyticsProps> = ({
   metric,
   setMetric,
   timeRange,
+  tags,
+  setTags,
+  loadTags,
   currentPage,
   children,
 }) => (
@@ -57,19 +55,21 @@ const AnalyticsProductivityPageBody: React.FC<ProductivityAnalyticsProps> = ({
         required
       />
     </div>
-    <div css={controlsStyles}>
-      <AnalyticsControls
-        currentPage={currentPage}
-        timeRange={timeRange}
-        href={analytics({}).productivity({}).metric({ metric }).$}
-      />
-    </div>
     <div css={tableHeaderStyles}>
       <Headline3>{metricOptions[metric]}</Headline3>
       <Paragraph>
         Overview of ASAP outputs shared on the CRN Hub by {metric}.
       </Paragraph>
     </div>
+    <AnalyticsControls
+      currentPage={currentPage}
+      timeRange={timeRange}
+      metricOption={metric}
+      tags={tags}
+      loadTags={loadTags}
+      setTags={setTags}
+      href={analytics({}).productivity({}).metric({ metric }).$}
+    />
     {children}
   </article>
 );

--- a/packages/react-components/src/templates/__tests__/AnalyticsCollaborationPageBody.test.tsx
+++ b/packages/react-components/src/templates/__tests__/AnalyticsCollaborationPageBody.test.tsx
@@ -2,7 +2,7 @@ import { render } from '@testing-library/react';
 import { ComponentProps } from 'react';
 import { AnalyticsCollaborationPageBody } from '..';
 
-describe('AnalyticsProductivityPageBody', () => {
+describe('AnalyticsCollaborationPageBody', () => {
   const props: ComponentProps<typeof AnalyticsCollaborationPageBody> = {
     setMetric: () => null,
     setType: () => null,

--- a/packages/react-components/src/templates/__tests__/AnalyticsProductivityPageBody.test.tsx
+++ b/packages/react-components/src/templates/__tests__/AnalyticsProductivityPageBody.test.tsx
@@ -7,6 +7,9 @@ describe('AnalyticsProductivityPageBody', () => {
     setMetric: () => null,
     metric: 'user',
     timeRange: '30d',
+    tags: [],
+    setTags: jest.fn(),
+    loadTags: jest.fn().mockResolvedValue([]),
     currentPage: 5,
     children: <span>table</span>,
   };


### PR DESCRIPTION
ref: https://asaphub.atlassian.net/jira/software/c/projects/ASAP/boards/13?selectedIssue=ASAP-373  (points 5 & 6: searching on the User & Team Productivity pages)

- Adds tags to the user & team productivity types in algolia
- Updates  frontend with search functionality
- Since all the Analytics pages have similar controls & labels (search, export etc), I've combined them into one component. The arrangement was different from what we have in the designs so I updated those as well (the view & export buttons are below the page title, description & search bar)

Design
<img width="445" alt="Screenshot 2024-06-04 at 09 36 51" src="https://github.com/yldio/asap-hub/assets/25244556/a9522e73-0a8e-4ade-942b-249df1a57337">

