### PR TITLE
[ASAP-889] - add original version id field

### DIFF
--- a/packages/contentful/migrations/crn/manuscriptVersions/20250501152002-add-original-version-id-field.js
+++ b/packages/contentful/migrations/crn/manuscriptVersions/20250501152002-add-original-version-id-field.js
@@ -13,7 +13,12 @@ module.exports.up = (migration) => {
     .disabled(false)
     .omitted(false);
 
-  manuscriptVersions.changeFieldControl('originalVersionId', 'app', '2finDNk15g5UtOq4DaLNxv', {});
+  manuscriptVersions.changeFieldControl(
+    'originalVersionId',
+    'app',
+    '2finDNk15g5UtOq4DaLNxv',
+    {},
+  );
 };
 
 module.exports.down = (migration) => {

--- a/packages/contentful/migrations/crn/manuscriptVersions/20250501152002-add-original-version-id-field.js
+++ b/packages/contentful/migrations/crn/manuscriptVersions/20250501152002-add-original-version-id-field.js
@@ -1,0 +1,22 @@
+module.exports.description =
+  'Add Original Version ID field to Manuscript Version';
+
+module.exports.up = (migration) => {
+  const manuscriptVersions = migration.editContentType('manuscriptVersions');
+  manuscriptVersions
+    .createField('originalVersionId')
+    .name('Original Version Id')
+    .type('Symbol')
+    .localized(false)
+    .required(false)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+
+  manuscriptVersions.changeFieldControl('originalVersionId', 'app', '2finDNk15g5UtOq4DaLNxv', {});
+};
+
+module.exports.down = (migration) => {
+  const manuscriptVersions = migration.editContentType('manuscriptVersions');
+  manuscriptVersions.deleteField('originalVersionId');
+};


### PR DESCRIPTION
Looking at the [manuscript sheet provided by ASAP](https://docs.google.com/spreadsheets/d/1x4hpX4-RTcKSqZELBgHQWXxciRZa77Nw-PX4aire7h0/edit?usp=sharing), there are missing manuscripts / manuscript versions. This means that after the migration, some manuscript versions will have different ids (ids refers to the id generated with the team grant id, manuscript count, version count etc). This field will store the original id to help the client cross reference. 
The field should not be editable in the cms