### PR TITLE
ASAP-1142 Add contributing teams to Import Manuscript selection

### DIFF
--- a/apps/crn-frontend/src/network/teams/__tests__/api.test.ts
+++ b/apps/crn-frontend/src/network/teams/__tests__/api.test.ts
@@ -755,7 +755,7 @@ describe('Manuscript', () => {
         expect.objectContaining({
           hitsPerPage: 25,
           page: 2,
-          filters: `(teamId:"${teamId}")`,
+          filters: `(teamId:"${teamId}" OR teams.id:"${teamId}")`,
         }),
       );
     });

--- a/apps/crn-frontend/src/network/teams/api.ts
+++ b/apps/crn-frontend/src/network/teams/api.ts
@@ -407,7 +407,9 @@ export const getManuscriptVersions = async (
       page: currentPage ?? undefined,
       hitsPerPage: pageSize ?? undefined,
       restrictSearchableAttributes: ['title', 'manuscriptId'],
-      ...(teamId && { filters: `(teamId:"${teamId}")` }),
+      ...(teamId && {
+        filters: `(teamId:"${teamId}" OR teams.id:"${teamId}")`,
+      }),
     },
   );
 


### PR DESCRIPTION
Ticket: https://asaphub.atlassian.net/browse/ASAP-1142

---

It wasn't necessary to add a new field on Algolia, it is possible to search for the team id in id from the existing field `teams`:


Data in teams          |  Filter Values
:-------------------------:|:-------------------------:
<img width="497" height="752" src="https://github.com/user-attachments/assets/4ed448bb-8f88-49c2-aed7-b25d355c91e2" />  |  <img width="887" height="807" src="https://github.com/user-attachments/assets/a2ae2e20-0421-40bc-8e23-32f1e181b6c7" />


