### PR TITLE
fix slack webhook reference actions

### DIFF
--- a/.github/workflows/on-demand-crn-analytics-algolia-sync.yml
+++ b/.github/workflows/on-demand-crn-analytics-algolia-sync.yml
@@ -58,5 +58,5 @@ jobs:
       - uses: ./.github/actions/slack/
         with:
           message: Analytics Algolia Prod Sync
-          webhook: ${{ env.SLACK_WEBHOOK }}
+          webhook: ${{ secrets.SLACK_WEBHOOK }}
           status: failure

--- a/.github/workflows/on-demand-gp2-algolia-sync.yml
+++ b/.github/workflows/on-demand-gp2-algolia-sync.yml
@@ -56,5 +56,5 @@ jobs:
       - uses: ./.github/actions/slack/
         with:
           message: GP2 Algolia Prod Sync
-          webhook: ${{ env.SLACK_WEBHOOK }}
+          webhook: ${{ secrets.SLACK_WEBHOOK }}
           status: failure

--- a/.github/workflows/on-demand-rollback-contentful-migration.yml
+++ b/.github/workflows/on-demand-rollback-contentful-migration.yml
@@ -80,5 +80,5 @@ jobs:
       - uses: ./.github/actions/slack/
         with:
           message: Rollback last Contentful migration failed
-          webhook: ${{ env.SLACK_WEBHOOK }}
+          webhook: ${{ secrets.SLACK_WEBHOOK }}
           status: failure


### PR DESCRIPTION
There are still some actions with the wrong reference to the slack webhook.

I'm taking as a reference this on-remove action (https://github.com/yldio/asap-hub/blob/master/.github/workflows/on-remove.yml#L293) that I know for sure it triggers an alert and it sets

```
webhook: ${{ secrets.SLACK_WEBHOOK }}
```

