### PR TITLE
[ASAP-1481] - Remove property 'text' in Tutorial model from the sync with Algolia

### DIFF
--- a/apps/crn-server/scripts/export-entity.ts
+++ b/apps/crn-server/scripts/export-entity.ts
@@ -236,10 +236,14 @@ const transformRecords = (
 
   // type 'tutorial'
   if ('usedInPublication' in record && 'shortText' in record) {
-    return {
-      ...payload,
-      _tags: record.tags,
+    const { text: _text, ...payloadWithoutText } = payload as typeof payload & {
+      text?: string;
     };
+
+    return {
+      ...payloadWithoutText,
+      _tags: record.tags,
+    } as ReturnType<typeof transformRecords>;
   }
 
   // type 'news'

--- a/apps/crn-server/src/handlers/tutorials/algolia-index-tutorials-handler.ts
+++ b/apps/crn-server/src/handlers/tutorials/algolia-index-tutorials-handler.ts
@@ -33,8 +33,10 @@ export const indexTutorialHandler =
           logger.debug(`Fetched tutorial ${tutorialId}`);
 
           if (tutorial) {
+            const { text: _text, ...tutorialWithoutText } = tutorial;
+
             await algoliaClient.save({
-              data: addTagsFunction(tutorial) as TutorialsResponse,
+              data: addTagsFunction(tutorialWithoutText) as TutorialsResponse,
               type: 'tutorial',
             });
 

--- a/apps/crn-server/test/handlers/tutorials/algolia-index-tutorials-handler.test.ts
+++ b/apps/crn-server/test/handlers/tutorials/algolia-index-tutorials-handler.test.ts
@@ -1,0 +1,42 @@
+import { TutorialPayload } from '@asap-hub/server-common';
+import { indexTutorialHandler } from '../../../src/handlers/tutorials/algolia-index-tutorials-handler';
+import { getTutorialResponse } from '../../fixtures/tutorials.fixtures';
+import { createEventBridgeEventMock } from '../../helpers/events';
+import { getAlgoliaSearchClientMock } from '../../mocks/algolia-client.mock';
+import { tutorialControllerMock } from '../../mocks/tutorial.controller.mock';
+
+const algoliaSearchClientMock = getAlgoliaSearchClientMock();
+
+jest.mock('../../../src/utils/logger');
+
+describe('Tutorial index handler', () => {
+  const indexHandler = indexTutorialHandler(
+    tutorialControllerMock,
+    algoliaSearchClientMock,
+  );
+
+  afterEach(() => jest.clearAllMocks());
+
+  test('Should not sync tutorial text when saving to Algolia', async () => {
+    const tutorialResponse = getTutorialResponse();
+    tutorialControllerMock.fetchById.mockResolvedValueOnce(tutorialResponse);
+
+    await indexHandler(publishedEvent());
+
+    const { text: _text, ...tutorialWithoutText } = tutorialResponse;
+    expect(algoliaSearchClientMock.save).toHaveBeenCalledWith({
+      data: {
+        ...tutorialWithoutText,
+        _tags: tutorialResponse.tags,
+      },
+      type: 'tutorial',
+    });
+  });
+});
+
+const publishedEvent = (id: string = 'tutorial-1') =>
+  createEventBridgeEventMock(
+    { resourceId: id } as TutorialPayload,
+    'TutorialsPublished',
+    id,
+  );


### PR DESCRIPTION
https://asaphub.atlassian.net/browse/ASAP-1481

After adding the Tutorial page to the Development environment, the sync with Algolia won't work anymore. The workaround is that, whenever there's a deploy to master, we need to unpublish this tutorial https://app.contentful.com/spaces/5v6w5j61tndm/environments/Development/entries/4EOkCzukXz6qNReA3PFz7T

So, the change in this PR makes the sync work no matter the size of the `text` property in the `tutorial` model.

This is to prevent errors like
https://github.com/yldio/asap-hub/actions/runs/25174201905/job/73811760054 when there's a large tutorial in the dev environment, which uses a cheaper plan in Algolia with lower limits for record size.

Error:
<img width="2022" height="115" alt="image" src="https://github.com/user-attachments/assets/8cbc0ac2-e18e-479f-987b-a8e1cf116d16" />

`could not send intermediate batch: Algolia API error [400] Record at the position 1 objectID=16JlmykX0R2tH5NGwPSDDq is too big size=10787/10000 bytes. Please have a look at
https://www.algolia.com/doc/guides/sending-and-managing-data/prepare-your-data/in-depth/index-and-records-size-and-usage-limitations/#record-size-limits`