### PR TITLE
(fix): add role to interest groups in the public api users route

### DIFF
--- a/apps/crn-server/src/controllers/user.controller.ts
+++ b/apps/crn-server/src/controllers/user.controller.ts
@@ -297,6 +297,7 @@ export const parsePublicUserToResponse = ({
   institution: user.institution,
   interestGroups: user.interestGroups.map((ig) => ({
     name: ig.name,
+    role: ig.role,
   })),
   labs: user.labs,
   researchTheme: user.researchTheme,


### PR DESCRIPTION
The `/users` and `/users/{id}` in the public api use different parsers. In the [#4408](https://github.com/yldio/asap-hub/commit/043f2367efc4253884b5cd4a93565cbaf63832bc) I've added only the role to `/users/{id}` so this PR adds the role for `/users` as well.

---

Link to test it: https://api-4410.hub.asap.science/public/users
<img width="1341" alt="Screenshot 2024-10-08 at 14 13 14" src="https://github.com/user-attachments/assets/f154fab4-eeee-446a-a94d-3dd974c22390">
