### PR TITLE
ASAP-1499 Add field type to Research Theme

### DIFF
--- a/packages/contentful/migrations/crn/researchTheme/20260512114259-add-type-to-research-theme.js
+++ b/packages/contentful/migrations/crn/researchTheme/20260512114259-add-type-to-research-theme.js
@@ -1,11 +1,11 @@
-module.exports.description = 'Add type to research theme';
+module.exports.description = 'Add types to research theme';
 
 module.exports.up = (migration) => {
   const researchTheme = migration.editContentType('researchTheme');
 
   researchTheme
-    .createField('type')
-    .name('Type')
+    .createField('types')
+    .name('Types')
     .type('Array')
     .localized(false)
     .required(false)
@@ -27,12 +27,11 @@ module.exports.up = (migration) => {
   migration.transformEntries({
     contentType: 'researchTheme',
     from: ['name'],
-    to: ['type'],
-    shouldPublish: false,
+    to: ['types'],
     transformEntryForLocale: async (from) => {
       if (!from?.name || !from?.name?.['en-US']) return;
       return {
-        type:
+        types:
           from.name['en-US'] !== 'Tool Generation'
             ? ['Discovery']
             : ['Resource'],
@@ -40,12 +39,12 @@ module.exports.up = (migration) => {
     },
   });
 
-  researchTheme.editField('type').required(true);
+  researchTheme.editField('types').required(true);
 
-  researchTheme.changeFieldControl('type', 'builtin', 'checkbox', {});
+  researchTheme.changeFieldControl('types', 'builtin', 'checkbox', {});
 };
 
 module.exports.down = (migration) => {
   const researchTheme = migration.editContentType('researchTheme');
-  researchTheme.deleteField('type');
+  researchTheme.deleteField('types');
 };

--- a/packages/contentful/migrations/crn/researchTheme/20260512114259-add-type-to-research-theme.js
+++ b/packages/contentful/migrations/crn/researchTheme/20260512114259-add-type-to-research-theme.js
@@ -1,0 +1,51 @@
+module.exports.description = 'Add type to research theme';
+
+module.exports.up = (migration) => {
+  const researchTheme = migration.editContentType('researchTheme');
+
+  researchTheme
+    .createField('type')
+    .name('Type')
+    .type('Array')
+    .localized(false)
+    .required(false)
+    .validations([])
+    .defaultValue({
+      'en-US': ['Discovery'],
+    })
+    .disabled(false)
+    .omitted(false)
+    .items({
+      type: 'Symbol',
+      validations: [
+        {
+          in: ['Discovery', 'Resource'],
+        },
+      ],
+    });
+
+  migration.transformEntries({
+    contentType: 'researchTheme',
+    from: ['name'],
+    to: ['type'],
+    shouldPublish: false,
+    transformEntryForLocale: async (from) => {
+      if (!from?.name || !from?.name?.['en-US']) return;
+      return {
+        type:
+          from.name['en-US'] !== 'Tool Generation'
+            ? ['Discovery']
+            : ['Resource'],
+      };
+    },
+  });
+
+  researchTheme.editField('type').required(true);
+
+  researchTheme.changeFieldControl('type', 'builtin', 'checkbox', {});
+};
+
+module.exports.down = (migration) => {
+  const researchTheme = migration.editContentType('researchTheme');
+  researchTheme.deleteField('type');
+};


### PR DESCRIPTION
JIRA ticket: https://asaphub.atlassian.net/browse/ASAP-1499

---

This PR adds the field `Type` to `Research Theme` the same way it has been added to `Tags`.

Also, it populates the existing  research themes to have type Discovery, except Tool, Generation.