### PR TITLE
[Do Not Merge] Split heavy vendor libraries into separate chunks

### DIFF
--- a/apps/crn-frontend/vite.config.ts
+++ b/apps/crn-frontend/vite.config.ts
@@ -61,6 +61,22 @@ export default defineConfig({
         if (warning.code === 'UNRESOLVED_IMPORT') return;
         warn(warning);
       },
+      output: {
+        manualChunks(id: string) {
+          if (id.includes('/lexical') || id.includes('/@lexical/')) {
+            return 'vendor-lexical';
+          }
+          if (id.includes('/react-select')) {
+            return 'vendor-react-select';
+          }
+          if (id.includes('/xlsx')) {
+            return 'vendor-xlsx';
+          }
+          if (id.includes('/csv-stringify')) {
+            return 'vendor-csv';
+          }
+        },
+      },
     },
   },
   server: {

--- a/apps/gp2-frontend/vite.config.ts
+++ b/apps/gp2-frontend/vite.config.ts
@@ -7,6 +7,21 @@ export default defineConfig({
   build: {
     sourcemap: true,
     target: browserslistToEsbuild(),
+    rollupOptions: {
+      output: {
+        manualChunks(id: string) {
+          if (id.includes('/lexical') || id.includes('/@lexical/')) {
+            return 'vendor-lexical';
+          }
+          if (id.includes('/react-select')) {
+            return 'vendor-react-select';
+          }
+          if (id.includes('/csv-stringify')) {
+            return 'vendor-csv';
+          }
+        },
+      },
+    },
   },
   server: {
     open: true,


### PR DESCRIPTION
**Idea:**

Lexical, React Select, XLSX, and CSV Stringify are now isolated into dedicated chunks using Vite’s manualChunks. This separates their cache lifecycle from application code, improving load times for returning users.

**Invalidation rules:**

App code changes, vendor dependencies unchanged — vendor chunk hashes remain the same, so the browser serves them from cache. Only the app chunks are re-downloaded.
Vendor dependency upgrades (e.g., Lexical 0.18 → 0.19) — chunk contents change, the hash updates, and the browser fetches the new version.
Yarn lock changes without a version bump — if the resolved code differs, the hash still changes and the chunk is re-fetched.

**Summary:**

Vendor chunks are only invalidated when their actual contents change. The goal is to decouple vendor caching from frequent application code updates.
