### PR TITLE
[ASAP-1449] - Populate NA for missing DOI in shared research CSV export

### DIFF
--- a/apps/crn-frontend/src/shared-research/__tests__/export.test.ts
+++ b/apps/crn-frontend/src/shared-research/__tests__/export.test.ts
@@ -270,6 +270,14 @@ describe('researchOutputToCSV', () => {
     expect(researchOutputToCSV(output).firstVersionAccession).toBe('');
     expect(researchOutputToCSV(output).firstVersionLink).toBe('');
   });
+
+  it('exports NA for doi when not present', () => {
+    const output: ResearchOutputResponse = {
+      ...createResearchOutputResponse(),
+      doi: undefined,
+    };
+    expect(researchOutputToCSV(output).doi).toBe('NA');
+  });
 });
 
 describe('squidexResultsToStream', () => {

--- a/apps/crn-frontend/src/shared-research/export.ts
+++ b/apps/crn-frontend/src/shared-research/export.ts
@@ -122,7 +122,7 @@ export const researchOutputToCSV = (
   sharingStatus: output.sharingStatus,
   asapFunded: output.asapFunded,
   link: output.link,
-  doi: output.doi,
+  doi: output.doi ?? 'NA',
   rrid: output.rrid,
   accession: output.accession,
   labCatalogNumber: output.labCatalogNumber,


### PR DESCRIPTION
When a research output has no DOI, the Shared Research export file showed an empty cell. This change populates NA for missing DOI values so the column is always filled.


**Before:** 

<img width="402" height="825" alt="Screenshot 2026-04-10 at 10 31 43" src="https://github.com/user-attachments/assets/311a34c4-d7a1-4a1f-b8aa-a98f4edad656" />


**After:** 

<img width="367" height="784" alt="Screenshot 2026-04-10 at 10 30 42" src="https://github.com/user-attachments/assets/35990fef-5719-40f4-bad2-81567c2b8398" />
