### PR TITLE
[ASAP-1478] - use milestone and aim ids as _id in opensearch to fix duplicates

### DIFF
--- a/apps/crn-server/scripts/opensearch/sync-opensearch-analytics.ts
+++ b/apps/crn-server/scripts/opensearch/sync-opensearch-analytics.ts
@@ -587,6 +587,8 @@ export const exportMetricToOpensearch = async <T extends Metrics>(
       documents,
       mapping: config.mapping,
     }),
+    useDocumentIdAsOpensearchId:
+      metric === 'project-aims' || metric === 'project-milestones',
   });
 
   console.log(

--- a/packages/server-common/src/utils/opensearch.ts
+++ b/packages/server-common/src/utils/opensearch.ts
@@ -114,14 +114,11 @@ const indexBatch = async <T>(
     `Processing batch ${batchNumber}/${totalBatches} (${batch.length} documents)`,
   );
 
-  const hasId = (value: unknown): value is { id: string } => {
-    return (
-      typeof value === 'object' &&
-      value !== null &&
-      'id' in value &&
-      typeof (value as { id: unknown }).id === 'string'
-    );
-  };
+  const hasId = (value: unknown): value is { id: string } =>
+    typeof value === 'object' &&
+    value !== null &&
+    'id' in value &&
+    typeof (value as { id: unknown }).id === 'string';
 
   const bulkBody = batch.flatMap((doc) => {
     const setIndexId = useDocumentIdAsOpensearchId && hasId(doc);

--- a/packages/server-common/src/utils/opensearch.ts
+++ b/packages/server-common/src/utils/opensearch.ts
@@ -17,6 +17,7 @@ interface IndexConfig<T> {
     mapping: OpensearchMapping['mappings'];
   }>;
   batchSize?: number;
+  useDocumentIdAsOpensearchId?: boolean;
 }
 
 interface BulkIndexResult {
@@ -107,15 +108,34 @@ const indexBatch = async <T>(
   batchNumber: number,
   totalBatches: number,
   startIndex: number,
+  useDocumentIdAsOpensearchId: boolean,
 ): Promise<{ indexed: number; errors: number }> => {
   console.log(
     `Processing batch ${batchNumber}/${totalBatches} (${batch.length} documents)`,
   );
 
-  const bulkBody = batch.flatMap((doc) => [
-    { index: { _index: indexName } },
-    doc as Record<string, unknown>,
-  ]);
+  const hasId = (value: unknown): value is { id: string } => {
+    return (
+      typeof value === 'object' &&
+      value !== null &&
+      'id' in value &&
+      typeof (value as { id: unknown }).id === 'string'
+    );
+  };
+
+  const bulkBody = batch.flatMap((doc) => {
+    const setIndexId = useDocumentIdAsOpensearchId && hasId(doc);
+
+    return [
+      {
+        index: {
+          _index: indexName,
+          ...(setIndexId ? { _id: doc.id } : {}),
+        },
+      },
+      doc as Record<string, unknown>,
+    ];
+  });
 
   const bulkResponse = await client.bulk({ body: bulkBody });
 
@@ -143,6 +163,7 @@ const bulkIndexDocuments = async <T>(
   indexName: string,
   documents: T[],
   batchSize: number,
+  useDocumentIdAsOpensearchId: boolean,
 ): Promise<BulkIndexResult> => {
   if (documents.length === 0) {
     return { totalIndexed: 0, totalErrors: 0 };
@@ -167,6 +188,7 @@ const bulkIndexDocuments = async <T>(
       batchNumber,
       totalBatches,
       i,
+      useDocumentIdAsOpensearchId,
     );
 
     totalIndexed += indexed;
@@ -353,6 +375,7 @@ export const indexOpensearchData = async <T>({
   indexAlias,
   getData,
   batchSize = DEFAULT_BATCH_SIZE,
+  useDocumentIdAsOpensearchId = false,
 }: IndexConfig<T>): Promise<void> => {
   const client = await getClient(
     awsRegion,
@@ -365,7 +388,13 @@ export const indexOpensearchData = async <T>({
   const newIndexName = `${indexAlias}-${Date.now()}`;
 
   await createIndex(client, newIndexName, mapping);
-  await bulkIndexDocuments(client, newIndexName, documents, batchSize);
+  await bulkIndexDocuments(
+    client,
+    newIndexName,
+    documents,
+    batchSize,
+    useDocumentIdAsOpensearchId,
+  );
   await client.indices.refresh({ index: newIndexName });
   await updateAliasAndCleanup(client, newIndexName, indexAlias);
 };

--- a/packages/server-common/test/utils/opensearch.test.ts
+++ b/packages/server-common/test/utils/opensearch.test.ts
@@ -388,6 +388,42 @@ describe('indexOpensearchData', () => {
       });
     });
 
+    test('should prepare bulk body correctly when set to use document id as index id', async () => {
+      mockClient.bulk.mockResolvedValue({
+        body: {
+          items: [
+            { index: { _index: 'test-index-1234567890' } },
+            { index: { _index: 'test-index-1234567890' } },
+          ],
+        },
+      } as any);
+
+      await indexOpensearchData({
+        awsRegion: 'us-east-1',
+        stage: 'dev',
+        opensearchUsername: 'testuser',
+        opensearchPassword: 'testpass',
+        indexAlias: mockIndexAlias,
+        getData: mockGetDataForBulkIndexing,
+        useDocumentIdAsOpensearchId: true,
+      });
+
+      const expectedBulkBody = [
+        {
+          index: { _index: expect.stringMatching(/test-index-\d+/), _id: '1' },
+        },
+        { id: '1', title: 'Test Document 1', content: 'Test content 1' },
+        {
+          index: { _index: expect.stringMatching(/test-index-\d+/), _id: '2' },
+        },
+        { id: '2', title: 'Test Document 2', content: 'Test content 2' },
+      ];
+
+      expect(mockClient.bulk).toHaveBeenCalledWith({
+        body: expectedBulkBody,
+      });
+    });
+
     test('should handle empty documents array', async () => {
       const emptyGetData = jest.fn().mockResolvedValue({
         documents: [],


### PR DESCRIPTION
ref: https://asaphub.atlassian.net/browse/ASAP-1478

To test: 
- sync project-aims and project-milestones in Opensearch using this pr's branch.
- Confirm that the _id in Opensearch is the same as the id field in a document (which is the sys.id in the cms)
<img width="789" height="538" alt="Screenshot 2026-05-06 at 09 48 37" src="https://github.com/user-attachments/assets/97746304-de32-406e-a879-19c08d527abc" />

- Edit a milestone by updating the articles
- You should not see duplicates of the edited milestone in the milestones table or duplicates of the aim(s) associated with the edited milestone