### PR TITLE
Fix: sls remove required env variables

### DIFF
--- a/.github/actions/sls-remove/action.yml
+++ b/.github/actions/sls-remove/action.yml
@@ -159,3 +159,5 @@ runs:
         SES_REGION: ${{ inputs.ses-region }}
         SLACK_WEBHOOK: ${{ inputs.slack-webhook }}
         SLS_STAGE: ${{ inputs.sls-stage }}
+        AWS_OS_USERNAME: 'n-a'
+        AWS_OS_PASSWORD: 'n-a'


### PR DESCRIPTION
This PR is created to fix the issue of having the newly added secrets as required but not passed down in the sls-remove stage as  shows below:

<img width="1284" height="225" alt="image" src="https://github.com/user-attachments/assets/2538808b-6628-4f75-8b6a-28a98ac5c7a3" />

Similar to what we have in our code base 'n-a' value is passed instead of the actual values since sls-remove doesn't really require those secrets