### PR TITLE
ASAP-754 Increase query limits in GP2 for users

### DIFF
--- a/packages/contentful/src/gp2/queries/user.queries.ts
+++ b/packages/contentful/src/gp2/queries/user.queries.ts
@@ -71,7 +71,7 @@ export const usersContentQueryFragment = gql`
       }
     }
     linkedFrom {
-      projectMembershipCollection(limit: 10) {
+      projectMembershipCollection(limit: 30) {
         items {
           user {
             sys {
@@ -118,7 +118,7 @@ export const usersContentQueryFragment = gql`
                   id
                 }
                 title
-                membersCollection(limit: 25) {
+                membersCollection(limit: 50) {
                   items {
                     role
                     user {


### PR DESCRIPTION
GP2 Production Values:

- The Working Group with the largest number of members has 40 members.
- The Project with the largest number of members has 16 members.
- The user connected to most working groups is linked to 5 working groups.
- The user connected to most projects is linked to 25 projects.

---

<img width="853" alt="query-limits" src="https://github.com/user-attachments/assets/2dcd2e8f-5aa9-4834-9228-f90a324b348c">

---

Dev: https://dev.gp2.asap.science/users/1I89P3TMz5YPL7aCn58Pjq/overview
PR Hub: https://4418.gp2.asap.science/users/1I89P3TMz5YPL7aCn58Pjq/overview

<img width="2232" alt="dev-pr-hub" src="https://github.com/user-attachments/assets/91ca919c-85ec-45f5-b479-dbc54f4bcde4">

