### PR TITLE
ASAP-812 Custom app to display lab membership

### DIFF
--- a/packages/contentful-app-extensions/membership-reference/src/locations/Field.tsx
+++ b/packages/contentful-app-extensions/membership-reference/src/locations/Field.tsx
@@ -60,6 +60,7 @@ const MembershipCard = ({
         return `${data.fields.firstName?.['en-US']} ${data.fields.lastName?.['en-US']}`;
       case 'team':
         return data.fields.displayName?.['en-US'];
+      case 'lab':
       case 'contributingCohort':
         return data.fields.name?.['en-US'];
       default:

--- a/packages/contentful-app-extensions/membership-reference/src/test/locations/Field.test.tsx
+++ b/packages/contentful-app-extensions/membership-reference/src/test/locations/Field.test.tsx
@@ -66,6 +66,7 @@ describe('Field component', () => {
       entityName
       ${'team'}
       ${'user'}
+      ${'lab'}
       ${'contributingCohort'}
     `('common - $entityName', ({ entityName }) => {
       beforeEach(() => {

--- a/packages/contentful/migrations/crn/users/20241216101304-change-lab-membership-appearance.js
+++ b/packages/contentful/migrations/crn/users/20241216101304-change-lab-membership-appearance.js
@@ -1,0 +1,20 @@
+module.exports.description = 'Change lab membership appearance';
+
+module.exports.up = (migration) => {
+  const users = migration.editContentType('users');
+  users.changeFieldControl('labs', 'app', 'Yp64pYYDuRNHdvAAAJPYa', {
+    entityName: 'lab',
+    showUserEmail: false,
+    showLinkEntityAction: false,
+    showCreateEntityAction: true,
+  });
+};
+
+module.exports.down = (migration) => {
+  const users = migration.editContentType('users');
+
+  users.changeFieldControl('labs', 'builtin', 'entryLinksEditor', {
+    showLinkEntityAction: false,
+    showCreateEntityAction: true,
+  });
+};


### PR DESCRIPTION
This PR updates the existing `membership-reference` Contentful custom app so it can show labs properly. It also adds a migration so the fields `labs` from `users` uses  `membership-reference` as appearance.
