### PR TITLE
[ASAP-1485] - Expand roles inline instead of broken scroll-to-element on network/users listing page

### DIFF
--- a/packages/react-components/src/molecules/UserProfilePersonalText.tsx
+++ b/packages/react-components/src/molecules/UserProfilePersonalText.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useContext } from 'react';
+import React, { FC, useContext, useState } from 'react';
 import { css } from '@emotion/react';
 import { UserListItemResponse, UserTeam } from '@asap-hub/model';
 import { network } from '@asap-hub/routing';
@@ -57,7 +57,7 @@ type UserProfilePersonalTextProps = Pick<
   | 'city'
   | 'labs'
   | 'tags'
-> & { userActiveTeamsRoute?: string; isAlumni?: boolean; teams: UserTeam[] };
+> & { isAlumni?: boolean; teams: UserTeam[] };
 const UserProfilePersonalText: FC<UserProfilePersonalTextProps> = ({
   institution,
   country,
@@ -70,6 +70,8 @@ const UserProfilePersonalText: FC<UserProfilePersonalTextProps> = ({
   isAlumni,
 }) => {
   const { isOwnProfile } = useContext(UserProfileContext);
+  const [showAllActive, setShowAllActive] = useState(false);
+  const [showAllInactive, setShowAllInactive] = useState(false);
 
   const labsList = getUniqueCommaStringWithSuffix(
     labs.map((lab) => lab.name),
@@ -81,6 +83,14 @@ const UserProfilePersonalText: FC<UserProfilePersonalTextProps> = ({
     (team) =>
       isAlumni || !!team?.teamInactiveSince || !!team?.inactiveSinceDate,
   );
+
+  const visibleActiveTeams = showAllActive
+    ? activeTeams
+    : activeTeams.slice(0, MAX_TEAMS);
+  const visibleInactiveTeams = showAllInactive
+    ? inactiveTeams
+    : inactiveTeams.slice(0, MAX_TEAMS);
+
   return (
     <div>
       <div css={paragraphStyles}>
@@ -92,7 +102,7 @@ const UserProfilePersonalText: FC<UserProfilePersonalTextProps> = ({
           </>
         ) : isOwnProfile ? (
           <span css={{ color: tin.rgb }}>
-            Where do you work and what’s your position?
+            Where do you work and what's your position?
           </span>
         ) : null}
 
@@ -112,17 +122,15 @@ const UserProfilePersonalText: FC<UserProfilePersonalTextProps> = ({
           </div>
         ) : (
           <>
-            {activeTeams
-              .slice(0, MAX_TEAMS)
-              .map(({ id, role: teamRole, displayName }) => (
-                <div style={{ display: 'flex' }} key={id}>
-                  <div>{teamRole} on&nbsp;</div>
-                  <Link href={network({}).teams({}).team({ teamId: id }).$}>
-                    Team {displayName}
-                  </Link>
-                </div>
-              ))}
-            {activeTeams.length > MAX_TEAMS && (
+            {visibleActiveTeams.map(({ id, role: teamRole, displayName }) => (
+              <div style={{ display: 'flex' }} key={id}>
+                <div>{teamRole} on&nbsp;</div>
+                <Link href={network({}).teams({}).team({ teamId: id }).$}>
+                  Team {displayName}
+                </Link>
+              </div>
+            ))}
+            {!showAllActive && activeTeams.length > MAX_TEAMS && (
               <Anchor
                 href="#"
                 onClick={(e: React.MouseEvent<HTMLAnchorElement>) => {
@@ -132,6 +140,8 @@ const UserProfilePersonalText: FC<UserProfilePersonalTextProps> = ({
                   );
                   if (teamsCard) {
                     teamsCard.scrollIntoView({ behavior: 'smooth' });
+                  } else {
+                    setShowAllActive(true);
                   }
                 }}
                 css={(theme) => [styles, getLinkColors(theme.colors, 'light')]}
@@ -151,17 +161,15 @@ const UserProfilePersonalText: FC<UserProfilePersonalTextProps> = ({
                 <span css={badgeStyles}>{alumniBadgeIcon}</span>
               </div>
             ) : null}
-            {inactiveTeams
-              .slice(0, MAX_TEAMS)
-              .map(({ id, role: teamRole, displayName }) => (
-                <div style={{ display: 'flex' }} key={id}>
-                  <div>{teamRole} on&nbsp;</div>
-                  <Link href={network({}).teams({}).team({ teamId: id }).$}>
-                    Team {displayName}
-                  </Link>
-                </div>
-              ))}
-            {inactiveTeams.length > MAX_TEAMS && (
+            {visibleInactiveTeams.map(({ id, role: teamRole, displayName }) => (
+              <div style={{ display: 'flex' }} key={id}>
+                <div>{teamRole} on&nbsp;</div>
+                <Link href={network({}).teams({}).team({ teamId: id }).$}>
+                  Team {displayName}
+                </Link>
+              </div>
+            ))}
+            {!showAllInactive && inactiveTeams.length > MAX_TEAMS && (
               <Anchor
                 href="#"
                 onClick={(e: React.MouseEvent<HTMLAnchorElement>) => {
@@ -171,6 +179,8 @@ const UserProfilePersonalText: FC<UserProfilePersonalTextProps> = ({
                   );
                   if (teamsCard) {
                     teamsCard.scrollIntoView({ behavior: 'smooth' });
+                  } else {
+                    setShowAllInactive(true);
                   }
                 }}
                 css={(theme) => [styles, getLinkColors(theme.colors, 'light')]}

--- a/packages/react-components/src/molecules/UserProfilePersonalText.tsx
+++ b/packages/react-components/src/molecules/UserProfilePersonalText.tsx
@@ -130,23 +130,27 @@ const UserProfilePersonalText: FC<UserProfilePersonalTextProps> = ({
                 </Link>
               </div>
             ))}
-            {!showAllActive && activeTeams.length > MAX_TEAMS && (
+            {activeTeams.length > MAX_TEAMS && (
               <Anchor
                 href="#"
                 onClick={(e: React.MouseEvent<HTMLAnchorElement>) => {
                   e.preventDefault();
-                  const teamsCard = document.getElementById(
-                    'user-teams-tabbed-card',
-                  );
-                  if (teamsCard) {
-                    teamsCard.scrollIntoView({ behavior: 'smooth' });
+                  if (showAllActive) {
+                    setShowAllActive(false);
                   } else {
-                    setShowAllActive(true);
+                    const teamsCard = document.getElementById(
+                      'user-teams-tabbed-card',
+                    );
+                    if (teamsCard) {
+                      teamsCard.scrollIntoView({ behavior: 'smooth' });
+                    } else {
+                      setShowAllActive(true);
+                    }
                   }
                 }}
                 css={(theme) => [styles, getLinkColors(theme.colors, 'light')]}
               >
-                View all roles
+                {showAllActive ? 'View less roles' : 'View all roles'}
               </Anchor>
             )}
             {inactiveTeams.length ? (
@@ -169,23 +173,29 @@ const UserProfilePersonalText: FC<UserProfilePersonalTextProps> = ({
                 </Link>
               </div>
             ))}
-            {!showAllInactive && inactiveTeams.length > MAX_TEAMS && (
+            {inactiveTeams.length > MAX_TEAMS && (
               <Anchor
                 href="#"
                 onClick={(e: React.MouseEvent<HTMLAnchorElement>) => {
                   e.preventDefault();
-                  const teamsCard = document.getElementById(
-                    'user-teams-tabbed-card',
-                  );
-                  if (teamsCard) {
-                    teamsCard.scrollIntoView({ behavior: 'smooth' });
+                  if (showAllInactive) {
+                    setShowAllInactive(false);
                   } else {
-                    setShowAllInactive(true);
+                    const teamsCard = document.getElementById(
+                      'user-teams-tabbed-card',
+                    );
+                    if (teamsCard) {
+                      teamsCard.scrollIntoView({ behavior: 'smooth' });
+                    } else {
+                      setShowAllInactive(true);
+                    }
                   }
                 }}
                 css={(theme) => [styles, getLinkColors(theme.colors, 'light')]}
               >
-                View all former roles
+                {showAllInactive
+                  ? 'View less former roles'
+                  : 'View all former roles'}
               </Anchor>
             )}
           </>

--- a/packages/react-components/src/molecules/__tests__/UserProfilePersonalText.test.tsx
+++ b/packages/react-components/src/molecules/__tests__/UserProfilePersonalText.test.tsx
@@ -1,12 +1,11 @@
 import { ComponentProps } from 'react';
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import { UserProfileContext } from '@asap-hub/react-context';
 import UserProfilePersonalText from '../UserProfilePersonalText';
 
 const props: ComponentProps<typeof UserProfilePersonalText> = {
   labs: [],
   teams: [],
-  userActiveTeamsRoute: '#',
 };
 
 it.each`
@@ -323,16 +322,14 @@ it('does not show "Former Roles" section when there are no inactive teams', () =
   expect(queryByText('Former Roles')).not.toBeInTheDocument();
 });
 
-it('handles "View all roles" click event', () => {
+it('scrolls to teams card when "View all roles" is clicked and card exists', () => {
   const mockScrollIntoView = jest.fn();
-  const mockElement = {
-    scrollIntoView: mockScrollIntoView,
-  } as unknown as HTMLElement;
-  const mockGetElementById = jest.fn(() => mockElement);
+  const teamsCard = document.createElement('div');
+  teamsCard.id = 'user-teams-tabbed-card';
+  teamsCard.scrollIntoView = mockScrollIntoView;
+  document.body.appendChild(teamsCard);
 
-  document.getElementById = mockGetElementById;
-
-  const { getByText } = render(
+  const { getByText, queryByText } = render(
     <UserProfilePersonalText
       {...props}
       teams={[
@@ -343,23 +340,22 @@ it('handles "View all roles" click event', () => {
     />,
   );
 
-  const viewAllLink = getByText('View all roles');
-  viewAllLink.click();
+  fireEvent.click(getByText('View all roles'));
 
-  expect(mockGetElementById).toHaveBeenCalledWith('user-teams-tabbed-card');
   expect(mockScrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth' });
+  expect(queryByText('View all roles')).toBeInTheDocument();
+
+  document.body.removeChild(teamsCard);
 });
 
-it('handles "View all former roles" click event', () => {
+it('scrolls to teams card when "View all former roles" is clicked and card exists', () => {
   const mockScrollIntoView = jest.fn();
-  const mockElement = {
-    scrollIntoView: mockScrollIntoView,
-  } as unknown as HTMLElement;
-  const mockGetElementById = jest.fn(() => mockElement);
+  const teamsCard = document.createElement('div');
+  teamsCard.id = 'user-teams-tabbed-card';
+  teamsCard.scrollIntoView = mockScrollIntoView;
+  document.body.appendChild(teamsCard);
 
-  document.getElementById = mockGetElementById;
-
-  const { getByText } = render(
+  const { getByText, queryByText } = render(
     <UserProfilePersonalText
       {...props}
       isAlumni={true}
@@ -371,9 +367,49 @@ it('handles "View all former roles" click event', () => {
     />,
   );
 
-  const viewAllLink = getByText('View all former roles');
-  viewAllLink.click();
+  fireEvent.click(getByText('View all former roles'));
 
-  expect(mockGetElementById).toHaveBeenCalledWith('user-teams-tabbed-card');
   expect(mockScrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth' });
+  expect(queryByText('View all former roles')).toBeInTheDocument();
+
+  document.body.removeChild(teamsCard);
+});
+
+it('expands all active teams when "View all roles" is clicked', () => {
+  const { getByText, queryByText, container } = render(
+    <UserProfilePersonalText
+      {...props}
+      teams={[
+        { id: '1', displayName: 'Team A', role: 'Lead PI (Core Leadership)' },
+        { id: '2', displayName: 'Team B', role: 'Collaborating PI' },
+        { id: '3', displayName: 'Team C', role: 'Project Manager' },
+      ]}
+    />,
+  );
+
+  expect(container).not.toHaveTextContent('Project Manager on');
+  fireEvent.click(getByText('View all roles'));
+
+  expect(container).toHaveTextContent('Project Manager on');
+  expect(queryByText('View all roles')).not.toBeInTheDocument();
+});
+
+it('expands all inactive teams when "View all former roles" is clicked', () => {
+  const { getByText, queryByText, container } = render(
+    <UserProfilePersonalText
+      {...props}
+      isAlumni={true}
+      teams={[
+        { id: '1', displayName: 'Former A', role: 'Lead PI (Core Leadership)' },
+        { id: '2', displayName: 'Former B', role: 'Collaborating PI' },
+        { id: '3', displayName: 'Former C', role: 'Project Manager' },
+      ]}
+    />,
+  );
+
+  expect(container).not.toHaveTextContent('Project Manager on');
+  fireEvent.click(getByText('View all former roles'));
+
+  expect(container).toHaveTextContent('Project Manager on');
+  expect(queryByText('View all former roles')).not.toBeInTheDocument();
 });

--- a/packages/react-components/src/molecules/__tests__/UserProfilePersonalText.test.tsx
+++ b/packages/react-components/src/molecules/__tests__/UserProfilePersonalText.test.tsx
@@ -375,8 +375,8 @@ it('scrolls to teams card when "View all former roles" is clicked and card exist
   document.body.removeChild(teamsCard);
 });
 
-it('expands all active teams when "View all roles" is clicked', () => {
-  const { getByText, queryByText, container } = render(
+it('toggles active teams between expanded and collapsed', () => {
+  const { getByText, container } = render(
     <UserProfilePersonalText
       {...props}
       teams={[
@@ -391,11 +391,16 @@ it('expands all active teams when "View all roles" is clicked', () => {
   fireEvent.click(getByText('View all roles'));
 
   expect(container).toHaveTextContent('Project Manager on');
-  expect(queryByText('View all roles')).not.toBeInTheDocument();
+  expect(getByText('View less roles')).toBeInTheDocument();
+
+  fireEvent.click(getByText('View less roles'));
+
+  expect(container).not.toHaveTextContent('Project Manager on');
+  expect(getByText('View all roles')).toBeInTheDocument();
 });
 
-it('expands all inactive teams when "View all former roles" is clicked', () => {
-  const { getByText, queryByText, container } = render(
+it('toggles inactive teams between expanded and collapsed', () => {
+  const { getByText, container } = render(
     <UserProfilePersonalText
       {...props}
       isAlumni={true}
@@ -411,5 +416,10 @@ it('expands all inactive teams when "View all former roles" is clicked', () => {
   fireEvent.click(getByText('View all former roles'));
 
   expect(container).toHaveTextContent('Project Manager on');
-  expect(queryByText('View all former roles')).not.toBeInTheDocument();
+  expect(getByText('View less former roles')).toBeInTheDocument();
+
+  fireEvent.click(getByText('View less former roles'));
+
+  expect(container).not.toHaveTextContent('Project Manager on');
+  expect(getByText('View all former roles')).toBeInTheDocument();
 });

--- a/packages/react-components/src/molecules/__tests__/UserProfilePersonalText.test.tsx
+++ b/packages/react-components/src/molecules/__tests__/UserProfilePersonalText.test.tsx
@@ -383,19 +383,30 @@ it('toggles active teams between expanded and collapsed', () => {
         { id: '1', displayName: 'Team A', role: 'Lead PI (Core Leadership)' },
         { id: '2', displayName: 'Team B', role: 'Collaborating PI' },
         { id: '3', displayName: 'Team C', role: 'Project Manager' },
+        { id: '4', displayName: 'Team D', role: 'Key Personnel' },
+        { id: '5', displayName: 'Team E', role: 'Trainee' },
       ]}
     />,
   );
 
+  expect(container).toHaveTextContent('Lead PI (Core Leadership) on');
+  expect(container).toHaveTextContent('Collaborating PI on');
   expect(container).not.toHaveTextContent('Project Manager on');
+  expect(container).not.toHaveTextContent('Key Personnel on');
+  expect(container).not.toHaveTextContent('Trainee on');
+
   fireEvent.click(getByText('View all roles'));
 
   expect(container).toHaveTextContent('Project Manager on');
+  expect(container).toHaveTextContent('Key Personnel on');
+  expect(container).toHaveTextContent('Trainee on');
   expect(getByText('View less roles')).toBeInTheDocument();
 
   fireEvent.click(getByText('View less roles'));
 
   expect(container).not.toHaveTextContent('Project Manager on');
+  expect(container).not.toHaveTextContent('Key Personnel on');
+  expect(container).not.toHaveTextContent('Trainee on');
   expect(getByText('View all roles')).toBeInTheDocument();
 });
 
@@ -408,18 +419,29 @@ it('toggles inactive teams between expanded and collapsed', () => {
         { id: '1', displayName: 'Former A', role: 'Lead PI (Core Leadership)' },
         { id: '2', displayName: 'Former B', role: 'Collaborating PI' },
         { id: '3', displayName: 'Former C', role: 'Project Manager' },
+        { id: '4', displayName: 'Former D', role: 'Key Personnel' },
+        { id: '5', displayName: 'Former E', role: 'Trainee' },
       ]}
     />,
   );
 
+  expect(container).toHaveTextContent('Lead PI (Core Leadership) on');
+  expect(container).toHaveTextContent('Collaborating PI on');
   expect(container).not.toHaveTextContent('Project Manager on');
+  expect(container).not.toHaveTextContent('Key Personnel on');
+  expect(container).not.toHaveTextContent('Trainee on');
+
   fireEvent.click(getByText('View all former roles'));
 
   expect(container).toHaveTextContent('Project Manager on');
+  expect(container).toHaveTextContent('Key Personnel on');
+  expect(container).toHaveTextContent('Trainee on');
   expect(getByText('View less former roles')).toBeInTheDocument();
 
   fireEvent.click(getByText('View less former roles'));
 
   expect(container).not.toHaveTextContent('Project Manager on');
+  expect(container).not.toHaveTextContent('Key Personnel on');
+  expect(container).not.toHaveTextContent('Trainee on');
   expect(getByText('View all former roles')).toBeInTheDocument();
 });

--- a/packages/react-components/src/templates/UserProfileHeader.tsx
+++ b/packages/react-components/src/templates/UserProfileHeader.tsx
@@ -268,7 +268,6 @@ const UserProfileHeader: React.FC<UserProfileHeaderProps> = ({
                     jobTitle={jobTitle}
                     teams={teams}
                     labs={labs}
-                    userActiveTeamsRoute={tabRoutes.research({}).$}
                     isAlumni={!!alumniSinceDate}
                   />
                 </div>


### PR DESCRIPTION
**Context**

The links used document.getElementById('user-teams-tabbed-card').scrollIntoView(), but that element only exists on the user profile page. On the network/users listing (PeopleCard), clicking did nothing because the scroll target was absent.

tldr; When the teams card exists on the page (user profile), scroll to it as before and when it doesn't exist (network/users listing), expand the truncated list inline.

**Test plan**

- On network/users listing, click "View all roles" on a user with 3+ teams — should
expand inline and hide the link
- On network/users listing, click "View all former roles" on a user with 3+ inactive
teams — same behavior
- On user profile page, click "View all roles" — should scroll to the Teams and Roles
card (no regression)
- Verify "View all roles" does not appear when user has 2 or fewer teams

**Before:**

https://github.com/user-attachments/assets/a4488739-ef4a-4af4-869a-d3063b2223e7

**After:**

https://github.com/user-attachments/assets/4f6690f1-a71f-49f0-8d43-97ace06e5bdc