### PR TITLE
[ASAP-534] - add discussions and messages models

### DIFF
--- a/packages/contentful/migrations/crn/discussions/20241016120158-create-discussions.js
+++ b/packages/contentful/migrations/crn/discussions/20241016120158-create-discussions.js
@@ -1,0 +1,48 @@
+module.exports.description = 'Create discussions content model';
+
+module.exports.up = (migration) => {
+  const discussions = migration
+    .createContentType('discussions')
+    .name('Discussions')
+    .description('');
+
+  discussions
+    .createField('message')
+    .name('Message')
+    .type('Link')
+    .localized(false)
+    .required(true)
+    .disabled(false)
+    .omitted(false)
+    .validations([
+      {
+        linkContentType: ['messages'],
+      },
+    ])
+    .linkType('Entry');
+
+  discussions
+    .createField('replies')
+    .name('Replies')
+    .type('Array')
+    .localized(false)
+    .required(false)
+    .validations([])
+    .disabled(false)
+    .omitted(false)
+    .items({
+      type: 'Link',
+
+      validations: [
+        {
+          linkContentType: ['messages'],
+        },
+      ],
+
+      linkType: 'Entry',
+    });
+};
+
+module.exports.down = (migration) => {
+  migration.deleteContentType('discussions');
+};

--- a/packages/contentful/migrations/crn/messages/20241016114412-create-messages.js
+++ b/packages/contentful/migrations/crn/messages/20241016114412-create-messages.js
@@ -1,0 +1,40 @@
+module.exports.description = 'Create messages content model';
+
+module.exports.up = (migration) => {
+  const messages = migration
+    .createContentType('messages')
+    .name('Messages')
+    .description('')
+    .displayField('text');
+
+  messages
+    .createField('text')
+    .name('Text')
+    .type('Symbol')
+    .localized(false)
+    .required(true)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+
+  messages
+    .createField('createdBy')
+    .name('Created By')
+    .type('Link')
+    .localized(false)
+    .required(true)
+    .disabled(false)
+    .omitted(false)
+    .validations([
+      {
+        linkContentType: ['users'],
+      },
+    ])
+    .linkType('Entry');
+
+  messages.changeFieldControl('text', 'builtin', 'singleLine', {});
+};
+
+module.exports.down = (migration) => {
+  migration.deleteContentType('messages');
+};


### PR DESCRIPTION
Based on the diagram below, this pr is to create the new content models (discussions & messages). In a subsequent pr I will update the quick checks details fields to reference the `Discussions` model. 
<img width="1088" alt="Screenshot 2024-10-15 at 14 39 03" src="https://github.com/user-attachments/assets/f4b492e9-fa39-4e6e-98ff-05b3d0d4a8eb">
