### PR TITLE
[ASAP-1078] - update FormCard component to match designs

### DIFF
--- a/packages/gp2-components/src/templates/OutputForm.tsx
+++ b/packages/gp2-components/src/templates/OutputForm.tsx
@@ -61,6 +61,9 @@ const DOC_TYPES_COHORTS_NOT_REQUIRED: gp2Model.OutputDocumentType[] = [
   'Code/Software',
 ];
 
+/** Auxiliary empty space to match designs */
+const EmptyGap = () => <div />;
+
 export const getRelatedOutputs = (
   relatedOutputs: gp2Model.OutputResponse['relatedOutputs'],
 ) =>
@@ -95,7 +98,7 @@ const linkStyles = css({
 const containerStyles = css({
   display: 'flex',
   flexDirection: 'column',
-  gap: rem(32),
+  gap: 32,
 });
 
 type OutputFormProps = {
@@ -462,6 +465,7 @@ const OutputForm: React.FC<OutputFormProps> = ({
                       }}
                       required
                       enabled={!isSaving}
+                      noPadding
                     />
                     <LabeledTextField
                       title="URL"
@@ -483,6 +487,7 @@ const OutputForm: React.FC<OutputFormProps> = ({
                       enabled={!isSaving}
                       labelIndicator={<GlobeIcon />}
                       placeholder="https://example.com"
+                      noPadding
                     />
                     {documentType === 'Article' && (
                       <LabeledDropdown
@@ -495,6 +500,7 @@ const OutputForm: React.FC<OutputFormProps> = ({
                           value: name,
                         }))}
                         onChange={setType}
+                        noPadding
                       />
                     )}
                     {newType === 'Research' && (
@@ -508,6 +514,7 @@ const OutputForm: React.FC<OutputFormProps> = ({
                           value: name,
                         }))}
                         onChange={setSubtype}
+                        noPadding
                       />
                     )}
 
@@ -526,6 +533,7 @@ const OutputForm: React.FC<OutputFormProps> = ({
         `}
                         ></Markdown>
                       }
+                      noPadding
                     />
                     <ShortDescriptionCard
                       onChange={(shortDescriptionNewValue) => {
@@ -603,9 +611,13 @@ const OutputForm: React.FC<OutputFormProps> = ({
                         getValidationMessage={(e) =>
                           getPublishDateValidationMessage(e)
                         }
+                        noPadding
                       />
                     ) : null}
                   </FormCard>
+
+                  <EmptyGap />
+
                   <FormCard title="What extra information can you provide?">
                     <LabeledMultiSelect
                       title="Additional Tags"
@@ -640,6 +652,7 @@ const OutputForm: React.FC<OutputFormProps> = ({
                       }}
                       placeholder="Start typing... (E.g. Neurology)"
                       maxMenuHeight={160}
+                      noPadding
                     />
                     <div css={linkStyles}>
                       <Link
@@ -702,6 +715,7 @@ const OutputForm: React.FC<OutputFormProps> = ({
                       noOptionsMessage={({ inputValue }) =>
                         `Sorry, no working groups match ${inputValue}`
                       }
+                      noPadding
                     />
                     <LabeledMultiSelect
                       title="Projects"
@@ -737,6 +751,7 @@ const OutputForm: React.FC<OutputFormProps> = ({
                       noOptionsMessage={({ inputValue }) =>
                         `Sorry, no projects match ${inputValue}`
                       }
+                      noPadding
                     />
                     {!DOC_TYPES_COHORTS_NOT_REQUIRED.includes(documentType) ? (
                       <>
@@ -774,6 +789,7 @@ const OutputForm: React.FC<OutputFormProps> = ({
                           }}
                           placeholder="Start typing..."
                           maxMenuHeight={160}
+                          noPadding
                         />
                         <div css={linkStyles}>
                           Don’t see a cohort in this list?{' '}
@@ -802,6 +818,7 @@ const OutputForm: React.FC<OutputFormProps> = ({
                       noOptionsMessage={({ inputValue }) =>
                         `Sorry, no authors match ${inputValue}`
                       }
+                      noPadding
                     />
                   </FormCard>
                   <OutputRelatedResearchCard

--- a/packages/gp2-components/src/templates/OutputForm.tsx
+++ b/packages/gp2-components/src/templates/OutputForm.tsx
@@ -92,9 +92,12 @@ const footerStyles = css({
   },
 });
 
-const linkStyles = css({
-  marginBottom: rem(36),
+const fieldWithLinkStyles = css({
+  display: 'flex',
+  flexFlow: 'column',
+  gap: 16,
 });
+
 const containerStyles = css({
   display: 'flex',
   flexDirection: 'column',
@@ -619,42 +622,42 @@ const OutputForm: React.FC<OutputFormProps> = ({
                   <EmptyGap />
 
                   <FormCard title="What extra information can you provide?">
-                    <LabeledMultiSelect
-                      title="Additional Tags"
-                      subtitle="(optional)"
-                      description={
-                        <>
-                          Increase the discoverability of this output by adding
-                          keywords.{' '}
-                        </>
-                      }
-                      values={newTags.map(({ id, name }) => ({
-                        label: name,
-                        value: id,
-                      }))}
-                      enabled={!isSaving}
-                      suggestions={tagSuggestions.map(({ id, name }) => ({
-                        label: name,
-                        value: id,
-                      }))}
-                      onChange={(newValues) => {
-                        setNewTags(
-                          newValues
-                            .slice(0, 10)
-                            .reduce(
-                              (acc, curr) => [
-                                ...acc,
-                                { id: curr.value, name: curr.label },
-                              ],
-                              [] as gp2Model.TagDataObject[],
-                            ),
-                        );
-                      }}
-                      placeholder="Start typing... (E.g. Neurology)"
-                      maxMenuHeight={160}
-                      noPadding
-                    />
-                    <div css={linkStyles}>
+                    <div css={fieldWithLinkStyles}>
+                      <LabeledMultiSelect
+                        title="Additional Tags"
+                        subtitle="(optional)"
+                        description={
+                          <>
+                            Increase the discoverability of this output by
+                            adding keywords.{' '}
+                          </>
+                        }
+                        values={newTags.map(({ id, name }) => ({
+                          label: name,
+                          value: id,
+                        }))}
+                        enabled={!isSaving}
+                        suggestions={tagSuggestions.map(({ id, name }) => ({
+                          label: name,
+                          value: id,
+                        }))}
+                        onChange={(newValues) => {
+                          setNewTags(
+                            newValues
+                              .slice(0, 10)
+                              .reduce(
+                                (acc, curr) => [
+                                  ...acc,
+                                  { id: curr.value, name: curr.label },
+                                ],
+                                [] as gp2Model.TagDataObject[],
+                              ),
+                          );
+                        }}
+                        placeholder="Start typing... (E.g. Neurology)"
+                        maxMenuHeight={160}
+                        noPadding
+                      />
                       <Link
                         href={mailToSupport({
                           email: INVITE_SUPPORT_EMAIL,
@@ -754,7 +757,7 @@ const OutputForm: React.FC<OutputFormProps> = ({
                       noPadding
                     />
                     {!DOC_TYPES_COHORTS_NOT_REQUIRED.includes(documentType) ? (
-                      <>
+                      <div css={fieldWithLinkStyles}>
                         <LabeledMultiSelect
                           title="Cohorts"
                           subtitle="(optional)"
@@ -791,7 +794,7 @@ const OutputForm: React.FC<OutputFormProps> = ({
                           maxMenuHeight={160}
                           noPadding
                         />
-                        <div css={linkStyles}>
+                        <div>
                           Don’t see a cohort in this list?{' '}
                           <Link
                             href={mailToSupport({
@@ -802,7 +805,7 @@ const OutputForm: React.FC<OutputFormProps> = ({
                             Contact {INVITE_SUPPORT_EMAIL}
                           </Link>
                         </div>
-                      </>
+                      </div>
                     ) : null}
                     <AuthorSelect
                       title="Authors"

--- a/packages/react-components/src/atoms/TextArea.tsx
+++ b/packages/react-components/src/atoms/TextArea.tsx
@@ -2,12 +2,7 @@
 import { InputHTMLAttributes } from 'react';
 import { css } from '@emotion/react';
 
-import {
-  useValidation,
-  styles,
-  validationMessageStyles,
-  hiddenWhenEmptyStyles,
-} from '../form';
+import { useValidation, styles, validationMessageStyles } from '../form';
 import { noop } from '../utils';
 import { ember, rose, fern, tin, lead, silver } from '../colors';
 import { perRem, tabletScreen } from '../pixels';

--- a/packages/react-components/src/atoms/TextArea.tsx
+++ b/packages/react-components/src/atoms/TextArea.tsx
@@ -2,7 +2,12 @@
 import { InputHTMLAttributes } from 'react';
 import { css } from '@emotion/react';
 
-import { useValidation, styles, validationMessageStyles } from '../form';
+import {
+  useValidation,
+  styles,
+  validationMessageStyles,
+  hiddenWhenEmptyStyles,
+} from '../form';
 import { noop } from '../utils';
 import { ember, rose, fern, tin, lead, silver } from '../colors';
 import { perRem, tabletScreen } from '../pixels';
@@ -58,6 +63,9 @@ const limitAndExtrasStyles = css({
   display: 'flex',
   justifyContent: 'space-between',
   paddingTop: `${16 / perRem}em`,
+  ':empty': {
+    display: 'none',
+  },
 });
 
 type TextAreaProps = {
@@ -125,12 +133,12 @@ const TextArea: React.FC<TextAreaProps> = ({
         ]}
         {...(onBlur ? { onBlur } : {})}
       />
-      <div>
+      <>
         <div css={validationMessageStyles}>
           {validationMessage || (reachedMaxLength && 'Character count reached')}
         </div>
         <div css={limitAndExtrasStyles}>
-          <div>{extras}</div>
+          {extras && <div>{extras}</div>}
           {maxLength !== undefined && (
             <div
               css={({ colors: { primary500 = fern } = {} }) => [
@@ -143,7 +151,7 @@ const TextArea: React.FC<TextAreaProps> = ({
             </div>
           )}
         </div>
-      </div>
+      </>
     </div>
   );
 };

--- a/packages/react-components/src/molecules/FormCard.tsx
+++ b/packages/react-components/src/molecules/FormCard.tsx
@@ -1,7 +1,5 @@
 import { css, SerializedStyles } from '@emotion/react';
 import { Card, Headline3, Paragraph } from '../atoms';
-import { paddingStyles } from '../card';
-import { perRem } from '../pixels';
 
 export type FormCardProps = {
   title: string;
@@ -14,12 +12,8 @@ const cardStyles = css({
 });
 
 const descriptionStyles = css({
-  paddingTop: 0,
+  paddingTop: 24,
   paddingBottom: 0,
-  'p:first-of-type': {
-    marginTop: 0,
-    marginBottom: `${10 / perRem}em`,
-  },
 });
 
 const childrenWrapStyles = css({
@@ -40,8 +34,10 @@ const FormCard: React.FC<FormCardProps> = ({
       <Headline3 noMargin>{title}</Headline3>
     </div>
     {!!description && (
-      <div css={[paddingStyles, descriptionStyles]}>
-        <Paragraph accent="lead">{description}</Paragraph>
+      <div css={[descriptionStyles]}>
+        <Paragraph noMargin accent="lead">
+          {description}
+        </Paragraph>
       </div>
     )}
     <div css={[childrenWrapStyles]}>{children}</div>

--- a/packages/react-components/src/molecules/FormCard.tsx
+++ b/packages/react-components/src/molecules/FormCard.tsx
@@ -10,7 +10,7 @@ export type FormCardProps = {
 };
 
 const cardStyles = css({
-  paddingTop: `${14 / perRem}em`,
+  padding: '32px 24px',
 });
 
 const descriptionStyles = css({
@@ -22,6 +22,13 @@ const descriptionStyles = css({
   },
 });
 
+const childrenWrapStyles = css({
+  marginTop: 32,
+  display: 'flex',
+  flexFlow: 'column',
+  gap: 48,
+});
+
 const FormCard: React.FC<FormCardProps> = ({
   children,
   title,
@@ -29,7 +36,7 @@ const FormCard: React.FC<FormCardProps> = ({
   overrideStyles,
 }) => (
   <Card padding={false} overrideStyles={cardStyles} title={title}>
-    <div role="presentation" css={[paddingStyles, overrideStyles]}>
+    <div role="presentation" css={[overrideStyles]}>
       <Headline3 noMargin>{title}</Headline3>
     </div>
     {!!description && (
@@ -37,7 +44,7 @@ const FormCard: React.FC<FormCardProps> = ({
         <Paragraph accent="lead">{description}</Paragraph>
       </div>
     )}
-    <div css={[paddingStyles]}>{children}</div>
+    <div css={[childrenWrapStyles]}>{children}</div>
   </Card>
 );
 

--- a/packages/react-components/src/molecules/LabeledDateField.tsx
+++ b/packages/react-components/src/molecules/LabeledDateField.tsx
@@ -7,6 +7,8 @@ import { lead } from '../colors';
 import { perRem } from '../pixels';
 import { noop } from '../utils';
 
+const containerStyles = css({ paddingBottom: `${18 / perRem}em` });
+
 type LabeledDateFieldProps = {
   readonly title: React.ReactNode;
   readonly subtitle?: React.ReactNode;
@@ -16,6 +18,7 @@ type LabeledDateFieldProps = {
   readonly value?: Date;
   readonly max?: Date;
   readonly onChange?: (newDate: Date | undefined) => void;
+  readonly noPadding?: boolean;
 } & Pick<
   ComponentProps<typeof TextField>,
   'required' | 'customValidationMessage' | 'getValidationMessage'
@@ -48,9 +51,10 @@ const LabeledDateField: React.FC<LabeledDateFieldProps> = ({
   max,
   value,
   onChange = noop,
+  noPadding = false,
   ...dateFieldProps
 }) => (
-  <div css={{ paddingBottom: `${18 / perRem}em` }}>
+  <div css={[containerStyles, noPadding && { paddingBottom: 0 }]}>
     <Label
       forContent={(id) => (
         <TextField
@@ -63,7 +67,7 @@ const LabeledDateField: React.FC<LabeledDateFieldProps> = ({
         />
       )}
     >
-      <Paragraph>
+      <Paragraph noMargin styles={css({ paddingBottom: 16 })}>
         <strong>{title}</strong>
         <span css={subtitleStyles}>{subtitle}</span> <br />
         <span css={descriptionStyles}>{description}</span>

--- a/packages/react-components/src/molecules/LabeledDropdown.tsx
+++ b/packages/react-components/src/molecules/LabeledDropdown.tsx
@@ -5,6 +5,8 @@ import { lead } from '../colors';
 import { perRem, tabletScreen } from '../pixels';
 import { TooltipInfo } from '.';
 
+const containerStyles = css({ paddingBottom: `${18 / perRem}em` });
+
 const subtitleStyles = css({
   paddingLeft: `${6 / perRem}em`,
 });
@@ -27,18 +29,20 @@ export type LabeledDropdownProps<V extends string> = {
   readonly subtitle?: React.ReactNode;
   readonly description?: React.ReactNode;
   readonly info?: Array<ReactElement>;
+  readonly noPadding?: boolean;
 } & Exclude<DropdownProps<V>, 'id'>;
 export default function LabeledDropdown<V extends string>({
   title,
   subtitle,
   description,
   info,
+  noPadding = false,
   ...dropdownProps
 }: LabeledDropdownProps<V>): ReturnType<React.FC> {
   return (
-    <div css={{ paddingBottom: `${18 / perRem}em` }}>
+    <div css={[containerStyles, noPadding && { paddingBottom: 0 }]}>
       <Label forContent={(id) => <Dropdown {...dropdownProps} id={id} />}>
-        <Paragraph>
+        <Paragraph noMargin styles={css({ paddingBottom: 16 })}>
           <strong>{title}</strong>
           <span css={subtitleStyles}>{subtitle}</span>
           {info ? (

--- a/packages/react-components/src/molecules/LabeledFileField.tsx
+++ b/packages/react-components/src/molecules/LabeledFileField.tsx
@@ -65,6 +65,7 @@ type LabeledFileFieldProps = {
   readonly handleFileUpload: (file: File) => Promise<void>;
   readonly accept?: string;
   readonly tagEnabled?: boolean;
+  readonly noPadding?: boolean;
 } & Pick<ComponentProps<typeof Button>, 'enabled'>;
 
 const LabeledFileField: React.FC<LabeledFileFieldProps> = ({
@@ -81,6 +82,7 @@ const LabeledFileField: React.FC<LabeledFileFieldProps> = ({
   customValidationMessage,
   handleFileUpload,
   tagEnabled = true,
+  noPadding = false,
 }) => {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -102,7 +104,7 @@ const LabeledFileField: React.FC<LabeledFileFieldProps> = ({
   const canUploadFile = !currentFiles || currentFiles.length < maxFiles;
 
   return (
-    <div css={containerStyles}>
+    <div css={[containerStyles, noPadding && { paddingBottom: 0 }]}>
       <input
         onChange={handleFileChange}
         multiple={maxFiles > 1}

--- a/packages/react-components/src/molecules/LabeledFileField.tsx
+++ b/packages/react-components/src/molecules/LabeledFileField.tsx
@@ -166,7 +166,7 @@ const LabeledFileField: React.FC<LabeledFileFieldProps> = ({
           </>
         )}
       >
-        <Paragraph>
+        <Paragraph noMargin styles={css({ paddingBottom: 16 })}>
           <strong>{title}</strong>
           <span css={subtitleStyles}>{subtitle}</span>
           <br />

--- a/packages/react-components/src/molecules/LabeledMultiSelect.tsx
+++ b/packages/react-components/src/molecules/LabeledMultiSelect.tsx
@@ -10,6 +10,8 @@ import {
 import { lead } from '../colors';
 import { perRem } from '../pixels';
 
+const containerStyles = css({ paddingBottom: `${18 / perRem}em` });
+
 const subtitleStyles = css({
   paddingLeft: `${6 / perRem}em`,
 });
@@ -25,6 +27,7 @@ export type LabeledMultiSelectProps<
   readonly title: ReactNode;
   readonly subtitle?: React.ReactNode;
   readonly description?: ReactNode;
+  readonly noPadding?: boolean;
 } & Exclude<MultiSelectProps<T, M>, 'id'>;
 
 const LabeledMultiSelect = <
@@ -34,11 +37,16 @@ const LabeledMultiSelect = <
   title,
   subtitle,
   description,
+  noPadding = false,
   ...multiSelectProps
 }: LabeledMultiSelectProps<T, M>): ReactElement => (
-  <div css={{ paddingBottom: `${18 / perRem}em` }}>
-    <Label forContent={(id) => <MultiSelect {...multiSelectProps} id={id} />}>
-      <Paragraph noMargin>
+  <div css={[containerStyles, noPadding && { paddingBottom: 0 }]}>
+    <Label
+      forContent={(id) => (
+        <MultiSelect noMargin {...multiSelectProps} id={id} />
+      )}
+    >
+      <Paragraph noMargin styles={css({ paddingBottom: 16 })}>
         <strong>{title}</strong>
         <span css={subtitleStyles}>{subtitle}</span>
         <br />

--- a/packages/react-components/src/molecules/LabeledTextArea.tsx
+++ b/packages/react-components/src/molecules/LabeledTextArea.tsx
@@ -62,7 +62,7 @@ const LabeledTextArea: React.FC<LabeledTextAreaProps> = ({
 }) => (
   <div css={[containerStyles, noPadding && { paddingBottom: 0 }]}>
     <Label forContent={(id) => <TextArea {...textAreaProps} id={id} />}>
-      <Paragraph>
+      <Paragraph noMargin styles={css({ paddingBottom: 16 })}>
         <span css={{ display: 'flex', marginBottom: 0 }}>
           <strong>{title}</strong>
           <span css={subtitleStyles}>{subtitle}</span>

--- a/packages/react-components/src/molecules/LabeledTextArea.tsx
+++ b/packages/react-components/src/molecules/LabeledTextArea.tsx
@@ -6,6 +6,8 @@ import { Label, Paragraph, TextArea } from '../atoms';
 import { lead, paper } from '../colors';
 import { TooltipInfo } from '.';
 
+const containerStyles = css({ paddingBottom: `${18 / perRem}em` });
+
 const tipStyles = css({
   marginTop: 0,
   ':empty': {
@@ -25,6 +27,7 @@ type LabeledTextAreaProps = {
   readonly subtitle?: React.ReactNode;
   readonly tip?: React.ReactNode;
   readonly info?: React.ReactNode;
+  readonly noPadding?: boolean;
 } & Exclude<ComponentProps<typeof TextArea>, 'id'>;
 
 const infoStyle = css({
@@ -54,9 +57,10 @@ const LabeledTextArea: React.FC<LabeledTextAreaProps> = ({
   subtitle,
   tip,
   info,
+  noPadding = false,
   ...textAreaProps
 }) => (
-  <div css={{ paddingBottom: `${18 / perRem}em` }}>
+  <div css={[containerStyles, noPadding && { paddingBottom: 0 }]}>
     <Label forContent={(id) => <TextArea {...textAreaProps} id={id} />}>
       <Paragraph>
         <span css={{ display: 'flex', marginBottom: 0 }}>

--- a/packages/react-components/src/molecules/LabeledTextEditor.tsx
+++ b/packages/react-components/src/molecules/LabeledTextEditor.tsx
@@ -5,6 +5,8 @@ import { perRem } from '../pixels';
 import { Label, Paragraph, TextEditor } from '../atoms';
 import { lead } from '../colors';
 
+const containerStyles = css({ paddingBottom: `${18 / perRem}em` });
+
 const tipStyles = css({
   marginTop: 0,
   ':empty': {
@@ -27,25 +29,33 @@ type LabeledTextEditorProps = {
   readonly editorStyles?: SerializedStyles;
   readonly hasError?: boolean;
   readonly autofocus?: boolean;
+  readonly noPadding?: boolean;
 } & Exclude<ComponentProps<typeof TextEditor>, 'id'>;
 
 const LabeledTextEditor: React.FC<LabeledTextEditorProps> = forwardRef<
   HTMLDivElement,
   LabeledTextEditorProps
->(({ title, subtitle, tip, info, ...textEditorProps }, ref) => (
-  <div css={{ paddingBottom: `${18 / perRem}em` }}>
-    <Label
-      forContent={(id) => <TextEditor {...textEditorProps} id={id} ref={ref} />}
-    >
-      <Paragraph>
-        <span css={{ display: 'flex', marginBottom: 0 }}>
-          <strong>{title}</strong>
-          <span css={subtitleStyles}>{subtitle}</span>
-        </span>
-        <span css={tipStyles}>{tip}</span>
-      </Paragraph>
-    </Label>
-  </div>
-));
+>(
+  (
+    { title, subtitle, tip, info, noPadding = false, ...textEditorProps },
+    ref,
+  ) => (
+    <div css={[containerStyles, noPadding && { paddingBottom: 0 }]}>
+      <Label
+        forContent={(id) => (
+          <TextEditor {...textEditorProps} id={id} ref={ref} />
+        )}
+      >
+        <Paragraph noMargin styles={css({ paddingBottom: 16 })}>
+          <span css={{ display: 'flex' }}>
+            <strong>{title}</strong>
+            <span css={subtitleStyles}>{subtitle}</span>
+          </span>
+          <span css={tipStyles}>{tip}</span>
+        </Paragraph>
+      </Label>
+    </div>
+  ),
+);
 
 export default LabeledTextEditor;

--- a/packages/react-components/src/molecules/LabeledTextField.tsx
+++ b/packages/react-components/src/molecules/LabeledTextField.tsx
@@ -48,7 +48,7 @@ const LabeledTextField: React.FC<LabeledTextFieldProps> = ({
     css={[containerStyles, overrideStyles, noPadding && { paddingBottom: 0 }]}
   >
     <Label forContent={(id) => <TextField {...textFieldProps} id={id} />}>
-      <Paragraph>
+      <Paragraph noMargin styles={css({ paddingBottom: 16 })}>
         <strong>{title}</strong>
         <span css={subtitleStyles}>{subtitle}</span>
         <br />

--- a/packages/react-components/src/organisms/AuthorSelect.tsx
+++ b/packages/react-components/src/organisms/AuthorSelect.tsx
@@ -93,6 +93,7 @@ const AuthorSelect: React.FC<AuthorSelectProps> = ({
   isMulti,
   creatable = true,
   useDefaultErrorMessage = true,
+  noPadding = false,
   ...props
 }) => (
   <LabeledMultiSelect<AuthorOption, boolean>
@@ -173,6 +174,7 @@ const AuthorSelect: React.FC<AuthorSelectProps> = ({
         </components.Option>
       ),
     }}
+    noPadding={noPadding}
   />
 );
 export type AuthorSelectType = typeof AuthorSelect;

--- a/packages/react-components/src/organisms/ManuscriptAuthors.tsx
+++ b/packages/react-components/src/organisms/ManuscriptAuthors.tsx
@@ -178,6 +178,7 @@ const ManuscriptAuthors = ({
             noOptionsMessage={({ inputValue }) =>
               `Sorry, no authors match ${inputValue}`
             }
+            noPadding
           />
         )}
       />
@@ -209,6 +210,7 @@ const ManuscriptAuthors = ({
                   trigger(`versions.0.${fieldName}Emails.${index}.email`);
                 }}
                 enabled={!isSubmitting}
+                noPadding
               />
             )}
           />

--- a/packages/react-components/src/organisms/ResearchOutputContributorsCard.tsx
+++ b/packages/react-components/src/organisms/ResearchOutputContributorsCard.tsx
@@ -67,6 +67,7 @@ const ResearchOutputContributorsCard: React.FC<
       noOptionsMessage={({ inputValue }) =>
         `Sorry, no teams match ${inputValue}`
       }
+      noPadding
     />
     <LabeledMultiSelect
       title="Labs"
@@ -80,6 +81,7 @@ const ResearchOutputContributorsCard: React.FC<
       noOptionsMessage={({ inputValue }) =>
         `Sorry, no labs match ${inputValue}`
       }
+      noPadding
     />
     <AuthorSelect
       title="Authors"
@@ -94,6 +96,7 @@ const ResearchOutputContributorsCard: React.FC<
       noOptionsMessage={({ inputValue }) =>
         `Sorry, no authors match ${inputValue}`
       }
+      noPadding
     />
   </FormCard>
 );

--- a/packages/react-components/src/organisms/ResearchOutputExtraInformationCard.tsx
+++ b/packages/react-components/src/organisms/ResearchOutputExtraInformationCard.tsx
@@ -89,6 +89,7 @@ const ResearchOutputExtraInformationCard: React.FC<
           onChange={(options) =>
             onChangeMethods(options.map(({ value }) => value))
           }
+          noPadding
         />
       )}
       {organismSuggestions.length > 0 && (
@@ -109,6 +110,7 @@ const ResearchOutputExtraInformationCard: React.FC<
           onChange={(options) =>
             onChangeOrganisms(options.map(({ value }) => value))
           }
+          noPadding
         />
       )}
       {environmentSuggestions.length > 0 && (
@@ -129,23 +131,30 @@ const ResearchOutputExtraInformationCard: React.FC<
           onChange={(options) =>
             onChangeEnvironments(options.map(({ value }) => value))
           }
+          noPadding
         />
       )}
 
-      <LabeledMultiSelect
-        title="Additional Tags"
-        description="Increase the discoverability of this output by adding keywords."
-        subtitle="(optional)"
-        values={tags.map((tag) => ({ label: tag, value: tag }))}
-        enabled={!isSaving}
-        suggestions={tagSuggestions}
-        placeholder="Start typing... (E.g. Cell Biology)"
-        onChange={(options) => onChangeTags(options.map(({ value }) => value))}
-      />
+      <div style={{ display: 'flex', flexFlow: 'column', gap: 16 }}>
+        <LabeledMultiSelect
+          title="Additional Tags"
+          description="Increase the discoverability of this output by adding keywords."
+          subtitle="(optional)"
+          values={tags.map((tag) => ({ label: tag, value: tag }))}
+          enabled={!isSaving}
+          suggestions={tagSuggestions}
+          placeholder="Start typing... (E.g. Cell Biology)"
+          onChange={(options) =>
+            onChangeTags(options.map(({ value }) => value))
+          }
+          noPadding
+        />
 
-      <Link href={mailToSupport({ subject: 'New keyword' }).toString()}>
-        Ask ASAP to add a new keyword
-      </Link>
+        <Link href={mailToSupport({ subject: 'New keyword' }).toString()}>
+          Ask ASAP to add a new keyword
+        </Link>
+      </div>
+
       {documentType !== 'Report' && (
         <>
           <ResearchOutputIdentifier
@@ -164,6 +173,7 @@ const ResearchOutputExtraInformationCard: React.FC<
               placeholder="Catalog number and vendor e.g. AB123 (Abcam)"
               enabled={!isSaving}
               value={labCatalogNumber || ''}
+              noPadding
             />
           )}
           <LabeledTextArea
@@ -173,6 +183,7 @@ const ResearchOutputExtraInformationCard: React.FC<
             placeholder="E.g. To access the output, you will first need to create an account on..."
             enabled={!isSaving}
             value={usageNotes || ''}
+            noPadding
           />
         </>
       )}

--- a/packages/react-components/src/organisms/ResearchOutputFormSharingCard.tsx
+++ b/packages/react-components/src/organisms/ResearchOutputFormSharingCard.tsx
@@ -259,6 +259,7 @@ const ResearchOutputFormSharingCard: React.FC<
         value={title}
         required
         enabled={!isSaving}
+        noPadding
       />
       <LabeledTextField
         title="URL"
@@ -280,6 +281,7 @@ const ResearchOutputFormSharingCard: React.FC<
         enabled={!isSaving}
         labelIndicator={<GlobeIcon />}
         placeholder="https://example.com"
+        noPadding
       />
       {!!typeOptions.length && (
         <LabeledDropdown<ResearchOutputType | ''>
@@ -425,6 +427,7 @@ const ResearchOutputFormSharingCard: React.FC<
           }}
           required
           enabled={!isSaving}
+          noPadding
         />
       )}
       <div css={css({ marginTop: '30px' })}>

--- a/packages/react-components/src/organisms/ResearchOutputFormSharingCard.tsx
+++ b/packages/react-components/src/organisms/ResearchOutputFormSharingCard.tsx
@@ -8,7 +8,6 @@ import {
   ValidationErrorResponse,
 } from '@asap-hub/model';
 import { urlExpression } from '@asap-hub/validation';
-import { css } from '@emotion/react';
 import { ComponentPropsWithRef, useCallback, useEffect, useState } from 'react';
 import { OptionsType } from 'react-select';
 import { getAjvErrorForPath } from '../ajv-errors';
@@ -301,6 +300,7 @@ const ResearchOutputFormSharingCard: React.FC<
             `Sorry, no types match ${option.inputValue}`
           }
           placeholder="Choose a type"
+          noPadding
         />
       )}
       {!!subtypeSuggestions.length && (
@@ -317,6 +317,7 @@ const ResearchOutputFormSharingCard: React.FC<
           getValidationMessage={() => 'Please choose a subtype'}
           enabled={!isSaving}
           placeholder="Select subtype"
+          noPadding
         />
       )}
 
@@ -345,6 +346,7 @@ const ResearchOutputFormSharingCard: React.FC<
             `Sorry, no impacts match ${option.inputValue}`
           }
           placeholder="Choose an impact"
+          noPadding
         />
       )}
       {documentType === 'Article' && (
@@ -373,6 +375,7 @@ const ResearchOutputFormSharingCard: React.FC<
           noOptionsMessage={({ inputValue }) =>
             `Sorry, no category options match ${inputValue}`
           }
+          noPadding
         />
       )}
 

--- a/packages/react-components/src/organisms/ResearchOutputFormSharingCard.tsx
+++ b/packages/react-components/src/organisms/ResearchOutputFormSharingCard.tsx
@@ -392,6 +392,7 @@ const ResearchOutputFormSharingCard: React.FC<
           ></Markdown>
         }
         autofocus={false}
+        noPadding
       />
       <ShortDescriptionCard
         onChange={(shortDescriptionNewValue) => {
@@ -430,87 +431,75 @@ const ResearchOutputFormSharingCard: React.FC<
           noPadding
         />
       )}
-      <div css={css({ marginTop: '30px' })}>
-        <LabeledRadioButtonGroup
-          title="Has this output been funded by ASAP"
-          subtitle="(required)"
-          options={[
-            { value: 'Yes', label: 'Yes' },
-            { value: 'No', label: 'No' },
-            { value: 'Not Sure', label: 'Not Sure' },
-          ]}
-          value={asapFunded}
-          onChange={onChangeAsapFunded}
-        />
-      </div>
-      <div
-        css={css({
-          marginTop: '48px',
-        })}
-      >
-        <LabeledRadioButtonGroup
-          title="Has this output been used in a publication"
-          subtitle="(required)"
-          options={[
-            { value: 'Yes', label: 'Yes' },
-            {
-              value: 'No',
-              label: 'No',
-              disabled:
-                isCreatingOutputRoute &&
-                documentType === 'Article' &&
-                researchOutputData?.usedInPublication === undefined,
-            },
-            {
-              value: 'Not Sure',
-              label: 'Not Sure',
-              disabled:
-                isCreatingOutputRoute &&
-                documentType === 'Article' &&
-                researchOutputData?.usedInPublication === undefined,
-            },
-          ]}
-          value={usedInPublication}
-          onChange={onChangeUsedInPublication}
-        />
-      </div>
-      <div
-        css={css({
-          marginTop: '48px',
-        })}
-      >
-        <LabeledRadioButtonGroup
-          title="Sharing status"
-          subtitle="(required)"
-          options={[
-            {
-              value: 'Network Only',
-              label: 'CRN Only',
-              disabled:
-                (documentType === 'Article' &&
-                  researchOutputData?.sharingStatus === undefined) ||
-                isImportedFromManuscript,
-            },
-            { value: 'Public', label: 'Public' },
-          ]}
-          value={sharingStatus}
-          onChange={onChangeSharingStatus}
-        />
-      </div>
+      <LabeledRadioButtonGroup
+        title="Has this output been funded by ASAP"
+        subtitle="(required)"
+        options={[
+          { value: 'Yes', label: 'Yes' },
+          { value: 'No', label: 'No' },
+          { value: 'Not Sure', label: 'Not Sure' },
+        ]}
+        value={asapFunded}
+        onChange={onChangeAsapFunded}
+      />
+
+      <LabeledRadioButtonGroup
+        title="Has this output been used in a publication"
+        subtitle="(required)"
+        options={[
+          { value: 'Yes', label: 'Yes' },
+          {
+            value: 'No',
+            label: 'No',
+            disabled:
+              isCreatingOutputRoute &&
+              documentType === 'Article' &&
+              researchOutputData?.usedInPublication === undefined,
+          },
+          {
+            value: 'Not Sure',
+            label: 'Not Sure',
+            disabled:
+              isCreatingOutputRoute &&
+              documentType === 'Article' &&
+              researchOutputData?.usedInPublication === undefined,
+          },
+        ]}
+        value={usedInPublication}
+        onChange={onChangeUsedInPublication}
+      />
+
+      <LabeledRadioButtonGroup
+        title="Sharing status"
+        subtitle="(required)"
+        options={[
+          {
+            value: 'Network Only',
+            label: 'CRN Only',
+            disabled:
+              (documentType === 'Article' &&
+                researchOutputData?.sharingStatus === undefined) ||
+              isImportedFromManuscript,
+          },
+          { value: 'Public', label: 'Public' },
+        ]}
+        value={sharingStatus}
+        onChange={onChangeSharingStatus}
+      />
+
       {sharingStatus === 'Public' ? (
-        <div css={css({ marginTop: '36px' })}>
-          <LabeledDateField
-            title={'Date Published'}
-            subtitle={'(optional)'}
-            description={
-              'This should be the date your output was shared publicly on its repository.'
-            }
-            onChange={onChangePublishDate}
-            value={publishDate}
-            max={new Date()}
-            getValidationMessage={(e) => getPublishDateValidationMessage(e)}
-          />
-        </div>
+        <LabeledDateField
+          title={'Date Published'}
+          subtitle={'(optional)'}
+          description={
+            'This should be the date your output was shared publicly on its repository.'
+          }
+          onChange={onChangePublishDate}
+          value={publishDate}
+          max={new Date()}
+          getValidationMessage={(e) => getPublishDateValidationMessage(e)}
+          noPadding
+        />
       ) : null}
     </FormCard>
   );

--- a/packages/react-components/src/organisms/ResearchOutputIdentifier.tsx
+++ b/packages/react-components/src/organisms/ResearchOutputIdentifier.tsx
@@ -139,6 +139,7 @@ export const ResearchOutputIdentifier: React.FC<
         getValidationMessage={() => `Please choose an identifier`}
         required={true}
         info={infoText}
+        noPadding
       />
 
       <TeamCreateOutputIdentifierField
@@ -173,6 +174,7 @@ export const TeamCreateOutputIdentifierField: React.FC<
           onChange={setIdentifier}
           pattern={regex}
           required={required}
+          noPadding
         />
       )}
       {type === ResearchOutputIdentifierType.DOI && (
@@ -186,6 +188,7 @@ export const TeamCreateOutputIdentifierField: React.FC<
           onChange={setIdentifier}
           pattern={regex}
           required={required}
+          noPadding
         />
       )}
       {type === ResearchOutputIdentifierType.RRID && (
@@ -199,6 +202,7 @@ export const TeamCreateOutputIdentifierField: React.FC<
           onChange={setIdentifier}
           pattern={regex}
           required={required}
+          noPadding
         />
       )}
     </>

--- a/packages/react-components/src/organisms/ResearchOutputRelatedEventsCard.tsx
+++ b/packages/react-components/src/organisms/ResearchOutputRelatedEventsCard.tsx
@@ -63,6 +63,7 @@ const ResearchOutputRelatedEventsCard: React.FC<
       noOptionsMessage={({ inputValue }) =>
         `Sorry, no related events match ${inputValue}`
       }
+      noPadding
       components={{
         MultiValueContainer: (multiValueContainerProps) => (
           <div

--- a/packages/react-components/src/organisms/ShortDescriptionCard.tsx
+++ b/packages/react-components/src/organisms/ShortDescriptionCard.tsx
@@ -83,6 +83,7 @@ const ShortDescriptionCard: React.FC<ShortDescriptionCardProps> = ({
             : 'Regenerate'}
         </Button>
       }
+      noPadding
     />
   );
 };

--- a/packages/react-components/src/templates/ManuscriptForm.tsx
+++ b/packages/react-components/src/templates/ManuscriptForm.tsx
@@ -486,28 +486,28 @@ const ManuscriptForm: React.FC<ManuscriptFormProps> = ({
           ),
           acknowledgedGrantNumberDetails: resubmitManuscript
             ? undefined
-            : (acknowledgedGrantNumberDetails ?? undefined),
+            : acknowledgedGrantNumberDetails ?? undefined,
           asapAffiliationIncludedDetails: resubmitManuscript
             ? undefined
-            : (asapAffiliationIncludedDetails ?? undefined),
+            : asapAffiliationIncludedDetails ?? undefined,
           manuscriptLicenseDetails: resubmitManuscript
             ? undefined
-            : (manuscriptLicenseDetails ?? undefined),
+            : manuscriptLicenseDetails ?? undefined,
           datasetsDepositedDetails: resubmitManuscript
             ? undefined
-            : (datasetsDepositedDetails ?? undefined),
+            : datasetsDepositedDetails ?? undefined,
           codeDepositedDetails: resubmitManuscript
             ? undefined
-            : (codeDepositedDetails ?? undefined),
+            : codeDepositedDetails ?? undefined,
           protocolsDepositedDetails: resubmitManuscript
             ? undefined
-            : (protocolsDepositedDetails ?? undefined),
+            : protocolsDepositedDetails ?? undefined,
           labMaterialsRegisteredDetails: resubmitManuscript
             ? undefined
-            : (labMaterialsRegisteredDetails ?? undefined),
+            : labMaterialsRegisteredDetails ?? undefined,
           availabilityStatementDetails: resubmitManuscript
             ? undefined
-            : (availabilityStatementDetails ?? undefined),
+            : availabilityStatementDetails ?? undefined,
           teams: selectedTeams || [],
           labs: selectedLabs || [],
           description: description || '',

--- a/packages/react-components/src/templates/ManuscriptForm.tsx
+++ b/packages/react-components/src/templates/ManuscriptForm.tsx
@@ -263,10 +263,6 @@ const setDefaultFieldValues = (fieldsList: OptionalVersionFields) => {
   return fieldDefaultValueMap;
 };
 
-const FixMarginWrapper = ({ children }: { children: React.ReactNode }) => (
-  <div css={{ marginTop: rem(18), marginBottom: rem(18) }}>{children}</div>
-);
-
 type ManuscriptFormProps = Omit<
   ManuscriptVersion,
   | 'id'
@@ -491,28 +487,28 @@ const ManuscriptForm: React.FC<ManuscriptFormProps> = ({
           ),
           acknowledgedGrantNumberDetails: resubmitManuscript
             ? undefined
-            : acknowledgedGrantNumberDetails ?? undefined,
+            : (acknowledgedGrantNumberDetails ?? undefined),
           asapAffiliationIncludedDetails: resubmitManuscript
             ? undefined
-            : asapAffiliationIncludedDetails ?? undefined,
+            : (asapAffiliationIncludedDetails ?? undefined),
           manuscriptLicenseDetails: resubmitManuscript
             ? undefined
-            : manuscriptLicenseDetails ?? undefined,
+            : (manuscriptLicenseDetails ?? undefined),
           datasetsDepositedDetails: resubmitManuscript
             ? undefined
-            : datasetsDepositedDetails ?? undefined,
+            : (datasetsDepositedDetails ?? undefined),
           codeDepositedDetails: resubmitManuscript
             ? undefined
-            : codeDepositedDetails ?? undefined,
+            : (codeDepositedDetails ?? undefined),
           protocolsDepositedDetails: resubmitManuscript
             ? undefined
-            : protocolsDepositedDetails ?? undefined,
+            : (protocolsDepositedDetails ?? undefined),
           labMaterialsRegisteredDetails: resubmitManuscript
             ? undefined
-            : labMaterialsRegisteredDetails ?? undefined,
+            : (labMaterialsRegisteredDetails ?? undefined),
           availabilityStatementDetails: resubmitManuscript
             ? undefined
-            : availabilityStatementDetails ?? undefined,
+            : (availabilityStatementDetails ?? undefined),
           teams: selectedTeams || [],
           labs: selectedLabs || [],
           description: description || '',
@@ -992,6 +988,7 @@ const ManuscriptForm: React.FC<ManuscriptFormProps> = ({
                   onChange={onChange}
                   onBlur={onBlur}
                   enabled={!isSubmitting}
+                  noPadding
                 />
               )}
             />
@@ -1010,19 +1007,18 @@ const ManuscriptForm: React.FC<ManuscriptFormProps> = ({
                 field: { value, onChange, onBlur },
                 fieldState: { error },
               }) => (
-                <FixMarginWrapper>
-                  <LabeledTextField
-                    title="URL"
-                    subtitle={isURLRequired ? '(required)' : '(optional)'}
-                    value={value ?? ''}
-                    onChange={onChange}
-                    onBlur={onBlur}
-                    enabled={!isSubmitting}
-                    customValidationMessage={error?.message}
-                    labelIndicator={<GlobeIcon />}
-                    placeholder="https://example.com"
-                  />
-                </FixMarginWrapper>
+                <LabeledTextField
+                  title="URL"
+                  subtitle={isURLRequired ? '(required)' : '(optional)'}
+                  value={value ?? ''}
+                  onChange={onChange}
+                  onBlur={onBlur}
+                  enabled={!isSubmitting}
+                  customValidationMessage={error?.message}
+                  labelIndicator={<GlobeIcon />}
+                  placeholder="https://example.com"
+                  noPadding
+                />
               )}
             />
             <Controller
@@ -1058,6 +1054,7 @@ const ManuscriptForm: React.FC<ManuscriptFormProps> = ({
                     `Sorry, no types match ${option.inputValue}`
                   }
                   placeholder="Choose a type of manuscript"
+                  noPadding
                 />
               )}
             />
@@ -1100,6 +1097,7 @@ const ManuscriptForm: React.FC<ManuscriptFormProps> = ({
                         `Sorry, no options match ${option.inputValue}`
                       }
                       placeholder="Choose an option"
+                      noPadding
                     />
                   )}
                 />
@@ -1145,6 +1143,7 @@ const ManuscriptForm: React.FC<ManuscriptFormProps> = ({
                           !isSubmitting
                         }
                         placeholder="e.g. 10.5555/YFRU1371"
+                        noPadding
                       />
                     )}
                   />
@@ -1184,6 +1183,7 @@ const ManuscriptForm: React.FC<ManuscriptFormProps> = ({
                           !isSubmitting
                         }
                         placeholder="e.g. 10.5555/YFRU1371"
+                        noPadding
                       />
                     )}
                   />
@@ -1221,6 +1221,7 @@ const ManuscriptForm: React.FC<ManuscriptFormProps> = ({
                           (!isEditMode || isOpenScienceTeamMember) &&
                           !isSubmitting
                         }
+                        noPadding
                       />
                     )}
                   />
@@ -1261,6 +1262,7 @@ const ManuscriptForm: React.FC<ManuscriptFormProps> = ({
                         `Sorry, no impacts match ${option.inputValue}`
                       }
                       placeholder="Choose an impact"
+                      noPadding
                     />
                   )}
                 />
@@ -1308,6 +1310,7 @@ const ManuscriptForm: React.FC<ManuscriptFormProps> = ({
                       }) => `Sorry, no categories match ${inputValue}`}
                       enabled={!isSubmitting}
                       onBlur={onBlur}
+                      noPadding
                     />
                   )}
                 />
@@ -1373,6 +1376,7 @@ const ManuscriptForm: React.FC<ManuscriptFormProps> = ({
                         !isUploadingManuscriptFile
                       }
                       tagEnabled={!isEditMode || isOpenScienceTeamMember}
+                      noPadding
                     />
                   )}
                 />
@@ -1453,6 +1457,7 @@ const ManuscriptForm: React.FC<ManuscriptFormProps> = ({
                           !isUploadingKeyResourceTable
                         }
                         tagEnabled={!isEditMode || isOpenScienceTeamMember}
+                        noPadding
                       />
                     )}
                   />
@@ -1543,6 +1548,7 @@ const ManuscriptForm: React.FC<ManuscriptFormProps> = ({
                         !isUploadingAdditionalFiles
                       }
                       tagEnabled={!isEditMode || isOpenScienceTeamMember}
+                      noPadding
                     />
                   )}
                 />
@@ -1578,6 +1584,7 @@ const ManuscriptForm: React.FC<ManuscriptFormProps> = ({
                     onChange={onChange}
                     onBlur={onBlur}
                     enabled={!isSubmitting}
+                    noPadding
                   />
                 )}
               />
@@ -1649,6 +1656,7 @@ const ManuscriptForm: React.FC<ManuscriptFormProps> = ({
                     }: {
                       inputValue: string;
                     }) => `Sorry, no teams match ${inputValue}`}
+                    noPadding
                   />
                 )}
               />
@@ -1689,6 +1697,7 @@ const ManuscriptForm: React.FC<ManuscriptFormProps> = ({
                       inputValue: string;
                     }) => `Sorry, no labs match ${inputValue}`}
                     customValidationMessage={error?.message}
+                    noPadding
                   />
                 )}
               />

--- a/packages/react-components/src/templates/ManuscriptForm.tsx
+++ b/packages/react-components/src/templates/ManuscriptForm.tsx
@@ -104,13 +104,12 @@ const mainStyles = css({
 });
 
 const contentStyles = css({
-  display: 'grid',
-  gridTemplateColumns: '1fr',
+  display: 'flex',
+  flexFlow: 'column',
+  gap: 32,
   width: '100%',
   maxWidth: rem(800),
   justifyContent: 'center',
-  gridAutoFlow: 'row',
-  rowGap: rem(36),
 });
 
 const buttonsOuterContainerStyles = css({

--- a/packages/react-components/src/templates/ManuscriptOutputSelection.tsx
+++ b/packages/react-components/src/templates/ManuscriptOutputSelection.tsx
@@ -24,13 +24,13 @@ const mainStyles = css({
 });
 
 const contentStyles = css({
-  display: 'grid',
-  gridTemplateColumns: '1fr',
+  display: 'flex',
+  flexFlow: 'column',
   maxWidth: rem(800),
   width: '100%',
   justifyContent: 'center',
   gridAutoFlow: 'row',
-  rowGap: rem(32),
+  gap: 32,
 });
 
 const optionListStyles = css({

--- a/packages/react-components/src/templates/ResearchOutputForm.tsx
+++ b/packages/react-components/src/templates/ResearchOutputForm.tsx
@@ -95,12 +95,12 @@ const mainStyles = css({
 });
 
 const contentStyles = css({
-  display: 'grid',
-  gridTemplateColumns: '1fr',
+  display: 'flex',
+  flexFlow: 'column',
   maxWidth: `${800 / perRem}em`,
   justifyContent: 'center',
   gridAutoFlow: 'row',
-  rowGap: `${36 / perRem}em`,
+  gap: 32,
 });
 
 const formControlsContainerStyles = css({

--- a/packages/react-components/src/templates/ResearchOutputForm.tsx
+++ b/packages/react-components/src/templates/ResearchOutputForm.tsx
@@ -679,6 +679,7 @@ const ResearchOutputForm: React.FC<ResearchOutputFormProps> = ({
                       enabled={!isSaving}
                       fullWidth
                       onClick={handleCancel}
+                      noMargin
                     >
                       Cancel
                     </Button>
@@ -693,6 +694,7 @@ const ResearchOutputForm: React.FC<ResearchOutputFormProps> = ({
                             : await save(true);
                         }}
                         primary={showSaveDraftButton && !showPublishButton}
+                        noMargin
                       >
                         Save Draft
                       </Button>
@@ -702,6 +704,7 @@ const ResearchOutputForm: React.FC<ResearchOutputFormProps> = ({
                         enabled={!isSaving}
                         fullWidth
                         primary
+                        noMargin
                         onClick={async () => {
                           setIsFormSubmitted(true);
 


### PR DESCRIPTION
Please check https://asaphub.atlassian.net/browse/ASAP-1078 to get a list of impacted areas/URLs.

The way I'd approach this PR is by first having a look at the `atoms` and `molecules` folder:

<img width="427" height="531" alt="image" src="https://github.com/user-attachments/assets/a78dc3a1-b533-4f27-b3b8-a1ed5a89863c" />

In these folders, I'm adding support for the `noPadding` property across multiple components that didn't have support for this attribute. I've done it in a similar way to other existing components that do have support for this attribute (comments are welcome). Most of the changes in these folders are backwards compatible, i.e. the changes won't affect existing use-cases. The only exceptions are the molecules that use a `Paragraph` to display a title/subtitle. The default `Paragraph` component has a default margin on the top/bottom which contributed to the overall problem of the aggregated white-spacing.

<img width="1581" height="76" alt="image" src="https://github.com/user-attachments/assets/ff31986d-1d99-427c-a312-5c2c02df1a60" />


Before/after
<img width="871" height="141" alt="Screenshot 2025-10-01 at 12 57 16" src="https://github.com/user-attachments/assets/2f46b7df-9c22-48e3-b693-f7e40d16e92a" />
<img width="786" height="123" alt="Screenshot 2025-10-01 at 12 59 40" src="https://github.com/user-attachments/assets/ee4f829e-e3f8-4758-a0e5-053c72748db1" />

This tiny difference may cause existing forms using these components to render slightly differently after the removal of the top margin. I don't think it will cause a lot of trouble and it can be solved on a case by case basis, but please let me know if this is an issue.

After checking those folders, the changes in organisms and templates aim to make use of the `noPadding` attribute in all the fields rendered within the `FormCard` (and derivatives) and also set the gaps between those components and the save buttons.

<img width="486" height="666" alt="image" src="https://github.com/user-attachments/assets/8e05a336-5325-4af8-956a-b1e6882f1897" />

FormCard Before/After

<img width="250" alt="before" src="https://github.com/user-attachments/assets/4bf89999-915a-4210-9ec4-78da22a6bc49" />

<img width="250" alt="after" src="https://github.com/user-attachments/assets/3750c416-ced1-40e3-82ee-8c8a19f5101e" />



