### PR TITLE
ASAP-597 Create supplement grant content model

### DIFF
--- a/packages/contentful/migrations/crn/supplementGrant/20240911131935-create-supplement-grant.js
+++ b/packages/contentful/migrations/crn/supplementGrant/20240911131935-create-supplement-grant.js
@@ -1,0 +1,89 @@
+module.exports.description = 'Create supplement grant model';
+
+module.exports.up = (migration) => {
+  const supplementGrant = migration
+    .createContentType('supplementGrant')
+    .name('Supplement Grant')
+    .description('')
+    .displayField('title');
+
+  supplementGrant
+    .createField('title')
+    .name('Grant Title')
+    .type('Text')
+    .localized(false)
+    .required(true)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+
+  supplementGrant
+    .createField('description')
+    .name('Grant Description')
+    .type('Text')
+    .localized(false)
+    .required(false)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+
+  supplementGrant
+    .createField('startDate')
+    .name('Grant Start Date')
+    .type('Date')
+    .localized(false)
+    .required(false)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+
+  supplementGrant
+    .createField('endDate')
+    .name('Grant End Date')
+    .type('Date')
+    .localized(false)
+    .required(false)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+
+  supplementGrant
+    .createField('proposal')
+    .name('Grant Proposal')
+    .type('Link')
+    .localized(false)
+    .required(false)
+    .validations([
+      {
+        linkContentType: ['researchOutputs'],
+      },
+    ])
+    .disabled(false)
+    .omitted(false)
+    .linkType('Entry');
+
+  supplementGrant.changeFieldControl('title', 'builtin', 'multipleLine', {});
+  supplementGrant.changeFieldControl(
+    'description',
+    'builtin',
+    'multipleLine',
+    {},
+  );
+
+  supplementGrant.changeFieldControl(
+    'supplementGrant',
+    'builtin',
+    'datePicker',
+    {},
+  );
+  supplementGrant.changeFieldControl('endDate', 'builtin', 'datePicker', {});
+
+  supplementGrant.changeFieldControl('proposal', 'builtin', 'entryLinkEditor', {
+    showLinkEntityAction: true,
+    showCreateEntityAction: false,
+  });
+};
+
+module.exports.down = (migration) => {
+  migration.deleteContentType('supplementGrant');
+};


### PR DESCRIPTION
JIRA ticket: https://asaphub.atlassian.net/browse/ASAP-597

---
This PR introduces a migration to create the supplement grant content model. I separated this change because I encountered an error when attempting to create the model and add a field in Teams that restricts entries to this content type in a single PR. This is the error https://github.com/yldio/asap-hub/actions/runs/10812932918/job/29996798171#step:5:164.