### PR TITLE
ASAP-1070 [CRN] Return lastModifiedDate in ResearchOutput Public API

### DIFF
--- a/apps/crn-server/src/routes/public/research-output.route.ts
+++ b/apps/crn-server/src/routes/public/research-output.route.ts
@@ -117,5 +117,6 @@ const mapToPublicResearchOutput = (
         ? researchOutput.publishDate
         : undefined,
     ...(preprint.title ? { preprint } : {}),
+    lastModifiedDate: researchOutput.lastUpdatedPartial,
   };
 };

--- a/apps/crn-server/test/fixtures/research-output.fixtures.ts
+++ b/apps/crn-server/test/fixtures/research-output.fixtures.ts
@@ -176,6 +176,7 @@ export const getPublicResearchOutputResponse =
         researchOutput.type === 'Preprint'
           ? researchOutput.publishDate
           : undefined,
+      lastModifiedDate: researchOutput.lastUpdatedPartial,
     };
   };
 

--- a/packages/model/src/research-output.ts
+++ b/packages/model/src/research-output.ts
@@ -376,6 +376,7 @@ export type PublicResearchOutputResponse = Pick<
     link?: string;
     addedDate?: string;
   };
+  lastModifiedDate?: string;
 };
 
 export type ListPublicOutputResponse =


### PR DESCRIPTION
[ASAP-1070](https://asaphub.atlassian.net/browse/ASAP-1070)

can be tested at: 
https://api-4622.hub.asap.science/public/research-outputs
https://api-4622.hub.asap.science/public/research-outputs/:id

[ASAP-962]: https://asaphub.atlassian.net/browse/ASAP-962?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ASAP-1070]: https://asaphub.atlassian.net/browse/ASAP-1070?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ