### PR TITLE
[ASAP-774] - fix public api description field

### DIFF
--- a/apps/crn-server/src/routes/public/research-output.route.ts
+++ b/apps/crn-server/src/routes/public/research-output.route.ts
@@ -66,7 +66,7 @@ const mapToPublicResearchOutput = (
   teams: researchOutput.teams.map((team) => team.displayName),
   authors: researchOutput.authors.map((author) => author.displayName),
   title: researchOutput.title,
-  description: researchOutput.descriptionMD ?? researchOutput.description,
+  description: researchOutput.descriptionMD || researchOutput.description,
   shortDescription: researchOutput.shortDescription,
   tags: [
     ...researchOutput.methods,


### PR DESCRIPTION
Tested using [this research output in dev](https://app.contentful.com/spaces/5v6w5j61tndm/environments/Development/entries/5e30d8a6-bbab-4688-b826-228b5fdf7ae8). 

In Dev Public API
<img width="500" alt="Screenshot 2024-11-14 at 13 20 26" src="https://github.com/user-attachments/assets/49400cd9-ec17-4d46-8539-a1f5cb7a4782">



In PR Public API
<img width="500" alt="Screenshot 2024-11-14 at 13 19 57" src="https://github.com/user-attachments/assets/669894ad-bb57-4d91-b857-be85a97d96b7">
