### PR TITLE
Improve watch:babel performance by separating build and watch phases

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "typecheck": "turbo typecheck",
     "update:browser-list": "yarn up -R caniuse-lite",
     "watch": "yarn watch:babel & yarn watch:typecheck",
-    "watch:babel": "yarn workspaces foreach -vpi -j 1000 run watch:babel",
+    "watch:babel": "yarn workspaces foreach -vpi -j 1 run build:babel && yarn workspaces foreach -vpi -j 1000 run watch:babel",
     "watch:typecheck": "yarn build:typecheck:tsc -w"
   },
   "resolutions": {

--- a/scripts/build-babel.sh
+++ b/scripts/build-babel.sh
@@ -13,12 +13,6 @@ case $1 in
     wait
   ;;
   watch)
-    echo Building ESM
-    eval $BUILD_CMD &
-    echo Building CJS
-    eval $BUILD_CJS_CMD &
-    wait
-
     echo Watching ESM
     eval $BUILD_CMD -w --verbose --skip-initial-build &
     echo Watching CJS


### PR DESCRIPTION
Improves Babel build performance by separating the initial compilation phase from watch mode.

Changes:
- Run initial build sequentially before starting watchers
- Move initial compilation from scripts/build-babel.sh to root package.json
- Use `-j 1` for build phase, then `-j 1000` for watch phase

Benefits:
- Reduces CPU competition during startup
- Prevents system slowdown on less powerful machines
- No significant increase in boot time
- System remains responsive during the initial compilation period (in my computer, this used to take 10 minutes 😁 ).

Technical details:
The `-j 1` parameter controls parallel processes during compilation. This can be adjusted based on machine capabilities, higher values may cause system slowness on weaker hardware.

The change to scripts/build-babel.sh only affects the watch command flow and doesn't impact other build processes.

Note: Individual workspace watch commands now require an initial build. If running `yarn workspace @asap-hub/react-components watch:babel` directly, you'll need to run `yarn workspace @asap-hub/react-components build:babel` first. This shouldn't affect current team workflow since we typically use `yarn watch` at the root level, but worth noting for any individual workspace development.
