### PR TITLE
fix: manuscript file validation

### DIFF
--- a/packages/contentful/migrations/crn/manuscripts/20240723115126-fix-manuscript-file-validation.js
+++ b/packages/contentful/migrations/crn/manuscripts/20240723115126-fix-manuscript-file-validation.js
@@ -1,0 +1,20 @@
+module.exports.description = 'Fix manuscript file validation';
+
+module.exports.up = (migration) => {
+  const manuscriptVersions = migration.editContentType('manuscriptVersions');
+
+  manuscriptVersions.editField('manuscriptFile').validations([
+    {
+      linkMimetypeGroup: ['pdfdocument'],
+    },
+  ]);
+};
+
+module.exports.down = (migration) => {
+  const manuscriptVersions = migration.editContentType('manuscriptVersions');
+  manuscriptVersions.editField('manuscriptFile').validations([
+    {
+      linkMimetypeGroup: ['application/pdf'],
+    },
+  ]);
+};


### PR DESCRIPTION
The validation type was wrong in the migration that created the manuscript file field. So when the user tries to create a manuscript we get this error
<img width="803" alt="Screenshot 2024-07-23 at 08 54 45" src="https://github.com/user-attachments/assets/e67b48a7-73d6-466b-8c68-1c5c39b3bd7d">


And the content model is like this in Production (without PDF document selected)
<img width="1655" alt="Screenshot 2024-07-23 at 08 55 03" src="https://github.com/user-attachments/assets/84f5ecaf-25a1-4c33-a602-857cb2682e38">


The fix is to add a migration editing the validation of the manuscript file field.

The mimetype is actually called `pdfdocument` instead of `application/pdf`
<img width="569" alt="Screenshot 2024-07-23 at 09 44 15" src="https://github.com/user-attachments/assets/c58c7303-fdde-4036-9e56-2470fca06606">

https://github.com/contentful/contentful-migration/blob/860fa6aa064772e4ae534f0da04d73beb0ca8e34/index.d.ts#L128