### PR TITLE
[ASAP-1502] - Prevent description text from triggering file picker in LabeledFileField

### DIFF
--- a/packages/react-components/src/molecules/LabeledFileField.tsx
+++ b/packages/react-components/src/molecules/LabeledFileField.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { ComponentProps, useRef, useState } from 'react';
+import { ComponentProps, useId, useRef, useState } from 'react';
 import Lottie from 'react-lottie';
 import { Button, Label, Paragraph, Tag } from '../atoms';
 import { lead } from '../colors';
@@ -10,6 +10,11 @@ import loading from '../lotties/loading.json';
 
 const descriptionStyles = css({
   color: lead.rgb,
+});
+
+const descriptionContainerStyles = css({
+  flexBasis: '100%',
+  paddingBottom: rem(12),
 });
 
 const hintStyles = css({
@@ -84,6 +89,7 @@ const LabeledFileField: React.FC<LabeledFileFieldProps> = ({
   tagEnabled = true,
 }) => {
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const descriptionId = useId();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const handleFileChange = async (
     event: React.ChangeEvent<HTMLInputElement>,
@@ -118,6 +124,13 @@ const LabeledFileField: React.FC<LabeledFileFieldProps> = ({
         forContent={(id) => (
           <>
             <div style={{ width: '100%' }} />
+            {description ? (
+              <div id={descriptionId} css={descriptionContainerStyles}>
+                <Paragraph noMargin>
+                  <span css={descriptionStyles}>{description}</span>
+                </Paragraph>
+              </div>
+            ) : null}
             <div css={fileSelectionContainerStyles}>
               {currentFiles && (
                 <div css={currentFilesContainerStyles}>
@@ -140,6 +153,7 @@ const LabeledFileField: React.FC<LabeledFileFieldProps> = ({
                 enabled={!!enabled && canUploadFile}
                 noMargin
                 id={id}
+                aria-describedby={description ? descriptionId : undefined}
                 preventDefault={false}
                 onClick={() => canUploadFile && fileInputRef.current?.click()}
               >
@@ -169,8 +183,6 @@ const LabeledFileField: React.FC<LabeledFileFieldProps> = ({
         <Paragraph noMargin styles={css({ paddingBottom: rem(16) })}>
           <strong>{title}</strong>
           <span css={subtitleStyles}>{subtitle}</span>
-          <br />
-          <span css={[descriptionStyles]}>{description}</span>
         </Paragraph>
       </Label>
       {customValidationMessage && (

--- a/packages/react-components/src/molecules/__tests__/LabeledFileField.test.tsx
+++ b/packages/react-components/src/molecules/__tests__/LabeledFileField.test.tsx
@@ -22,7 +22,7 @@ it('renders a labeled button when no file is selected', () => {
   );
   expect(screen.getByLabelText(/Title/i)).toBeVisible();
   expect(screen.getByLabelText(/Subtitle/i)).toBeVisible();
-  expect(screen.getByLabelText(/Description/i)).toBeVisible();
+  expect(screen.getByText(/Description/i)).toBeVisible();
   expect(screen.getByText('Add File')).toBeVisible();
 });
 
@@ -193,6 +193,37 @@ it('calls the onRemove function when the remove button is clicked and allows for
   });
   await userEvent.upload(uploadInput, differentFile);
   expect(handleFileUploadMock).toHaveBeenCalledTimes(2);
+});
+
+it('renders the description outside the label to prevent unintended button activation', () => {
+  render(
+    <LabeledFileField
+      title="Title"
+      description="Description"
+      handleFileUpload={handleFileUploadMock}
+      enabled
+    />,
+  );
+  expect(screen.getByText('Description').closest('label')).toBeNull();
+});
+
+it('does not open file picker when clicking the description text', async () => {
+  const user = userEvent.setup();
+  render(
+    <LabeledFileField
+      title="Title"
+      description="Description"
+      handleFileUpload={handleFileUploadMock}
+      placeholder="Upload File"
+      enabled
+    />,
+  );
+  const uploadInput = screen.getByLabelText(/Upload File/i);
+  const clickSpy = jest.spyOn(uploadInput, 'click');
+
+  await user.click(screen.getByText('Description'));
+
+  expect(clickSpy).not.toHaveBeenCalled();
 });
 
 it('trigger file upload when clicking on the add file button', async () => {


### PR DESCRIPTION
Move description outside <label> into forContent so clicking it no longer activates the associated button. Also, added aria-describedby to preserve screen reader association.

**Before:**

https://github.com/user-attachments/assets/bfc3f0ba-1184-493c-a7ec-ae02a977705b

**After:**

https://github.com/user-attachments/assets/7516cbcb-dd09-4a3c-a662-ffa3704f245b

