### PR TITLE
[ASAP-1463] - Display Project Name in the Assign User form

### DIFF
--- a/packages/react-components/src/organisms/ComplianceAssignUsersModal.tsx
+++ b/packages/react-components/src/organisms/ComplianceAssignUsersModal.tsx
@@ -138,8 +138,7 @@ const ComplianceAssignUsersModal: React.FC<ComplianceAssignUsersModalProps> = ({
   const watchedAssignedUsers = watch('assignedUsers');
   const isEditing = assignedUsers.length > 0;
 
-  const isButtonEnabled =
-    !isSubmitting && watchedAssignedUsers.length > 0;
+  const isButtonEnabled = !isSubmitting && watchedAssignedUsers.length > 0;
 
   return (
     <form>

--- a/packages/react-components/src/organisms/ComplianceAssignUsersModal.tsx
+++ b/packages/react-components/src/organisms/ComplianceAssignUsersModal.tsx
@@ -105,6 +105,8 @@ type ComplianceAssignUsersModalProps = Pick<
   teams: string;
   manuscriptTitle: string;
   assignedUsers: OptionsType<AuthorOption>;
+  projectName?: string;
+  isUserBasedProject?: boolean;
 };
 
 const ComplianceAssignUsersModal: React.FC<ComplianceAssignUsersModalProps> = ({
@@ -115,6 +117,8 @@ const ComplianceAssignUsersModal: React.FC<ComplianceAssignUsersModalProps> = ({
   manuscriptTitle,
   getAssignedUsersSuggestions,
   assignedUsers,
+  projectName,
+  isUserBasedProject,
 }) => {
   const bottomDivRef = useRef<HTMLDivElement>(null);
   const { setValue, watch, handleSubmit } = useForm<AssignedUsersFormData>({
@@ -134,13 +138,8 @@ const ComplianceAssignUsersModal: React.FC<ComplianceAssignUsersModalProps> = ({
   const watchedAssignedUsers = watch('assignedUsers');
   const isEditing = assignedUsers.length > 0;
 
-  const hasRemovedAllPreviousUsers =
-    watchedAssignedUsers.length === 0 && isEditing;
-
-  const hasAddedUsers = watchedAssignedUsers.length > 0;
-
   const isButtonEnabled =
-    !isSubmitting && (hasAddedUsers || hasRemovedAllPreviousUsers);
+    !isSubmitting && watchedAssignedUsers.length > 0;
 
   return (
     <form>
@@ -160,7 +159,12 @@ const ComplianceAssignUsersModal: React.FC<ComplianceAssignUsersModalProps> = ({
             <InformationRow title="ID">
               <PillId />
             </InformationRow>
-            <InformationRow title="Team(s)" value={teams} />
+            {projectName && (
+              <InformationRow title="Project" value={projectName} />
+            )}
+            {!isUserBasedProject && (
+              <InformationRow title="Team(s)" value={teams} />
+            )}
 
             <AuthorSelect
               maxMenuHeight={170}

--- a/packages/react-components/src/organisms/ComplianceTable.tsx
+++ b/packages/react-components/src/organisms/ComplianceTable.tsx
@@ -206,6 +206,10 @@ const ComplianceTable: React.FC<ComplianceTableProps> = ({
           PillId={PillId}
           teams={manuscriptDetails.teams ?? ''}
           manuscriptTitle={manuscriptDetails.title}
+          projectName={manuscriptDetails.project?.title}
+          isUserBasedProject={
+            manuscriptDetails.project?.isTeamBased === false
+          }
           getAssignedUsersSuggestions={getAssignedUsersSuggestions}
           assignedUsers={manuscriptDetails.assignedUsers.map((user) => ({
             author: {

--- a/packages/react-components/src/organisms/ComplianceTable.tsx
+++ b/packages/react-components/src/organisms/ComplianceTable.tsx
@@ -207,9 +207,7 @@ const ComplianceTable: React.FC<ComplianceTableProps> = ({
           teams={manuscriptDetails.teams ?? ''}
           manuscriptTitle={manuscriptDetails.title}
           projectName={manuscriptDetails.project?.title}
-          isUserBasedProject={
-            manuscriptDetails.project?.isTeamBased === false
-          }
+          isUserBasedProject={manuscriptDetails.project?.isTeamBased === false}
           getAssignedUsersSuggestions={getAssignedUsersSuggestions}
           assignedUsers={manuscriptDetails.assignedUsers.map((user) => ({
             author: {

--- a/packages/react-components/src/organisms/__tests__/ComplianceAssignUsersModal.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/ComplianceAssignUsersModal.test.tsx
@@ -190,7 +190,7 @@ describe('ComplianceAssignUsersModal', () => {
     expect(screen.getByRole('button', { name: /Assign/ })).toBeEnabled();
   });
 
-  it('displays Assign button as enabled when removing all previous assignedusers', async () => {
+  it('displays Update button as disabled when all assigned users are removed', async () => {
     render(
       <ComplianceAssignUsersModal
         onDismiss={onDismiss}
@@ -223,6 +223,63 @@ describe('ComplianceAssignUsersModal', () => {
       0,
     );
 
-    expect(screen.getByRole('button', { name: /Update/ })).toBeEnabled();
+    expect(screen.getByRole('button', { name: /Update/ })).toBeDisabled();
+  });
+
+  it('displays Project and Team(s) for team-based project manuscripts', () => {
+    render(
+      <ComplianceAssignUsersModal
+        onDismiss={onDismiss}
+        onConfirm={onConfirm}
+        PillId={mockPillId}
+        teams="Team A"
+        manuscriptTitle="Test Manuscript"
+        getAssignedUsersSuggestions={mockGetAssignedUsersSuggestions}
+        assignedUsers={[]}
+        projectName="My Research Project"
+      />,
+    );
+
+    expect(screen.getByText('Project')).toBeInTheDocument();
+    expect(screen.getByText('My Research Project')).toBeInTheDocument();
+    expect(screen.getByText('Team(s)')).toBeInTheDocument();
+    expect(screen.getByText('Team A')).toBeInTheDocument();
+  });
+
+  it('displays Project without Team(s) for user-based project manuscripts', () => {
+    render(
+      <ComplianceAssignUsersModal
+        onDismiss={onDismiss}
+        onConfirm={onConfirm}
+        PillId={mockPillId}
+        teams="Team A"
+        manuscriptTitle="Test Manuscript"
+        getAssignedUsersSuggestions={mockGetAssignedUsersSuggestions}
+        assignedUsers={[]}
+        projectName="User Project"
+        isUserBasedProject
+      />,
+    );
+
+    expect(screen.getByText('Project')).toBeInTheDocument();
+    expect(screen.getByText('User Project')).toBeInTheDocument();
+    expect(screen.queryByText('Team(s)')).not.toBeInTheDocument();
+  });
+
+  it('displays Team(s) without Project when no project name', () => {
+    render(
+      <ComplianceAssignUsersModal
+        onDismiss={onDismiss}
+        onConfirm={onConfirm}
+        PillId={mockPillId}
+        teams="Team A"
+        manuscriptTitle="Test Manuscript"
+        getAssignedUsersSuggestions={mockGetAssignedUsersSuggestions}
+        assignedUsers={[]}
+      />,
+    );
+
+    expect(screen.getByText('Team(s)')).toBeInTheDocument();
+    expect(screen.queryByText('Project')).not.toBeInTheDocument();
   });
 });

--- a/packages/react-components/src/organisms/__tests__/ComplianceTable.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/ComplianceTable.test.tsx
@@ -240,6 +240,55 @@ describe('ComplianceTable', () => {
       ).not.toBeInTheDocument();
     });
 
+    it('shows Project without Team(s) for user-based project manuscripts', async () => {
+      const userBasedProjectData = [
+        {
+          ...complianceData,
+          assignedUsers: [],
+          project: {
+            id: 'project-id',
+            title: 'User Project',
+            isTeamBased: false,
+          },
+        },
+      ];
+      const { getByLabelText, getByRole } = render(
+        <ComplianceTable {...defaultProps} data={userBasedProjectData} />,
+      );
+
+      await userEvent.click(getByLabelText(/Assign Users/i));
+      const dialog = getByRole('dialog');
+
+      expect(within(dialog).getByText('Project')).toBeInTheDocument();
+      expect(within(dialog).getByText('User Project')).toBeInTheDocument();
+      expect(within(dialog).queryByText('Team(s)')).not.toBeInTheDocument();
+    });
+
+    it('shows Project and Team(s) for team-based project manuscripts', async () => {
+      const teamBasedProjectData = [
+        {
+          ...complianceData,
+          assignedUsers: [],
+          project: {
+            id: 'project-id',
+            title: 'Team Project',
+            isTeamBased: true,
+          },
+        },
+      ];
+      const { getByLabelText, getByRole } = render(
+        <ComplianceTable {...defaultProps} data={teamBasedProjectData} />,
+      );
+
+      await userEvent.click(getByLabelText(/Assign Users/i));
+      const dialog = getByRole('dialog');
+
+      expect(within(dialog).getByText('Project')).toBeInTheDocument();
+      expect(within(dialog).getByText('Team Project')).toBeInTheDocument();
+      expect(within(dialog).getByText('Team(s)')).toBeInTheDocument();
+      expect(within(dialog).getByText('Test Team')).toBeInTheDocument();
+    });
+
     it('calls onUpdateManuscript when assigning users and closes modal', async () => {
       const { getByLabelText, getByRole, queryByText } = render(
         <ComplianceTable {...defaultProps} />,


### PR DESCRIPTION
Hey, just a few UI changes for ASAP-1463.

* Team-based manuscript: display the Project Name and Team Name.
  
<img width="1510" height="801" alt="Screenshot 2026-05-07 at 17 44 37" src="https://github.com/user-attachments/assets/a82d3df7-4899-464b-b6c1-33c85ab28d22" />

* User-based project: show the Project Name without the Team Name
  
<img width="1511" height="804" alt="Screenshot 2026-05-07 at 17 44 18" src="https://github.com/user-attachments/assets/c681f412-84ca-4133-be74-b0854405a7fc" />

*  Confirm ‘Assign Users’ form cannot be saved when a User is not populated

https://github.com/user-attachments/assets/76bcd304-6a47-427e-878d-d948a7f47159

