### PR TITLE
[ASAP-1432] - Create Project Outputs tab

### DIFF
--- a/apps/crn-frontend/src/projects/ProjectDetail.tsx
+++ b/apps/crn-frontend/src/projects/ProjectDetail.tsx
@@ -6,6 +6,7 @@ import {
   ProjectDetailPage,
   ProjectDetailAbout,
   NotFoundPage,
+  NoOutputsPage,
 } from '@asap-hub/react-components';
 import { useCurrentUserCRN, useFlags } from '@asap-hub/react-context';
 import { useProjectArticlesSuggestions, useProjectById } from './state';
@@ -68,6 +69,8 @@ const ProjectDetail: FC<Props> = ({ config }) => {
 
   const workspaceHref = showWorkspace ? route.workspace({}).$ : undefined;
   const isProjectMilestonesEnabled = isEnabled('PROJECT_AIMS_AND_MILESTONES');
+  const isProjectOutputsEnabled = isEnabled('PROJECT_OUTPUTS');
+
   const hasSupplementGrant =
     'supplementGrant' in projectDetail && !!projectDetail.supplementGrant;
   const activeProjectAims =
@@ -148,6 +151,14 @@ const ProjectDetail: FC<Props> = ({ config }) => {
                   aboutHref={route.about({}).$}
                   workspaceHref={workspaceHref}
                   milestonesHref={route.milestones({}).$}
+                  outputsHref={
+                    isProjectOutputsEnabled ? route.outputs({}).$ : undefined
+                  }
+                  draftOutputsHref={
+                    isProjectOutputsEnabled
+                      ? route.draftOutputs({}).$
+                      : undefined
+                  }
                 >
                   <Routes>
                     <Route
@@ -235,6 +246,38 @@ const ProjectDetail: FC<Props> = ({ config }) => {
                         }
                       />
                     )}
+                    <Route
+                      path="outputs"
+                      element={
+                        isProjectOutputsEnabled ? (
+                          <Frame title="Project Outputs">
+                            <NoOutputsPage
+                              title="No outputs available."
+                              description="When this project shares an output, it will be listed here."
+                              hideExploreButton
+                            />
+                          </Frame>
+                        ) : (
+                          <NotFoundPage />
+                        )
+                      }
+                    />
+                    <Route
+                      path="draft-outputs"
+                      element={
+                        isProjectOutputsEnabled ? (
+                          <Frame title="Project Draft Outputs">
+                            <NoOutputsPage
+                              title="No draft outputs available."
+                              description="When this project shares a draft output, it will be listed here."
+                              hideExploreButton
+                            />
+                          </Frame>
+                        ) : (
+                          <NotFoundPage />
+                        )
+                      }
+                    />
                     <Route
                       index
                       element={<Navigate to={route.about({}).$} replace />}

--- a/apps/crn-frontend/src/projects/__tests__/ProjectDetail.test.tsx
+++ b/apps/crn-frontend/src/projects/__tests__/ProjectDetail.test.tsx
@@ -521,6 +521,81 @@ describe.each(variants)(
       ).toBeInTheDocument();
     });
 
+    it('renders Outputs tab when flag is enabled', async () => {
+      enable('PROJECT_OUTPUTS');
+      await renderProjectDetail(Component, routeKeyword, mainProjectId);
+      expect(screen.getByText('Outputs')).toBeInTheDocument();
+    });
+
+    it('renders Draft Outputs tab when flag is enabled', async () => {
+      enable('PROJECT_OUTPUTS');
+      await renderProjectDetail(Component, routeKeyword, mainProjectId);
+      expect(screen.getByText('Draft Outputs')).toBeInTheDocument();
+    });
+
+    it('does not render Outputs or Draft Outputs tabs when flag is disabled', async () => {
+      disable('PROJECT_OUTPUTS');
+      await renderProjectDetail(Component, routeKeyword, mainProjectId);
+      expect(screen.queryByText('Outputs')).not.toBeInTheDocument();
+      expect(screen.queryByText('Draft Outputs')).not.toBeInTheDocument();
+    });
+
+    it('renders outputs empty state when navigating to outputs route', async () => {
+      enable('PROJECT_OUTPUTS');
+      await renderProjectDetail(
+        Component,
+        routeKeyword,
+        mainProjectId,
+        {},
+        'outputs',
+      );
+      expect(
+        await screen.findByText('No outputs available.'),
+      ).toBeInTheDocument();
+    });
+
+    it('renders draft outputs empty state when navigating to draft-outputs route', async () => {
+      enable('PROJECT_OUTPUTS');
+      await renderProjectDetail(
+        Component,
+        routeKeyword,
+        mainProjectId,
+        {},
+        'draft-outputs',
+      );
+      expect(
+        await screen.findByText('No draft outputs available.'),
+      ).toBeInTheDocument();
+    });
+
+    it('does not render outputs empty state when flag is disabled', async () => {
+      disable('PROJECT_OUTPUTS');
+      await renderProjectDetail(
+        Component,
+        routeKeyword,
+        mainProjectId,
+        {},
+        'outputs',
+      );
+      expect(
+        screen.queryByText('No outputs available.'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('does not render draft outputs empty state when flag is disabled', async () => {
+      disable('PROJECT_OUTPUTS');
+      await renderProjectDetail(
+        Component,
+        routeKeyword,
+        mainProjectId,
+        {},
+        'draft-outputs',
+      );
+      expect(
+        screen.queryByText('No draft outputs available.'),
+      ).not.toBeInTheDocument();
+    });
+
     it('renders milestones route and covers hasSupplementGrant logic', async () => {
       enable('PROJECT_AIMS_AND_MILESTONES');
       await renderProjectDetail(

--- a/packages/flags/src/index.ts
+++ b/packages/flags/src/index.ts
@@ -2,7 +2,8 @@ export type Flag =
   | 'PERSISTENT_EXAMPLE'
   | 'COMPLIANCE_NOTIFICATION_LIST'
   | 'PROJECT_WORKSPACE'
-  | 'PROJECT_AIMS_AND_MILESTONES';
+  | 'PROJECT_AIMS_AND_MILESTONES'
+  | 'PROJECT_OUTPUTS';
 
 export type Flags = Partial<Record<Flag, boolean | string | undefined>>;
 let overrides: Flags = {
@@ -11,6 +12,7 @@ let overrides: Flags = {
   COMPLIANCE_NOTIFICATION_LIST: '',
   PROJECT_WORKSPACE: false,
   PROJECT_AIMS_AND_MILESTONES: false,
+  PROJECT_OUTPUTS: false,
 };
 
 const envDefaults: Record<string, boolean> = {

--- a/packages/react-components/src/templates/ProjectDetailHeader.tsx
+++ b/packages/react-components/src/templates/ProjectDetailHeader.tsx
@@ -131,6 +131,8 @@ type ProjectDetailHeaderProps = ProjectDetail & {
   readonly aboutHref: string;
   readonly workspaceHref?: string;
   readonly milestonesHref: string;
+  readonly outputsHref?: string;
+  readonly draftOutputsHref?: string;
 };
 
 export const getTeamIcon = (project: ProjectDetail) => {
@@ -152,10 +154,17 @@ export const getTeamIcon = (project: ProjectDetail) => {
 type MemberWithHref = ProjectMember & { href: string };
 
 const ProjectDetailHeader = (project: ProjectDetailHeaderProps) => {
-  const { pointOfContactEmail, aboutHref, workspaceHref, milestonesHref } =
-    project;
+  const {
+    pointOfContactEmail,
+    aboutHref,
+    workspaceHref,
+    milestonesHref,
+    outputsHref,
+    draftOutputsHref,
+  } = project;
   const { isEnabled } = useFlags();
   const isProjectMilestonesEnabled = isEnabled('PROJECT_AIMS_AND_MILESTONES');
+  const isProjectOutputsEnabled = isEnabled('PROJECT_OUTPUTS');
 
   const membersWithHref =
     'members' in project
@@ -186,6 +195,12 @@ const ProjectDetailHeader = (project: ProjectDetailHeaderProps) => {
               )}
               {isEnabled('PROJECT_WORKSPACE') && workspaceHref ? (
                 <TabLink href={workspaceHref}>Workspace</TabLink>
+              ) : null}
+              {isProjectOutputsEnabled && outputsHref ? (
+                <TabLink href={outputsHref}>Outputs</TabLink>
+              ) : null}
+              {isProjectOutputsEnabled && draftOutputsHref ? (
+                <TabLink href={draftOutputsHref}>Draft Outputs</TabLink>
               ) : null}
             </TabNav>
           }

--- a/packages/react-components/src/templates/ProjectDetailPage.tsx
+++ b/packages/react-components/src/templates/ProjectDetailPage.tsx
@@ -7,6 +7,8 @@ type ProjectDetailPageProps = ProjectDetail & {
   readonly aboutHref: string;
   readonly workspaceHref?: string;
   readonly milestonesHref: string;
+  readonly outputsHref?: string;
+  readonly draftOutputsHref?: string;
   readonly children?: React.ReactNode;
 };
 
@@ -16,6 +18,8 @@ const ProjectDetailPage: React.FC<ProjectDetailPageProps> = ({
   workspaceHref,
   pointOfContactEmail,
   milestonesHref,
+  outputsHref,
+  draftOutputsHref,
   ...project
 }) => (
   <article>
@@ -25,6 +29,8 @@ const ProjectDetailPage: React.FC<ProjectDetailPageProps> = ({
       aboutHref={aboutHref}
       workspaceHref={workspaceHref}
       milestonesHref={milestonesHref}
+      outputsHref={outputsHref}
+      draftOutputsHref={draftOutputsHref}
     />
     <PageConstraints as="main">{children}</PageConstraints>
   </article>

--- a/packages/react-components/src/templates/__tests__/ProjectDetailHeader.test.tsx
+++ b/packages/react-components/src/templates/__tests__/ProjectDetailHeader.test.tsx
@@ -746,4 +746,84 @@ describe('ProjectDetailHeader', () => {
       expect(screen.queryByText('Workspace')).not.toBeInTheDocument();
     });
   });
+
+  describe('Outputs tab', () => {
+    it('renders Outputs tab when flag is enabled and outputsHref is provided', () => {
+      mockIsEnabled.mockReturnValue(true);
+      render(
+        <ProjectDetailHeader
+          {...mockDiscoveryProject}
+          aboutHref="/projects/discovery/1/about"
+          milestonesHref="/projects/discovery/1/milestones"
+          outputsHref="/projects/discovery/1/outputs"
+        />,
+      );
+      expect(screen.getByText('Outputs')).toBeInTheDocument();
+    });
+
+    it('does not render Outputs tab when flag is disabled', () => {
+      mockIsEnabled.mockReturnValue(false);
+      render(
+        <ProjectDetailHeader
+          {...mockDiscoveryProject}
+          aboutHref="/projects/discovery/1/about"
+          milestonesHref="/projects/discovery/1/milestones"
+          outputsHref="/projects/discovery/1/outputs"
+        />,
+      );
+      expect(screen.queryByText('Outputs')).not.toBeInTheDocument();
+    });
+
+    it('does not render Outputs tab when outputsHref is not provided', () => {
+      mockIsEnabled.mockReturnValue(true);
+      render(
+        <ProjectDetailHeader
+          {...mockDiscoveryProject}
+          aboutHref="/projects/discovery/1/about"
+          milestonesHref="/projects/discovery/1/milestones"
+        />,
+      );
+      expect(screen.queryByText('Outputs')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Draft Outputs tab', () => {
+    it('renders Draft Outputs tab when flag is enabled and draftOutputsHref is provided', () => {
+      mockIsEnabled.mockReturnValue(true);
+      render(
+        <ProjectDetailHeader
+          {...mockDiscoveryProject}
+          aboutHref="/projects/discovery/1/about"
+          milestonesHref="/projects/discovery/1/milestones"
+          draftOutputsHref="/projects/discovery/1/draft-outputs"
+        />,
+      );
+      expect(screen.getByText('Draft Outputs')).toBeInTheDocument();
+    });
+
+    it('does not render Draft Outputs tab when flag is disabled', () => {
+      mockIsEnabled.mockReturnValue(false);
+      render(
+        <ProjectDetailHeader
+          {...mockDiscoveryProject}
+          aboutHref="/projects/discovery/1/about"
+          milestonesHref="/projects/discovery/1/milestones"
+          draftOutputsHref="/projects/discovery/1/draft-outputs"
+        />,
+      );
+      expect(screen.queryByText('Draft Outputs')).not.toBeInTheDocument();
+    });
+
+    it('does not render Draft Outputs tab when draftOutputsHref is not provided', () => {
+      mockIsEnabled.mockReturnValue(true);
+      render(
+        <ProjectDetailHeader
+          {...mockDiscoveryProject}
+          aboutHref="/projects/discovery/1/about"
+          milestonesHref="/projects/discovery/1/milestones"
+        />,
+      );
+      expect(screen.queryByText('Draft Outputs')).not.toBeInTheDocument();
+    });
+  });
 });

--- a/packages/react-components/src/templates/__tests__/ProjectDetailPage.test.tsx
+++ b/packages/react-components/src/templates/__tests__/ProjectDetailPage.test.tsx
@@ -167,4 +167,41 @@ describe('ProjectDetailPage', () => {
     const milestonesLink = screen.getByRole('link', { name: 'Milestones' });
     expect(milestonesLink).toHaveAttribute('href', '/projects/1/milestones');
   });
+
+  it('passes outputsHref to ProjectDetailHeader', () => {
+    render(
+      <ProjectDetailPage
+        {...mockProject}
+        aboutHref="/projects/1/about"
+        milestonesHref="/projects/1/milestones"
+        outputsHref="/projects/1/outputs"
+      >
+        <div>Test Content</div>
+      </ProjectDetailPage>,
+    );
+
+    const outputsLink = screen.getByRole('link', { name: 'Outputs' });
+    expect(outputsLink).toHaveAttribute('href', '/projects/1/outputs');
+  });
+
+  it('passes draftOutputsHref to ProjectDetailHeader', () => {
+    render(
+      <ProjectDetailPage
+        {...mockProject}
+        aboutHref="/projects/1/about"
+        milestonesHref="/projects/1/milestones"
+        draftOutputsHref="/projects/1/draft-outputs"
+      >
+        <div>Test Content</div>
+      </ProjectDetailPage>,
+    );
+
+    const draftOutputsLink = screen.getByRole('link', {
+      name: 'Draft Outputs',
+    });
+    expect(draftOutputsLink).toHaveAttribute(
+      'href',
+      '/projects/1/draft-outputs',
+    );
+  });
 });

--- a/packages/routing/src/projects.ts
+++ b/packages/routing/src/projects.ts
@@ -32,11 +32,13 @@ const createProjectRoute = () => {
     },
   );
   const milestones = route('/milestones', {}, {});
+  const outputs = route('/outputs', {}, {});
+  const draftOutputs = route('/draft-outputs', {}, {});
 
   return route(
     '/:projectId',
     { projectId: stringParser },
-    { about, workspace, milestones },
+    { about, workspace, milestones, outputs, draftOutputs },
   );
 };
 


### PR DESCRIPTION
## Summary                                               

Adds Outputs and Draft Outputs tabs to the Project Detail page (all project   
types), behind the `PROJECT_OUTPUTS` feature flag. Both tabs render an empty state
page. List components come in the next ticket.

https://github.com/user-attachments/assets/6d1b51e5-ab37-4e68-b968-ff60cab50829

https://github.com/user-attachments/assets/6b1b3973-7ae5-4620-a31f-3a58c9ff6f12


