### PR TITLE
Asap-544 manage manuscript status colors

### DIFF
--- a/packages/react-components/src/icons/index.ts
+++ b/packages/react-components/src/icons/index.ts
@@ -117,6 +117,7 @@ export { default as showPasswordIcon } from './show-password';
 export { default as slackIcon } from './slack';
 export { default as speakerIcon } from './speaker';
 export { default as successIcon } from './success';
+export { default as successIconNew } from './success-icon';
 export { default as successLargeIcon } from './success-large';
 export { default as systemCalendarIcon } from './system-calendar';
 export { default as tagSearchIcon } from './tag-search';

--- a/packages/react-components/src/icons/success-icon.tsx
+++ b/packages/react-components/src/icons/success-icon.tsx
@@ -11,8 +11,8 @@ const successIconNew = (
     <rect x="0.5" y="0.5" width="15" height="15" rx="7.5" fill="#34A270" />
     <rect x="0.5" y="0.5" width="15" height="15" rx="7.5" stroke="#34A270" />
     <path
-      fill-rule="evenodd"
-      clip-rule="evenodd"
+      fillRule="evenodd"
+      clipRule="evenodd"
       d="M12.9375 5.64488L7.10582 11.4749C6.91429 11.6664 6.65328 11.772 6.38248 11.7676C6.11168 11.7632 5.85426 11.6491 5.66909 11.4515L3.05469 8.66118L4.51415 7.29372L6.4223 9.33024L11.5235 4.23047L12.9375 5.64488Z"
       fill="#E4F5EE"
     />

--- a/packages/react-components/src/icons/success-icon.tsx
+++ b/packages/react-components/src/icons/success-icon.tsx
@@ -1,0 +1,22 @@
+/* istanbul ignore file */
+
+const successIconNew = (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 16 16"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <rect x="0.5" y="0.5" width="15" height="15" rx="7.5" fill="#34A270" />
+    <rect x="0.5" y="0.5" width="15" height="15" rx="7.5" stroke="#34A270" />
+    <path
+      fill-rule="evenodd"
+      clip-rule="evenodd"
+      d="M12.9375 5.64488L7.10582 11.4749C6.91429 11.6664 6.65328 11.772 6.38248 11.7676C6.11168 11.7632 5.85426 11.6491 5.66909 11.4515L3.05469 8.66118L4.51415 7.29372L6.4223 9.33024L11.5235 4.23047L12.9375 5.64488Z"
+      fill="#E4F5EE"
+    />
+  </svg>
+);
+
+export default successIconNew;

--- a/packages/react-components/src/molecules/StatusButton.tsx
+++ b/packages/react-components/src/molecules/StatusButton.tsx
@@ -8,7 +8,13 @@ import {
   ComponentProps,
 } from 'react';
 import { css } from '@emotion/react';
-import { Button, chevronUpIcon, chevronDownIcon } from '..';
+import {
+  Button,
+  chevronUpIcon,
+  chevronDownIcon,
+  successIconNew,
+  informationIcon,
+} from '..';
 
 import { perRem, mobileScreen, formTargetWidth } from '../pixels';
 
@@ -74,13 +80,15 @@ const listStyles = css({
   },
 });
 
-export type StatusType = 'warning' | 'final' | 'default';
+export type StatusType = 'warning' | 'final' | 'default' | 'none';
 
-const itemContentStyles = (type: StatusType = 'default') =>
+export const itemContentStyles = (type: StatusType = 'default') =>
   css({
     display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'start',
     columnGap: `${15 / perRem}rem`,
-    padding: `${4 / perRem}rem ${16 / perRem}rem`,
+    padding: `${4 / perRem}rem ${14 / perRem}rem`,
     fontWeight: 'normal',
     fontSize: '14px',
     margin: `${8 / perRem}em ${16 / perRem}em !important`,
@@ -89,16 +97,15 @@ const itemContentStyles = (type: StatusType = 'default') =>
     borderRadius: `${24 / perRem}em`,
     alignSelf: 'initial',
     maxWidth: 'fit-content',
-    ...(type === 'warning'
+    ...(type === 'warning' || type === 'final'
       ? {
-          color: warning500.rgba,
-          backgroundColor: warning100.rgba,
-        }
-      : {}),
-    ...(type === 'final'
-      ? {
-          color: success500.rgba,
-          backgroundColor: success100.rgba,
+          color: type === 'warning' ? warning500.rgba : success500.rgba,
+          backgroundColor:
+            type === 'warning' ? warning100.rgba : success100.rgba,
+          columnGap: `${6 / perRem}rem`,
+          padding: `${4 / perRem}rem ${16 / perRem}rem ${4 / perRem}rem ${
+            8 / perRem
+          }rem`,
         }
       : {}),
   });
@@ -121,32 +128,67 @@ const alignLeftStyles = css({
   left: 0,
 });
 
-const statusButtonStyles = css({
-  borderRadius: `${24 / perRem}em`,
-  fontWeight: 400,
-  border: 'none',
-  background: info100.rgba,
-  color: info500.rgba,
-  'svg #Group-7': {
-    stroke: info500.rgba,
-  },
-  paddingLeft: `${16 / perRem}em`,
-  paddingRight: `${8 / perRem}em !important`,
-  textWrap: 'nowrap',
-  maxWidth: 'fit-content',
-});
+const statusButtonStyles = (type: StatusType, isComplianceReviewer: boolean) =>
+  css({
+    borderRadius: `${24 / perRem}em`,
+    fontWeight: 400,
+    border: 'none',
+    background: info100.rgba,
+    color: info500.rgba,
+    ...(type === 'warning'
+      ? {
+          background: warning100.rgba,
+          color: warning500.rgba,
+        }
+      : type === 'final'
+        ? {
+            background: success100.rgba,
+            color: success500.rgba,
+          }
+        : {}),
+    'svg #Group-7': {
+      stroke: info500.rgba,
+      ...([isComplianceReviewer ? 'warning' : 'default', 'final'].includes(type)
+        ? {
+            stroke: warning500.rgba,
+          }
+        : {}),
+    },
+    paddingLeft: `${16 / perRem}em`,
+    paddingRight: `${8 / perRem}em !important`,
+    textWrap: 'nowrap',
+    maxWidth: 'fit-content',
+    display: 'flex',
+    alignItems: 'center',
+    gap: `${8 / perRem}em`,
+  });
 
-const statusTagStyles = css({
-  borderRadius: `${24 / perRem}em`,
-  fontWeight: 400,
-  border: 'none',
-  background: info100.rgba,
-  color: info500.rgba,
-  paddingLeft: `${16 / perRem}em`,
-  paddingRight: `${16 / perRem}em`,
-  textWrap: 'nowrap',
-  maxWidth: 'fit-content',
-});
+const statusTagStyles = (type: StatusType) =>
+  css({
+    borderRadius: `${24 / perRem}em`,
+    fontWeight: 400,
+    border: 'none',
+    background: info100.rgba,
+    color: info500.rgba,
+    ...(type === 'default'
+      ? {
+          background: warning100.rgba,
+          color: warning500.rgba,
+        }
+      : type === 'final'
+        ? {
+            background: success100.rgba,
+            color: success500.rgba,
+          }
+        : {}),
+    paddingLeft: `${16 / perRem}em`,
+    paddingRight: `${16 / perRem}em`,
+    textWrap: 'nowrap',
+    maxWidth: 'fit-content',
+    display: 'flex',
+    alignItems: 'center',
+    gap: `${8 / perRem}em`,
+  });
 
 const itemStyles = css({
   color: lead.rgb,
@@ -155,6 +197,42 @@ const itemStyles = css({
     backgroundColor: neutral200.rgba,
   },
 });
+
+export const iconStyles = (type: string, isComplianceReviewer: boolean) =>
+  css({
+    display: 'flex',
+    alignSelf: 'center',
+
+    '& > svg': {
+      width: '16px',
+      height: '16px',
+      filter: 'revert!important',
+      '-webkit-filter': 'revert!important',
+      ...((type === 'warning' && isComplianceReviewer) ||
+      (type === 'default' && !isComplianceReviewer)
+        ? {
+            '& > g > path': {
+              fill: warning500.rgba,
+            },
+          }
+        : {}),
+      '& > rect:first-of-type': {
+        ...(type === 'final' ? { fill: success500.rgba } : {}),
+      },
+      '& > rect:last-of-type': {
+        stroke: info500.rgba,
+        ...(type === 'final' ? { stroke: success500.rgba } : {}),
+      },
+    },
+  });
+
+export const statusIcon = (type: StatusType, isComplianceReviewer: boolean) =>
+  ({
+    warning: isComplianceReviewer ? informationIcon : '',
+    final: successIconNew,
+    default: isComplianceReviewer ? '' : informationIcon,
+    none: '',
+  })[type];
 
 type ButtonItemData = {
   item: ReactNode;
@@ -168,6 +246,7 @@ type StatusButtonProps = {
   buttonChildren: (menuShown: boolean) => ReactNode;
   alignLeft?: boolean;
   canEdit?: boolean;
+  selectedStatusType?: StatusType;
 } & Partial<Pick<ComponentProps<typeof Button>, 'primary'>>;
 
 const StatusButton: React.FC<StatusButtonProps> = ({
@@ -176,6 +255,7 @@ const StatusButton: React.FC<StatusButtonProps> = ({
   alignLeft = false,
   primary,
   canEdit = false,
+  selectedStatusType = 'none',
 }) => {
   const reference = useRef<HTMLDivElement>(null);
   const handleClick = () => setMenuShown(!menuShown);
@@ -197,6 +277,10 @@ const StatusButton: React.FC<StatusButtonProps> = ({
     };
   }, [reference]);
 
+  const hasIcon = ['final', canEdit ? 'warning' : 'default'].includes(
+    selectedStatusType,
+  );
+
   return (
     <div css={containerStyles} ref={reference}>
       <Button
@@ -206,12 +290,19 @@ const StatusButton: React.FC<StatusButtonProps> = ({
         primary={primary}
         onClick={handleClick}
         enabled={canEdit}
-        overrideStyles={canEdit ? statusButtonStyles : statusTagStyles}
+        overrideStyles={
+          canEdit
+            ? statusButtonStyles(selectedStatusType, canEdit)
+            : statusTagStyles(selectedStatusType)
+        }
       >
-        <>
-          {buttonChildren(menuShown)}
-          {canEdit ? (menuShown ? chevronUpIcon : chevronDownIcon) : null}
-        </>
+        {hasIcon && (
+          <span css={iconStyles(selectedStatusType, canEdit)}>
+            {statusIcon(selectedStatusType, canEdit)}
+          </span>
+        )}
+        {buttonChildren(menuShown)}
+        {canEdit ? (menuShown ? chevronUpIcon : chevronDownIcon) : null}
       </Button>
       <div css={menuWrapperStyles}>
         <div
@@ -237,7 +328,14 @@ const StatusButton: React.FC<StatusButtonProps> = ({
                       onClick && onClick(e);
                     }}
                   >
-                    <span css={itemContentStyles(type)}>{item}</span>
+                    <span css={itemContentStyles(type)}>
+                      {['warning', 'final'].includes(type) && (
+                        <span css={iconStyles(type, canEdit)}>
+                          {statusIcon(type, canEdit)}
+                        </span>
+                      )}
+                      <span>{item}</span>
+                    </span>
                   </button>
                 </li>
               ),

--- a/packages/react-components/src/molecules/StatusButton.tsx
+++ b/packages/react-components/src/molecules/StatusButton.tsx
@@ -207,7 +207,7 @@ export const iconStyles = (type: string, isComplianceReviewer: boolean) =>
       width: '16px',
       height: '16px',
       filter: 'revert!important',
-      '-webkit-filter': 'revert!important',
+      WebkitFilter: 'revert!important',
       ...((type === 'warning' && isComplianceReviewer) ||
       (type === 'default' && !isComplianceReviewer)
         ? {

--- a/packages/react-components/src/molecules/StatusButton.tsx
+++ b/packages/react-components/src/molecules/StatusButton.tsx
@@ -128,7 +128,10 @@ const alignLeftStyles = css({
   left: 0,
 });
 
-const statusButtonStyles = (type: StatusType, isComplianceReviewer: boolean) =>
+export const statusButtonStyles = (
+  type: StatusType,
+  isComplianceReviewer: boolean,
+) =>
   css({
     borderRadius: `${24 / perRem}em`,
     fontWeight: 400,
@@ -163,7 +166,7 @@ const statusButtonStyles = (type: StatusType, isComplianceReviewer: boolean) =>
     gap: `${8 / perRem}em`,
   });
 
-const statusTagStyles = (type: StatusType) =>
+export const statusTagStyles = (type: StatusType) =>
   css({
     borderRadius: `${24 / perRem}em`,
     fontWeight: 400,

--- a/packages/react-components/src/molecules/__tests__/StatusButton.test.tsx
+++ b/packages/react-components/src/molecules/__tests__/StatusButton.test.tsx
@@ -1,7 +1,21 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import {
+  info100,
+  info500,
+  success100,
+  success500,
+  warning100,
+  warning500,
+} from '../../colors';
 
-import StatusButton from '../StatusButton';
+import StatusButton, {
+  iconStyles,
+  statusButtonStyles,
+  statusIcon,
+  statusTagStyles,
+  StatusType,
+} from '../StatusButton';
 
 it('renders a StatusButton as Label when canEdit is false', () => {
   render(<StatusButton buttonChildren={() => <>Status</>} />);
@@ -63,4 +77,85 @@ it('renders items on modal and hides it on outside click', () => {
   screen.getAllByRole('listitem').forEach((e) => expect(e).toBeVisible());
   userEvent.click(screen.getByRole('heading'));
   screen.queryAllByRole('listitem').forEach((e) => expect(e).not.toBeVisible());
+});
+
+describe('statusButtonStyles', () => {
+  it.each([
+    ['warning', true, warning100.rgba, warning500.rgba],
+    ['final', true, success100.rgba, success500.rgba],
+    ['default', true, info100.rgba, info500.rgba],
+    ['none', true, info100.rgba, info500.rgba],
+  ] as [StatusType, boolean, string, string][])(
+    'applies correct styles for type %s and isComplianceReviewer %s',
+    (type, isComplianceReviewer, expectedBackgroundColor, expectedColor) => {
+      const { container } = render(
+        <div css={statusButtonStyles(type, isComplianceReviewer)} />,
+      );
+      expect(container.firstChild).toHaveStyle(
+        `backgroundColor: ${expectedBackgroundColor}`,
+      );
+      expect(container.firstChild).toHaveStyle(`color: ${expectedColor}`);
+    },
+  );
+});
+
+describe('statusTagStyles', () => {
+  it.each([
+    ['warning', info100.rgba, info500.rgba],
+    ['final', success100.rgba, success500.rgba],
+    ['default', warning100.rgba, warning500.rgba],
+    ['none', info100.rgba, info500.rgba],
+  ] as [StatusType, string, string][])(
+    'applies correct styles for type %s',
+    (type, expectedBackgroundColor, expectedColor) => {
+      const { container } = render(<div css={statusTagStyles(type)}>Test</div>);
+
+      expect(container.firstChild).toHaveStyle(
+        `backgroundColor: ${expectedBackgroundColor}`,
+      );
+      expect(container.firstChild).toHaveStyle(`color: ${expectedColor}`);
+    },
+  );
+});
+
+describe('iconStyles', () => {
+  it.each([
+    ['warning', true, warning500.rgba],
+    ['final', true, success500.rgba],
+    ['final', false, success500.rgba],
+    ['default', false, warning500.rgba],
+  ] as [StatusType, boolean, string | null][])(
+    'applies correct styles for icon with type %s and isComplianceReviewer %s',
+    (type, isComplianceReviewer, iconExpectedColor) => {
+      const { container } = render(
+        <span css={iconStyles(type, isComplianceReviewer)}>
+          {statusIcon(type, isComplianceReviewer)}
+        </span>,
+      );
+      const pathElement =
+        container.querySelector('svg g path') ??
+        container.querySelector('svg rect');
+
+      expect(pathElement).toBeInTheDocument();
+      expect(pathElement).toHaveStyle(`fill: ${iconExpectedColor}`);
+    },
+  );
+
+  it.each([
+    ['default', true, null],
+    ['none', true, null],
+    ['warning', false, null],
+    ['none', false, null],
+  ] as [StatusType, boolean, string | null][])(
+    'applies correct styles for icon with type %s and isComplianceReviewer %s (where icon should not show)',
+    (type, isComplianceReviewer) => {
+      const { container } = render(
+        <span css={iconStyles(type, isComplianceReviewer)}>
+          {statusIcon(type, isComplianceReviewer)}
+        </span>,
+      );
+      const svgElement = container.querySelector('svg');
+      expect(svgElement).not.toBeInTheDocument();
+    },
+  );
 });

--- a/packages/react-components/src/organisms/ManuscriptCard.tsx
+++ b/packages/react-components/src/organisms/ManuscriptCard.tsx
@@ -16,6 +16,7 @@ import {
   minusRectIcon,
   plusRectIcon,
   StatusButton,
+  StatusType,
   Subtitle,
 } from '..';
 import { mobileScreen, perRem, rem } from '../pixels';
@@ -135,6 +136,24 @@ const ManuscriptCard: React.FC<ManuscriptCardProps> = ({
       setSelectedStatus(newSelectedStatus);
     }
   };
+
+  const getReviewerStatusType = (
+    statusItem: (typeof manuscriptStatus)[number],
+  ): StatusType =>
+    (
+      ({
+        [manuscriptStatus[0]]: 'warning',
+        [manuscriptStatus[1]]: 'default',
+        [manuscriptStatus[2]]: 'warning',
+        [manuscriptStatus[3]]: 'default',
+        [manuscriptStatus[4]]: 'warning',
+        [manuscriptStatus[5]]: 'default',
+        [manuscriptStatus[6]]: 'warning',
+        [manuscriptStatus[7]]: 'final',
+        [manuscriptStatus[8]]: 'final',
+      }) as Record<string, StatusType>
+    )[statusItem] || 'none';
+
   return (
     <>
       {displayConfirmStatusChangeModal && newSelectedStatus && (
@@ -172,9 +191,13 @@ const ManuscriptCard: React.FC<ManuscriptCardProps> = ({
                 isComplianceReviewer &&
                 !closedManuscriptStatuses.includes(selectedStatus)
               }
+              selectedStatusType={getReviewerStatusType(
+                selectedStatus as (typeof manuscriptStatus)[number],
+              )}
             >
               {manuscriptStatus.map((statusItem) => ({
                 item: statusItem,
+                type: getReviewerStatusType(statusItem),
                 onClick: () => {
                   setNewSelectedStatus(statusItem);
                   handleStatusClick(statusItem);

--- a/packages/react-components/src/organisms/__tests__/ManuscriptCard.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/ManuscriptCard.test.tsx
@@ -97,7 +97,9 @@ it('displays the confirmation modal when isComplianceReviewer is true and the us
   const statusButton = getByTestId('status-button');
   expect(statusButton).toBeEnabled();
   userEvent.click(statusButton);
-  userEvent.click(getByRole('button', { name: 'Information Manuscript Resubmitted' }));
+  userEvent.click(
+    getByRole('button', { name: 'Information Manuscript Resubmitted' }),
+  );
   expect(getByText('Update status and notify?')).toBeInTheDocument();
 });
 
@@ -113,7 +115,9 @@ it('does not display confirmation modal when isComplianceReviewer is true but th
   const statusButton = getByTestId('status-button');
   expect(statusButton).toBeEnabled();
   userEvent.click(statusButton);
-  userEvent.click(getByRole('button', { name: 'Information Addendum Required' }));
+  userEvent.click(
+    getByRole('button', { name: 'Information Addendum Required' }),
+  );
   expect(queryByText('Update status and notify?')).not.toBeInTheDocument();
 });
 
@@ -139,7 +143,9 @@ it('calls onUpdateManuscript when user confirms status change', async () => {
 
   const statusButton = getByTestId('status-button');
   userEvent.click(statusButton);
-  userEvent.click(getByRole('button', { name: 'Information Manuscript Resubmitted' }));
+  userEvent.click(
+    getByRole('button', { name: 'Information Manuscript Resubmitted' }),
+  );
 
   await act(async () => {
     userEvent.click(

--- a/packages/react-components/src/organisms/__tests__/ManuscriptCard.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/ManuscriptCard.test.tsx
@@ -97,7 +97,7 @@ it('displays the confirmation modal when isComplianceReviewer is true and the us
   const statusButton = getByTestId('status-button');
   expect(statusButton).toBeEnabled();
   userEvent.click(statusButton);
-  userEvent.click(getByRole('button', { name: 'Manuscript Resubmitted' }));
+  userEvent.click(getByRole('button', { name: 'Information Manuscript Resubmitted' }));
   expect(getByText('Update status and notify?')).toBeInTheDocument();
 });
 
@@ -113,7 +113,7 @@ it('does not display confirmation modal when isComplianceReviewer is true but th
   const statusButton = getByTestId('status-button');
   expect(statusButton).toBeEnabled();
   userEvent.click(statusButton);
-  userEvent.click(getByRole('button', { name: 'Addendum Required' }));
+  userEvent.click(getByRole('button', { name: 'Information Addendum Required' }));
   expect(queryByText('Update status and notify?')).not.toBeInTheDocument();
 });
 
@@ -139,7 +139,7 @@ it('calls onUpdateManuscript when user confirms status change', async () => {
 
   const statusButton = getByTestId('status-button');
   userEvent.click(statusButton);
-  userEvent.click(getByRole('button', { name: 'Manuscript Resubmitted' }));
+  userEvent.click(getByRole('button', { name: 'Information Manuscript Resubmitted' }));
 
   await act(async () => {
     userEvent.click(


### PR DESCRIPTION
- Manages different styles and visuals depending on the status of the manuscript and the role of the current user (compliance reviewer or not)
- Expected outcome: [Check on figma](https://www.figma.com/design/zY4fHBAsXCiyW6gGrnS4Yy/CRN-%2F-Design-%2F-Network?node-id=26060-273891&t=RkoV3BRPPPebSuqY-1)
- Acceptance criteria:

  1. Confirm the statues are displayed in the above defined colors for Grantees and ASAP Staff on Compliance Summary page

