### PR TITLE
[ASAP-1500] - Compliance backup script crashes on manuscripts without versions

### DIFF
--- a/apps/crn-server/scripts/export-compliance-data.ts
+++ b/apps/crn-server/scripts/export-compliance-data.ts
@@ -251,7 +251,13 @@ const formatComplianceData = (entries: GroupedEntries) => {
 
   for (const manuscriptEntry of manuscriptEntries) {
     const manuscriptFields = manuscriptEntry.fields;
-    const versionLinks = manuscriptEntry.fields.versions['en-US'];
+    const versionLinks = manuscriptFields.versions?.['en-US'];
+    if (!versionLinks?.length) {
+      console.warn(
+        `Manuscript ${manuscriptEntry.sys.id} has no versions, skipping`,
+      );
+      continue;
+    }
     versionLinks.forEach((versionLink: Link<'Entry'>) => {
       const versionEntry = versionEntries.find(
         (entry) => entry.sys.id === versionLink.sys.id,


### PR DESCRIPTION
[ASAP-1500](https://asaphub.atlassian.net/browse/ASAP-1500)

<img width="1857" height="880" alt="image" src="https://github.com/user-attachments/assets/6966152e-5359-479d-a5af-f0a5f91e13f9" />


this was tested locally and I got same issue, now after fix, I'm able to see the generated csv and here are the logs

<img width="1192" height="121" alt="image" src="https://github.com/user-attachments/assets/b4e021bc-9722-4ad9-9c8b-f89b125d5581" />


[ASAP-1500]: https://asaphub.atlassian.net/browse/ASAP-1500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ