### PR TITLE
[ASAP-1466][Auth0] Register DataSeer KR-Sync app in Production tenant

### DIFF
--- a/.github/workflows/reusable-deployment.yml
+++ b/.github/workflows/reusable-deployment.yml
@@ -466,6 +466,7 @@ jobs:
           BASE_PR_APP_DOMAIN: ${{ steps.setup.outputs.crn-base-pr-app-domain }}
           API_URL: ${{ steps.setup.outputs.crn-api-url }}
           AUTH0_ADDITIONAL_CLAIM_DOMAIN: ${{ steps.setup.outputs.crn-auth0-additional-claim-domain }}
+          AUTH0_KEYWORD_REPLACE_MAPPINGS: '{"APPLICATION_NAME":"crn","BASE_PR_APP_DOMAIN":"${{ steps.setup.outputs.crn-base-pr-app-domain }}","API_URL":"${{ steps.setup.outputs.crn-api-url }}","AUTH0_ADDITIONAL_CLAIM_DOMAIN":"${{ steps.setup.outputs.crn-auth0-additional-claim-domain }}","AUTH0_SHARED_SECRET":"${{ secrets.CRN_AUTH0_SHARED_SECRET }}"}'
 
       - name: Deploy CRN
         if: ${{ inputs.environment-name=='Development' || inputs.environment-name=='Production' }}
@@ -479,6 +480,7 @@ jobs:
           API_URL: ${{ steps.setup.outputs.crn-api-url }}
           AUTH0_ADDITIONAL_CLAIM_DOMAIN: ${{ steps.setup.outputs.crn-auth0-additional-claim-domain }}
           AUTH0_SHARED_SECRET: ${{ secrets.CRN_AUTH0_SHARED_SECRET }}
+          AUTH0_KEYWORD_REPLACE_MAPPINGS: '{"APPLICATION_NAME":"crn","BASE_PR_APP_DOMAIN":"${{ steps.setup.outputs.crn-base-pr-app-domain }}","API_URL":"${{ steps.setup.outputs.crn-api-url }}","AUTH0_ADDITIONAL_CLAIM_DOMAIN":"${{ steps.setup.outputs.crn-auth0-additional-claim-domain }}","AUTH0_SHARED_SECRET":"${{ secrets.CRN_AUTH0_SHARED_SECRET }}"}'
 
       - name: Deploy GP2 PR
         if: ${{ inputs.environment-name == 'Branch' && steps.setup.outputs.auth0-label == 'true' }}
@@ -492,6 +494,7 @@ jobs:
           BASE_PR_APP_DOMAIN: ${{ steps.setup.outputs.gp2-base-pr-app-domain }}
           API_URL: ${{ steps.setup.outputs.gp2-api-url }}
           AUTH0_ADDITIONAL_CLAIM_DOMAIN: ${{ steps.setup.outputs.gp2-auth0-additional-claim-domain }}
+          AUTH0_KEYWORD_REPLACE_MAPPINGS: '{"APPLICATION_NAME":"gp2","BASE_PR_APP_DOMAIN":"${{ steps.setup.outputs.gp2-base-pr-app-domain }}","API_URL":"${{ steps.setup.outputs.gp2-api-url }}","AUTH0_ADDITIONAL_CLAIM_DOMAIN":"${{ steps.setup.outputs.gp2-auth0-additional-claim-domain }}","AUTH0_SHARED_SECRET":"${{ secrets.GP2_AUTH0_SHARED_SECRET }}"}'
 
       - name: Deploy GP2
         if: ${{ inputs.environment-name=='Development' || inputs.environment-name=='Production' }}
@@ -505,6 +508,7 @@ jobs:
           API_URL: ${{ steps.setup.outputs.gp2-api-url }}
           AUTH0_ADDITIONAL_CLAIM_DOMAIN: ${{ steps.setup.outputs.gp2-auth0-additional-claim-domain }}
           AUTH0_SHARED_SECRET: ${{ secrets.GP2_AUTH0_SHARED_SECRET }}
+          AUTH0_KEYWORD_REPLACE_MAPPINGS: '{"APPLICATION_NAME":"gp2","BASE_PR_APP_DOMAIN":"${{ steps.setup.outputs.gp2-base-pr-app-domain }}","API_URL":"${{ steps.setup.outputs.gp2-api-url }}","AUTH0_ADDITIONAL_CLAIM_DOMAIN":"${{ steps.setup.outputs.gp2-auth0-additional-claim-domain }}","AUTH0_SHARED_SECRET":"${{ secrets.GP2_AUTH0_SHARED_SECRET }}"}'
 
   postmark-templates:
     if: ${{ inputs.environment-name != 'Branch' || contains(github.event.pull_request.labels.*.name, 'postmark-templates-update')}}

--- a/apps/auth0/src/__tests__/post-login-add-metadata.test.ts
+++ b/apps/auth0/src/__tests__/post-login-add-metadata.test.ts
@@ -70,18 +70,82 @@ beforeEach(() => {
   nock.cleanAll();
 });
 
-it('skips metadata for KR-Sync client', async () => {
-  await onExecutePostLogin(
-    {
-      ...eventBase,
-      client: {
-        ...eventBase.client,
-        name: 'ASAP KR-Sync',
-      },
+describe('For an ASAP KR-Sync login', () => {
+  const krSyncEvent = {
+    ...eventBase,
+    client: {
+      ...eventBase.client,
+      name: 'ASAP KR-Sync',
     },
-    apiBase,
-  );
-  expect(apiBase.idToken.setCustomClaim).not.toHaveBeenCalled();
+  };
+
+  it('verifies the user against the webhook without setting custom claims', async () => {
+    nock(apiUrl).get(`/webhook/users/${user.user_id}`).reply(200, { id: '42' });
+
+    await onExecutePostLogin(krSyncEvent, apiBase);
+
+    expect(nock.isDone()).toBe(true);
+    expect(apiBase.idToken.setCustomClaim).not.toHaveBeenCalled();
+    expect(apiBase.access.deny).not.toHaveBeenCalled();
+  });
+
+  it('passes the AUTH0_SHARED_SECRET as a basic auth token', async () => {
+    const token = 'KR_SYNC_SECRET';
+    nock(apiUrl, {
+      reqheaders: { authorization: `Basic ${token}` },
+    })
+      .get(`/webhook/users/${user.user_id}`)
+      .reply(200, { id: '42' });
+
+    await onExecutePostLogin(
+      {
+        ...krSyncEvent,
+        secrets: { ...krSyncEvent.secrets, AUTH0_SHARED_SECRET: token },
+      },
+      apiBase,
+    );
+
+    expect(nock.isDone()).toBe(true);
+  });
+
+  it('denies access for alumni users', async () => {
+    nock(apiUrl)
+      .get(`/webhook/users/${user.user_id}`)
+      .reply(200, {
+        id: '42',
+        teams: [],
+        alumniSinceDate: '2024-01-01',
+      });
+
+    await onExecutePostLogin(krSyncEvent, apiBase);
+
+    expect(apiBase.access.deny).toHaveBeenCalledWith(
+      'alumni-user-access-denied',
+    );
+    expect(apiBase.idToken.setCustomClaim).not.toHaveBeenCalled();
+  });
+
+  it('denies access if the webhook returns an error (unknown user)', async () => {
+    nock(apiUrl).get(`/webhook/users/${user.user_id}`).reply(404);
+
+    await onExecutePostLogin(krSyncEvent, apiBase);
+
+    expect(apiBase.access.deny).toHaveBeenCalledWith(
+      'Response code 404 (Not Found)',
+    );
+    expect(apiBase.idToken.setCustomClaim).not.toHaveBeenCalled();
+  });
+
+  it('allows non-alumni GP2 users (no teams field on response)', async () => {
+    nock(apiUrl)
+      .get(`/webhook/users/${user.user_id}`)
+      .reply(200, { id: '42', role: 'Trainee' });
+
+    await onExecutePostLogin(krSyncEvent, apiBase);
+
+    expect(apiBase.access.deny).not.toHaveBeenCalled();
+    expect(apiBase.idToken.setCustomClaim).not.toHaveBeenCalled();
+  });
 });
 
 it('denies login if the redirect_uri is missing from query and body', async () => {

--- a/apps/auth0/src/__tests__/post-login-add-metadata.test.ts
+++ b/apps/auth0/src/__tests__/post-login-add-metadata.test.ts
@@ -109,13 +109,11 @@ describe('For an ASAP KR-Sync login', () => {
   });
 
   it('denies access for alumni users', async () => {
-    nock(apiUrl)
-      .get(`/webhook/users/${user.user_id}`)
-      .reply(200, {
-        id: '42',
-        teams: [],
-        alumniSinceDate: '2024-01-01',
-      });
+    nock(apiUrl).get(`/webhook/users/${user.user_id}`).reply(200, {
+      id: '42',
+      teams: [],
+      alumniSinceDate: '2024-01-01',
+    });
 
     await onExecutePostLogin(krSyncEvent, apiBase);
 

--- a/apps/auth0/src/post-login-add-metadata.ts
+++ b/apps/auth0/src/post-login-add-metadata.ts
@@ -73,12 +73,24 @@ const extractUser = (response: Auth0UserResponse): User | gp2Auth.User => ({
     : parseGP2UserMetadata(response)),
 });
 
-const getApiUrls = (event: Auth0PostLoginEventWithSecrets) => {
-  const redirect_uri = new URLSearchParams(event.request.query).get(
+const fetchUserMetadata = (
+  apiUrl: string,
+  event: Auth0PostLoginEventWithSecrets,
+) =>
+  got(`${apiUrl}/webhook/users/${event.user.user_id}`, {
+    headers: {
+      Authorization: `Basic ${event.secrets.AUTH0_SHARED_SECRET}`,
+    },
+    timeout: 10000,
+  }).json<Auth0UserResponse>();
+
+const getApiUrls = (
+  event: Auth0PostLoginEventWithSecrets,
+): [string, string] => {
+  const queryRedirectUri = new URLSearchParams(event.request.query).get(
     'redirect_uri',
-  )
-    ? new URLSearchParams(event.request.query).get('redirect_uri')
-    : event.request.body.redirect_uri;
+  );
+  const redirect_uri = queryRedirectUri ?? event.request.body.redirect_uri;
   if (!redirect_uri) {
     throw new Error('Missing redirect_uri');
   }
@@ -104,22 +116,21 @@ export const onExecutePostLogin = async (
 ) => {
   try {
     if (event.client.name === 'ASAP KR-Sync') {
-      console.log('Skipping metadata for ASAP KR-Sync');
+      const response = await fetchUserMetadata(event.secrets.API_URL, event);
+
+      if (isUserMetadataResponse(response) && response.alumniSinceDate) {
+        console.log('Rejecting KR-Sync login: User is alumni');
+        return api.access.deny('alumni-user-access-denied');
+      }
+
+      console.log('Successfully verified KR-Sync user');
       return true;
     }
     const [apiUrl, redirect_uri] = getApiUrls(event);
     console.log(
       `requesting metadata from ${apiUrl}/webhook/users/${event.user.user_id}`,
     );
-    const response = await got(
-      `${apiUrl}/webhook/users/${event.user.user_id}`,
-      {
-        headers: {
-          Authorization: `Basic ${event.secrets.AUTH0_SHARED_SECRET}`,
-        },
-        timeout: 10000,
-      },
-    ).json<Auth0UserResponse>();
+    const response = await fetchUserMetadata(apiUrl, event);
     if (isUserMetadataResponse(response) && response.alumniSinceDate) {
       return api.access.deny('alumni-user-access-denied');
     }

--- a/apps/auth0/src/post-login-add-metadata.ts
+++ b/apps/auth0/src/post-login-add-metadata.ts
@@ -116,7 +116,8 @@ export const onExecutePostLogin = async (
 ) => {
   try {
     if (event.client.name === 'ASAP KR-Sync') {
-      const response = await fetchUserMetadata(event.secrets.API_URL, event);
+      const apiUrl = event.secrets.API_URL ?? '##API_URL##';
+      const response = await fetchUserMetadata(apiUrl, event);
 
       if (isUserMetadataResponse(response) && response.alumniSinceDate) {
         console.log('Rejecting KR-Sync login: User is alumni');

--- a/apps/auth0/tenant.yaml
+++ b/apps/auth0/tenant.yaml
@@ -15,6 +15,10 @@ actions:
         value: '##AUTH0_ADDITIONAL_CLAIM_DOMAIN##'
       - name: AUTH0_SHARED_SECRET
         value: '##AUTH0_SHARED_SECRET##'
+      - name: API_URL
+        value: '##API_URL##'
+      - name: BASE_PR_APP_DOMAIN
+        value: '##BASE_PR_APP_DOMAIN##'
     status: built
     supported_triggers:
       - id: post-login
@@ -31,6 +35,10 @@ actions:
         value: '##AUTH0_ADDITIONAL_CLAIM_DOMAIN##'
       - name: AUTH0_SHARED_SECRET
         value: '##AUTH0_SHARED_SECRET##'
+      - name: API_URL
+        value: '##API_URL##'
+      - name: BASE_PR_APP_DOMAIN
+        value: '##BASE_PR_APP_DOMAIN##'
     status: built
     supported_triggers:
       - id: post-login


### PR DESCRIPTION
[ASAP-1466](https://asaphub.atlassian.net/browse/ASAP-1466)

**Summary**                                                                                                                        

Add identity verification for the ASAP KR-Sync Auth0 client (DataSeer integration). On login, the post-login action calls the `/webhook/users/:id` endpoint to confirm the user exists in our system and is not an alumnus — denying access otherwise. 

 Changes                                                                                                                        
                                                                                                                                 
  - `apps/auth0/src/post-login-add-metadata.ts` — KR-Sync branch now verifies the user via the existing webhook and denies alumni / unknown users.                                                                                                              
  - Extracted fetchUserMetadata helper to remove duplication between the KR-Sync and main flows.                                 
  - Tightened getApiUrls return type to [string, string].

[ASAP-1466]: https://asaphub.atlassian.net/browse/ASAP-1466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ