### PR TITLE
ASAP-606 Fix analytics empty pages

### DIFF
--- a/packages/algolia/schema/crn-analytics/algolia-schema.json
+++ b/packages/algolia/schema/crn-analytics/algolia-schema.json
@@ -17,7 +17,7 @@
   ],
   "attributesToSnippet": null,
   "attributesToHighlight": null,
-  "paginationLimitedTo": 1000,
+  "paginationLimitedTo": 5000,
   "attributeForDistinct": null,
   "exactOnSingleWordQuery": "attribute",
   "ranking": [


### PR DESCRIPTION
JIRA ticket: https://asaphub.atlassian.net/browse/ASAP-606

---

The issue is that `paginationLimitedTo` was set to 1000 but in Prod we have more than 1700 users. And with this `paginationLimitedTo` it was showing only the first 1000 users. Reference: https://www.algolia.com/doc/api-reference/api-parameters/paginationLimitedTo/?utm_medium=page_link&utm_source=dashboard&client=javascript

---

After the fix:
<img width="2262" alt="Screenshot 2024-08-08 at 05 32 47" src="https://github.com/user-attachments/assets/41f5db26-449a-48c5-9ade-08697740036d">
