### PR TITLE
[ASAP-1494] - Implement loading spinner pattern in add/edit article modal

### DIFF
--- a/apps/crn-frontend/src/projects/ProjectMilestones.tsx
+++ b/apps/crn-frontend/src/projects/ProjectMilestones.tsx
@@ -75,21 +75,9 @@ const ProjectMilestonesTableContent: React.FC<TableContentProps> = ({
 
   const { numberOfPages, renderPageHref } = usePagination(total, pageSize);
   const fetchArticles = useFetchMilestoneArticles();
-  const rawSaveArticles = useUpdateMilestoneArticles();
+  const onSaveArticles = useUpdateMilestoneArticles();
   const rawUpdateMilestone = useUpdateMilestone();
   const { setFormType } = useManuscriptToast();
-
-  const onSaveArticles = useCallback<typeof rawSaveArticles>(
-    async (milestoneId, articles) => {
-      try {
-        await rawSaveArticles(milestoneId, articles);
-      } catch (e) {
-        setFormType({ type: 'default-error', accent: 'error' });
-        throw e;
-      }
-    },
-    [rawSaveArticles, setFormType],
-  );
 
   const onChangeStatus = useCallback(
     async (

--- a/packages/react-components/src/atoms/Button.tsx
+++ b/packages/react-components/src/atoms/Button.tsx
@@ -2,7 +2,12 @@
 import { css, SerializedStyles } from '@emotion/react';
 import { InputHTMLAttributes } from 'react';
 
-import { getButtonChildren, getButtonStyles } from '../button';
+import {
+  buttonLoadingContentStyles,
+  buttonSpinnerStyles,
+  getButtonChildren,
+  getButtonStyles,
+} from '../button';
 import { defaultThemeVariant, ThemeVariant } from '../theme';
 import { noop } from '../utils';
 import { getLinkColors, styles as linkStyles } from './Link';
@@ -47,6 +52,7 @@ interface LinkStyleButtonProps {
 type ButtonProps = (NormalButtonProps | LinkStyleButtonProps) & {
   readonly preventDefault?: boolean;
   readonly submit?: boolean;
+  readonly loading?: boolean;
   readonly children?: React.ReactNode;
   readonly overrideStyles?: SerializedStyles;
   readonly onClick?: () => void;
@@ -63,6 +69,7 @@ const Button: React.FC<ButtonProps> = ({
   noMargin,
   theme = defaultThemeVariant,
   submit = primary,
+  loading = false,
   id,
   children,
   onClick = noop,
@@ -97,7 +104,14 @@ const Button: React.FC<ButtonProps> = ({
     ]}
     {...props}
   >
-    {getButtonChildren(children)}
+    {loading ? (
+      <span css={buttonLoadingContentStyles}>
+        <div css={buttonSpinnerStyles} />
+        {getButtonChildren(children)}
+      </span>
+    ) : (
+      getButtonChildren(children)
+    )}
   </button>
 );
 

--- a/packages/react-components/src/button.tsx
+++ b/packages/react-components/src/button.tsx
@@ -1,4 +1,4 @@
-import { css, Theme } from '@emotion/react';
+import { css, keyframes, Theme } from '@emotion/react';
 
 import {
   charcoal,
@@ -7,6 +7,7 @@ import {
   error900,
   fern,
   lead,
+  neutral300,
   OpaqueColor,
   paper,
   pine,
@@ -280,6 +281,26 @@ export const getButtonStyles = ({
       (small ? smallIconOnlyStyles : largeIconOnlyStyles),
     fullWidth && fullWidthStyles,
   ]);
+
+const spin = keyframes`
+  from { transform: rotate(0deg) }
+  to { transform: rotate(360deg) }
+`;
+
+export const buttonSpinnerStyles = css({
+  width: rem(16),
+  height: rem(16),
+  border: `${rem(2)} solid ${neutral300.rgb}`,
+  borderTop: `${rem(2)} solid white`,
+  borderRadius: '50%',
+  animation: `${spin} 1s linear infinite`,
+});
+
+export const buttonLoadingContentStyles = css({
+  display: 'flex',
+  alignItems: 'center',
+  gap: rem(8),
+});
 
 export const getButtonChildren = (children = [] as React.ReactNode) =>
   Array.isArray(children) ? (

--- a/packages/react-components/src/organisms/ConfirmModal.tsx
+++ b/packages/react-components/src/organisms/ConfirmModal.tsx
@@ -10,26 +10,6 @@ import { Button, Headline3, Link, Paragraph } from '../atoms';
 import { paddingStyles } from '../card';
 import { Toast } from '.';
 import { usePushFromHere } from '../routing';
-import { colors } from '..';
-
-const confirmButtonContentStyles = css({
-  display: 'flex',
-  alignItems: 'center',
-  gap: rem(8),
-});
-
-const spinnerStyles = css({
-  '@keyframes confirmModalSpin': {
-    '0%': { transform: 'rotate(0deg)' },
-    '100%': { transform: 'rotate(360deg)' },
-  },
-  width: rem(16),
-  height: rem(16),
-  border: `${rem(2)} solid ${colors.neutral300.rgb}`,
-  borderTop: `${rem(2)} solid white`,
-  borderRadius: '50%',
-  animation: 'confirmModalSpin 1s linear infinite',
-});
 
 const headerStyles = css(paddingStyles, {
   paddingBottom: 0,
@@ -150,6 +130,7 @@ const ConfirmModal: React.FC<ConfirmModalProps> = ({
                 ? { primary: true }
                 : { warning: true })}
               enabled={status !== 'isSaving'}
+              loading={status === 'isSaving'}
               onClick={async () => {
                 setStatus('isSaving');
                 try {
@@ -165,10 +146,7 @@ const ConfirmModal: React.FC<ConfirmModalProps> = ({
                 }
               }}
             >
-              <span css={confirmButtonContentStyles}>
-                {status === 'isSaving' && <div css={spinnerStyles} />}
-                {confirmText}
-              </span>
+              {confirmText}
             </Button>
           </div>
         </div>

--- a/packages/react-components/src/organisms/Milestone.tsx
+++ b/packages/react-components/src/organisms/Milestone.tsx
@@ -278,12 +278,9 @@ const Milestone: FC<MilestoneProps> = ({
         <MilestoneArticlesModal
           articles={articles ?? []}
           onClose={() => setIsModalOpen(false)}
-          onConfirm={(updated) => {
-            void onSaveArticles(milestoneId, updated)
-              .then(() => {
-                setArticles(updated);
-              })
-              .catch(noop);
+          onConfirm={async (updated) => {
+            await onSaveArticles(milestoneId, updated);
+            setArticles(updated);
           }}
           loadOptions={loadArticleOptions}
         />

--- a/packages/react-components/src/organisms/MilestoneArticlesModal.tsx
+++ b/packages/react-components/src/organisms/MilestoneArticlesModal.tsx
@@ -129,8 +129,9 @@ const MilestoneArticlesModal: React.FC<MilestoneArticlesModalProps> = ({
       await onConfirm(optionsToArticles(selectedOptions));
       onClose();
     } catch {
-      setIsRequestInProgress(false);
       setHasError(true);
+    } finally {
+      setIsRequestInProgress(false);
     }
   };
 

--- a/packages/react-components/src/organisms/MilestoneArticlesModal.tsx
+++ b/packages/react-components/src/organisms/MilestoneArticlesModal.tsx
@@ -1,4 +1,4 @@
-import { css, keyframes } from '@emotion/react';
+import { css } from '@emotion/react';
 import { ComponentProps, useState } from 'react';
 import { ArticleItem, ResearchOutputType } from '@asap-hub/model';
 
@@ -9,7 +9,6 @@ import { mobileScreen, rem } from '../pixels';
 import { ResearchOutputOption } from '../utils';
 import { articleSelectComponents } from '../utils/article-select-components';
 import Toast from './Toast';
-import { neutral300 } from '../colors';
 
 const headerStyles = css({
   display: 'flex',
@@ -64,26 +63,6 @@ const cancelStyles = css({
   [buttonMediaQuery]: {
     gridRow: '1',
   },
-});
-
-const confirmButtonContentStyles = css({
-  display: 'flex',
-  alignItems: 'center',
-  gap: rem(8),
-});
-
-const spin = keyframes`
-  from { transform: rotate(0deg) }
-  to { transform: rotate(360deg) }
-`;
-
-const spinnerStyles = css({
-  width: rem(16),
-  height: rem(16),
-  border: `${rem(2)} solid ${neutral300.rgb}`,
-  borderTop: `${rem(2)} solid white`,
-  borderRadius: '50%',
-  animation: `${spin} 1s linear infinite`,
 });
 
 const selectContainerStyles = css({});
@@ -206,12 +185,10 @@ const MilestoneArticlesModal: React.FC<MilestoneArticlesModalProps> = ({
                 primary
                 noMargin
                 enabled={!isRequestInProgress}
+                loading={isRequestInProgress}
                 onClick={handleConfirm}
               >
-                <span css={confirmButtonContentStyles}>
-                  {isRequestInProgress && <div css={spinnerStyles} />}
-                  Confirm
-                </span>
+                Confirm
               </Button>
             </div>
           </div>

--- a/packages/react-components/src/organisms/MilestoneArticlesModal.tsx
+++ b/packages/react-components/src/organisms/MilestoneArticlesModal.tsx
@@ -151,10 +151,10 @@ const MilestoneArticlesModal: React.FC<MilestoneArticlesModalProps> = ({
           <Headline3 noMargin>{title}</Headline3>
         </header>
       </div>
-      {hasError && (
-        <Toast>An error has occurred. Please try again later.</Toast>
-      )}
       <div css={contentWrapStyles}>
+        {hasError && (
+          <Toast>An error has occurred. Please try again later.</Toast>
+        )}
         <div>
           <div css={selectContainerStyles}>
             <LabeledMultiSelect<ResearchOutputOption>

--- a/packages/react-components/src/organisms/MilestoneArticlesModal.tsx
+++ b/packages/react-components/src/organisms/MilestoneArticlesModal.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/react';
+import { css, keyframes } from '@emotion/react';
 import { ComponentProps, useState } from 'react';
 import { ArticleItem, ResearchOutputType } from '@asap-hub/model';
 
@@ -8,6 +8,8 @@ import { Button, Headline3 } from '../atoms';
 import { mobileScreen, rem } from '../pixels';
 import { ResearchOutputOption } from '../utils';
 import { articleSelectComponents } from '../utils/article-select-components';
+import Toast from './Toast';
+import { neutral300 } from '../colors';
 
 const headerStyles = css({
   display: 'flex',
@@ -64,10 +66,34 @@ const cancelStyles = css({
   },
 });
 
+const confirmButtonContentStyles = css({
+  display: 'flex',
+  alignItems: 'center',
+  gap: rem(8),
+});
+
+const spin = keyframes`
+  from { transform: rotate(0deg) }
+  to { transform: rotate(360deg) }
+`;
+
+const spinnerStyles = css({
+  width: rem(16),
+  height: rem(16),
+  border: `${rem(2)} solid ${neutral300.rgb}`,
+  borderTop: `${rem(2)} solid white`,
+  borderRadius: '50%',
+  animation: `${spin} 1s linear infinite`,
+});
+
 const selectContainerStyles = css({});
 
-const mainWrapStyles = css({
-  padding: `${rem(32)} ${rem(24)}`,
+const headerWrapStyles = css({
+  padding: `${rem(32)} ${rem(24)} ${rem(16)}`,
+});
+
+const contentWrapStyles = css({
+  padding: `${rem(16)} ${rem(24)} ${rem(32)}`,
 });
 
 export const articlesToOptions = (
@@ -93,7 +119,7 @@ const optionsToArticles = (
 type MilestoneArticlesModalProps = {
   readonly articles: ReadonlyArray<ArticleItem>;
   readonly onClose: () => void;
-  readonly onConfirm: (articles: ReadonlyArray<ArticleItem>) => void;
+  readonly onConfirm: (articles: ReadonlyArray<ArticleItem>) => Promise<void>;
   readonly loadOptions: NonNullable<
     ComponentProps<
       typeof LabeledMultiSelect<ResearchOutputOption>
@@ -111,20 +137,45 @@ const MilestoneArticlesModal: React.FC<MilestoneArticlesModalProps> = ({
     ResearchOutputOption[]
   >(articlesToOptions(initialArticles));
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [isRequestInProgress, setIsRequestInProgress] = useState(false);
+  const [hasError, setHasError] = useState(false);
   const hasArticles = initialArticles.length > 0;
   const title = hasArticles ? 'Edit Related Articles' : 'Add Related Articles';
 
+  const handleConfirm = async () => {
+    if (isRequestInProgress) return;
+    setHasError(false);
+    setIsRequestInProgress(true);
+    try {
+      await onConfirm(optionsToArticles(selectedOptions));
+      onClose();
+    } catch {
+      setIsRequestInProgress(false);
+      setHasError(true);
+    }
+  };
+
   return (
     <Modal padding={false} overrideModalStyles={widerModalStyles}>
-      <div css={mainWrapStyles}>
+      <div css={headerWrapStyles}>
         <header css={headerStyles}>
           <div css={controlsContainerStyles}>
-            <Button small noMargin onClick={onClose}>
+            <Button
+              small
+              noMargin
+              onClick={onClose}
+              enabled={!isRequestInProgress}
+            >
               {crossIcon}
             </Button>
           </div>
           <Headline3 noMargin>{title}</Headline3>
         </header>
+      </div>
+      {hasError && (
+        <Toast>An error has occurred. Please try again later.</Toast>
+      )}
+      <div css={contentWrapStyles}>
         <div>
           <div css={selectContainerStyles}>
             <LabeledMultiSelect<ResearchOutputOption>
@@ -133,16 +184,20 @@ const MilestoneArticlesModal: React.FC<MilestoneArticlesModalProps> = ({
               placeholder="Start typing..."
               values={selectedOptions}
               loadOptions={loadOptions}
-              onChange={(newValues) => setSelectedOptions([...newValues])}
+              onChange={(newValues) => {
+                setSelectedOptions([...newValues]);
+                setHasError(false);
+              }}
               noOptionsMessage={() => 'No articles found'}
               components={articleSelectComponents}
               onMenuOpen={() => setIsMenuOpen(true)}
               onMenuClose={() => setIsMenuOpen(false)}
+              enabled={!isRequestInProgress}
             />
           </div>
           <div css={buttonContainerStyles(isMenuOpen)}>
             <div css={cancelStyles}>
-              <Button noMargin onClick={onClose}>
+              <Button noMargin onClick={onClose} enabled={!isRequestInProgress}>
                 Cancel
               </Button>
             </div>
@@ -150,12 +205,13 @@ const MilestoneArticlesModal: React.FC<MilestoneArticlesModalProps> = ({
               <Button
                 primary
                 noMargin
-                onClick={() => {
-                  onClose();
-                  onConfirm(optionsToArticles(selectedOptions));
-                }}
+                enabled={!isRequestInProgress}
+                onClick={handleConfirm}
               >
-                Confirm
+                <span css={confirmButtonContentStyles}>
+                  {isRequestInProgress && <div css={spinnerStyles} />}
+                  Confirm
+                </span>
               </Button>
             </div>
           </div>

--- a/packages/react-components/src/organisms/__tests__/ConfirmModal.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/ConfirmModal.test.tsx
@@ -45,12 +45,13 @@ it('triggers the save function', async () => {
       onSave={jestFn}
     />,
   );
-  const publish = getByText(/Publish and Explore/i);
-  await userEvent.click(publish);
+  await userEvent.click(getByText(/Publish and Explore/i));
 
   expect(jestFn).toHaveBeenCalled();
 
-  await waitFor(() => expect(publish.closest('button')).toBeEnabled());
+  await waitFor(() =>
+    expect(getByText(/Publish and Explore/i).closest('button')).toBeEnabled(),
+  );
 });
 
 it('triggers the cancel function', async () => {
@@ -83,14 +84,15 @@ it('disables publish & back while submitting', async () => {
       onSave={handleSave}
     />,
   );
-  const publish = getByText(/Publish and Explore/i);
 
-  await userEvent.click(publish);
-  expect(publish.closest('button')).toBeDisabled();
+  await userEvent.click(getByText(/Publish and Explore/i));
+  expect(getByText(/Publish and Explore/i).closest('button')).toBeDisabled();
   expect(getByText(/back/i).closest('a')).not.toHaveAttribute('href');
 
   act(resolveSubmit);
-  await waitFor(() => expect(publish.closest('button')).toBeEnabled());
+  await waitFor(() =>
+    expect(getByText(/Publish and Explore/i).closest('button')).toBeEnabled(),
+  );
 });
 
 it('displays error message when save fails', async () => {
@@ -99,7 +101,7 @@ it('displays error message when save fails', async () => {
     new Promise<void>((_, reject) => {
       rejectSubmit = reject;
     });
-  const { getByText } = renderModal(
+  const { getByText, findByText } = renderModal(
     <ConfirmModal
       {...props}
       confirmText="Publish and Explore"
@@ -108,12 +110,12 @@ it('displays error message when save fails', async () => {
     />,
   );
 
-  const publish = getByText(/Publish and Explore/i);
-  await userEvent.click(publish);
+  await userEvent.click(getByText(/Publish and Explore/i));
   act(rejectSubmit);
 
-  await waitFor(() => {
-    expect(publish.closest('button')).toBeEnabled();
-    expect(getByText(/error.+publish/i)).toBeVisible();
-  });
+  const errorMsg = await findByText(/error.+publish/i);
+  expect(errorMsg).toBeVisible();
+  await waitFor(() =>
+    expect(getByText(/Publish and Explore/i).closest('button')).toBeEnabled(),
+  );
 });

--- a/packages/react-components/src/organisms/__tests__/Milestone.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/Milestone.test.tsx
@@ -458,7 +458,7 @@ describe('Milestone', () => {
       expect(localFetchMock).toHaveBeenCalledTimes(2);
     });
 
-    it('closes modal immediately on confirm even when save fails', async () => {
+    it('keeps modal open and shows error when save fails', async () => {
       mockOnSaveArticles.mockRejectedValueOnce(new Error('save failed'));
       render(
         <Milestone
@@ -476,8 +476,11 @@ describe('Milestone', () => {
       await userEvent.click(screen.getByRole('button', { name: /confirm/i }));
 
       await waitFor(() => {
-        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+        expect(
+          screen.getByText('An error has occurred. Please try again later.'),
+        ).toBeInTheDocument();
       });
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
     });
 
     it('displays saved articles in list after confirming modal', async () => {

--- a/packages/react-components/src/organisms/__tests__/MilestoneArticlesModal.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/MilestoneArticlesModal.test.tsx
@@ -15,7 +15,7 @@ const mockArticles: ArticleItem[] = [
 
 const defaultProps = {
   onClose: jest.fn(),
-  onConfirm: jest.fn(),
+  onConfirm: jest.fn().mockResolvedValue(undefined),
   loadOptions: jest.fn().mockResolvedValue([]),
 };
 
@@ -87,7 +87,7 @@ describe('MilestoneArticlesModal', () => {
       <MilestoneArticlesModal
         articles={[]}
         onClose={onClose}
-        onConfirm={jest.fn()}
+        onConfirm={jest.fn().mockResolvedValue(undefined)}
         loadOptions={defaultProps.loadOptions}
       />,
     );
@@ -106,7 +106,7 @@ describe('MilestoneArticlesModal', () => {
       <MilestoneArticlesModal
         articles={[]}
         onClose={onClose}
-        onConfirm={jest.fn()}
+        onConfirm={jest.fn().mockResolvedValue(undefined)}
         loadOptions={defaultProps.loadOptions}
       />,
     );
@@ -127,9 +127,9 @@ describe('MilestoneArticlesModal', () => {
     });
   });
 
-  it('calls onClose and onConfirm when Confirm is clicked', async () => {
+  it('calls onConfirm and onClose when Confirm is clicked', async () => {
     const onClose = jest.fn();
-    const onConfirm = jest.fn();
+    const onConfirm = jest.fn().mockResolvedValue(undefined);
     render(
       <MilestoneArticlesModal
         articles={mockArticles}
@@ -139,7 +139,9 @@ describe('MilestoneArticlesModal', () => {
       />,
     );
     await userEvent.click(screen.getByRole('button', { name: /confirm/i }));
-    expect(onClose).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
     expect(onConfirm).toHaveBeenCalledTimes(1);
     expect(onConfirm).toHaveBeenCalledWith(
       expect.arrayContaining([
@@ -169,7 +171,7 @@ describe('MilestoneArticlesModal', () => {
       <MilestoneArticlesModal
         articles={[]}
         onClose={jest.fn()}
-        onConfirm={jest.fn()}
+        onConfirm={jest.fn().mockResolvedValue(undefined)}
         loadOptions={loadOptions}
       />,
     );
@@ -219,7 +221,7 @@ describe('MilestoneArticlesModal', () => {
           { id: 'no-type', title: 'Article without type', href: '/no-type' },
         ]}
         onClose={jest.fn()}
-        onConfirm={jest.fn()}
+        onConfirm={jest.fn().mockResolvedValue(undefined)}
         loadOptions={loadOptions}
       />,
     );
@@ -239,7 +241,7 @@ describe('MilestoneArticlesModal', () => {
       <MilestoneArticlesModal
         articles={[]}
         onClose={jest.fn()}
-        onConfirm={jest.fn()}
+        onConfirm={jest.fn().mockResolvedValue(undefined)}
         loadOptions={loadOptions}
       />,
     );
@@ -250,6 +252,203 @@ describe('MilestoneArticlesModal', () => {
     await userEvent.type(input, 'nonexistent');
     await waitFor(() => {
       expect(screen.getByText('No articles found')).toBeInTheDocument();
+    });
+  });
+
+  it('disables buttons while request is in progress', async () => {
+    const onConfirm = jest.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          setTimeout(resolve, 200);
+        }),
+    );
+    const onClose = jest.fn();
+
+    render(
+      <MilestoneArticlesModal
+        articles={mockArticles}
+        onClose={onClose}
+        onConfirm={onConfirm}
+        loadOptions={defaultProps.loadOptions}
+      />,
+    );
+
+    const confirmButton = screen.getByRole('button', { name: /confirm/i });
+    const cancelButton = screen.getByRole('button', { name: /cancel/i });
+
+    expect(confirmButton).not.toBeDisabled();
+    expect(cancelButton).not.toBeDisabled();
+
+    await userEvent.click(confirmButton);
+
+    expect(confirmButton).toBeDisabled();
+    expect(cancelButton).toBeDisabled();
+
+    await waitFor(() => {
+      expect(onConfirm).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+
+  it('shows error message, keeps modal open, and re-enables inputs on save failure', async () => {
+    const onConfirm = jest.fn().mockRejectedValue(new Error('fail'));
+    const onClose = jest.fn();
+
+    render(
+      <MilestoneArticlesModal
+        articles={mockArticles}
+        onClose={onClose}
+        onConfirm={onConfirm}
+        loadOptions={defaultProps.loadOptions}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: /confirm/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('An error has occurred. Please try again later.'),
+      ).toBeInTheDocument();
+    });
+
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: /confirm/i })).not.toBeDisabled();
+  });
+
+  it('disables close button while request is in progress', async () => {
+    const onConfirm = jest.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          setTimeout(resolve, 200);
+        }),
+    );
+    const onClose = jest.fn();
+
+    render(
+      <MilestoneArticlesModal
+        articles={mockArticles}
+        onClose={onClose}
+        onConfirm={onConfirm}
+        loadOptions={defaultProps.loadOptions}
+      />,
+    );
+
+    const dialog = screen.getByRole('dialog');
+    const closeButton = within(dialog).getAllByRole('button')[0]!;
+
+    await userEvent.click(screen.getByRole('button', { name: /confirm/i }));
+
+    expect(closeButton).toBeDisabled();
+
+    await waitFor(() => {
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+
+  it('disables select input while request is in progress', async () => {
+    const onConfirm = jest.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          setTimeout(resolve, 200);
+        }),
+    );
+    const onClose = jest.fn();
+
+    render(
+      <MilestoneArticlesModal
+        articles={[]}
+        onClose={onClose}
+        onConfirm={onConfirm}
+        loadOptions={defaultProps.loadOptions}
+      />,
+    );
+
+    const combobox = screen.getByRole('combobox');
+
+    await userEvent.click(screen.getByRole('button', { name: /confirm/i }));
+
+    expect(combobox).toBeDisabled();
+
+    await waitFor(() => {
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+
+  it('clears error message when selection changes after failure', async () => {
+    const onConfirm = jest.fn().mockRejectedValue(new Error('fail'));
+    const loadOptions = jest.fn().mockResolvedValue([
+      {
+        label: 'New Article',
+        value: 'new-1',
+        documentType: 'Article',
+        type: 'Preprint',
+      },
+    ]);
+
+    render(
+      <MilestoneArticlesModal
+        articles={[]}
+        onClose={jest.fn()}
+        onConfirm={onConfirm}
+        loadOptions={loadOptions}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: /confirm/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('An error has occurred. Please try again later.'),
+      ).toBeInTheDocument();
+    });
+
+    const input = screen.getByRole('combobox');
+    await userEvent.type(input, 'New');
+    await waitFor(() => {
+      expect(screen.getByText('New Article')).toBeInTheDocument();
+    });
+    await userEvent.click(screen.getByText('New Article'));
+
+    expect(
+      screen.queryByText('An error has occurred. Please try again later.'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('clears error message on retry', async () => {
+    const onConfirm = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('fail'))
+      .mockResolvedValueOnce(undefined);
+    const onClose = jest.fn();
+
+    render(
+      <MilestoneArticlesModal
+        articles={mockArticles}
+        onClose={onClose}
+        onConfirm={onConfirm}
+        loadOptions={defaultProps.loadOptions}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: /confirm/i }));
+    await waitFor(() => {
+      expect(
+        screen.getByText('An error has occurred. Please try again later.'),
+      ).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: /confirm/i }));
+    await waitFor(() => {
+      expect(
+        screen.queryByText('An error has occurred. Please try again later.'),
+      ).not.toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(onClose).toHaveBeenCalled();
     });
   });
 });

--- a/packages/react-components/src/templates/ToolModal.tsx
+++ b/packages/react-components/src/templates/ToolModal.tsx
@@ -10,26 +10,6 @@ import { noop } from '../utils';
 import { EditModal } from '../organisms';
 import { GlobeIcon } from '../icons';
 import { mobileScreen, rem } from '../pixels';
-import { colors } from '..';
-
-const saveButtonContentStyles = css({
-  display: 'flex',
-  alignItems: 'center',
-  gap: rem(8),
-});
-
-const spinnerStyles = css({
-  '@keyframes toolModalSpin': {
-    '0%': { transform: 'rotate(0deg)' },
-    '100%': { transform: 'rotate(360deg)' },
-  },
-  width: rem(16),
-  height: rem(16),
-  border: `${rem(2)} solid ${colors.neutral300.rgb}`,
-  borderTop: `${rem(2)} solid white`,
-  borderRadius: '50%',
-  animation: 'toolModalSpin 1s linear infinite',
-});
 
 const buttonMediaQuery = `@media (min-width: ${mobileScreen.max - 100}px)`;
 
@@ -176,6 +156,7 @@ const ToolModal: React.FC<ToolModalProps> = ({
                   <Button
                     primary
                     enabled={!isSaving}
+                    loading={isSaving}
                     onClick={() =>
                       asyncFunctionWrapper(() =>
                         onSave({
@@ -187,10 +168,7 @@ const ToolModal: React.FC<ToolModalProps> = ({
                       )
                     }
                   >
-                    <span css={saveButtonContentStyles}>
-                      {isSaving && <div css={spinnerStyles} />}
-                      {saveButtonText}
-                    </span>
+                    {saveButtonText}
                   </Button>
                 </div>
               </div>

--- a/packages/react-components/src/templates/__tests__/ToolModal.test.tsx
+++ b/packages/react-components/src/templates/__tests__/ToolModal.test.tsx
@@ -254,7 +254,7 @@ it('disables bottom buttons and shows spinner while submitting', async () => {
 
   expect(getByText('Add Tool').closest('button')).toBeDisabled();
   expect(
-    container.querySelector('[class*="spinnerStyles"]'),
+    container.querySelector('[class*="buttonSpinnerStyles"]'),
   ).toBeInTheDocument();
 
   act(resolveSubmit);


### PR DESCRIPTION
### Changes:

- MilestoneArticlesModal now stays open during save with all inputs disabled and a spinner in the confirm button; closes only on success, shows inline error on failure.

- Extracted the duplicated button spinner into a shared loading prop on Button, replacing identical implementations in ConfirmModal, ToolModal, and MilestoneArticlesModal.

### How it's looking like:

Normal flow:

https://github.com/user-attachments/assets/95278d37-0931-45c8-b068-02912e4214c2

When there is an error:
_when we have an error when trying to persisting data to the server (e.g when we're offline)_

**Before:**

https://github.com/user-attachments/assets/7b1fd7fe-3950-45e8-89d1-5bc118017c35

**After:**

https://github.com/user-attachments/assets/ad04ff68-ba46-4b4b-8f3b-674a22f711de

