### PR TITLE
[ASAP-1471] - Debounce MultiSelect loadOptions

### DIFF
--- a/apps/crn-frontend/src/network/teams/__tests__/TeamManuscript2.test.tsx
+++ b/apps/crn-frontend/src/network/teams/__tests__/TeamManuscript2.test.tsx
@@ -226,7 +226,7 @@ it('can publish a form when the data is valid and navigates to team workspace', 
   await user.type(screen.getByLabelText(/First Authors/i), 'Jane Doe');
 
   // External author email
-  await user.click(screen.getByText(/Non CRN/i));
+  await user.click(await screen.findByText(/Non CRN/i, {}, { timeout: 5000 }));
   await user.type(
     screen.getByLabelText(/Jane Doe Email/i),
     'jane@doe.com{enter}',

--- a/apps/crn-frontend/src/network/teams/__tests__/TeamManuscript3.test.tsx
+++ b/apps/crn-frontend/src/network/teams/__tests__/TeamManuscript3.test.tsx
@@ -227,7 +227,7 @@ it('shows server validation error toast and a message when submitting with dupli
   await user.type(screen.getByLabelText(/First Authors/i), 'Jane Doe');
 
   // External author email
-  await user.click(screen.getByText(/Non CRN/i));
+  await user.click(await screen.findByText(/Non CRN/i, {}, { timeout: 5000 }));
   await user.type(
     screen.getByLabelText(/Jane Doe Email/i),
     'jane@doe.com{enter}',

--- a/apps/crn-frontend/src/network/teams/__tests__/TeamManuscript4.test.tsx
+++ b/apps/crn-frontend/src/network/teams/__tests__/TeamManuscript4.test.tsx
@@ -219,7 +219,7 @@ it('shows default error toast when submitting with any other error', async () =>
   await user.type(screen.getByLabelText(/First Authors/i), 'Jane Doe');
 
   // External author email
-  await user.click(screen.getByText(/Non CRN/i));
+  await user.click(await screen.findByText(/Non CRN/i, {}, { timeout: 5000 }));
   await user.type(
     screen.getByLabelText(/Jane Doe Email/i),
     'jane@doe.com{enter}',

--- a/apps/crn-frontend/src/network/teams/__tests__/TeamOutput.test.tsx
+++ b/apps/crn-frontend/src/network/teams/__tests__/TeamOutput.test.tsx
@@ -332,9 +332,13 @@ it('can publish a form when the data is valid', async () => {
   );
 
   await user.click(screen.getByRole('combobox', { name: /Labs/i }));
-  await user.click(screen.getByText('Example 1 Lab'));
+  await user.click(
+    await screen.findByText('Example 1 Lab', {}, { timeout: 5000 }),
+  );
   await user.click(screen.getByRole('combobox', { name: /Authors/i }));
-  await user.click(screen.getByText('Person A 3'));
+  await user.click(
+    await screen.findByText('Person A 3', {}, { timeout: 5000 }),
+  );
 
   await publish();
 
@@ -406,9 +410,13 @@ it('can save draft when form data is valid', async () => {
   );
 
   await user.click(screen.getByRole('combobox', { name: /Labs/i }));
-  await user.click(screen.getByText('Example 1 Lab'));
+  await user.click(
+    await screen.findByText('Example 1 Lab', {}, { timeout: 5000 }),
+  );
   await user.click(screen.getByRole('combobox', { name: /Authors/i }));
-  await user.click(screen.getByText('Person A 3'));
+  await user.click(
+    await screen.findByText('Person A 3', {}, { timeout: 5000 }),
+  );
 
   await saveDraft();
 
@@ -1185,9 +1193,16 @@ describe('manuscript outputs flow', () => {
 
     const input = screen.getByRole('combobox');
     await user.type(input, 'Version One');
-    await user.keyboard('{Tab}');
 
-    expect(screen.getByRole('button', { name: /import/i })).toBeEnabled();
+    await user.click(
+      await screen.findByText('Version One', {}, { timeout: 5000 }),
+    );
+
+    await waitFor(
+      () =>
+        expect(screen.getByRole('button', { name: /import/i })).toBeEnabled(),
+      { timeout: 5000 },
+    );
   });
 
   it('can publish a form with selected manuscript version data', async () => {

--- a/apps/crn-frontend/src/network/teams/__tests__/TeamProfile.test.tsx
+++ b/apps/crn-frontend/src/network/teams/__tests__/TeamProfile.test.tsx
@@ -417,13 +417,17 @@ it('displays manuscript success toast message and user can dismiss toast', async
     name: /Impact/i,
   });
   await user.type(impactInput, 'My Imp');
-  await user.click(screen.getByText(/^My Impact$/i));
+  await user.click(
+    await screen.findByText(/^My Impact$/i, {}, { timeout: 5000 }),
+  );
 
   const categoryInput = screen.getByRole('combobox', {
     name: /Category/i,
   });
   await user.type(categoryInput, 'My Cat');
-  await user.click(screen.getByText(/^My Category$/i));
+  await user.click(
+    await screen.findByText(/^My Category$/i, {}, { timeout: 5000 }),
+  );
 
   fireEvent.change(screen.getByLabelText(/First Authors/i), {
     target: { value: 'Jane Doe' },
@@ -433,7 +437,7 @@ it('displays manuscript success toast message and user can dismiss toast', async
     expect(screen.queryByText(/loading/i)).not.toBeInTheDocument(),
   );
 
-  await user.click(screen.getByText(/Non CRN/i));
+  await user.click(await screen.findByText(/Non CRN/i, {}, { timeout: 5000 }));
 
   expect(screen.getByText(/Jane Doe Email/i)).toBeInTheDocument();
   fireEvent.change(screen.getByLabelText(/Jane Doe Email/i), {

--- a/apps/crn-frontend/src/network/working-groups/__tests__/WorkingGroupOutput.test.tsx
+++ b/apps/crn-frontend/src/network/working-groups/__tests__/WorkingGroupOutput.test.tsx
@@ -134,10 +134,14 @@ const mandatoryFields = async (
     target: { value: doi },
   });
   await user.click(screen.getByRole('combobox', { name: /Authors/i }));
-  await user.click(screen.getByText('Person A 3'));
+  await user.click(
+    await screen.findByText('Person A 3', {}, { timeout: 5000 }),
+  );
 
   await user.click(screen.getByRole('combobox', { name: /Teams/i }));
-  await user.click(screen.getByText('Abu-Remaileh, M 1'));
+  await user.click(
+    await screen.findByText('Abu-Remaileh, M 1', {}, { timeout: 5000 }),
+  );
 
   return {
     publish: async () => {
@@ -356,7 +360,9 @@ it('can submit a form when form data is valid', async () => {
   );
 
   await user.click(screen.getByRole('combobox', { name: /Labs/i }));
-  await user.click(screen.getByText('Example 1 Lab'));
+  await user.click(
+    await screen.findByText('Example 1 Lab', {}, { timeout: 5000 }),
+  );
 
   await publish();
 
@@ -443,7 +449,9 @@ it('can save draft when form data is valid', async () => {
   );
 
   await user.click(screen.getByRole('combobox', { name: /Labs/i }));
-  await user.click(screen.getByText('Example 1 Lab'));
+  await user.click(
+    await screen.findByText('Example 1 Lab', {}, { timeout: 5000 }),
+  );
 
   await saveDraft();
 

--- a/apps/crn-frontend/src/tags/__tests__/Routes.test.tsx
+++ b/apps/crn-frontend/src/tags/__tests__/Routes.test.tsx
@@ -106,7 +106,9 @@ describe('tags', () => {
     await renderTagsPage();
 
     await userEvent.click(screen.getByRole('combobox'));
-    await userEvent.click(screen.getByText('LGW'));
+    await userEvent.click(
+      await screen.findByRole('option', { name: 'LGW' }, { timeout: 5000 }),
+    );
     await waitFor(() =>
       expect(mockGetTagSearch).toHaveBeenCalledWith(
         expect.anything(),
@@ -127,7 +129,9 @@ describe('tags', () => {
     await renderTagsPage();
 
     await userEvent.click(screen.getByRole('combobox'));
-    await userEvent.click(screen.getByText('LGW'));
+    await userEvent.click(
+      await screen.findByRole('option', { name: 'LGW' }, { timeout: 5000 }),
+    );
     await waitFor(() => {
       expect(mockGetTagSearch).toHaveBeenCalled();
       expect(mockSearchForTagValues).toHaveBeenCalledWith(
@@ -222,7 +226,9 @@ it('Will show algolia results', async () => {
   await renderTagsPage();
 
   await userEvent.click(screen.getByRole('combobox'));
-  await userEvent.click(screen.getByText('LGW'));
+  await userEvent.click(
+    await screen.findByRole('option', { name: 'LGW' }, { timeout: 5000 }),
+  );
   await waitFor(() =>
     expect(screen.getByText('Tom Cruise')).toBeInTheDocument(),
   );
@@ -239,7 +245,9 @@ it('Will show page when algolia rejects with undefined', async () => {
   await renderTagsPage();
 
   await userEvent.click(screen.getByRole('combobox'));
-  await userEvent.click(screen.getByText('LGW'));
+  await userEvent.click(
+    await screen.findByRole('option', { name: 'LGW' }, { timeout: 5000 }),
+  );
   await waitFor(() =>
     expect(mockGetTagSearch).toHaveBeenCalledWith(
       expect.anything(),
@@ -263,7 +271,9 @@ it('Will show page when algolia rejects with error', async () => {
   await renderTagsPage();
 
   await userEvent.click(screen.getByRole('combobox'));
-  await userEvent.click(screen.getByText('LGW'));
+  await userEvent.click(
+    await screen.findByRole('option', { name: 'LGW' }, { timeout: 5000 }),
+  );
   await waitFor(() =>
     expect(mockGetTagSearch).toHaveBeenCalledWith(
       expect.anything(),

--- a/apps/gp2-frontend/src/projects/__tests__/CreateProjectOutput.test.tsx
+++ b/apps/gp2-frontend/src/projects/__tests__/CreateProjectOutput.test.tsx
@@ -154,13 +154,17 @@ describe('Create Projects Output', () => {
     );
     const authors = screen.getByRole('combobox', { name: /Authors/i });
     await user.click(authors);
-    await user.click(screen.getByText('Tony Stark'));
+    await user.click(
+      await screen.findByText('Tony Stark', {}, { timeout: 5000 }),
+    );
     await user.click(authors);
-    await user.click(screen.getByText(/Steve Rogers \(/i));
+    await user.click(
+      await screen.findByText(/Steve Rogers \(/i, {}, { timeout: 5000 }),
+    );
     await user.click(
       screen.getByRole('combobox', { name: /identifier type/i }),
     );
-    await user.click(screen.getByText(/^none/i));
+    await user.click(await screen.findByText(/^none/i, {}, { timeout: 5000 }));
     expect(screen.getByText('Project Title')).toBeVisible();
     await user.click(screen.getByRole('button', { name: 'Publish' }));
     await user.click(screen.getByRole('button', { name: 'Publish Output' }));
@@ -233,11 +237,13 @@ describe('Create Projects Output', () => {
     );
     const authors = screen.getByRole('combobox', { name: /Authors/i });
     await user.click(authors);
-    await user.click(screen.getByText('Tony Stark'));
+    await user.click(
+      await screen.findByText('Tony Stark', {}, { timeout: 5000 }),
+    );
     await user.click(
       screen.getByRole('combobox', { name: /identifier type/i }),
     );
-    await user.click(screen.getByText(/^none/i));
+    await user.click(await screen.findByText(/^none/i, {}, { timeout: 5000 }));
     expect(screen.getByText('Project Title')).toBeVisible();
     await user.click(screen.getByRole('button', { name: 'Publish' }));
     await user.click(screen.getByRole('button', { name: 'Publish Output' }));

--- a/apps/gp2-frontend/src/tags/__tests__/TagSearch.test.tsx
+++ b/apps/gp2-frontend/src/tags/__tests__/TagSearch.test.tsx
@@ -110,7 +110,9 @@ describe('TagSearch', () => {
 
     await renderPage();
     await userEvent.click(screen.getByRole('combobox'));
-    await userEvent.click(screen.getByText('LGW'));
+    await userEvent.click(
+      await screen.findByRole('option', { name: 'LGW' }, { timeout: 5000 }),
+    );
     expect(mockSetTags).toHaveBeenCalledWith(['LGW']);
   });
 });

--- a/apps/gp2-frontend/src/working-groups/__tests__/CreateWorkingGroupOutput.test.tsx
+++ b/apps/gp2-frontend/src/working-groups/__tests__/CreateWorkingGroupOutput.test.tsx
@@ -154,13 +154,19 @@ describe('Create WorkingGroup Output', () => {
     );
     const authors = screen.getByRole('combobox', { name: /Authors/i });
     await userEvent.click(authors);
-    await userEvent.click(screen.getByText('Tony Stark'));
+    await userEvent.click(
+      await screen.findByText('Tony Stark', {}, { timeout: 5000 }),
+    );
     await userEvent.click(authors);
-    await userEvent.click(screen.getByText(/Steve Rogers \(/i));
+    await userEvent.click(
+      await screen.findByText(/Steve Rogers \(/i, {}, { timeout: 5000 }),
+    );
     await userEvent.click(
       screen.getByRole('combobox', { name: /identifier type/i }),
     );
-    await userEvent.click(screen.getByText(/^none/i));
+    await userEvent.click(
+      await screen.findByText(/^none/i, {}, { timeout: 5000 }),
+    );
     expect(screen.getByText('Working Group Title')).toBeVisible();
     await userEvent.click(screen.getByRole('button', { name: 'Publish' }));
     await userEvent.click(
@@ -233,11 +239,15 @@ describe('Create WorkingGroup Output', () => {
     );
     const authors = screen.getByRole('combobox', { name: /Authors/i });
     await userEvent.click(authors);
-    await userEvent.click(screen.getByText('Tony Stark'));
+    await userEvent.click(
+      await screen.findByText('Tony Stark', {}, { timeout: 5000 }),
+    );
     await userEvent.click(
       screen.getByRole('combobox', { name: /identifier type/i }),
     );
-    await userEvent.click(screen.getByText(/^none/i));
+    await userEvent.click(
+      await screen.findByText(/^none/i, {}, { timeout: 5000 }),
+    );
     expect(screen.getByText('Working Group Title')).toBeVisible();
     await userEvent.click(screen.getByRole('button', { name: 'Publish' }));
     await userEvent.click(

--- a/packages/gp2-components/src/templates/OutputForm.tsx
+++ b/packages/gp2-components/src/templates/OutputForm.tsx
@@ -798,6 +798,7 @@ const OutputForm: React.FC<OutputFormProps> = ({
                       enabled={!isSaving}
                       placeholder="Start typing..."
                       loadOptions={getAuthorSuggestions}
+                      defaultOptions
                       externalLabel="Non GP2"
                       onChange={setAuthors}
                       values={newAuthors}

--- a/packages/gp2-components/src/templates/TagSearchPageList.tsx
+++ b/packages/gp2-components/src/templates/TagSearchPageList.tsx
@@ -63,6 +63,7 @@ const TagSearchPageList: React.FC<TagSearchPageListProps> = ({
         leftIndicator={searchIcon}
         noOptionsMessage={() => 'No results found'}
         loadOptions={loadTags}
+        defaultOptions
         onChange={(items) => setTags(items.map(({ value }) => value))}
         values={tags.map((tag) => ({
           label: tag,

--- a/packages/gp2-components/src/templates/__tests__/OutputForm.test.tsx
+++ b/packages/gp2-components/src/templates/__tests__/OutputForm.test.tsx
@@ -221,7 +221,9 @@ describe('OutputForm', () => {
       await user.click(screen.getByText('Chris Blue'));
       await user.click(authors);
       await user.type(authors, 'Alex White');
-      await user.click(await screen.findByRole('option', { name: /Alex White/i }));
+      await user.click(
+        await screen.findByRole('option', { name: /Alex White/i }),
+      );
 
       await user.click(
         screen.getByRole('combobox', {

--- a/packages/gp2-components/src/templates/__tests__/OutputForm.test.tsx
+++ b/packages/gp2-components/src/templates/__tests__/OutputForm.test.tsx
@@ -221,7 +221,7 @@ describe('OutputForm', () => {
       await user.click(screen.getByText('Chris Blue'));
       await user.click(authors);
       await user.type(authors, 'Alex White');
-      await user.keyboard('{Enter}');
+      await user.click(await screen.findByRole('option', { name: /Alex White/i }));
 
       await user.click(
         screen.getByRole('combobox', {
@@ -266,6 +266,9 @@ describe('OutputForm', () => {
             { userId: 'u2' },
             { externalUserName: 'Alex White' },
           ],
+          type: undefined,
+          subtype: undefined,
+          publishDate: undefined,
           mainEntityId: '12',
           workingGroupIds: ['2'],
           projectIds: ['3'],

--- a/packages/gp2-components/src/templates/__tests__/TagSearchPageList.test.tsx
+++ b/packages/gp2-components/src/templates/__tests__/TagSearchPageList.test.tsx
@@ -30,7 +30,7 @@ describe('TagSearchPageList', () => {
     );
 
     await userEvent.click(screen.getByRole('combobox'));
-    expect(loadTags).toHaveBeenCalled();
+    await waitFor(() => expect(loadTags).toHaveBeenCalled());
     await waitFor(() =>
       expect(screen.getByText('No results found')).toBeVisible(),
     );

--- a/packages/react-components/src/atoms/MultiSelect.tsx
+++ b/packages/react-components/src/atoms/MultiSelect.tsx
@@ -157,7 +157,7 @@ const MultiSelect = <
       debounceTimerRef.current = setTimeout(() => {
         const result = loadOptionsRef.current?.(inputValue, callback);
         if (result instanceof Promise) {
-          result.then(callback);
+          void result.then(callback);
         }
       }, loadOptionsDebounceMs);
     },

--- a/packages/react-components/src/atoms/MultiSelect.tsx
+++ b/packages/react-components/src/atoms/MultiSelect.tsx
@@ -2,8 +2,9 @@ import { css, useTheme } from '@emotion/react';
 import {
   ReactElement,
   ReactNode,
+  createContext,
+  useContext,
   useEffect,
-  useMemo,
   useRef,
   useState,
 } from 'react';
@@ -32,6 +33,20 @@ const indicatorStyles = css({
   paddingLeft: rem(6),
   paddingRight: rem(3),
 });
+
+const LeftIndicatorContext = createContext<ReactNode>(null);
+
+const IndicatorControl = (
+  props: Parameters<typeof reactAsyncComponents.Control>[0],
+) => {
+  const leftIndicator = useContext(LeftIndicatorContext);
+  return (
+    <reactAsyncComponents.Control {...props}>
+      <div css={indicatorStyles}>{leftIndicator}</div>
+      {props.children}
+    </reactAsyncComponents.Control>
+  );
+};
 
 export type MultiSelectOptionsType = {
   isFixed?: boolean;
@@ -148,6 +163,7 @@ const MultiSelect = <
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const loadOptionsRef = useRef(loadOptions);
   loadOptionsRef.current = loadOptions;
+  const requestCounterRef = useRef(0);
 
   // Stable function reference — created once per mount, reads loadOptionsRef for
   // latest value. This prevents react-select from resetting when parent re-renders.
@@ -155,9 +171,13 @@ const MultiSelect = <
     (inputValue: string, callback: (opts: ReadonlyArray<T>) => void): void => {
       if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
       debounceTimerRef.current = setTimeout(() => {
-        const result = loadOptionsRef.current?.(inputValue, callback);
+        const requestId = ++requestCounterRef.current;
+        const guardedCallback = (options: ReadonlyArray<T>) => {
+          if (requestId === requestCounterRef.current) callback(options);
+        };
+        const result = loadOptionsRef.current?.(inputValue, guardedCallback);
         if (result instanceof Promise) {
-          void result.then(callback).catch(() => callback([]));
+          void result.then(guardedCallback).catch(() => guardedCallback([]));
         }
       }, loadOptionsDebounceMs);
     },
@@ -168,19 +188,6 @@ const MultiSelect = <
       ? stableDebouncedFn
       : loadOptions
     : undefined;
-
-  const ControlComponent = useMemo(
-    () =>
-      leftIndicator
-        ? (props: Parameters<typeof reactAsyncComponents.Control>[0]) => (
-            <reactAsyncComponents.Control {...props}>
-              <div css={indicatorStyles}>{leftIndicator}</div>
-              {props.children}
-            </reactAsyncComponents.Control>
-          )
-        : undefined,
-    [leftIndicator],
-  );
 
   const handleOnContextMenu = () => {
     inputRef?.blur?.();
@@ -212,7 +219,7 @@ const MultiSelect = <
     value: values ?? getValues<T, M>(isMulti),
     components: {
       MultiValueRemove,
-      ...(ControlComponent ? { Control: ControlComponent } : {}),
+      ...(leftIndicator ? { Control: IndicatorControl } : {}),
       ...components,
     } as Props<T, M, GroupBase<T>>['components'],
     noOptionsMessage,
@@ -261,59 +268,63 @@ const MultiSelect = <
   };
 
   return (
-    <div css={containerStyles(noMargin)} onContextMenu={handleOnContextMenu}>
-      {suggestions ? (
-        <Select<T, typeof isMulti, GroupBase<T>>
-          {...commonProps}
-          ref={(ref) => {
-            inputRef = ref;
-          }}
-          options={suggestions as T[]}
-          maxMenuHeight={maxMenuHeight}
+    <LeftIndicatorContext.Provider value={leftIndicator}>
+      <div css={containerStyles(noMargin)} onContextMenu={handleOnContextMenu}>
+        {suggestions ? (
+          <Select<T, typeof isMulti, GroupBase<T>>
+            {...commonProps}
+            ref={(ref) => {
+              inputRef = ref;
+            }}
+            options={suggestions as T[]}
+            maxMenuHeight={maxMenuHeight}
+          />
+        ) : creatable ? (
+          <AsyncCreatableSelect<T, typeof isMulti, GroupBase<T>>
+            {...commonProps}
+            ref={(ref) => {
+              inputRef = ref;
+            }}
+            loadOptions={effectiveLoadOptions}
+            cacheOptions
+            defaultOptions={defaultOptions}
+            maxMenuHeight={maxMenuHeight}
+          />
+        ) : (
+          <AsyncSelect<T, typeof isMulti, GroupBase<T>>
+            {...commonProps}
+            ref={(ref) => {
+              inputRef = ref;
+            }}
+            loadOptions={effectiveLoadOptions}
+            cacheOptions
+            defaultOptions={defaultOptions}
+            maxMenuHeight={maxMenuHeight}
+          />
+        )}
+        <input
+          {...validationTargetProps}
+          tabIndex={-1}
+          autoComplete="off"
+          onChange={noop}
+          value={
+            Array.isArray(values)
+              ? values.map((value) => value.label).join(',')
+              : typeof values === 'object' &&
+                  values !== null &&
+                  'label' in values
+                ? values.label ?? ''
+                : ''
+          }
+          required={required}
+          disabled={!enabled}
+          hidden
         />
-      ) : creatable ? (
-        <AsyncCreatableSelect<T, typeof isMulti, GroupBase<T>>
-          {...commonProps}
-          ref={(ref) => {
-            inputRef = ref;
-          }}
-          loadOptions={effectiveLoadOptions}
-          cacheOptions
-          defaultOptions={defaultOptions}
-          maxMenuHeight={maxMenuHeight}
-        />
-      ) : (
-        <AsyncSelect<T, typeof isMulti, GroupBase<T>>
-          {...commonProps}
-          ref={(ref) => {
-            inputRef = ref;
-          }}
-          loadOptions={effectiveLoadOptions}
-          cacheOptions
-          defaultOptions={defaultOptions}
-          maxMenuHeight={maxMenuHeight}
-        />
-      )}
-      <input
-        {...validationTargetProps}
-        tabIndex={-1}
-        autoComplete="off"
-        onChange={noop}
-        value={
-          Array.isArray(values)
-            ? values.map((value) => value.label).join(',')
-            : typeof values === 'object' && values !== null && 'label' in values
-              ? values.label ?? ''
-              : ''
-        }
-        required={required}
-        disabled={!enabled}
-        hidden
-      />
-      {validationMessage?.trim() && (
-        <div css={validationMessageStyles}>{validationMessage}</div>
-      )}
-    </div>
+        {validationMessage?.trim() && (
+          <div css={validationMessageStyles}>{validationMessage}</div>
+        )}
+      </div>
+    </LeftIndicatorContext.Provider>
   );
 };
 

--- a/packages/react-components/src/atoms/MultiSelect.tsx
+++ b/packages/react-components/src/atoms/MultiSelect.tsx
@@ -157,7 +157,7 @@ const MultiSelect = <
       debounceTimerRef.current = setTimeout(() => {
         const result = loadOptionsRef.current?.(inputValue, callback);
         if (result instanceof Promise) {
-          void result.then(callback);
+          void result.then(callback).catch(() => callback([]));
         }
       }, loadOptionsDebounceMs);
     },

--- a/packages/react-components/src/atoms/MultiSelect.tsx
+++ b/packages/react-components/src/atoms/MultiSelect.tsx
@@ -1,5 +1,12 @@
 import { css, useTheme } from '@emotion/react';
-import { ReactElement, ReactNode, useEffect, useRef, useState } from 'react';
+import {
+  ReactElement,
+  ReactNode,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import Select, {
   ActionMeta,
   components as reactAsyncComponents,
@@ -85,6 +92,8 @@ export type MultiSelectProps<
   | (Pick<Props<T, true, GroupBase<T>>, 'noOptionsMessage' | 'components'> & {
       readonly suggestions: ReadonlyArray<T>;
       readonly loadOptions?: undefined;
+      readonly loadOptionsDebounceMs?: undefined;
+      readonly defaultOptions?: undefined;
     })
   | (Pick<
       AsyncProps<T, true, GroupBase<T>>,
@@ -95,6 +104,8 @@ export type MultiSelectProps<
         callback: (options: ReadonlyArray<T>) => void,
       ) => Promise<ReadonlyArray<T>> | void;
       readonly suggestions?: undefined;
+      readonly loadOptionsDebounceMs?: number;
+      readonly defaultOptions?: boolean;
     })
 );
 
@@ -109,6 +120,8 @@ const MultiSelect = <
 >({
   customValidationMessage = '',
   loadOptions,
+  loadOptionsDebounceMs = 300,
+  defaultOptions = true,
   id,
   suggestions,
   components,
@@ -131,6 +144,44 @@ const MultiSelect = <
 }: MultiSelectProps<T, M>): ReactElement => {
   const theme = useTheme();
   let inputRef: RefType<T, M> = null;
+
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const loadOptionsRef = useRef(loadOptions);
+  loadOptionsRef.current = loadOptions;
+
+  // Stable function reference — created once per mount, reads loadOptionsRef for
+  // latest value. This prevents react-select from resetting when parent re-renders.
+  const stableDebouncedFn = useRef(
+    (inputValue: string, callback: (opts: ReadonlyArray<T>) => void): void => {
+      if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
+      debounceTimerRef.current = setTimeout(() => {
+        const result = loadOptionsRef.current?.(inputValue, callback);
+        if (result instanceof Promise) {
+          result.then(callback);
+        }
+      }, loadOptionsDebounceMs);
+    },
+  ).current;
+
+  const effectiveLoadOptions: typeof loadOptions = loadOptions
+    ? loadOptionsDebounceMs > 0
+      ? stableDebouncedFn
+      : loadOptions
+    : undefined;
+
+  const ControlComponent = useMemo(
+    () =>
+      leftIndicator
+        ? (props: Parameters<typeof reactAsyncComponents.Control>[0]) => (
+            <reactAsyncComponents.Control {...props}>
+              <div css={indicatorStyles}>{leftIndicator}</div>
+              {props.children}
+            </reactAsyncComponents.Control>
+          )
+        : undefined,
+    [leftIndicator],
+  );
+
   const handleOnContextMenu = () => {
     inputRef?.blur?.();
   };
@@ -161,27 +212,13 @@ const MultiSelect = <
     value: values ?? getValues<T, M>(isMulti),
     components: {
       MultiValueRemove,
-      ...(leftIndicator
-        ? {
-            Control: (
-              props: Parameters<typeof reactAsyncComponents.Control>[0],
-            ) => (
-              <reactAsyncComponents.Control {...props}>
-                <div css={indicatorStyles}>{leftIndicator}</div>
-                {props.children}
-              </reactAsyncComponents.Control>
-            ),
-          }
-        : {}),
-
+      ...(ControlComponent ? { Control: ControlComponent } : {}),
       ...components,
     } as Props<T, M, GroupBase<T>>['components'],
     noOptionsMessage,
     styles: reactMultiSelectStyles(theme, !!validationMessage, isMulti),
     onFocus: () => {
-      if (onFocus) {
-        onFocus();
-      }
+      onFocus();
     },
     onBlur: () => {
       setHasBlurred(true);
@@ -240,9 +277,9 @@ const MultiSelect = <
           ref={(ref) => {
             inputRef = ref;
           }}
-          loadOptions={loadOptions}
+          loadOptions={effectiveLoadOptions}
           cacheOptions
-          defaultOptions
+          defaultOptions={defaultOptions}
           maxMenuHeight={maxMenuHeight}
         />
       ) : (
@@ -251,9 +288,9 @@ const MultiSelect = <
           ref={(ref) => {
             inputRef = ref;
           }}
-          loadOptions={loadOptions}
+          loadOptions={effectiveLoadOptions}
           cacheOptions
-          defaultOptions
+          defaultOptions={defaultOptions}
           maxMenuHeight={maxMenuHeight}
         />
       )}

--- a/packages/react-components/src/atoms/MultiSelect.tsx
+++ b/packages/react-components/src/atoms/MultiSelect.tsx
@@ -171,7 +171,8 @@ const MultiSelect = <
     (inputValue: string, callback: (opts: ReadonlyArray<T>) => void): void => {
       if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
       debounceTimerRef.current = setTimeout(() => {
-        const requestId = ++requestCounterRef.current;
+        requestCounterRef.current += 1;
+        const requestId = requestCounterRef.current;
         const guardedCallback = (options: ReadonlyArray<T>) => {
           if (requestId === requestCounterRef.current) callback(options);
         };

--- a/packages/react-components/src/atoms/__tests__/MultiSelect.test.tsx
+++ b/packages/react-components/src/atoms/__tests__/MultiSelect.test.tsx
@@ -219,9 +219,18 @@ describe('invalidity', () => {
 
 describe('Async debounce', () => {
   it('does not call loadOptions on mount when defaultOptions is false (default)', () => {
+    jest.useFakeTimers();
     const loadOptions = jest.fn().mockResolvedValue([]);
-    render(<MultiSelect loadOptions={loadOptions} />);
+    render(
+      <MultiSelect
+        loadOptions={loadOptions}
+        loadOptionsDebounceMs={300}
+        defaultOptions={false}
+      />,
+    );
+    jest.advanceTimersByTime(350); // wait a bit more than 300ms to make sure  the test is not passing because the 300ms didn't pass yet
     expect(loadOptions).not.toHaveBeenCalled();
+    jest.useRealTimers();
   });
 
   it('calls loadOptions on mount with empty string when defaultOptions is true', async () => {
@@ -242,12 +251,10 @@ describe('Async debounce', () => {
     const { getByRole } = render(
       <MultiSelect loadOptions={loadOptions} loadOptionsDebounceMs={300} />,
     );
-
     // Type quickly — the debounce timer is reset on each keystroke
     await userEvent.type(getByRole('combobox'), 'cancer');
     // Immediately after typing, debounce hasn't fired yet
     expect(loadOptions).not.toHaveBeenCalled();
-
     // Wait for debounce to fire (> 300ms)
     await waitFor(() => expect(loadOptions).toHaveBeenCalledTimes(1), {
       timeout: 600,
@@ -261,6 +268,46 @@ describe('Async debounce', () => {
     );
     await userEvent.type(getByRole('combobox'), 'a');
     expect(loadOptions).toHaveBeenCalled();
+  });
+
+  it('ignores stale response when newer request has already resolved', async () => {
+    type Resolver = (
+      opts: ReadonlyArray<{ label: string; value: string }>,
+    ) => void;
+    const resolvers: Resolver[] = [];
+    const loadOptions = jest.fn().mockImplementation(
+      () =>
+        new Promise<ReadonlyArray<{ label: string; value: string }>>(
+          (resolve) => {
+            resolvers.push(resolve);
+          },
+        ),
+    );
+
+    const { getByRole, getByText, queryByText } = render(
+      <MultiSelect
+        loadOptions={loadOptions}
+        loadOptionsDebounceMs={50}
+        defaultOptions={false}
+      />,
+    );
+
+    await userEvent.type(getByRole('combobox'), 'amin-tesin');
+    await waitFor(() => expect(loadOptions).toHaveBeenCalledTimes(1));
+
+    await userEvent.type(getByRole('combobox'), '{backspace}{backspace}');
+    await waitFor(() => expect(loadOptions).toHaveBeenCalledTimes(2));
+
+    // Resolve newer (2nd) request first
+    resolvers[1]!([{ label: 'Newer Result', value: 'newer' }]);
+    await waitFor(() => expect(getByText('Newer Result')).toBeInTheDocument());
+
+    // Resolve stale (1st) request — must be discarded
+    resolvers[0]!([{ label: 'Stale Result', value: 'stale' }]);
+    await waitFor(() =>
+      expect(queryByText('Stale Result')).not.toBeInTheDocument(),
+    );
+    expect(getByText('Newer Result')).toBeInTheDocument();
   });
 });
 

--- a/packages/react-components/src/atoms/__tests__/MultiSelect.test.tsx
+++ b/packages/react-components/src/atoms/__tests__/MultiSelect.test.tsx
@@ -217,6 +217,53 @@ describe('invalidity', () => {
   });
 });
 
+describe('Async debounce', () => {
+  it('does not call loadOptions on mount when defaultOptions is false (default)', () => {
+    const loadOptions = jest.fn().mockResolvedValue([]);
+    render(<MultiSelect loadOptions={loadOptions} />);
+    expect(loadOptions).not.toHaveBeenCalled();
+  });
+
+  it('calls loadOptions on mount with empty string when defaultOptions is true', async () => {
+    const loadOptions = jest.fn().mockResolvedValue([]);
+    render(
+      <MultiSelect
+        loadOptions={loadOptions}
+        loadOptionsDebounceMs={0}
+        defaultOptions
+      />,
+    );
+    await waitFor(() => expect(loadOptions).toHaveBeenCalledTimes(1));
+    expect(loadOptions).toHaveBeenCalledWith('', expect.any(Function));
+  });
+
+  it('debounces loadOptions calls — only fires after the delay', async () => {
+    const loadOptions = jest.fn().mockResolvedValue([]);
+    const { getByRole } = render(
+      <MultiSelect loadOptions={loadOptions} loadOptionsDebounceMs={300} />,
+    );
+
+    // Type quickly — the debounce timer is reset on each keystroke
+    await userEvent.type(getByRole('combobox'), 'cancer');
+    // Immediately after typing, debounce hasn't fired yet
+    expect(loadOptions).not.toHaveBeenCalled();
+
+    // Wait for debounce to fire (> 300ms)
+    await waitFor(() => expect(loadOptions).toHaveBeenCalledTimes(1), {
+      timeout: 600,
+    });
+  });
+
+  it('bypasses debounce when loadOptionsDebounceMs is 0', async () => {
+    const loadOptions = jest.fn().mockResolvedValue([]);
+    const { getByRole } = render(
+      <MultiSelect loadOptions={loadOptions} loadOptionsDebounceMs={0} />,
+    );
+    await userEvent.type(getByRole('combobox'), 'a');
+    expect(loadOptions).toHaveBeenCalled();
+  });
+});
+
 describe('Async', () => {
   const asyncProps: ComponentProps<typeof MultiSelect> = {
     loadOptions: jest.fn(),
@@ -227,6 +274,7 @@ describe('Async', () => {
     const { getByRole, getByText, queryByText } = render(
       <MultiSelect
         loadOptions={loadOptionsEmpty}
+        loadOptionsDebounceMs={0}
         noOptionsMessage={() => 'No options'}
       />,
     );
@@ -252,6 +300,8 @@ describe('Async', () => {
       const { getByText, getByRole, queryByText } = render(
         <MultiSelect
           loadOptions={loadOptions}
+          loadOptionsDebounceMs={0}
+          defaultOptions
           onChange={handleChange}
           isMulti={isMulti}
         />,
@@ -370,6 +420,8 @@ describe('Async', () => {
         loadOptions={jest
           .fn()
           .mockResolvedValue([{ label: 'Example', value: '123' }])}
+        loadOptionsDebounceMs={0}
+        defaultOptions
         creatable={true}
         onChange={mockOnChange}
       />,

--- a/packages/react-components/src/molecules/AnalyticsControls.tsx
+++ b/packages/react-components/src/molecules/AnalyticsControls.tsx
@@ -241,6 +241,7 @@ const AnalyticsControls: React.FC<AnalyticsControlsProps> = ({
                     : 'No results found'
                 }
                 loadOptions={debouncedLoadTags}
+                loadOptionsDebounceMs={0}
                 onChange={(items) => setTags(items.map(({ value }) => value))}
                 values={tags.map((tag) => ({
                   label: tag,

--- a/packages/react-components/src/organisms/__tests__/ManuscriptAuthors.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/ManuscriptAuthors.test.tsx
@@ -105,7 +105,9 @@ it.each([true, false])(
     expect(screen.getByText(/Jane Doe/i, { selector: 'strong' })).toBeVisible();
     expect(screen.getByText(/(Non CRN)/i, { selector: 'span' })).toBeVisible();
 
-    await userEvent.click(screen.getByText(/Non CRN/i));
+    await userEvent.click(
+      await screen.findByText(/Non CRN/i, {}, { timeout: 5000 }),
+    );
 
     expect(screen.getByText(/Jane Doe Email/i)).toBeInTheDocument();
   },
@@ -139,7 +141,9 @@ it.each([true, false])(
       expect(screen.queryByText(/loading/i)).not.toBeInTheDocument(),
     );
 
-    await userEvent.click(screen.getByText(/External Author/i));
+    await userEvent.click(
+      await screen.findByText(/External Author/i, {}, { timeout: 5000 }),
+    );
 
     expect(screen.getByText(/External Author Email/i)).toBeInTheDocument();
   },
@@ -156,7 +160,9 @@ it.each([true, false])(
       expect(screen.queryByText(/loading/i)).not.toBeInTheDocument();
     });
 
-    await userEvent.click(screen.getByText(/Non CRN/i));
+    await userEvent.click(
+      await screen.findByText(/Non CRN/i, {}, { timeout: 5000 }),
+    );
 
     expect(screen.getByText(/Jane Doe Email/i)).toBeInTheDocument();
 
@@ -197,7 +203,9 @@ describe('Multiple Option Selection', () => {
       expect(screen.queryByText(/loading/i)).not.toBeInTheDocument(),
     );
 
-    await userEvent.click(screen.getByText('Author Two'));
+    await userEvent.click(
+      await screen.findByText('Author Two', {}, { timeout: 5000 }),
+    );
 
     expect(screen.getByText(/Author Two/i)).toBeInTheDocument();
     expect(screen.queryByText(/Author One/i)).not.toBeInTheDocument();
@@ -207,7 +215,9 @@ describe('Multiple Option Selection', () => {
       expect(screen.queryByText(/loading/i)).not.toBeInTheDocument(),
     );
 
-    await userEvent.click(screen.getByText('Author One'));
+    await userEvent.click(
+      await screen.findByText('Author One', {}, { timeout: 5000 }),
+    );
 
     expect(screen.getByText(/Author One/i)).toBeInTheDocument();
     expect(screen.getByText(/Author Two/i)).toBeInTheDocument();
@@ -221,7 +231,9 @@ describe('Multiple Option Selection', () => {
       expect(screen.queryByText(/loading/i)).not.toBeInTheDocument(),
     );
 
-    await userEvent.click(screen.getByText('Author Two'));
+    await userEvent.click(
+      await screen.findByText('Author Two', {}, { timeout: 5000 }),
+    );
 
     await userEvent.type(screen.getByRole('combobox'), 'Jane Doe');
 
@@ -229,7 +241,9 @@ describe('Multiple Option Selection', () => {
       expect(screen.queryByText(/loading/i)).not.toBeInTheDocument();
     });
 
-    await userEvent.click(screen.getByText(/Non CRN/i));
+    await userEvent.click(
+      await screen.findByText(/Non CRN/i, {}, { timeout: 5000 }),
+    );
 
     expect(screen.getByText(/Jane Doe Email/i)).toBeInTheDocument();
 
@@ -251,7 +265,9 @@ describe('Single Option Selection', () => {
       expect(screen.queryByText(/loading/i)).not.toBeInTheDocument(),
     );
 
-    await userEvent.click(screen.getByText('Author Two'));
+    await userEvent.click(
+      await screen.findByText('Author Two', {}, { timeout: 5000 }),
+    );
 
     expect(screen.getByText(/Author Two/i)).toBeInTheDocument();
     expect(screen.queryByText(/Author One/i)).not.toBeInTheDocument();
@@ -261,7 +277,9 @@ describe('Single Option Selection', () => {
       expect(screen.queryByText(/loading/i)).not.toBeInTheDocument(),
     );
 
-    await userEvent.click(screen.getByText('Author One'));
+    await userEvent.click(
+      await screen.findByText('Author One', {}, { timeout: 5000 }),
+    );
 
     expect(screen.getByText(/Author One/i)).toBeInTheDocument();
     expect(screen.queryByText(/Author Two/i)).not.toBeInTheDocument();

--- a/packages/react-components/src/templates/__tests__/ManuscriptForm.basic.test.tsx
+++ b/packages/react-components/src/templates/__tests__/ManuscriptForm.basic.test.tsx
@@ -494,7 +494,7 @@ describe('Manuscript form', () => {
   });
 
   it('lets user select valid impact and category, and shows no match message on invalid input', async () => {
-    const { getByRole, getByText } = await renderManuscriptForm({
+    const { getByRole, getByText, findByText } = await renderManuscriptForm({
       ...defaultProps,
       impact: undefined,
       categories: [],
@@ -524,16 +524,16 @@ describe('Manuscript form', () => {
       expect(getByText(/This field is required/i)).toBeVisible();
     });
     await userEvent.type(categoryInput, 'Category');
-    await userEvent.click(getByText('Category A'));
+    await userEvent.click(await findByText('Category A'));
     categoryInput.blur();
 
     expect(getByText('Category A')).toBeInTheDocument();
 
     // --- Category limit ---
     await userEvent.click(categoryInput);
-    await userEvent.click(getByText('Category B'));
+    await userEvent.click(await findByText('Category B'));
     await userEvent.click(categoryInput);
-    await userEvent.click(getByText('Category C'));
+    await userEvent.click(await findByText('Category C'));
     categoryInput.blur();
 
     await waitFor(() => {

--- a/packages/react-components/src/templates/__tests__/ManuscriptForm.other.test.tsx
+++ b/packages/react-components/src/templates/__tests__/ManuscriptForm.other.test.tsx
@@ -212,39 +212,42 @@ describe('authors', () => {
         },
       ]);
 
-      const { getByLabelText, findByText, findByRole, findByLabelText } = render(
-        <StaticRouter location="/">
-          <Suspense fallback={<div>Loading...</div>}>
-            <ManuscriptForm
-              {...defaultProps}
-              title="manuscript title"
-              onCreate={onCreate}
-              type="Original Research"
-              lifecycle="Publication"
-              url="http://example.com"
-              preprintDoi="10.4444/test"
-              publicationDoi="10.4467/test"
-              manuscriptFile={{
-                id: '123',
-                url: 'https://test-url',
-                filename: 'abc.jpeg',
-              }}
-              keyResourceTable={{
-                id: '124',
-                url: 'https://test-url',
-                filename: 'abc.jpeg',
-              }}
-              getAuthorSuggestions={getAuthorSuggestionsMock}
-            />
-          </Suspense>
-        </StaticRouter>,
-      );
+      const { getByLabelText, findByText, findByRole, findByLabelText } =
+        render(
+          <StaticRouter location="/">
+            <Suspense fallback={<div>Loading...</div>}>
+              <ManuscriptForm
+                {...defaultProps}
+                title="manuscript title"
+                onCreate={onCreate}
+                type="Original Research"
+                lifecycle="Publication"
+                url="http://example.com"
+                preprintDoi="10.4444/test"
+                publicationDoi="10.4467/test"
+                manuscriptFile={{
+                  id: '123',
+                  url: 'https://test-url',
+                  filename: 'abc.jpeg',
+                }}
+                keyResourceTable={{
+                  id: '124',
+                  url: 'https://test-url',
+                  filename: 'abc.jpeg',
+                }}
+                getAuthorSuggestions={getAuthorSuggestionsMock}
+              />
+            </Suspense>
+          </StaticRouter>,
+        );
 
       // Wait for the form section to be ready - findByLabelText waits for the element to appear
       // This avoids race conditions with Suspense fallbacks in CI environments
       const sectionInput = await findByLabelText(section);
       await userEvent.click(sectionInput);
-      await userEvent.click(await findByText(/External Author One \(Non CRN\)/));
+      await userEvent.click(
+        await findByText(/External Author One \(Non CRN\)/),
+      );
       await userEvent.type(
         getByLabelText(/External Author One Email/i),
         'external@author.com',
@@ -288,33 +291,34 @@ describe('authors', () => {
         },
       ]);
 
-      const { getByLabelText, findByText, findByRole, findByLabelText } = render(
-        <StaticRouter location="/">
-          <Suspense fallback={<div>Loading...</div>}>
-            <ManuscriptForm
-              {...defaultProps}
-              title="manuscript title"
-              onCreate={onCreate}
-              type="Original Research"
-              lifecycle="Publication"
-              url="http://example.com"
-              preprintDoi="10.4444/test"
-              publicationDoi="10.4467/test"
-              manuscriptFile={{
-                id: '123',
-                url: 'https://test-url',
-                filename: 'abc.jpeg',
-              }}
-              keyResourceTable={{
-                id: '124',
-                url: 'https://test-url',
-                filename: 'abc.jpeg',
-              }}
-              getAuthorSuggestions={getAuthorSuggestionsMock}
-            />
-          </Suspense>
-        </StaticRouter>,
-      );
+      const { getByLabelText, findByText, findByRole, findByLabelText } =
+        render(
+          <StaticRouter location="/">
+            <Suspense fallback={<div>Loading...</div>}>
+              <ManuscriptForm
+                {...defaultProps}
+                title="manuscript title"
+                onCreate={onCreate}
+                type="Original Research"
+                lifecycle="Publication"
+                url="http://example.com"
+                preprintDoi="10.4444/test"
+                publicationDoi="10.4467/test"
+                manuscriptFile={{
+                  id: '123',
+                  url: 'https://test-url',
+                  filename: 'abc.jpeg',
+                }}
+                keyResourceTable={{
+                  id: '124',
+                  url: 'https://test-url',
+                  filename: 'abc.jpeg',
+                }}
+                getAuthorSuggestions={getAuthorSuggestionsMock}
+              />
+            </Suspense>
+          </StaticRouter>,
+        );
 
       // Wait for the form section to be ready - findByLabelText waits for the element to appear
       // This avoids race conditions with Suspense fallbacks in CI environments
@@ -322,7 +326,9 @@ describe('authors', () => {
 
       await userEvent.type(sectionInput, 'Jane Doe');
 
-      await userEvent.click(await findByText(/Jane Doe/, { selector: 'strong' }));
+      await userEvent.click(
+        await findByText(/Jane Doe/, { selector: 'strong' }),
+      );
       await userEvent.type(getByLabelText(/Jane Doe Email/i), 'jane@doe.com');
 
       await submitForm({ findByRole });

--- a/packages/react-components/src/templates/__tests__/ManuscriptForm.other.test.tsx
+++ b/packages/react-components/src/templates/__tests__/ManuscriptForm.other.test.tsx
@@ -143,7 +143,7 @@ describe('authors', () => {
         },
       ]);
 
-      const { getByText, findByRole, findByLabelText } = render(
+      const { findByText, findByRole, findByLabelText } = render(
         <StaticRouter location="/">
           <Suspense fallback={<div>Loading...</div>}>
             <ManuscriptForm
@@ -176,7 +176,7 @@ describe('authors', () => {
       });
 
       await userEvent.click(sectionInput);
-      await userEvent.click(getByText('Author One'));
+      await userEvent.click(await findByText('Author One'));
 
       await submitForm({ findByRole });
       await waitFor(() => {
@@ -212,7 +212,7 @@ describe('authors', () => {
         },
       ]);
 
-      const { getByLabelText, getByText, findByRole, findByLabelText } = render(
+      const { getByLabelText, findByText, findByRole, findByLabelText } = render(
         <StaticRouter location="/">
           <Suspense fallback={<div>Loading...</div>}>
             <ManuscriptForm
@@ -244,7 +244,7 @@ describe('authors', () => {
       // This avoids race conditions with Suspense fallbacks in CI environments
       const sectionInput = await findByLabelText(section);
       await userEvent.click(sectionInput);
-      await userEvent.click(getByText(/External Author One \(Non CRN\)/));
+      await userEvent.click(await findByText(/External Author One \(Non CRN\)/));
       await userEvent.type(
         getByLabelText(/External Author One Email/i),
         'external@author.com',
@@ -288,7 +288,7 @@ describe('authors', () => {
         },
       ]);
 
-      const { getByLabelText, getByText, findByRole, findByLabelText } = render(
+      const { getByLabelText, findByText, findByRole, findByLabelText } = render(
         <StaticRouter location="/">
           <Suspense fallback={<div>Loading...</div>}>
             <ManuscriptForm
@@ -322,7 +322,7 @@ describe('authors', () => {
 
       await userEvent.type(sectionInput, 'Jane Doe');
 
-      await userEvent.click(getByText(/Jane Doe/, { selector: 'strong' }));
+      await userEvent.click(await findByText(/Jane Doe/, { selector: 'strong' }));
       await userEvent.type(getByLabelText(/Jane Doe Email/i), 'jane@doe.com');
 
       await submitForm({ findByRole });


### PR DESCRIPTION
All async selects now batch rapid keystrokes into a single Algolia query via a 300ms debounce (configurable via loadOptionsDebounceMs).

The loadOptions function is kept in a ref so react-select always receives the same stable reference, preventing internal state resets on parent re-renders. Also memoizes the custom Control component when leftIndicator is provided, and exposes defaultOptions as a configurable prop.

AnalyticsControls opts out of the internal debounce (loadOptionsDebounceMs=0) since it already debounces loadOptions externally.

**Before:**

https://github.com/user-attachments/assets/465ab094-4266-494f-b2bb-41b613a07202

**After:**


https://github.com/user-attachments/assets/0be2777a-5559-447d-a265-de39ab8ddf2b

