### PR TITLE
ASAP-831 Preliminary Data Sharing and Attendance on CMS

### DIFF
--- a/packages/contentful-app-extensions/membership-reference/src/locations/Field.tsx
+++ b/packages/contentful-app-extensions/membership-reference/src/locations/Field.tsx
@@ -32,6 +32,7 @@ type CardProps = {
 type MembershipCardProps = {
   entityName: string;
   showUserEmail: boolean;
+  booleanField: boolean | null;
   id: string;
   role?: string;
   workstreamRole?: string;
@@ -41,6 +42,7 @@ type MembershipCardProps = {
 const MembershipCard = ({
   entityName,
   showUserEmail,
+  booleanField,
   id,
   actions,
   inactiveSince,
@@ -83,6 +85,11 @@ const MembershipCard = ({
             {data.fields.email?.['en-US']}
           </Paragraph>
         )}
+      {booleanField !== null && (
+        <Paragraph marginBottom="none">
+          {String(booleanField) === 'true' ? 'Yes' : 'No'}
+        </Paragraph>
+      )}
       {role && <Paragraph marginBottom="none">{role}</Paragraph>}
       {workstreamRole && (
         <Paragraph marginBottom="none">{workstreamRole}</Paragraph>
@@ -117,17 +124,19 @@ const MissingMembershipCard = ({
 type ParameterInstance = {
   entityName: string;
   showUserEmail: boolean;
+  booleanFieldName: string;
 };
 
 const Card = ({ entity, onEdit, onRemove }: CustomEntryCardProps) => {
   const sdk = useSDK<FieldExtensionSDK>();
   const { fields, sys } = entity;
-  const { entityName, showUserEmail } = sdk.parameters
+  const { entityName, showUserEmail, booleanFieldName } = sdk.parameters
     .instance as ParameterInstance;
   const entityId = fields[entityName]?.['en-US'].sys.id;
   const role = fields.role?.['en-US'];
   const workstreamRole = fields.workstreamRole?.['en-US'];
   const inactiveSince = fields.inactiveSinceDate?.['en-US'];
+  const booleanField = fields[booleanFieldName]?.['en-US'];
   const removeMembership = async () => {
     if (sys.publishedVersion) {
       await sdk.space.unpublishEntry(entity);
@@ -156,6 +165,7 @@ const Card = ({ entity, onEdit, onRemove }: CustomEntryCardProps) => {
       {...defaultProps}
       entityName={entityName}
       showUserEmail={showUserEmail}
+      booleanField={booleanField ?? null}
       id={entityId}
       role={role}
       workstreamRole={workstreamRole}

--- a/packages/contentful-app-extensions/membership-reference/src/test/locations/Field.test.tsx
+++ b/packages/contentful-app-extensions/membership-reference/src/test/locations/Field.test.tsx
@@ -329,6 +329,138 @@ describe('Field component', () => {
           expect(screen.getByText('Project Manager')).toBeInTheDocument();
         });
       });
+
+      it('displays boolean field if parameter booleanFieldName is set and its value is true', async () => {
+        sdk = {
+          ...mockBaseSdk(),
+          parameters: {
+            instance: {
+              entityName: 'team',
+              showUserEmail: false,
+              booleanFieldName: 'preliminaryDataShared',
+            },
+          },
+        } as unknown as jest.Mocked<FieldExtensionSDK>;
+        (useSDK as jest.Mock).mockReturnValue(sdk);
+
+        (useEntity as jest.Mock).mockImplementation((type, id) => {
+          if (id === 'team-1') {
+            return {
+              data: {
+                fields: {
+                  displayName: {
+                    'en-US': 'My Team',
+                  },
+                  preliminaryDataShared: {
+                    'en-US': true,
+                  },
+                },
+              },
+            };
+          }
+        });
+
+        const props = {
+          entity: {
+            fields: {
+              team: {
+                'en-US': {
+                  sys: {
+                    id: 'team-1',
+                  },
+                  displayName: {
+                    'en-US': 'My Team',
+                  },
+                },
+              },
+              preliminaryDataShared: {
+                'en-US': true,
+              },
+            },
+            sys: {
+              type: 'Entry',
+              publishedVersion: 1,
+              version: 1,
+            },
+          },
+          onEdit: jest.fn(),
+          onRemove: jest.fn(),
+        } as unknown as CustomEntityCardProps;
+
+        render(<CustomCard {...props} />);
+
+        await waitFor(() => {
+          expect(useEntity).toHaveBeenCalledWith('Entry', 'team-1');
+          expect(screen.getByText('My Team')).toBeInTheDocument();
+          expect(screen.getByText('Yes')).toBeInTheDocument();
+        });
+      });
+
+      it('displays boolean field if parameter booleanFieldName is set and its value is false', async () => {
+        sdk = {
+          ...mockBaseSdk(),
+          parameters: {
+            instance: {
+              entityName: 'team',
+              showUserEmail: false,
+              booleanFieldName: 'preliminaryDataShared',
+            },
+          },
+        } as unknown as jest.Mocked<FieldExtensionSDK>;
+        (useSDK as jest.Mock).mockReturnValue(sdk);
+
+        (useEntity as jest.Mock).mockImplementation((type, id) => {
+          if (id === 'team-1') {
+            return {
+              data: {
+                fields: {
+                  displayName: {
+                    'en-US': 'My Team',
+                  },
+                  preliminaryDataShared: {
+                    'en-US': false,
+                  },
+                },
+              },
+            };
+          }
+        });
+
+        const props = {
+          entity: {
+            fields: {
+              team: {
+                'en-US': {
+                  sys: {
+                    id: 'team-1',
+                  },
+                  displayName: {
+                    'en-US': 'My Team',
+                  },
+                },
+              },
+              preliminaryDataShared: {
+                'en-US': false,
+              },
+            },
+            sys: {
+              type: 'Entry',
+              publishedVersion: 1,
+              version: 1,
+            },
+          },
+          onEdit: jest.fn(),
+          onRemove: jest.fn(),
+        } as unknown as CustomEntityCardProps;
+
+        render(<CustomCard {...props} />);
+
+        await waitFor(() => {
+          expect(useEntity).toHaveBeenCalledWith('Entry', 'team-1');
+          expect(screen.getByText('My Team')).toBeInTheDocument();
+          expect(screen.getByText('No')).toBeInTheDocument();
+        });
+      });
     });
 
     describe('with entityName parameter equals user', () => {

--- a/packages/contentful/migrations/crn/attendance/20250717135446-add-attendance-model.js
+++ b/packages/contentful/migrations/crn/attendance/20250717135446-add-attendance-model.js
@@ -1,0 +1,44 @@
+module.exports.description = 'Add attendance model';
+
+module.exports.up = (migration) => {
+  const attendance = migration
+    .createContentType('attendance')
+    .name('Attendance')
+    .description('');
+
+  attendance
+    .createField('team')
+    .name('Team')
+    .type('Link')
+    .localized(false)
+    .required(true)
+    .validations([
+      {
+        linkContentType: ['teams'],
+      },
+    ])
+    .disabled(false)
+    .omitted(false)
+    .linkType('Entry');
+
+  attendance
+    .createField('attended')
+    .name('Attended')
+    .type('Boolean')
+    .localized(false)
+    .required(true)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+
+  attendance.changeFieldControl('team', 'builtin', 'entryLinkEditor', {
+    showLinkEntityAction: true,
+    showCreateEntityAction: false,
+  });
+
+  attendance.changeFieldControl('attended', 'builtin', 'boolean', {});
+};
+
+module.exports.down = (migration) => {
+  migration.deleteContentType('attendance');
+};

--- a/packages/contentful/migrations/crn/events/20250717141315-add-preliminary-data-shared-and-attendance-fields.js
+++ b/packages/contentful/migrations/crn/events/20250717141315-add-preliminary-data-shared-and-attendance-fields.js
@@ -1,0 +1,77 @@
+module.exports.description =
+  'Add preliminary data shared and attendance fields';
+
+module.exports.up = (migration) => {
+  const events = migration.editContentType('events');
+
+  events
+    .createField('preliminaryDataShared')
+    .name('Preliminary Data Shared')
+    .type('Array')
+    .localized(false)
+    .required(false)
+    .validations([])
+    .disabled(false)
+    .omitted(false)
+    .items({
+      type: 'Link',
+
+      validations: [
+        {
+          linkContentType: ['preliminaryDataSharing'],
+        },
+      ],
+
+      linkType: 'Entry',
+    });
+
+  events
+    .createField('attendance')
+    .name('Attendance')
+    .type('Array')
+    .localized(false)
+    .required(false)
+    .validations([])
+    .disabled(false)
+    .omitted(false)
+    .items({
+      type: 'Link',
+
+      validations: [
+        {
+          linkContentType: ['attendance'],
+        },
+      ],
+
+      linkType: 'Entry',
+    });
+
+  events.changeFieldControl(
+    'preliminaryDataShared',
+    'app',
+    'Yp64pYYDuRNHdvAAAJPYa',
+    {
+      entityName: 'team',
+      bulkEditing: false,
+      showUserEmail: false,
+      booleanFieldName: 'preliminaryDataShared',
+      showLinkEntityAction: false,
+      showCreateEntityAction: true,
+    },
+  );
+
+  events.changeFieldControl('attendance', 'app', 'Yp64pYYDuRNHdvAAAJPYa', {
+    entityName: 'team',
+    bulkEditing: false,
+    showUserEmail: false,
+    booleanFieldName: 'attended',
+    showLinkEntityAction: false,
+    showCreateEntityAction: true,
+  });
+};
+
+module.exports.down = (migration) => {
+  const events = migration.editContentType('events');
+  events.deleteField('preliminaryDataShared');
+  events.deleteField('attendance');
+};

--- a/packages/contentful/migrations/crn/preliminaryDataSharing/20250717135623-add-preliminarydatasharing-model.js
+++ b/packages/contentful/migrations/crn/preliminaryDataSharing/20250717135623-add-preliminarydatasharing-model.js
@@ -1,0 +1,54 @@
+module.exports.description = 'Add preliminary data sharing model';
+
+module.exports.up = (migration) => {
+  const preliminaryDataSharing = migration
+    .createContentType('preliminaryDataSharing')
+    .name('Preliminary Data Sharing')
+    .description('');
+
+  preliminaryDataSharing
+    .createField('team')
+    .name('Team')
+    .type('Link')
+    .localized(false)
+    .required(true)
+    .validations([
+      {
+        linkContentType: ['teams'],
+      },
+    ])
+    .disabled(false)
+    .omitted(false)
+    .linkType('Entry');
+
+  preliminaryDataSharing
+    .createField('preliminaryDataShared')
+    .name('Preliminary Data Shared')
+    .type('Boolean')
+    .localized(false)
+    .required(true)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+
+  preliminaryDataSharing.changeFieldControl(
+    'team',
+    'builtin',
+    'entryLinkEditor',
+    {
+      showLinkEntityAction: true,
+      showCreateEntityAction: false,
+    },
+  );
+
+  preliminaryDataSharing.changeFieldControl(
+    'preliminaryDataShared',
+    'builtin',
+    'boolean',
+    {},
+  );
+};
+
+module.exports.down = (migration) => {
+  migration.deleteContentType('preliminaryDataSharing');
+};

--- a/packages/contentful/package.json
+++ b/packages/contentful/package.json
@@ -14,6 +14,7 @@
     "migrate-assign-users-as-lab-pi": "ts-node ./scripts/assign-users-as-lab-pi.ts",
     "migrate-preprint-versions": "ts-node ./scripts/migrate-research-output-versions.ts",
     "migrate-interest-group-teams": "ts-node ./scripts/migrate-interest-group-teams.ts",
+    "migrate-preliminary-data-sharing": "ts-node ./scripts/migrate-preliminary-data-sharing.ts",
     "watch:babel": "../../scripts/build-babel.sh watch",
     "space:rollback-migration": "yarn ctf-migrate down -c $CONTENT_TYPE -d $DRY_RUN",
     "space:migrate:run": "yarn ctf-migrate up --all",

--- a/packages/contentful/scripts/migrate-preliminary-data-sharing.ts
+++ b/packages/contentful/scripts/migrate-preliminary-data-sharing.ts
@@ -1,0 +1,169 @@
+import * as contentful from 'contentful-management';
+import fs from 'fs/promises';
+import csvParse from 'csv-parse';
+import { resolve } from 'path';
+import { RateLimiter } from 'limiter';
+import { addLocaleToFields } from '../src/utils/parse-fields';
+
+const spaceId = process.env.CONTENTFUL_SPACE_ID!;
+const contentfulManagementAccessToken =
+  process.env.CONTENTFUL_MANAGEMENT_ACCESS_TOKEN!;
+const environmentId = process.env.CONTENTFUL_ENV_ID!;
+
+const client = contentful.createClient({
+  accessToken: contentfulManagementAccessToken,
+});
+
+const rateLimiter = new RateLimiter({
+  tokensPerInterval: 10,
+  interval: 5000,
+});
+
+interface ErrorLog {
+  eventId: string;
+  teamId: string;
+  preliminaryDataShared: string;
+  error: string;
+  timestamp: string;
+}
+
+const errors: ErrorLog[] = [];
+
+const updateEvents = async (input: string[]) => {
+  const data = input.map((s) => s.trim());
+  const eventId = data[0]!;
+  const teamId = data[1]!;
+  const preliminaryDataShared = data[2]!;
+  const space = await client.getSpace(spaceId);
+  const environment = await space.getEnvironment(environmentId);
+
+  try {
+    await rateLimiter.removeTokens(1);
+    const preliminaryDataSharedEntry = await environment.createEntry(
+      'preliminaryDataSharing',
+      {
+        fields: addLocaleToFields({
+          team: {
+            sys: {
+              type: 'Link',
+              linkType: 'Entry',
+              id: teamId,
+            },
+          },
+          preliminaryDataShared: preliminaryDataShared === 'Y',
+        }),
+      },
+    );
+
+    await rateLimiter.removeTokens(1);
+    const publishedPreliminaryDataSharedEntry =
+      await preliminaryDataSharedEntry.publish();
+
+    await rateLimiter.removeTokens(1);
+    const eventEntry = await environment.getEntry(eventId);
+
+    const eventFields = eventEntry.fields;
+    const currentPreliminaryDataShared =
+      eventFields.preliminaryDataShared?.['en-US'] || [];
+
+    await rateLimiter.removeTokens(1);
+    const existingTeamLinks = await environment.getEntries({
+      content_type: 'preliminaryDataSharing',
+      'fields.team.sys.id': teamId,
+    });
+
+    const existingTeamLinkIds = existingTeamLinks.items.map(
+      (item) => item.sys.id,
+    );
+    const hasAnyTeamLink = currentPreliminaryDataShared.some(
+      (item: { sys: { id: string } }) =>
+        existingTeamLinkIds.includes(item.sys.id),
+    );
+
+    if (hasAnyTeamLink) {
+      console.log(
+        `Event ${eventId} already has a preliminary data sharing link for team ${teamId}`,
+      );
+    } else {
+      const newPreliminaryDataShared = [
+        ...currentPreliminaryDataShared,
+        {
+          sys: {
+            type: 'Link',
+            linkType: 'Entry',
+            id: publishedPreliminaryDataSharedEntry.sys.id,
+          },
+        },
+      ];
+
+      eventFields.preliminaryDataShared = {
+        'en-US': newPreliminaryDataShared,
+      };
+
+      await rateLimiter.removeTokens(1);
+      const updatedEventEntry = await eventEntry.update();
+
+      await rateLimiter.removeTokens(1);
+      await updatedEventEntry.publish();
+
+      console.log(
+        `Added preliminary data sharing link to event ${eventId} for team ${teamId} with preliminaryDataShared=${preliminaryDataShared}`,
+      );
+    }
+  } catch (e) {
+    const errorMessage = e instanceof Error ? e.message : String(e);
+    console.error(
+      `Error for event ${eventId} and team ${teamId}: ${errorMessage}`,
+    );
+
+    errors.push({
+      eventId,
+      teamId,
+      preliminaryDataShared,
+      error: errorMessage,
+      timestamp: new Date().toISOString(),
+    });
+  }
+};
+
+const saveErrorsToFile = async () => {
+  if (errors.length > 0) {
+    const errorOutputPath = resolve(__dirname, './migration-errors.json');
+    const errorReport = {
+      totalErrors: errors.length,
+      timestamp: new Date().toISOString(),
+      errors,
+    };
+
+    await fs.writeFile(errorOutputPath, JSON.stringify(errorReport, null, 2));
+    console.log(`\n${errors.length} errors saved to: ${errorOutputPath}`);
+  } else {
+    console.log('\nNo errors occurred during migration.');
+  }
+};
+
+const migratePreliminaryDataSharing = async () => {
+  const path = resolve(__dirname, './preliminary_data_sharing.csv');
+  const content = await fs.readFile(path, 'utf8');
+
+  const parser = csvParse(content, {
+    delimiter: ',',
+    from_line: 2,
+  });
+
+  parser.on('readable', async function () {
+    let record: string[];
+    while ((record = parser.read()) !== null) {
+      await updateEvents(record);
+    }
+  });
+
+  parser.on('end', async () => {
+    await saveErrorsToFile();
+  });
+};
+
+migratePreliminaryDataSharing().catch(async (error) => {
+  console.error('Fatal error:', error);
+  await saveErrorsToFile();
+});


### PR DESCRIPTION
Ticket: https://asaphub.atlassian.net/browse/ASAP-831

---

For the migration, I manually pulled the `teamId` and `teamName` from Production. Using the team names from the spreadsheet linked in the ticket, I matched them to their corresponding IDs. Then I put everything together into a new CSV that looks like this:

| Event ID                               | TeamId                                 | PRELIMINARY DATA SHARED? |
|----------------------------------------|----------------------------------------|---------------------------|
| c7e6413e-ece9-4d08-92a5-a04f95b6bfb1    | 83a895b9-9800-47b2-8cd1-d4110325b811    | N                         |
| c7e6413e-ece9-4d08-92a5-a04f95b6bfb1    | a572993f-3a00-43fa-b5ed-64cb207ad151    | Y                         |
| ... | ... | ...|

This will be used as input for the migration in Production.

--- 

#### Events Example on CMS
<img width="1949" height="1356" src="https://github.com/user-attachments/assets/65004dd9-9d57-46bd-9cc0-9d7f7322dced" />
