### PR TITLE
ASAP-845 Fix GP2 filter event by project

### DIFF
--- a/packages/algolia/schema/gp2/algolia-reverse-timestamp-schema.json
+++ b/packages/algolia/schema/gp2/algolia-reverse-timestamp-schema.json
@@ -10,6 +10,7 @@
     "authors.id",
     "documentType",
     "eventTypes",
+    "project.id",
     "projects.id",
     "projectIds",
     "region",

--- a/packages/algolia/schema/gp2/algolia-schema.json
+++ b/packages/algolia/schema/gp2/algolia-schema.json
@@ -44,6 +44,7 @@
     "documentType",
     "eventTypes",
     "id",
+    "project.id",
     "projects.id",
     "projectIds",
     "region",

--- a/packages/algolia/src/filters.ts
+++ b/packages/algolia/src/filters.ts
@@ -1,4 +1,9 @@
-import { EventConstraint } from '@asap-hub/model';
+import {
+  EventConstraint as CRNEventConstraint,
+  gp2 as gp2Model,
+} from '@asap-hub/model';
+
+type EventConstraint = CRNEventConstraint | gp2Model.EventConstraint;
 
 type Filters = {
   before?: string;
@@ -11,21 +16,39 @@ const timeFilter = (time: string, symbol: string) => {
 };
 
 const getFilter = (filters: string[], constraint?: EventConstraint) => {
-  if (constraint?.userId && constraint?.teamId) {
+  if (!constraint) return filters.join(' OR ');
+
+  if (constraint.userId && 'teamId' in constraint) {
     throw new Error('userId and teamId not supported!');
   }
-  const constraintFilters = [
-    constraint?.teamId && `speakers.team.id: "${constraint.teamId}"`,
-    constraint?.userId && `speakers.user.id: "${constraint.userId}"`,
-    constraint?.interestGroupId &&
+
+  const constraintFiltersList: string[] = [];
+
+  if ('teamId' in constraint && constraint.teamId) {
+    constraintFiltersList.push(`speakers.team.id: "${constraint.teamId}"`);
+  }
+  if ('userId' in constraint && constraint.userId) {
+    constraintFiltersList.push(`speakers.user.id: "${constraint.userId}"`);
+  }
+  if ('interestGroupId' in constraint && constraint.interestGroupId) {
+    constraintFiltersList.push(
       `interestGroup.id: "${constraint.interestGroupId}"`,
-    constraint?.workingGroupId &&
+    );
+  }
+  if ('workingGroupId' in constraint && constraint.workingGroupId) {
+    constraintFiltersList.push(
       `workingGroup.id: "${constraint.workingGroupId}"`,
-    constraint?.projectId && `project.id: "${constraint.projectId}"`,
-    constraint?.notStatus && `NOT status:${constraint.notStatus}`,
-  ]
-    .filter(Boolean)
-    .join(' AND ');
+    );
+  }
+  if ('notStatus' in constraint && constraint.notStatus) {
+    constraintFiltersList.push(`NOT status:${constraint.notStatus}`);
+  }
+
+  if ('projectId' in constraint && constraint.projectId) {
+    constraintFiltersList.push(`project.id: "${constraint.projectId}"`);
+  }
+
+  const constraintFilters = constraintFiltersList.filter(Boolean).join(' AND ');
 
   if (filters.length === 0) {
     return constraintFilters;

--- a/packages/algolia/src/filters.ts
+++ b/packages/algolia/src/filters.ts
@@ -48,7 +48,7 @@ const getFilter = (filters: string[], constraint?: EventConstraint) => {
     constraintFiltersList.push(`project.id: "${constraint.projectId}"`);
   }
 
-  const constraintFilters = constraintFiltersList.filter(Boolean).join(' AND ');
+  const constraintFilters = constraintFiltersList.join(' AND ');
 
   if (filters.length === 0) {
     return constraintFilters;

--- a/packages/algolia/src/filters.ts
+++ b/packages/algolia/src/filters.ts
@@ -21,6 +21,7 @@ const getFilter = (filters: string[], constraint?: EventConstraint) => {
       `interestGroup.id: "${constraint.interestGroupId}"`,
     constraint?.workingGroupId &&
       `workingGroup.id: "${constraint.workingGroupId}"`,
+    constraint?.projectId && `project.id: "${constraint.projectId}"`,
     constraint?.notStatus && `NOT status:${constraint.notStatus}`,
   ]
     .filter(Boolean)

--- a/packages/algolia/test/filters.test.ts
+++ b/packages/algolia/test/filters.test.ts
@@ -47,6 +47,11 @@ describe('Filters', () => {
       'speakers.team.id: "1103"',
     );
   });
+  test('only status is passed', () => {
+    expect(getEventFilters({}, { notStatus: 'Cancelled' })).toEqual(
+      'NOT status:Cancelled',
+    );
+  });
   test('throws when both userId and teamId are passed', () => {
     expect(() =>
       getEventFilters({}, { userId: '1103', teamId: '1103' }),
@@ -57,6 +62,7 @@ describe('Filters', () => {
     groupName           | entity             | field
     ${`interest group`} | ${`interestGroup`} | ${`interestGroupId`}
     ${`working group`}  | ${`workingGroup`}  | ${`workingGroupId`}
+    ${`project`}        | ${`project`}       | ${`projectId`}
   `('$groupName', ({ groupName, entity, field }) => {
     test(`dates constrained by ${groupName}`, () => {
       expect(

--- a/packages/model/src/event.ts
+++ b/packages/model/src/event.ts
@@ -82,6 +82,7 @@ export type EventConstraint = {
   userId?: string;
   teamId?: string;
   notStatus?: string;
+  projectId?: string;
 };
 
 export type EventCreateDataObject = Pick<

--- a/packages/model/src/event.ts
+++ b/packages/model/src/event.ts
@@ -82,7 +82,6 @@ export type EventConstraint = {
   userId?: string;
   teamId?: string;
   notStatus?: string;
-  projectId?: string;
 };
 
 export type EventCreateDataObject = Pick<


### PR DESCRIPTION
Ticket: https://asaphub.atlassian.net/browse/ASAP-845

This bug happens because the filter `project.id` was missing in the query sent to algolia and in the facet configuration.

---

It's possible to see below that in dev the past events tab is showing events from another project (left side of screenshot) in the PR env it doesn't.

<img width="2278" alt="Screenshot 2025-01-14 at 14 44 33" src="https://github.com/user-attachments/assets/835e330b-fd37-4224-9abb-5e1c143329a0" />
