### PR TITLE
ASAP-552 Remove hidden events from algolia in GP2

### DIFF
--- a/apps/gp2-server/src/handlers/event/algolia-index-handler.ts
+++ b/apps/gp2-server/src/handlers/event/algolia-index-handler.ts
@@ -2,7 +2,7 @@ import { AlgoliaClient, algoliaSearchClientFactory } from '@asap-hub/algolia';
 import { NotFoundError } from '@asap-hub/errors';
 import { gp2 as gp2Model } from '@asap-hub/model';
 import { EventBridgeHandler, Logger } from '@asap-hub/server-common';
-import { isBoom } from '@hapi/boom';
+import { notFound, isBoom } from '@hapi/boom';
 import { algoliaApiKey, algoliaAppId, algoliaIndex } from '../../config';
 import EventController from '../../controllers/event.controller';
 import { EventContentfulDataProvider } from '../../data-providers/event.data-provider';
@@ -28,6 +28,10 @@ export const indexEventHandler =
       try {
         const calendarEvent = await eventController.fetchById(id);
         log.debug(`Fetched calendar event ${calendarEvent.id}`);
+
+        if (calendarEvent.hidden) {
+          throw notFound();
+        }
 
         const data = {
           ...calendarEvent,

--- a/apps/gp2-server/test/handlers/event/algolia-index-handler.test.ts
+++ b/apps/gp2-server/test/handlers/event/algolia-index-handler.test.ts
@@ -29,6 +29,18 @@ describe('Event index handler', () => {
     });
   });
 
+  test('Should fetch the event and remove the record in Algolia when event is hidden', async () => {
+    const eventResponse = { ...getEventResponse(), hidden: true };
+    eventControllerMock.fetchById.mockResolvedValueOnce(eventResponse);
+
+    await indexHandler(publishedEvent(eventResponse.id));
+
+    expect(algoliaSearchClientMock.save).not.toHaveBeenCalled();
+    expect(algoliaSearchClientMock.remove).toHaveBeenCalledWith(
+      eventResponse.id,
+    );
+  });
+
   test('Should populate the _tags field before saving the event to Algolia', async () => {
     const eventResponse = getEventResponse();
     eventResponse.tags = [{ id: '1', name: 'event tag' }];


### PR DESCRIPTION
This PR adds the same condition to the GP2 event index handler as we have in CRN (https://github.com/yldio/asap-hub/blob/master/apps/crn-server/src/handlers/event/algolia-index-event-handler.ts#L28) to remove hidden events from algolia, this way we won't have multiple cancelled events in the frontend.