### PR TITLE
ASAP-949 Fix on-remove action to not give an error when FilesBucket is not empty

### DIFF
--- a/.github/actions/sls-remove/action.yml
+++ b/.github/actions/sls-remove/action.yml
@@ -70,6 +70,54 @@ runs:
     - name: Build type definitions
       shell: bash
       run: yarn build:typecheck
+    - name: Clean S3 Files Bucket
+      if: ${{ env.SLS_STAGE != 'production' && env.SLS_STAGE != 'dev' }}
+      shell: bash
+      run: |
+        # Function to clean S3 bucket
+        cleanup_s3_bucket() {
+          local bucket_name="asap-hub-${SLS_STAGE}-files"
+
+          echo "Checking if bucket $bucket_name exists..."
+          if aws s3api head-bucket --bucket "$bucket_name" 2>/dev/null; then
+            echo "Bucket $bucket_name exists. Cleaning up..."
+
+            # Remove all current objects
+            echo "Removing all objects..."
+            aws s3 rm "s3://$bucket_name" --recursive || echo "No objects to remove or already empty"
+
+            # Abort incomplete multipart uploads
+            echo "Aborting incomplete multipart uploads..."
+            aws s3api list-multipart-uploads --bucket "$bucket_name" --output json 2>/dev/null | \
+            jq -r '.Uploads[]? | "\(.Key)\t\(.UploadId)"' | \
+            while IFS=$'\t' read -r key upload_id; do
+              if [ ! -z "$key" ] && [ ! -z "$upload_id" ]; then
+                echo "Aborting multipart upload: $key ($upload_id)"
+                aws s3api abort-multipart-upload --bucket "$bucket_name" --key "$key" --upload-id "$upload_id" || true
+              fi
+            done
+
+            # Verify bucket is empty
+            echo "Verifying bucket is empty..."
+            local object_count=$(aws s3 ls "s3://$bucket_name" --recursive | wc -l)
+            if [ "$object_count" -eq 0 ]; then
+              echo "Bucket $bucket_name is now empty and ready for deletion"
+            else
+              echo "⚠️ Warning: Bucket still contains $object_count objects"
+              aws s3 ls "s3://$bucket_name" --recursive
+            fi
+          else
+            echo "Bucket $bucket_name does not exist, skipping cleanup"
+          fi
+        }
+
+        # Call the cleanup function
+        cleanup_s3_bucket
+      env:
+        AWS_ACCESS_KEY_ID: ${{ inputs.aws-access-key-id }}
+        AWS_SECRET_ACCESS_KEY: ${{ inputs.aws-secret-access-key }}
+        AWS_REGION: ${{ inputs.aws-region }}
+        SLS_STAGE: ${{ inputs.sls-stage }}
     - name: Remove CF Stack
       if: ${{ env.SLS_STAGE != 'production' && env.SLS_STAGE != 'dev' }}
       shell: bash


### PR DESCRIPTION
[ASAP-949](https://asaphub.atlassian.net/browse/ASAP-949)

📚[Documentation](https://www.notion.so/S3-cleanup-when-removing-an-environment-20d0dae759ea80c58346f402f8a3e183?source=copy_link)

Note for reviewer:

- [Remove environment / crn-sls-remove (pull_request_target)](https://github.com/yldio/asap-hub/actions/runs/15530593840/job/43718529723?pr=4612) has failed as shown below due to the fact it was running the old yml from master, another test was made by triggering the updated version of [.github/actions/sls-remove/action.yml](https://github.com/yldio/asap-hub/pull/4612/files#diff-bd1cd170fe13d8dae3c771fcd629e3b3755b4413a1bba986258514b60b8cc86c) which succeeded as shown below:

1- Bueckt has two files:
![Screenshot 2025-06-09 at 10 55 35](https://github.com/user-attachments/assets/be0f481a-1823-4966-a980-6aa396c85258)

2- Running the job manually:
![Screenshot 2025-06-09 at 10 56 19](https://github.com/user-attachments/assets/4cbee058-9c75-404f-9dab-fce8f1190e89)

3-Job succeeds with logs showing that files has been removed:
![Screenshot 2025-06-09 at 11 05 19](https://github.com/user-attachments/assets/8833b248-ec48-490c-9df0-d4566377a14a)



[ASAP-949]: https://asaphub.atlassian.net/browse/ASAP-949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ