### PR TITLE
CI caching optimizations (DO NOT MERGE - testing only)

### DIFF
--- a/.github/actions/cache-build/action.yml
+++ b/.github/actions/cache-build/action.yml
@@ -16,7 +16,7 @@ runs:
       with:
         environment-name: ${{ inputs.environment-name }}
     - name: Cache
-      uses: actions/cache@v3
+      uses: actions/cache@v5
       with:
         path: |
           apps/**/build*

--- a/.github/actions/cache-unplugged/action.yml
+++ b/.github/actions/cache-unplugged/action.yml
@@ -7,8 +7,10 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/cache@v3
+    - uses: actions/cache@v5
       with:
         path: |
           .yarn/unplugged/
-        key: rebuild-output-${{ inputs.environment-name }}-${{ github.sha }}
+        key: rebuild-output-${{ inputs.environment-name }}-${{ hashFiles('yarn.lock') }}
+        restore-keys: |
+          rebuild-output-${{ inputs.environment-name }}-

--- a/.github/workflows/on-demand-contentful-restore.yml
+++ b/.github/workflows/on-demand-contentful-restore.yml
@@ -36,7 +36,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Setup
         id: setup
         uses: ./.github/actions/setup-environment

--- a/.github/workflows/on-demand-crn-algolia-sync.yml
+++ b/.github/workflows/on-demand-crn-algolia-sync.yml
@@ -57,7 +57,7 @@ jobs:
     if: ${{ failure() && github.event.inputs.environment-name=='Production' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - uses: ./.github/actions/slack/
         with:
           message: CRN Algolia Prod Sync

--- a/.github/workflows/on-demand-export-tags-utilisation.yml
+++ b/.github/workflows/on-demand-export-tags-utilisation.yml
@@ -29,7 +29,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Setup
         id: setup
         uses: ./.github/actions/setup-environment

--- a/.github/workflows/on-demand-gp2-algolia-sync.yml
+++ b/.github/workflows/on-demand-gp2-algolia-sync.yml
@@ -52,7 +52,7 @@ jobs:
     if: ${{ failure() && github.event.inputs.environment-name=='Production' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - uses: ./.github/actions/slack/
         with:
           message: GP2 Algolia Prod Sync

--- a/.github/workflows/on-demand-migrate-external-tools-to-projects.yml
+++ b/.github/workflows/on-demand-migrate-external-tools-to-projects.yml
@@ -26,7 +26,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Setup
         id: setup
         uses: ./.github/actions/setup-environment
@@ -46,7 +46,7 @@ jobs:
     if: ${{ failure() && inputs.environment-name=='Production' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - uses: ./.github/actions/slack/
         with:
           message: External tools to projects migration failed

--- a/.github/workflows/on-demand-migrate-impact-categories.yml
+++ b/.github/workflows/on-demand-migrate-impact-categories.yml
@@ -13,7 +13,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Setup
         id: setup
         uses: ./.github/actions/setup-environment
@@ -33,7 +33,7 @@ jobs:
     if: ${{ failure() }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - uses: ./.github/actions/slack/
         with:
           message: Impact and categories migration failed

--- a/.github/workflows/on-demand-migrate-preprint-versions.yml
+++ b/.github/workflows/on-demand-migrate-preprint-versions.yml
@@ -13,7 +13,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Setup
         id: setup
         uses: ./.github/actions/setup-environment
@@ -33,7 +33,7 @@ jobs:
     if: ${{ failure() }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - uses: ./.github/actions/slack/
         with:
           message: Migrate preprint versions failed

--- a/.github/workflows/on-demand-migrate-projects.yml
+++ b/.github/workflows/on-demand-migrate-projects.yml
@@ -26,7 +26,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Setup
         id: setup
         uses: ./.github/actions/setup-environment
@@ -46,7 +46,7 @@ jobs:
     if: ${{ failure() && inputs.environment-name=='Production' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - uses: ./.github/actions/slack/
         with:
           message: Projects migration failed

--- a/.github/workflows/on-demand-migrate-user-labs-rollback.yml
+++ b/.github/workflows/on-demand-migrate-user-labs-rollback.yml
@@ -26,7 +26,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Setup
         id: setup
         uses: ./.github/actions/setup-environment
@@ -46,7 +46,7 @@ jobs:
     if: ${{ failure() && inputs.environment-name=='Production' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - uses: ./.github/actions/slack/
         with:
           message: Migrate user labs rollback failed

--- a/.github/workflows/on-demand-migrate-user-labs.yml
+++ b/.github/workflows/on-demand-migrate-user-labs.yml
@@ -26,7 +26,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Setup
         id: setup
         uses: ./.github/actions/setup-environment
@@ -46,7 +46,7 @@ jobs:
     if: ${{ failure() && inputs.environment-name=='Production' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - uses: ./.github/actions/slack/
         with:
           message: Migrate user labs failed

--- a/.github/workflows/on-demand-publish-team-entities.yml
+++ b/.github/workflows/on-demand-publish-team-entities.yml
@@ -45,7 +45,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Setup
         id: setup

--- a/.github/workflows/on-demand-rollback-contentful-migration.yml
+++ b/.github/workflows/on-demand-rollback-contentful-migration.yml
@@ -42,7 +42,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Setup
         id: setup
         uses: ./.github/actions/setup-environment
@@ -76,7 +76,7 @@ jobs:
     if: ${{ failure() && inputs.environment-name=='Production' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - uses: ./.github/actions/slack/
         with:
           message: Rollback last Contentful migration failed

--- a/.github/workflows/on-demand-rollback-privacy-policy.yml
+++ b/.github/workflows/on-demand-rollback-privacy-policy.yml
@@ -33,7 +33,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Setup
         id: setup
         uses: ./.github/actions/setup-environment
@@ -59,7 +59,7 @@ jobs:
     if: ${{ failure() && inputs.environment-name=='Production' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - uses: ./.github/actions/slack/
         with:
           message: Rollback Privacy Policy failed

--- a/.github/workflows/on-demand-transform-privacy-policy.yml
+++ b/.github/workflows/on-demand-transform-privacy-policy.yml
@@ -33,7 +33,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Setup
         id: setup
         uses: ./.github/actions/setup-environment
@@ -59,7 +59,7 @@ jobs:
     if: ${{ failure() && inputs.environment-name=='Production' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - uses: ./.github/actions/slack/
         with:
           message: Transform Privacy Policy failed

--- a/.github/workflows/on-push-app-extensions.yml
+++ b/.github/workflows/on-push-app-extensions.yml
@@ -17,7 +17,7 @@ jobs:
       GIT_DIFF: ${{ steps.diff.outputs.diff }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Re-Build
         uses: ./.github/actions/build-rebuild
       - name: Cache build typecheck output
@@ -47,7 +47,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Run contentful app extension tests
         run: yarn workspaces foreach -j 2 --include "*/contentful-app-*" -vp run test:no-watch
 
@@ -83,7 +83,7 @@ jobs:
           - project-membership-role
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Setup
         id: setup
         uses: ./.github/actions/setup-environment

--- a/.github/workflows/on-push-branch.yml
+++ b/.github/workflows/on-push-branch.yml
@@ -23,7 +23,7 @@ jobs:
       gp2-contentful-limit-reached: ${{ steps.get-gp2-contentful-state.outputs.contentful-limit-reached }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Setup
         id: setup
         uses: ./.github/actions/setup-environment
@@ -159,7 +159,7 @@ jobs:
     steps:
       - name: Checkout
         if: ${{ success() }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Setup
         id: setup
         uses: ./.github/actions/setup-environment

--- a/.github/workflows/on-push-master.yml
+++ b/.github/workflows/on-push-master.yml
@@ -242,7 +242,7 @@ jobs:
     if: failure()
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - uses: ./.github/actions/slack/
         with:
           message: 'Build failed on master branch!'
@@ -258,7 +258,7 @@ jobs:
       url: ${{ steps.setup.outputs.crn-app-url }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Setup
         id: setup
         uses: ./.github/actions/setup-environment

--- a/.github/workflows/on-remove.yml
+++ b/.github/workflows/on-remove.yml
@@ -29,7 +29,7 @@ jobs:
     environment: Branch
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Setup
         id: setup
         uses: ./.github/actions/setup-environment
@@ -66,7 +66,7 @@ jobs:
     environment: Branch
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Setup
         id: setup
         uses: ./.github/actions/setup-environment
@@ -103,7 +103,7 @@ jobs:
     environment: Branch
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Check PR number
         if: ${{ github.event.inputs.pr-number }}
         uses: ./.github/actions/is-number
@@ -144,7 +144,7 @@ jobs:
     environment: Branch
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Check PR number
         if: ${{ github.event.inputs.pr-number }}
         uses: ./.github/actions/is-number
@@ -184,7 +184,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Re-Build
         uses: ./.github/actions/build-rebuild
       - name: Cache build typecheck output
@@ -232,7 +232,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Re-Build
         uses: ./.github/actions/build-rebuild
       - name: Cache build typecheck output
@@ -284,7 +284,7 @@ jobs:
     if: ${{ failure() && (github.event.inputs.pr-number || github.event.pull_request.head.repo.full_name == 'yldio/asap-hub') }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - uses: ./.github/actions/slack/
         with:
           message: Environment teardown

--- a/.github/workflows/on-schedule-backup-dev.yml
+++ b/.github/workflows/on-schedule-backup-dev.yml
@@ -14,7 +14,7 @@ jobs:
     environment: Development
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Re-Build
         uses: ./.github/actions/build-rebuild
       - name: Cache build typecheck output
@@ -50,7 +50,7 @@ jobs:
     environment: Development
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Setup
         id: setup
         uses: ./.github/actions/setup-environment

--- a/.github/workflows/on-schedule-backup-prod.yml
+++ b/.github/workflows/on-schedule-backup-prod.yml
@@ -14,7 +14,7 @@ jobs:
     environment: Production
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Re-Build
         uses: ./.github/actions/build-rebuild
       - name: Cache build typecheck output
@@ -50,7 +50,7 @@ jobs:
     environment: Production
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Setup
         id: setup
         uses: ./.github/actions/setup-environment

--- a/.github/workflows/reusable-build-analysis.yml
+++ b/.github/workflows/reusable-build-analysis.yml
@@ -28,7 +28,7 @@ jobs:
       CI_REPO_OWNER: ${{ github.repository_owner }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Setup
         id: setup
         uses: ./.github/actions/setup-environment
@@ -54,7 +54,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Setup
         id: setup
         uses: ./.github/actions/setup-environment

--- a/.github/workflows/reusable-build-images.yml
+++ b/.github/workflows/reusable-build-images.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
         with:

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -81,7 +81,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Re-Build
         uses: ./.github/actions/build-rebuild
       - name: Cache build output
@@ -99,14 +99,14 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Setup
         id: setup
         uses: ./.github/actions/setup-environment
         with:
           environment-name: ${{ inputs.environment-name }}
       - name: Cache turbo build setup
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: .turbo
           key: ${{ runner.os }}-turbo-transpile-${{ github.sha }}
@@ -137,14 +137,14 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Setup
         id: setup
         uses: ./.github/actions/setup-environment
         with:
           environment-name: ${{ inputs.environment-name }}
       - name: Cache turbo build setup
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: .turbo
           key: ${{ runner.os }}-turbo-definitions-${{ github.sha }}
@@ -173,7 +173,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Setup
         id: setup
         uses: ./.github/actions/setup-environment
@@ -198,7 +198,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-default-region: ${{ steps.setup.outputs.aws-default-region }}
       - name: Cache turbo build setup
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: .turbo
           key: ${{ runner.os }}-turbo-frontend-${{ github.sha }}
@@ -271,14 +271,14 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Setup
         id: setup
         uses: ./.github/actions/setup-environment
         with:
           environment-name: ${{ inputs.environment-name }}
       - name: Cache turbo build setup
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: .turbo
           key: ${{ runner.os }}-turbo-typecheck-${{ github.sha }}
@@ -308,7 +308,7 @@ jobs:
     environment: ${{ inputs.environment-name }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Setup
         id: setup
         uses: ./.github/actions/setup-environment
@@ -357,7 +357,7 @@ jobs:
     environment: ${{ inputs.environment-name }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Setup
         id: setup
         uses: ./.github/actions/setup-environment

--- a/.github/workflows/reusable-compliance-sheet-sync.yml
+++ b/.github/workflows/reusable-compliance-sheet-sync.yml
@@ -27,7 +27,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Setup
         id: setup
         uses: ./.github/actions/setup-environment
@@ -73,7 +73,7 @@ jobs:
     if: ${{ failure()}}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - uses: ./.github/actions/slack/
         with:
           message: Compliance Sheet Sync

--- a/.github/workflows/reusable-create-environment.yml
+++ b/.github/workflows/reusable-create-environment.yml
@@ -58,7 +58,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Setup
         id: setup
         uses: ./.github/actions/setup-environment
@@ -85,7 +85,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Setup
         id: setup
         uses: ./.github/actions/setup-environment
@@ -111,7 +111,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Install Algolia CLI
         uses: algolia/setup-algolia-cli@master
         with:
@@ -175,7 +175,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Install Algolia CLI
         uses: algolia/setup-algolia-cli@master
         with:

--- a/.github/workflows/reusable-crn-algolia-sync.yml
+++ b/.github/workflows/reusable-crn-algolia-sync.yml
@@ -50,7 +50,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Re-Build
         uses: ./.github/actions/build-rebuild
       - name: Cache build typecheck output

--- a/.github/workflows/reusable-crn-opensearch-sync.yml
+++ b/.github/workflows/reusable-crn-opensearch-sync.yml
@@ -46,7 +46,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Setup
         id: setup
         uses: ./.github/actions/setup-environment
@@ -104,7 +104,7 @@ jobs:
     if: ${{ failure() && inputs.environment-name=='Production' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - uses: ./.github/actions/slack/
         with:
           message: Opensearch Analytics Sync

--- a/.github/workflows/reusable-deployment.yml
+++ b/.github/workflows/reusable-deployment.yml
@@ -97,7 +97,7 @@ jobs:
       url: ${{ steps.setup.outputs.crn-app-url }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Setup
         id: setup
         uses: ./.github/actions/setup-environment
@@ -151,7 +151,7 @@ jobs:
       url: ${{ steps.setup.outputs.app-url }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Setup
         id: setup
         uses: ./.github/actions/setup-environment
@@ -201,7 +201,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Cache build typecheck output
         uses: ./.github/actions/cache-unplugged
         with:
@@ -244,7 +244,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Cache build typecheck output
         uses: ./.github/actions/cache-unplugged
         with:
@@ -289,7 +289,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Setup
         id: setup
         uses: ./.github/actions/setup-environment
@@ -319,7 +319,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Setup
         id: setup
         uses: ./.github/actions/setup-environment
@@ -346,7 +346,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Setup
         id: setup
         uses: ./.github/actions/setup-environment
@@ -376,7 +376,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Setup
         id: setup
         uses: ./.github/actions/setup-environment
@@ -401,7 +401,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Setup
         id: setup
         uses: ./.github/actions/setup-environment
@@ -438,7 +438,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Setup
         id: setup
         uses: ./.github/actions/setup-environment
@@ -522,7 +522,7 @@ jobs:
       name: ${{ inputs.environment-name }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Push templates to Postmark
         uses: ./.github/actions/push-postmark-templates
         with:

--- a/.github/workflows/reusable-gp2-algolia-sync.yml
+++ b/.github/workflows/reusable-gp2-algolia-sync.yml
@@ -49,7 +49,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Re-Build
         uses: ./.github/actions/build-rebuild
       - name: Cache build typecheck output

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -34,7 +34,7 @@ jobs:
         script: [constraints, 'lint:format', 'check:packages']
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Re-Build
         uses: ./.github/actions/build-rebuild
       - name: Cache build typecheck output
@@ -53,7 +53,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Run contentful app extension tests
         run: yarn workspaces foreach --include "*/contentful-app-*" -v run test:no-watch
   setup-turbo:
@@ -68,7 +68,7 @@ jobs:
       matrix: ${{ steps.setup.outputs.matrix }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Re-Build
         uses: ./.github/actions/build-rebuild
       - name: Setup turborepo test pipeline
@@ -92,7 +92,7 @@ jobs:
       matrix: ${{ fromJson(needs.setup-turbo.outputs.matrix) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
       - name: Re-Build
@@ -107,7 +107,7 @@ jobs:
             echo "suffix=" >> $GITHUB_OUTPUT
           fi
       - name: Cache .turbo and jest cache
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: |
             .turbo
@@ -154,7 +154,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [unit]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - uses: actions/download-artifact@v4
         with:
           path: coverage
@@ -183,16 +183,23 @@ jobs:
   linting:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - name: Re-Build
         uses: ./.github/actions/build-rebuild
       - name: Cache build typecheck output
         uses: ./.github/actions/cache-unplugged
         with:
           environment-name: ${{ inputs.environment-name }}
+      - name: Cache turbo for typecheck
+        uses: actions/cache@v5
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-lint-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-lint-
       - name: Build type definitions
         shell: bash
-        run: yarn build:typecheck
+        run: yarn build:typecheck --cache-dir=.turbo
       - name: lint
         run: yarn lint
 
@@ -202,7 +209,7 @@ jobs:
     if: ${{ inputs.environment-name == 'Branch' }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Run copy-paste detection
@@ -222,7 +229,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Setup
         id: setup
         uses: ./.github/actions/setup-environment
@@ -263,7 +270,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Validate
         uses: rinchsan/renovate-config-validator@v0.0.12
         with:

--- a/.github/workflows/reusable-verify.yml
+++ b/.github/workflows/reusable-verify.yml
@@ -37,7 +37,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Cache build typecheck output
         uses: ./.github/actions/cache-unplugged
         with:
@@ -67,7 +67,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Cache build typecheck output
         uses: ./.github/actions/cache-unplugged
         with:
@@ -100,7 +100,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Setup
         id: setup
         uses: ./.github/actions/setup-environment

--- a/turbo.json
+++ b/turbo.json
@@ -9,8 +9,7 @@
       "outputs": [
         "{apps,packages}/**/build/**/*.d.ts",
         "{apps,packages}/**/*.tsbuildinfo"
-      ],
-      "cache": false
+      ]
     },
     "topo": {
       "dependsOn": ["^topo"]


### PR DESCRIPTION
> **DO NOT MERGE** — This PR is for measuring CI performance impact only. Will be closed after collecting before/after metrics.

## Summary

Four changes to improve CI cache hit rates. Currently several caches are misconfigured and never reuse across commits or PRs.

## Results:

| Job | Run 1 (cold) | Run 2 (warm) | Run 3 (warm) | Run 4 (warm) | Avg delta |       
|-----|-------------|--------------|--------------|--------------|-----------|
| `linting` | 228s | 153s | 141s | 141s | **-82s (-36%)** |                           
| `build / typecheck` | 57s | 42s | 62s | 46s | -7s (-12%) |                        
| `build / definitions` | 125s | 110s | 123s | 120s | -7s (-6%) |                     
| `build / transpile` | 61s | 96s | 60s | 61s | ~0 (noise) |
| `build / rebuild` | 47s | 77s | 46s | 48s | ~0 (noise) |
