### PR TITLE
ASAP-813 Allow only lab membership creation on the CMS

### DIFF
--- a/packages/contentful/migrations/crn/users/20241213103301-remove-labs-link-existing-entries.js
+++ b/packages/contentful/migrations/crn/users/20241213103301-remove-labs-link-existing-entries.js
@@ -1,0 +1,19 @@
+module.exports.description = 'Allow only creation of lab membership';
+
+module.exports.up = (migration) => {
+  const users = migration.editContentType('users');
+
+  users.changeFieldControl('labs', 'builtin', 'entryLinksEditor', {
+    showLinkEntityAction: false,
+    showCreateEntityAction: true,
+  });
+};
+
+module.exports.down = (migration) => {
+  const users = migration.editContentType('users');
+
+  users.changeFieldControl('labs', 'builtin', 'entryLinksEditor', {
+    showLinkEntityAction: false,
+    showCreateEntityAction: true,
+  });
+};

--- a/packages/contentful/migrations/crn/users/20241213103301-remove-labs-link-existing-entries.js
+++ b/packages/contentful/migrations/crn/users/20241213103301-remove-labs-link-existing-entries.js
@@ -13,7 +13,7 @@ module.exports.down = (migration) => {
   const users = migration.editContentType('users');
 
   users.changeFieldControl('labs', 'builtin', 'entryLinksEditor', {
-    showLinkEntityAction: false,
+    showLinkEntityAction: true,
     showCreateEntityAction: true,
   });
 };


### PR DESCRIPTION
Adding an existing linked entry was causing confusion

<img width="870" alt="Screenshot 2024-12-13 at 07 39 54" src="https://github.com/user-attachments/assets/c4b57b1c-d0a0-481f-a580-929e90482b23" />

so we're going to change it to always create a new lab-membership entry
<img width="2515" alt="Screenshot 2024-12-13 at 08 54 50" src="https://github.com/user-attachments/assets/25114609-b408-4f3d-926d-c101d13d0206" />
