### PR TITLE
[ASAP-1433] - Create Project Output List component

### DIFF
--- a/apps/crn-frontend/src/projects/ProjectDetail.tsx
+++ b/apps/crn-frontend/src/projects/ProjectDetail.tsx
@@ -14,6 +14,10 @@ import { ManuscriptToastProvider } from '../network/teams/ManuscriptToastProvide
 import { EligibilityReasonProvider } from '../network/teams/EligibilityReasonProvider';
 import ProjectWorkspace from './ProjectWorkspace';
 import ProjectOutputs from './ProjectOutputs';
+import {
+  createProjectDraftOutputsMock,
+  createProjectOutputsMock,
+} from './projectOutputs.mock';
 import type { ProjectDetailConfig } from './projectDetailConfig';
 
 const loadProjectManuscript = () =>
@@ -163,6 +167,22 @@ const ProjectDetail: FC<Props> = ({ config }) => {
                   draftOutputsHref={
                     isProjectOutputsEnabled
                       ? route.draftOutputs({}).$
+                      : undefined
+                  }
+                  outputsCount={
+                    isProjectOutputsEnabled
+                      ? createProjectOutputsMock(
+                          projectId,
+                          projectDetail.title || '',
+                        ).length
+                      : undefined
+                  }
+                  draftOutputsCount={
+                    isProjectOutputsEnabled
+                      ? createProjectDraftOutputsMock(
+                          projectId,
+                          projectDetail.title || '',
+                        ).length
                       : undefined
                   }
                 >

--- a/apps/crn-frontend/src/projects/ProjectDetail.tsx
+++ b/apps/crn-frontend/src/projects/ProjectDetail.tsx
@@ -6,7 +6,6 @@ import {
   ProjectDetailPage,
   ProjectDetailAbout,
   NotFoundPage,
-  NoOutputsPage,
 } from '@asap-hub/react-components';
 import { useCurrentUserCRN, useFlags } from '@asap-hub/react-context';
 import { useProjectArticlesSuggestions, useProjectById } from './state';
@@ -14,6 +13,7 @@ import { useFetchAimArticles } from './articles-state';
 import { ManuscriptToastProvider } from '../network/teams/ManuscriptToastProvider';
 import { EligibilityReasonProvider } from '../network/teams/EligibilityReasonProvider';
 import ProjectWorkspace from './ProjectWorkspace';
+import ProjectOutputs from './ProjectOutputs';
 import type { ProjectDetailConfig } from './projectDetailConfig';
 
 const loadProjectManuscript = () =>
@@ -257,10 +257,9 @@ const ProjectDetail: FC<Props> = ({ config }) => {
                       element={
                         isProjectOutputsEnabled ? (
                           <Frame title="Project Outputs">
-                            <NoOutputsPage
-                              title="No outputs available."
-                              description="When this project shares an output, it will be listed here."
-                              hideExploreButton
+                            <ProjectOutputs
+                              projectId={projectId}
+                              projectTitle={projectDetail.title || ''}
                             />
                           </Frame>
                         ) : (
@@ -273,10 +272,10 @@ const ProjectDetail: FC<Props> = ({ config }) => {
                       element={
                         isProjectOutputsEnabled ? (
                           <Frame title="Project Draft Outputs">
-                            <NoOutputsPage
-                              title="No draft outputs available."
-                              description="When this project shares a draft output, it will be listed here."
-                              hideExploreButton
+                            <ProjectOutputs
+                              projectId={projectId}
+                              projectTitle={projectDetail.title || ''}
+                              draftOutputs
                             />
                           </Frame>
                         ) : (

--- a/apps/crn-frontend/src/projects/ProjectOutputs.tsx
+++ b/apps/crn-frontend/src/projects/ProjectOutputs.tsx
@@ -65,7 +65,7 @@ const ProjectOutputs: React.FC<ProjectOutputsProps> = ({
       isListView={isListView}
       cardViewHref={location.pathname + cardViewParams}
       listViewHref={location.pathname + listViewParams}
-      exportResults={() => Promise.resolve()}
+      exportResults={/* istanbul ignore next */ () => Promise.resolve()}
       showTags
     />
   );

--- a/apps/crn-frontend/src/projects/ProjectOutputs.tsx
+++ b/apps/crn-frontend/src/projects/ProjectOutputs.tsx
@@ -1,0 +1,76 @@
+import { useMemo } from 'react';
+import { useLocation } from 'react-router';
+import {
+  NoOutputsPage,
+  ProjectOutputList,
+} from '@asap-hub/react-components';
+
+import { usePagination, usePaginationParams } from '../hooks';
+import {
+  createProjectOutputsMock,
+  createProjectDraftOutputsMock,
+} from './projectOutputs.mock';
+
+type ProjectOutputsProps = {
+  projectId: string;
+  projectTitle: string;
+  draftOutputs?: boolean;
+};
+
+const ProjectOutputs: React.FC<ProjectOutputsProps> = ({
+  projectId,
+  projectTitle,
+  draftOutputs = false,
+}) => {
+  const location = useLocation();
+  const { currentPage, pageSize, isListView, cardViewParams, listViewParams } =
+    usePaginationParams();
+
+  const researchOutputs = useMemo(
+    () =>
+      draftOutputs
+        ? createProjectDraftOutputsMock(projectId, projectTitle)
+        : createProjectOutputsMock(projectId, projectTitle),
+    [projectId, projectTitle, draftOutputs],
+  );
+
+  const total = researchOutputs.length;
+  const { numberOfPages, renderPageHref } = usePagination(total, pageSize);
+
+  if (total === 0) {
+    return (
+      <NoOutputsPage
+        title={
+          draftOutputs ? 'No draft outputs available.' : 'No outputs available.'
+        }
+        description={
+          draftOutputs
+            ? 'When this project shares a draft output, it will be listed here.'
+            : 'When this project shares an output, it will be listed here.'
+        }
+        hideExploreButton
+      />
+    );
+  }
+
+  const pageItems = researchOutputs.slice(
+    currentPage * pageSize,
+    currentPage * pageSize + pageSize,
+  );
+
+  return (
+    <ProjectOutputList
+      researchOutputs={pageItems}
+      numberOfItems={total}
+      numberOfPages={numberOfPages}
+      currentPageIndex={currentPage}
+      renderPageHref={renderPageHref}
+      isListView={isListView}
+      cardViewHref={location.pathname + cardViewParams}
+      listViewHref={location.pathname + listViewParams}
+      showTags
+    />
+  );
+};
+
+export default ProjectOutputs;

--- a/apps/crn-frontend/src/projects/ProjectOutputs.tsx
+++ b/apps/crn-frontend/src/projects/ProjectOutputs.tsx
@@ -68,6 +68,7 @@ const ProjectOutputs: React.FC<ProjectOutputsProps> = ({
       isListView={isListView}
       cardViewHref={location.pathname + cardViewParams}
       listViewHref={location.pathname + listViewParams}
+      exportResults={() => Promise.resolve()}
       showTags
     />
   );

--- a/apps/crn-frontend/src/projects/ProjectOutputs.tsx
+++ b/apps/crn-frontend/src/projects/ProjectOutputs.tsx
@@ -1,9 +1,6 @@
 import { useMemo } from 'react';
 import { useLocation } from 'react-router';
-import {
-  NoOutputsPage,
-  ProjectOutputList,
-} from '@asap-hub/react-components';
+import { NoOutputsPage, ProjectOutputList } from '@asap-hub/react-components';
 
 import { usePagination, usePaginationParams } from '../hooks';
 import {

--- a/apps/crn-frontend/src/projects/__tests__/ProjectDetail.test.tsx
+++ b/apps/crn-frontend/src/projects/__tests__/ProjectDetail.test.tsx
@@ -618,7 +618,7 @@ describe.each(variants)(
       expect(screen.queryByText('Draft Outputs')).not.toBeInTheDocument();
     });
 
-    it('renders outputs empty state when navigating to outputs route', async () => {
+    it('renders outputs list when navigating to outputs route', async () => {
       enable('PROJECT_OUTPUTS');
       await renderProjectDetail(
         Component,
@@ -628,11 +628,13 @@ describe.each(variants)(
         'outputs',
       );
       expect(
-        await screen.findByText('No outputs available.'),
+        await screen.findByText(
+          /Tracing the Origin and Progression of Parkinson/i,
+        ),
       ).toBeInTheDocument();
     });
 
-    it('renders draft outputs empty state when navigating to draft-outputs route', async () => {
+    it('renders draft outputs list when navigating to draft-outputs route', async () => {
       enable('PROJECT_OUTPUTS');
       await renderProjectDetail(
         Component,
@@ -642,11 +644,11 @@ describe.each(variants)(
         'draft-outputs',
       );
       expect(
-        await screen.findByText('No draft outputs available.'),
+        await screen.findByText(/Draft: Longitudinal cohort analysis/i),
       ).toBeInTheDocument();
     });
 
-    it('does not render outputs empty state when flag is disabled', async () => {
+    it('does not render outputs list when flag is disabled', async () => {
       disable('PROJECT_OUTPUTS');
       await renderProjectDetail(
         Component,
@@ -656,11 +658,13 @@ describe.each(variants)(
         'outputs',
       );
       expect(
-        screen.queryByText('No outputs available.'),
+        screen.queryByText(
+          /Tracing the Origin and Progression of Parkinson/i,
+        ),
       ).not.toBeInTheDocument();
     });
 
-    it('does not render draft outputs empty state when flag is disabled', async () => {
+    it('does not render draft outputs list when flag is disabled', async () => {
       disable('PROJECT_OUTPUTS');
       await renderProjectDetail(
         Component,
@@ -670,7 +674,7 @@ describe.each(variants)(
         'draft-outputs',
       );
       expect(
-        screen.queryByText('No draft outputs available.'),
+        screen.queryByText(/Draft: Longitudinal cohort analysis/i),
       ).not.toBeInTheDocument();
     });
 

--- a/apps/crn-frontend/src/projects/__tests__/ProjectDetail.test.tsx
+++ b/apps/crn-frontend/src/projects/__tests__/ProjectDetail.test.tsx
@@ -599,23 +599,23 @@ describe.each(variants)(
       ).not.toBeInTheDocument();
     });
 
-    it('renders Outputs tab when flag is enabled', async () => {
+    it('renders Outputs tab with count when flag is enabled', async () => {
       enable('PROJECT_OUTPUTS');
       await renderProjectDetail(Component, routeKeyword, mainProjectId);
-      expect(screen.getByText('Outputs')).toBeInTheDocument();
+      expect(screen.getByText(/^Outputs \(\d+\)$/)).toBeInTheDocument();
     });
 
-    it('renders Draft Outputs tab when flag is enabled', async () => {
+    it('renders Draft Outputs tab with count when flag is enabled', async () => {
       enable('PROJECT_OUTPUTS');
       await renderProjectDetail(Component, routeKeyword, mainProjectId);
-      expect(screen.getByText('Draft Outputs')).toBeInTheDocument();
+      expect(screen.getByText(/^Draft Outputs \(\d+\)$/)).toBeInTheDocument();
     });
 
     it('does not render Outputs or Draft Outputs tabs when flag is disabled', async () => {
       disable('PROJECT_OUTPUTS');
       await renderProjectDetail(Component, routeKeyword, mainProjectId);
-      expect(screen.queryByText('Outputs')).not.toBeInTheDocument();
-      expect(screen.queryByText('Draft Outputs')).not.toBeInTheDocument();
+      expect(screen.queryByText(/^Outputs/)).not.toBeInTheDocument();
+      expect(screen.queryByText(/^Draft Outputs/)).not.toBeInTheDocument();
     });
 
     it('renders outputs list when navigating to outputs route', async () => {

--- a/apps/crn-frontend/src/projects/__tests__/ProjectDetail.test.tsx
+++ b/apps/crn-frontend/src/projects/__tests__/ProjectDetail.test.tsx
@@ -658,9 +658,7 @@ describe.each(variants)(
         'outputs',
       );
       expect(
-        screen.queryByText(
-          /Tracing the Origin and Progression of Parkinson/i,
-        ),
+        screen.queryByText(/Tracing the Origin and Progression of Parkinson/i),
       ).not.toBeInTheDocument();
     });
 

--- a/apps/crn-frontend/src/projects/__tests__/ProjectOutputs.test.tsx
+++ b/apps/crn-frontend/src/projects/__tests__/ProjectOutputs.test.tsx
@@ -93,7 +93,14 @@ describe('Draft outputs', () => {
         created: new Date(2024, 0, 1).toISOString(),
         addedDate: new Date(2024, 0, 1).toISOString(),
         source: 'project',
-        projects: [{ id: 'p1', title: 'Project Alpha', href: '/projects/p1' }],
+        projects: [
+          {
+            id: 'p1',
+            title: 'Project Alpha',
+            projectType: 'discovery',
+            href: '/projects/p1',
+          },
+        ],
       },
     ]);
     renderProjectOutputs(true);
@@ -118,7 +125,14 @@ describe('Pagination and view', () => {
     created: new Date(2024, 0, 1).toISOString(),
     addedDate: new Date(2024, 0, 1).toISOString(),
     source: 'project' as const,
-    projects: [{ id: 'p1', title: 'Project Alpha', href: '/projects/p1' }],
+    projects: [
+      {
+        id: 'p1',
+        title: 'Project Alpha',
+        projectType: 'discovery',
+        href: '/projects/p1',
+      },
+    ],
   });
 
   it('paginates outputs into pages of the card page size', () => {

--- a/apps/crn-frontend/src/projects/__tests__/ProjectOutputs.test.tsx
+++ b/apps/crn-frontend/src/projects/__tests__/ProjectOutputs.test.tsx
@@ -18,20 +18,23 @@ const mockedOutputs = createProjectOutputsMock as jest.Mock;
 const mockedDrafts = createProjectDraftOutputsMock as jest.Mock;
 
 const renderProjectOutputs = (
-  draftOutputs = false,
+  draftOutputs?: boolean,
   initialEntries: string[] = ['/'],
 ) => {
   const router = createMemoryRouter(
     [
       {
         path: '*',
-        element: (
-          <ProjectOutputs
-            projectId="p1"
-            projectTitle="Project Alpha"
-            draftOutputs={draftOutputs}
-          />
-        ),
+        element:
+          draftOutputs === undefined ? (
+            <ProjectOutputs projectId="p1" projectTitle="Project Alpha" />
+          ) : (
+            <ProjectOutputs
+              projectId="p1"
+              projectTitle="Project Alpha"
+              draftOutputs={draftOutputs}
+            />
+          ),
       },
     ],
     { initialEntries },
@@ -53,36 +56,13 @@ beforeEach(() => {
 describe('Published outputs', () => {
   it('renders NoOutputsPage when no outputs', () => {
     mockedOutputs.mockReturnValue([]);
-    renderProjectOutputs(false);
+    renderProjectOutputs();
     expect(screen.getByText('No outputs available.')).toBeInTheDocument();
     expect(
       screen.getByText(
         'When this project shares an output, it will be listed here.',
       ),
     ).toBeInTheDocument();
-  });
-
-  it('renders the list when there are outputs', () => {
-    mockedOutputs.mockReturnValue([
-      {
-        id: 'o1',
-        title: 'Example output',
-        documentType: 'Article',
-        type: 'Preprint',
-        authors: [],
-        teams: [],
-        keywords: [],
-        published: true,
-        isInReview: false,
-        created: new Date(2024, 0, 1).toISOString(),
-        addedDate: new Date(2024, 0, 1).toISOString(),
-        source: 'project',
-        projects: [{ id: 'p1', title: 'Project Alpha', href: '/projects/p1' }],
-      },
-    ]);
-    renderProjectOutputs(false);
-    expect(screen.getByText('Example output')).toBeInTheDocument();
-    expect(screen.queryByText('No outputs available.')).not.toBeInTheDocument();
   });
 });
 
@@ -121,5 +101,40 @@ describe('Draft outputs', () => {
     expect(
       screen.queryByText('No draft outputs available.'),
     ).not.toBeInTheDocument();
+  });
+});
+
+describe('Pagination and view', () => {
+  const buildOutput = (i: number) => ({
+    id: `o${i}`,
+    title: `Output ${i}`,
+    documentType: 'Article',
+    type: 'Preprint',
+    authors: [],
+    teams: [],
+    keywords: [],
+    published: true,
+    isInReview: false,
+    created: new Date(2024, 0, 1).toISOString(),
+    addedDate: new Date(2024, 0, 1).toISOString(),
+    source: 'project' as const,
+    projects: [{ id: 'p1', title: 'Project Alpha', href: '/projects/p1' }],
+  });
+
+  it('paginates outputs into pages of the card page size', () => {
+    mockedOutputs.mockReturnValue(
+      Array.from({ length: 15 }, (_, i) => buildOutput(i + 1)),
+    );
+    renderProjectOutputs(false, ['/?currentPage=1']);
+    // Card page size = 10; second page (currentPage=1) shows items 11..15
+    expect(screen.getByText('Output 11')).toBeInTheDocument();
+    expect(screen.queryByText('Output 1')).not.toBeInTheDocument();
+  });
+
+  it('switches to list view when the view URL param is set', () => {
+    mockedOutputs.mockReturnValue([buildOutput(1)]);
+    renderProjectOutputs(false, ['/?view=list']);
+    // List variant wraps each output in a <li>; card variant does not.
+    expect(screen.getByText('Output 1').closest('li')).not.toBeNull();
   });
 });

--- a/apps/crn-frontend/src/projects/__tests__/ProjectOutputs.test.tsx
+++ b/apps/crn-frontend/src/projects/__tests__/ProjectOutputs.test.tsx
@@ -4,16 +4,15 @@ import { render, screen } from '@testing-library/react';
 import { RecoilRoot } from 'recoil';
 
 import ProjectOutputs from '../ProjectOutputs';
+import {
+  createProjectOutputsMock,
+  createProjectDraftOutputsMock,
+} from '../projectOutputs.mock';
 
 jest.mock('../projectOutputs.mock', () => ({
   createProjectOutputsMock: jest.fn(),
   createProjectDraftOutputsMock: jest.fn(),
 }));
-
-import {
-  createProjectOutputsMock,
-  createProjectDraftOutputsMock,
-} from '../projectOutputs.mock';
 
 const mockedOutputs = createProjectOutputsMock as jest.Mock;
 const mockedDrafts = createProjectDraftOutputsMock as jest.Mock;

--- a/apps/crn-frontend/src/projects/__tests__/ProjectOutputs.test.tsx
+++ b/apps/crn-frontend/src/projects/__tests__/ProjectOutputs.test.tsx
@@ -1,0 +1,126 @@
+import { Suspense } from 'react';
+import { createMemoryRouter, RouterProvider } from 'react-router';
+import { render, screen } from '@testing-library/react';
+import { RecoilRoot } from 'recoil';
+
+import ProjectOutputs from '../ProjectOutputs';
+
+jest.mock('../projectOutputs.mock', () => ({
+  createProjectOutputsMock: jest.fn(),
+  createProjectDraftOutputsMock: jest.fn(),
+}));
+
+import {
+  createProjectOutputsMock,
+  createProjectDraftOutputsMock,
+} from '../projectOutputs.mock';
+
+const mockedOutputs = createProjectOutputsMock as jest.Mock;
+const mockedDrafts = createProjectDraftOutputsMock as jest.Mock;
+
+const renderProjectOutputs = (
+  draftOutputs = false,
+  initialEntries: string[] = ['/'],
+) => {
+  const router = createMemoryRouter(
+    [
+      {
+        path: '*',
+        element: (
+          <ProjectOutputs
+            projectId="p1"
+            projectTitle="Project Alpha"
+            draftOutputs={draftOutputs}
+          />
+        ),
+      },
+    ],
+    { initialEntries },
+  );
+  return render(
+    <RecoilRoot>
+      <Suspense fallback={null}>
+        <RouterProvider router={router} />
+      </Suspense>
+    </RecoilRoot>,
+  );
+};
+
+beforeEach(() => {
+  mockedOutputs.mockReset();
+  mockedDrafts.mockReset();
+});
+
+describe('Published outputs', () => {
+  it('renders NoOutputsPage when no outputs', () => {
+    mockedOutputs.mockReturnValue([]);
+    renderProjectOutputs(false);
+    expect(screen.getByText('No outputs available.')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'When this project shares an output, it will be listed here.',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the list when there are outputs', () => {
+    mockedOutputs.mockReturnValue([
+      {
+        id: 'o1',
+        title: 'Example output',
+        documentType: 'Article',
+        type: 'Preprint',
+        authors: [],
+        teams: [],
+        keywords: [],
+        published: true,
+        isInReview: false,
+        created: new Date(2024, 0, 1).toISOString(),
+        addedDate: new Date(2024, 0, 1).toISOString(),
+        source: 'project',
+        projects: [{ id: 'p1', title: 'Project Alpha', href: '/projects/p1' }],
+      },
+    ]);
+    renderProjectOutputs(false);
+    expect(screen.getByText('Example output')).toBeInTheDocument();
+    expect(screen.queryByText('No outputs available.')).not.toBeInTheDocument();
+  });
+});
+
+describe('Draft outputs', () => {
+  it('renders NoOutputsPage with draft copy when no drafts', () => {
+    mockedDrafts.mockReturnValue([]);
+    renderProjectOutputs(true);
+    expect(screen.getByText('No draft outputs available.')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'When this project shares a draft output, it will be listed here.',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the list when there are draft outputs', () => {
+    mockedDrafts.mockReturnValue([
+      {
+        id: 'd1',
+        title: 'Example draft',
+        documentType: 'Article',
+        type: 'Preprint',
+        authors: [],
+        teams: [],
+        keywords: [],
+        published: false,
+        isInReview: false,
+        created: new Date(2024, 0, 1).toISOString(),
+        addedDate: new Date(2024, 0, 1).toISOString(),
+        source: 'project',
+        projects: [{ id: 'p1', title: 'Project Alpha', href: '/projects/p1' }],
+      },
+    ]);
+    renderProjectOutputs(true);
+    expect(screen.getByText('Example draft')).toBeInTheDocument();
+    expect(
+      screen.queryByText('No draft outputs available.'),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/crn-frontend/src/projects/projectOutputs.mock.ts
+++ b/apps/crn-frontend/src/projects/projectOutputs.mock.ts
@@ -41,11 +41,13 @@ const EXTRA_PROJECTS = [
   {
     id: 'mock-project-2',
     title: 'Cross-cohort Synuclein Imaging',
+    projectType: 'resource' as const,
     href: '/projects/resource/mock-project-2',
   },
   {
     id: 'mock-project-3',
     title: 'Neuro-immune Trainee Initiative',
+    projectType: 'trainee' as const,
     href: '/projects/trainee/mock-project-3',
   },
 ];
@@ -53,6 +55,7 @@ const EXTRA_PROJECTS = [
 const currentProject = (id: string, title: string) => ({
   id,
   title,
+  projectType: 'discovery' as const,
   href: `/projects/discovery/${id}`,
 });
 

--- a/apps/crn-frontend/src/projects/projectOutputs.mock.ts
+++ b/apps/crn-frontend/src/projects/projectOutputs.mock.ts
@@ -5,12 +5,36 @@ import {
 import type { ProjectOutput } from '@asap-hub/react-components';
 
 const TEAM_POOL = [
-  { id: 'team-1', displayName: 'Jakobsson, J', teamType: 'Discovery Team' as const },
-  { id: 'team-2', displayName: 'Smith, A', teamType: 'Discovery Team' as const },
-  { id: 'team-3', displayName: 'Okafor, B', teamType: 'Resource Team' as const },
-  { id: 'team-4', displayName: 'Müller, K', teamType: 'Discovery Team' as const },
-  { id: 'team-5', displayName: 'Ribeiro, L', teamType: 'Resource Team' as const },
-  { id: 'team-6', displayName: 'Yamamoto, H', teamType: 'Discovery Team' as const },
+  {
+    id: 'team-1',
+    displayName: 'Jakobsson, J',
+    teamType: 'Discovery Team' as const,
+  },
+  {
+    id: 'team-2',
+    displayName: 'Smith, A',
+    teamType: 'Discovery Team' as const,
+  },
+  {
+    id: 'team-3',
+    displayName: 'Okafor, B',
+    teamType: 'Resource Team' as const,
+  },
+  {
+    id: 'team-4',
+    displayName: 'Müller, K',
+    teamType: 'Discovery Team' as const,
+  },
+  {
+    id: 'team-5',
+    displayName: 'Ribeiro, L',
+    teamType: 'Resource Team' as const,
+  },
+  {
+    id: 'team-6',
+    displayName: 'Yamamoto, H',
+    teamType: 'Discovery Team' as const,
+  },
 ];
 
 const EXTRA_PROJECTS = [

--- a/apps/crn-frontend/src/projects/projectOutputs.mock.ts
+++ b/apps/crn-frontend/src/projects/projectOutputs.mock.ts
@@ -1,0 +1,354 @@
+import {
+  createListUserResponse,
+  createResearchOutputResponse,
+} from '@asap-hub/fixtures';
+import type { ProjectOutput } from '@asap-hub/react-components';
+
+const TEAM_POOL = [
+  { id: 'team-1', displayName: 'Jakobsson, J', teamType: 'Discovery Team' as const },
+  { id: 'team-2', displayName: 'Smith, A', teamType: 'Discovery Team' as const },
+  { id: 'team-3', displayName: 'Okafor, B', teamType: 'Resource Team' as const },
+  { id: 'team-4', displayName: 'Müller, K', teamType: 'Discovery Team' as const },
+  { id: 'team-5', displayName: 'Ribeiro, L', teamType: 'Resource Team' as const },
+  { id: 'team-6', displayName: 'Yamamoto, H', teamType: 'Discovery Team' as const },
+];
+
+const EXTRA_PROJECTS = [
+  {
+    id: 'mock-project-2',
+    title: 'Cross-cohort Synuclein Imaging',
+    href: '/projects/resource/mock-project-2',
+  },
+  {
+    id: 'mock-project-3',
+    title: 'Neuro-immune Trainee Initiative',
+    href: '/projects/trainee/mock-project-3',
+  },
+];
+
+const currentProject = (id: string, title: string) => ({
+  id,
+  title,
+  href: `/projects/discovery/${id}`,
+});
+
+const userPool = createListUserResponse(10).items;
+
+type Entry = {
+  id: string;
+  title: string;
+  documentType: ProjectOutput['documentType'];
+  type?: ProjectOutput['type'];
+  addedDate: string;
+  lastModifiedDate: string;
+  keywords: string[];
+  authorCount: number;
+  teamIds: string[];
+  extraProjects: number;
+  source: 'team' | 'project';
+  link?: string;
+  published: boolean;
+  isInReview?: boolean;
+};
+
+const buildOutput = (
+  entry: Entry,
+  projectId: string,
+  projectTitle: string,
+  itemIndex: number,
+): ProjectOutput => ({
+  ...createResearchOutputResponse(itemIndex),
+  id: entry.id,
+  title: entry.title,
+  documentType: entry.documentType,
+  type: entry.type,
+  addedDate: entry.addedDate,
+  lastModifiedDate: entry.lastModifiedDate,
+  keywords: entry.keywords,
+  authors: userPool.slice(0, entry.authorCount),
+  teams: entry.teamIds
+    .map((tid) => TEAM_POOL.find((t) => t.id === tid))
+    .filter((t): t is (typeof TEAM_POOL)[number] => Boolean(t)),
+  published: entry.published,
+  isInReview: entry.isInReview ?? false,
+  link: entry.link,
+  source: entry.source,
+  projects: [
+    currentProject(projectId, projectTitle),
+    ...EXTRA_PROJECTS.slice(0, entry.extraProjects),
+  ],
+});
+
+const PUBLISHED_ENTRIES: Entry[] = [
+  {
+    id: 'mock-output-1',
+    title:
+      'Tracing the Origin and Progression of Parkinson’s Disease through the Neuro-Immune Interactome',
+    documentType: 'Article',
+    type: 'Preprint',
+    addedDate: new Date(2024, 9, 14).toISOString(),
+    lastModifiedDate: new Date(2024, 11, 2).toISOString(),
+    keywords: ['Neuroinflammation', 'Single-cell', 'Parkinson'],
+    authorCount: 5,
+    teamIds: ['team-1', 'team-2'],
+    extraProjects: 0,
+    source: 'team',
+    link: 'https://example.com/output-1',
+    published: true,
+  },
+  {
+    id: 'mock-output-2',
+    title: 'iPSC-derived dopaminergic neuron differentiation protocol v3',
+    documentType: 'Protocol',
+    type: 'Cell Culture & Differentiation',
+    addedDate: new Date(2024, 8, 20).toISOString(),
+    lastModifiedDate: new Date(2024, 11, 8).toISOString(),
+    keywords: ['iPSC', 'Dopaminergic', 'Differentiation', 'Protocol'],
+    authorCount: 3,
+    teamIds: ['team-1'],
+    extraProjects: 0,
+    source: 'team',
+    link: 'https://example.com/output-2',
+    published: true,
+  },
+  {
+    id: 'mock-output-3',
+    title: 'Cross-cohort RNA-Seq dataset of substantia nigra samples',
+    documentType: 'Dataset',
+    type: 'Genetic Data - RNA',
+    addedDate: new Date(2024, 8, 1).toISOString(),
+    lastModifiedDate: new Date(2024, 10, 28).toISOString(),
+    keywords: ['RNA-Seq', 'Substantia Nigra', 'Cohort', 'Open Data'],
+    authorCount: 8,
+    teamIds: [],
+    extraProjects: 2,
+    source: 'project',
+    link: 'https://example.com/output-3',
+    published: true,
+  },
+  {
+    id: 'mock-output-4',
+    title: 'Bioinformatics pipeline for proteomics analysis (snakemake)',
+    documentType: 'Bioinformatics',
+    type: 'Code',
+    addedDate: new Date(2024, 7, 18).toISOString(),
+    lastModifiedDate: new Date(2024, 10, 5).toISOString(),
+    keywords: ['Proteomics', 'Pipeline', 'Snakemake'],
+    authorCount: 2,
+    teamIds: ['team-2'],
+    extraProjects: 0,
+    source: 'team',
+    link: 'https://example.com/output-4',
+    published: true,
+  },
+  {
+    id: 'mock-output-5',
+    title: 'Multi-author consortium paper on PD biomarkers',
+    documentType: 'Article',
+    type: 'Published',
+    addedDate: new Date(2024, 6, 22).toISOString(),
+    lastModifiedDate: new Date(2024, 9, 30).toISOString(),
+    keywords: ['Biomarkers', 'Consortium', 'Parkinson', 'Cohort'],
+    authorCount: 10,
+    teamIds: [],
+    extraProjects: 1,
+    source: 'project',
+    link: 'https://example.com/output-5',
+    published: true,
+  },
+  {
+    id: 'mock-output-6',
+    title: 'Anti-α-Synuclein antibody validation across six labs',
+    documentType: 'Lab Material',
+    type: 'Antibody',
+    addedDate: new Date(2024, 5, 30).toISOString(),
+    lastModifiedDate: new Date(2024, 10, 1).toISOString(),
+    keywords: ['Antibody', 'Validation', 'Synuclein', 'Reproducibility'],
+    authorCount: 6,
+    teamIds: ['team-1', 'team-2', 'team-3', 'team-4', 'team-5'],
+    extraProjects: 2,
+    source: 'team',
+    link: 'https://example.com/output-6',
+    published: true,
+  },
+  {
+    id: 'mock-output-7',
+    title: 'Mitochondrial complex I assay (96-well format)',
+    documentType: 'Protocol',
+    type: 'Assay',
+    addedDate: new Date(2024, 5, 10).toISOString(),
+    lastModifiedDate: new Date(2024, 8, 12).toISOString(),
+    keywords: ['Mitochondria', 'Complex I', 'Assay'],
+    authorCount: 2,
+    teamIds: ['team-3'],
+    extraProjects: 0,
+    source: 'team',
+    link: 'https://example.com/output-7',
+    published: true,
+  },
+  {
+    id: 'mock-output-8',
+    title: 'Open dataset: gait dynamics in early-stage PD patients',
+    documentType: 'Dataset',
+    type: 'Clinical',
+    addedDate: new Date(2024, 4, 4).toISOString(),
+    lastModifiedDate: new Date(2024, 10, 18).toISOString(),
+    keywords: ['Gait', 'Clinical', 'Wearable', 'Early-Stage'],
+    authorCount: 4,
+    teamIds: ['team-4'],
+    extraProjects: 1,
+    source: 'team',
+    link: 'https://example.com/output-8',
+    published: true,
+  },
+  {
+    id: 'mock-output-9',
+    title: 'AAV9-SNCA viral vector for in vivo PD modeling',
+    documentType: 'Lab Material',
+    type: 'Viral Vector',
+    addedDate: new Date(2024, 3, 15).toISOString(),
+    lastModifiedDate: new Date(2024, 7, 22).toISOString(),
+    keywords: ['AAV', 'SNCA', 'In Vivo'],
+    authorCount: 3,
+    teamIds: ['team-5'],
+    extraProjects: 0,
+    source: 'team',
+    published: true,
+  },
+  {
+    id: 'mock-output-10',
+    title: 'Tutorial: integrating single-cell atlases with bulk PD cohorts',
+    documentType: 'Presentation',
+    type: 'ASAP annual meeting',
+    addedDate: new Date(2024, 3, 2).toISOString(),
+    lastModifiedDate: new Date(2024, 5, 19).toISOString(),
+    keywords: ['Single-cell', 'Integration', 'Tutorial'],
+    authorCount: 1,
+    teamIds: [],
+    extraProjects: 0,
+    source: 'project',
+    link: 'https://example.com/output-10',
+    published: true,
+  },
+  {
+    id: 'mock-output-11',
+    title: 'Computational model of α-synuclein aggregation kinetics',
+    documentType: 'Bioinformatics',
+    type: 'Computational Model',
+    addedDate: new Date(2024, 2, 8).toISOString(),
+    lastModifiedDate: new Date(2024, 9, 14).toISOString(),
+    keywords: ['Modeling', 'Kinetics', 'Synuclein'],
+    authorCount: 3,
+    teamIds: ['team-6'],
+    extraProjects: 1,
+    source: 'team',
+    link: 'https://example.com/output-11',
+    published: true,
+  },
+  {
+    id: 'mock-output-12',
+    title: 'Grant supplement: cross-team trainee exchange program',
+    documentType: 'Grant Document',
+    type: 'Proposal',
+    addedDate: new Date(2024, 1, 25).toISOString(),
+    lastModifiedDate: new Date(2024, 4, 30).toISOString(),
+    keywords: ['Trainees', 'Exchange'],
+    authorCount: 2,
+    teamIds: [],
+    extraProjects: 2,
+    source: 'project',
+    published: true,
+  },
+];
+
+const DRAFT_ENTRIES: Entry[] = [
+  {
+    id: 'mock-draft-1',
+    title: 'Draft: Longitudinal cohort analysis (work in progress)',
+    documentType: 'Article',
+    type: 'Preprint',
+    addedDate: new Date(2025, 0, 5).toISOString(),
+    lastModifiedDate: new Date(2025, 1, 1).toISOString(),
+    keywords: ['Cohort', 'Longitudinal'],
+    authorCount: 3,
+    teamIds: [],
+    extraProjects: 0,
+    source: 'project',
+    published: false,
+  },
+  {
+    id: 'mock-draft-2',
+    title: 'In review: Team-shared sequencing dataset',
+    documentType: 'Dataset',
+    type: 'Sequencing',
+    addedDate: new Date(2024, 11, 20).toISOString(),
+    lastModifiedDate: new Date(2025, 0, 10).toISOString(),
+    keywords: ['Sequencing', 'Dataset'],
+    authorCount: 5,
+    teamIds: ['team-1'],
+    extraProjects: 0,
+    source: 'team',
+    link: 'https://example.com/draft-2',
+    isInReview: true,
+    published: false,
+  },
+  {
+    id: 'mock-draft-3',
+    title: 'Draft: Multi-team protocol harmonization across resource teams',
+    documentType: 'Protocol',
+    type: 'Sample Prep',
+    addedDate: new Date(2024, 11, 1).toISOString(),
+    lastModifiedDate: new Date(2025, 0, 22).toISOString(),
+    keywords: ['Harmonization', 'Protocol', 'Resource'],
+    authorCount: 4,
+    teamIds: ['team-3', 'team-5'],
+    extraProjects: 1,
+    source: 'team',
+    published: false,
+  },
+  {
+    id: 'mock-draft-4',
+    title: 'Draft: PD-specific imaging analysis software',
+    documentType: 'Bioinformatics',
+    type: 'Software',
+    addedDate: new Date(2024, 10, 14).toISOString(),
+    lastModifiedDate: new Date(2025, 0, 30).toISOString(),
+    keywords: ['Software', 'Imaging', 'Analysis'],
+    authorCount: 2,
+    teamIds: ['team-2'],
+    extraProjects: 0,
+    source: 'team',
+    link: 'https://example.com/draft-4',
+    published: false,
+  },
+  {
+    id: 'mock-draft-5',
+    title: 'Draft: Cross-cohort proposal for early biomarker study',
+    documentType: 'Grant Document',
+    type: 'Proposal',
+    addedDate: new Date(2024, 9, 28).toISOString(),
+    lastModifiedDate: new Date(2025, 1, 3).toISOString(),
+    keywords: ['Proposal', 'Biomarker', 'Cross-Cohort'],
+    authorCount: 6,
+    teamIds: [],
+    extraProjects: 2,
+    source: 'project',
+    published: false,
+  },
+];
+
+export const createProjectOutputsMock = (
+  projectId: string,
+  projectTitle: string,
+): ProjectOutput[] =>
+  PUBLISHED_ENTRIES.map((entry, i) =>
+    buildOutput(entry, projectId, projectTitle, i),
+  );
+
+export const createProjectDraftOutputsMock = (
+  projectId: string,
+  projectTitle: string,
+): ProjectOutput[] =>
+  DRAFT_ENTRIES.map((entry, i) =>
+    buildOutput(entry, projectId, projectTitle, 100 + i),
+  );

--- a/apps/storybook/src/ProjectOutputCard.stories.tsx
+++ b/apps/storybook/src/ProjectOutputCard.stories.tsx
@@ -4,78 +4,124 @@ import {
 } from '@asap-hub/fixtures';
 import { ProjectOutputCard } from '@asap-hub/react-components';
 
-import { text, date, number, boolean } from './knobs';
+import { boolean, date, number, select, text } from './knobs';
 
 export default {
   title: 'Organisms / Project Outputs / Card',
 };
 
+const PROJECT_POOL = [
+  { id: 'p1', title: 'Project Alpha', href: '/projects/discovery/p1' },
+  { id: 'p2', title: 'Cross-cohort Synuclein Imaging', href: '/projects/resource/p2' },
+  { id: 'p3', title: 'Neuro-immune Trainee Initiative', href: '/projects/trainee/p3' },
+];
+
 export const Normal = () => (
   <ProjectOutputCard
-    keywords={['Etag', 'Exercise']}
     id="r42"
+    title={text(
+      'Title',
+      'Tracing the Origin and Progression of Parkinson’s Disease through the Neuro-Immune Interactome',
+    )}
     link={text('Link', 'https://hub.asap.science')}
-    title={text('Title', 'Tracing the Origin and Progression of PD')}
-    documentType="Article"
-    type={'Code'}
-    created={new Date(
-      date('Created Date', new Date(2020, 6, 4, 14, 32)),
-    ).toISOString()}
-    addedDate={new Date(
-      date('Added Date', new Date(2020, 6, 4, 14, 32)),
-    ).toISOString()}
+    documentType={select(
+      'Document type',
+      ['Article', 'Protocol', 'Dataset', 'Bioinformatics', 'Lab Material', 'Presentation', 'Grant Document', 'Report'],
+      'Article',
+    )}
+    type={select(
+      'Type',
+      ['Preprint', 'Code', 'Antibody', 'Cell Culture & Differentiation', 'Genetic Data - RNA'],
+      'Preprint',
+    )}
+    source={select('Source', ['project', 'team'], 'project')}
+    keywords={['Neuroinflammation', 'Single-cell', 'Parkinson', 'Cohort']}
+    created={new Date(date('Created', new Date(2024, 5, 1))).toISOString()}
+    addedDate={new Date(date('Added', new Date(2024, 9, 14))).toISOString()}
     lastModifiedDate={new Date(
-      date('Last Modified', new Date(2021, 6, 4, 14, 32)),
+      date('Last Modified', new Date(2024, 11, 2)),
     ).toISOString()}
-    teams={createListTeamResponse(number('Number of Teams', 0)).items}
-    authors={createListUserResponse(number('Number of Authors', 3)).items}
-    projects={[
-      { id: 'p1', title: 'Project Alpha', href: '/projects/p1' },
-    ]}
-    published={boolean('published', true)}
-    isInReview={boolean('Is in review', false)}
-  />
-);
-
-export const TeamBased = () => (
-  <ProjectOutputCard
-    keywords={['Etag']}
-    id="r44"
-    link={'https://hub.asap.science'}
-    title={'Team-based project output'}
-    documentType="Article"
-    type={'Code'}
-    created={new Date(2020, 6, 4).toISOString()}
-    addedDate={new Date(2020, 6, 4).toISOString()}
-    lastModifiedDate={new Date(2021, 6, 4).toISOString()}
-    teams={createListTeamResponse(2).items}
-    authors={createListUserResponse(2).items}
-    projects={[
-      { id: 'p1', title: 'Project Alpha', href: '/projects/p1' },
-    ]}
-    published={true}
-    isInReview={false}
-    source="team"
+    teams={createListTeamResponse(number('Number of Teams', 2)).items}
+    authors={createListUserResponse(number('Number of Authors', 5)).items}
+    projects={PROJECT_POOL.slice(0, number('Number of Projects', 1, { min: 1, max: 3 }))}
+    published={boolean('Published', true)}
+    isInReview={boolean('In Review', false)}
   />
 );
 
 export const Draft = () => (
   <ProjectOutputCard
-    keywords={['Etag']}
-    id="r43"
-    link={'https://hub.asap.science'}
-    title={'Draft project output'}
+    id="d1"
+    title="Draft: Longitudinal cohort analysis (work in progress)"
     documentType="Article"
-    type={'Code'}
-    created={new Date(2020, 6, 4).toISOString()}
-    addedDate={new Date(2020, 6, 4).toISOString()}
-    lastModifiedDate={new Date(2021, 6, 4).toISOString()}
+    type="Preprint"
+    keywords={['Cohort', 'Longitudinal']}
+    created={new Date(2024, 11, 1).toISOString()}
+    addedDate={new Date(2025, 0, 5).toISOString()}
+    lastModifiedDate={new Date(2025, 1, 1).toISOString()}
     teams={[]}
-    authors={createListUserResponse(2).items}
-    projects={[
-      { id: 'p1', title: 'Project Alpha', href: '/projects/p1' },
-    ]}
+    authors={createListUserResponse(3).items}
+    projects={[PROJECT_POOL[0]!]}
+    source="project"
     published={false}
+    isInReview={false}
+  />
+);
+
+export const InReview = () => (
+  <ProjectOutputCard
+    id="r1"
+    title="In review: Team-shared sequencing dataset"
+    documentType="Dataset"
+    type="Genetic Data - RNA"
+    link="https://example.com/dataset"
+    keywords={['Sequencing', 'Dataset']}
+    created={new Date(2024, 10, 1).toISOString()}
+    addedDate={new Date(2024, 11, 20).toISOString()}
+    lastModifiedDate={new Date(2025, 0, 10).toISOString()}
+    teams={createListTeamResponse(1).items}
+    authors={createListUserResponse(5).items}
+    projects={[PROJECT_POOL[0]!]}
+    source="team"
+    published={false}
+    isInReview={true}
+  />
+);
+
+export const TeamBasedWithOverflow = () => (
+  <ProjectOutputCard
+    id="r6"
+    title="Anti-α-Synuclein antibody validation across six labs"
+    documentType="Lab Material"
+    type="Antibody"
+    link="https://example.com/output-6"
+    keywords={['Antibody', 'Validation', 'Synuclein', 'Reproducibility']}
+    created={new Date(2024, 4, 15).toISOString()}
+    addedDate={new Date(2024, 5, 30).toISOString()}
+    lastModifiedDate={new Date(2024, 10, 1).toISOString()}
+    teams={createListTeamResponse(5).items}
+    authors={createListUserResponse(6).items}
+    projects={PROJECT_POOL}
+    source="team"
+    published
+    isInReview={false}
+  />
+);
+
+export const Minimal = () => (
+  <ProjectOutputCard
+    id="m1"
+    title="Single-author presentation"
+    documentType="Presentation"
+    type="ASAP annual meeting"
+    keywords={[]}
+    created={new Date(2024, 3, 2).toISOString()}
+    addedDate={new Date(2024, 3, 2).toISOString()}
+    teams={[]}
+    authors={createListUserResponse(1).items}
+    projects={[PROJECT_POOL[0]!]}
+    source="project"
+    published
     isInReview={false}
   />
 );

--- a/apps/storybook/src/ProjectOutputCard.stories.tsx
+++ b/apps/storybook/src/ProjectOutputCard.stories.tsx
@@ -12,8 +12,16 @@ export default {
 
 const PROJECT_POOL = [
   { id: 'p1', title: 'Project Alpha', href: '/projects/discovery/p1' },
-  { id: 'p2', title: 'Cross-cohort Synuclein Imaging', href: '/projects/resource/p2' },
-  { id: 'p3', title: 'Neuro-immune Trainee Initiative', href: '/projects/trainee/p3' },
+  {
+    id: 'p2',
+    title: 'Cross-cohort Synuclein Imaging',
+    href: '/projects/resource/p2',
+  },
+  {
+    id: 'p3',
+    title: 'Neuro-immune Trainee Initiative',
+    href: '/projects/trainee/p3',
+  },
 ];
 
 export const Normal = () => (
@@ -26,12 +34,27 @@ export const Normal = () => (
     link={text('Link', 'https://hub.asap.science')}
     documentType={select(
       'Document type',
-      ['Article', 'Protocol', 'Dataset', 'Bioinformatics', 'Lab Material', 'Presentation', 'Grant Document', 'Report'],
+      [
+        'Article',
+        'Protocol',
+        'Dataset',
+        'Bioinformatics',
+        'Lab Material',
+        'Presentation',
+        'Grant Document',
+        'Report',
+      ],
       'Article',
     )}
     type={select(
       'Type',
-      ['Preprint', 'Code', 'Antibody', 'Cell Culture & Differentiation', 'Genetic Data - RNA'],
+      [
+        'Preprint',
+        'Code',
+        'Antibody',
+        'Cell Culture & Differentiation',
+        'Genetic Data - RNA',
+      ],
       'Preprint',
     )}
     source={select('Source', ['project', 'team'], 'project')}
@@ -43,7 +66,10 @@ export const Normal = () => (
     ).toISOString()}
     teams={createListTeamResponse(number('Number of Teams', 2)).items}
     authors={createListUserResponse(number('Number of Authors', 5)).items}
-    projects={PROJECT_POOL.slice(0, number('Number of Projects', 1, { min: 1, max: 3 }))}
+    projects={PROJECT_POOL.slice(
+      0,
+      number('Number of Projects', 1, { min: 1, max: 3 }),
+    )}
     published={boolean('Published', true)}
     isInReview={boolean('In Review', false)}
   />

--- a/apps/storybook/src/ProjectOutputCard.stories.tsx
+++ b/apps/storybook/src/ProjectOutputCard.stories.tsx
@@ -1,0 +1,81 @@
+import {
+  createListTeamResponse,
+  createListUserResponse,
+} from '@asap-hub/fixtures';
+import { ProjectOutputCard } from '@asap-hub/react-components';
+
+import { text, date, number, boolean } from './knobs';
+
+export default {
+  title: 'Organisms / Project Outputs / Card',
+};
+
+export const Normal = () => (
+  <ProjectOutputCard
+    keywords={['Etag', 'Exercise']}
+    id="r42"
+    link={text('Link', 'https://hub.asap.science')}
+    title={text('Title', 'Tracing the Origin and Progression of PD')}
+    documentType="Article"
+    type={'Code'}
+    created={new Date(
+      date('Created Date', new Date(2020, 6, 4, 14, 32)),
+    ).toISOString()}
+    addedDate={new Date(
+      date('Added Date', new Date(2020, 6, 4, 14, 32)),
+    ).toISOString()}
+    lastModifiedDate={new Date(
+      date('Last Modified', new Date(2021, 6, 4, 14, 32)),
+    ).toISOString()}
+    teams={createListTeamResponse(number('Number of Teams', 0)).items}
+    authors={createListUserResponse(number('Number of Authors', 3)).items}
+    projects={[
+      { id: 'p1', title: 'Project Alpha', href: '/projects/p1' },
+    ]}
+    published={boolean('published', true)}
+    isInReview={boolean('Is in review', false)}
+  />
+);
+
+export const TeamBased = () => (
+  <ProjectOutputCard
+    keywords={['Etag']}
+    id="r44"
+    link={'https://hub.asap.science'}
+    title={'Team-based project output'}
+    documentType="Article"
+    type={'Code'}
+    created={new Date(2020, 6, 4).toISOString()}
+    addedDate={new Date(2020, 6, 4).toISOString()}
+    lastModifiedDate={new Date(2021, 6, 4).toISOString()}
+    teams={createListTeamResponse(2).items}
+    authors={createListUserResponse(2).items}
+    projects={[
+      { id: 'p1', title: 'Project Alpha', href: '/projects/p1' },
+    ]}
+    published={true}
+    isInReview={false}
+    source="team"
+  />
+);
+
+export const Draft = () => (
+  <ProjectOutputCard
+    keywords={['Etag']}
+    id="r43"
+    link={'https://hub.asap.science'}
+    title={'Draft project output'}
+    documentType="Article"
+    type={'Code'}
+    created={new Date(2020, 6, 4).toISOString()}
+    addedDate={new Date(2020, 6, 4).toISOString()}
+    lastModifiedDate={new Date(2021, 6, 4).toISOString()}
+    teams={[]}
+    authors={createListUserResponse(2).items}
+    projects={[
+      { id: 'p1', title: 'Project Alpha', href: '/projects/p1' },
+    ]}
+    published={false}
+    isInReview={false}
+  />
+);

--- a/apps/storybook/src/ProjectOutputCard.stories.tsx
+++ b/apps/storybook/src/ProjectOutputCard.stories.tsx
@@ -10,19 +10,22 @@ export default {
   title: 'Organisms / Project Outputs / Card',
 };
 
-const PROJECT_POOL = [
-  { id: 'p1', title: 'Project Alpha', href: '/projects/discovery/p1' },
-  {
-    id: 'p2',
-    title: 'Cross-cohort Synuclein Imaging',
-    href: '/projects/resource/p2',
-  },
-  {
-    id: 'p3',
-    title: 'Neuro-immune Trainee Initiative',
-    href: '/projects/trainee/p3',
-  },
-];
+const PROJECT_ALPHA = {
+  id: 'p1',
+  title: 'Project Alpha',
+  href: '/projects/discovery/p1',
+};
+const PROJECT_BETA = {
+  id: 'p2',
+  title: 'Cross-cohort Synuclein Imaging',
+  href: '/projects/resource/p2',
+};
+const PROJECT_GAMMA = {
+  id: 'p3',
+  title: 'Neuro-immune Trainee Initiative',
+  href: '/projects/trainee/p3',
+};
+const PROJECT_POOL = [PROJECT_ALPHA, PROJECT_BETA, PROJECT_GAMMA];
 
 export const Normal = () => (
   <ProjectOutputCard
@@ -87,7 +90,7 @@ export const Draft = () => (
     lastModifiedDate={new Date(2025, 1, 1).toISOString()}
     teams={[]}
     authors={createListUserResponse(3).items}
-    projects={[PROJECT_POOL[0]!]}
+    projects={[PROJECT_ALPHA]}
     source="project"
     published={false}
     isInReview={false}
@@ -107,7 +110,7 @@ export const InReview = () => (
     lastModifiedDate={new Date(2025, 0, 10).toISOString()}
     teams={createListTeamResponse(1).items}
     authors={createListUserResponse(5).items}
-    projects={[PROJECT_POOL[0]!]}
+    projects={[PROJECT_ALPHA]}
     source="team"
     published={false}
     isInReview={true}
@@ -145,7 +148,7 @@ export const Minimal = () => (
     addedDate={new Date(2024, 3, 2).toISOString()}
     teams={[]}
     authors={createListUserResponse(1).items}
-    projects={[PROJECT_POOL[0]!]}
+    projects={[PROJECT_ALPHA]}
     source="project"
     published
     isInReview={false}

--- a/apps/storybook/src/ProjectOutputCard.stories.tsx
+++ b/apps/storybook/src/ProjectOutputCard.stories.tsx
@@ -13,16 +13,19 @@ export default {
 const PROJECT_ALPHA = {
   id: 'p1',
   title: 'Project Alpha',
+  projectType: 'discovery' as const,
   href: '/projects/discovery/p1',
 };
 const PROJECT_BETA = {
   id: 'p2',
   title: 'Cross-cohort Synuclein Imaging',
+  projectType: 'resource' as const,
   href: '/projects/resource/p2',
 };
 const PROJECT_GAMMA = {
   id: 'p3',
   title: 'Neuro-immune Trainee Initiative',
+  projectType: 'trainee' as const,
   href: '/projects/trainee/p3',
 };
 const PROJECT_POOL = [PROJECT_ALPHA, PROJECT_BETA, PROJECT_GAMMA];

--- a/apps/storybook/src/ProjectOutputList.stories.tsx
+++ b/apps/storybook/src/ProjectOutputList.stories.tsx
@@ -2,6 +2,7 @@ import { ComponentProps } from 'react';
 import { ProjectOutputList } from '@asap-hub/react-components';
 import { StaticRouter } from 'react-router';
 import { createListResearchOutputResponse } from '@asap-hub/fixtures';
+import type { ProjectOutput } from '@asap-hub/react-components';
 
 import { number } from './knobs';
 
@@ -9,36 +10,80 @@ export default {
   title: 'Templates / Project Outputs / List',
 };
 
-const props = (): ComponentProps<typeof ProjectOutputList> => {
-  const numberOfItems = number('Number of Outputs', 4, { min: 0 });
-  const currentPageIndex = number('Current Page', 1, { min: 1 }) - 1;
-  return {
-    researchOutputs: createListResearchOutputResponse(numberOfItems)
-      .items.slice(currentPageIndex * 10, currentPageIndex * 10 + 10)
-      .map((output) => ({
-        ...output,
-        teams: [],
-        projects: [
-          { id: 'p1', title: 'Project Alpha', href: '/projects/p1' },
-        ],
-      })),
-    numberOfItems,
-    numberOfPages: Math.max(1, Math.ceil(numberOfItems / 10)),
-    currentPageIndex,
-    renderPageHref: (index) => `#${index}`,
-    exportResults: () => Promise.resolve(),
-    listViewHref: '',
-    cardViewHref: '',
-  };
+const projectAlpha = {
+  id: 'p1',
+  title: 'Project Alpha',
+  href: '/projects/discovery/p1',
 };
 
-export const CardView = () => (
+const buildOutputs = (count: number): ProjectOutput[] =>
+  createListResearchOutputResponse(count).items.map((output) => ({
+    ...output,
+    teams: [],
+    projects: [projectAlpha],
+  }));
+
+const buildProps = (
+  numberOfItems: number,
+  currentPageIndex: number,
+  pageSize: number,
+): ComponentProps<typeof ProjectOutputList> => ({
+  researchOutputs: buildOutputs(numberOfItems).slice(
+    currentPageIndex * pageSize,
+    currentPageIndex * pageSize + pageSize,
+  ),
+  numberOfItems,
+  numberOfPages: Math.max(1, Math.ceil(numberOfItems / pageSize)),
+  currentPageIndex,
+  renderPageHref: (index) => `#${index}`,
+  exportResults: () => Promise.resolve(),
+  listViewHref: '?view=list',
+  cardViewHref: '?view=card',
+});
+
+export const CardView = () => {
+  const numberOfItems = number('Number of Outputs', 4, { min: 0 });
+  const currentPageIndex = number('Current Page', 1, { min: 1 }) - 1;
+  return (
+    <StaticRouter location="/">
+      <ProjectOutputList
+        {...buildProps(numberOfItems, currentPageIndex, 10)}
+        isListView={false}
+      />
+    </StaticRouter>
+  );
+};
+
+export const ListView = () => {
+  const numberOfItems = number('Number of Outputs', 8, { min: 0 });
+  const currentPageIndex = number('Current Page', 1, { min: 1 }) - 1;
+  return (
+    <StaticRouter location="/">
+      <ProjectOutputList
+        {...buildProps(numberOfItems, currentPageIndex, 20)}
+        isListView
+      />
+    </StaticRouter>
+  );
+};
+
+export const Paginated = () => (
   <StaticRouter location="/">
-    <ProjectOutputList {...props()} isListView={false} />
+    <ProjectOutputList
+      {...buildProps(25, 0, 10)}
+      isListView={false}
+    />
   </StaticRouter>
 );
-export const ListView = () => (
+
+export const SingleResult = () => (
   <StaticRouter location="/">
-    <ProjectOutputList {...props()} isListView />
+    <ProjectOutputList {...buildProps(1, 0, 10)} isListView={false} />
+  </StaticRouter>
+);
+
+export const Empty = () => (
+  <StaticRouter location="/">
+    <ProjectOutputList {...buildProps(0, 0, 10)} isListView={false} />
   </StaticRouter>
 );

--- a/apps/storybook/src/ProjectOutputList.stories.tsx
+++ b/apps/storybook/src/ProjectOutputList.stories.tsx
@@ -13,6 +13,7 @@ export default {
 const projectAlpha = {
   id: 'p1',
   title: 'Project Alpha',
+  projectType: 'discovery' as const,
   href: '/projects/discovery/p1',
 };
 

--- a/apps/storybook/src/ProjectOutputList.stories.tsx
+++ b/apps/storybook/src/ProjectOutputList.stories.tsx
@@ -1,0 +1,44 @@
+import { ComponentProps } from 'react';
+import { ProjectOutputList } from '@asap-hub/react-components';
+import { StaticRouter } from 'react-router';
+import { createListResearchOutputResponse } from '@asap-hub/fixtures';
+
+import { number } from './knobs';
+
+export default {
+  title: 'Templates / Project Outputs / List',
+};
+
+const props = (): ComponentProps<typeof ProjectOutputList> => {
+  const numberOfItems = number('Number of Outputs', 4, { min: 0 });
+  const currentPageIndex = number('Current Page', 1, { min: 1 }) - 1;
+  return {
+    researchOutputs: createListResearchOutputResponse(numberOfItems)
+      .items.slice(currentPageIndex * 10, currentPageIndex * 10 + 10)
+      .map((output) => ({
+        ...output,
+        teams: [],
+        projects: [
+          { id: 'p1', title: 'Project Alpha', href: '/projects/p1' },
+        ],
+      })),
+    numberOfItems,
+    numberOfPages: Math.max(1, Math.ceil(numberOfItems / 10)),
+    currentPageIndex,
+    renderPageHref: (index) => `#${index}`,
+    exportResults: () => Promise.resolve(),
+    listViewHref: '',
+    cardViewHref: '',
+  };
+};
+
+export const CardView = () => (
+  <StaticRouter location="/">
+    <ProjectOutputList {...props()} isListView={false} />
+  </StaticRouter>
+);
+export const ListView = () => (
+  <StaticRouter location="/">
+    <ProjectOutputList {...props()} isListView />
+  </StaticRouter>
+);

--- a/apps/storybook/src/ProjectOutputList.stories.tsx
+++ b/apps/storybook/src/ProjectOutputList.stories.tsx
@@ -69,10 +69,7 @@ export const ListView = () => {
 
 export const Paginated = () => (
   <StaticRouter location="/">
-    <ProjectOutputList
-      {...buildProps(25, 0, 10)}
-      isListView={false}
-    />
+    <ProjectOutputList {...buildProps(25, 0, 10)} isListView={false} />
   </StaticRouter>
 );
 

--- a/apps/storybook/src/ProjectOutputListCard.stories.tsx
+++ b/apps/storybook/src/ProjectOutputListCard.stories.tsx
@@ -18,7 +18,11 @@ const projectAlpha = {
 };
 
 const teamPool = [
-  { id: 't1', displayName: 'Jakobsson, J', teamType: 'Discovery Team' as const },
+  {
+    id: 't1',
+    displayName: 'Jakobsson, J',
+    teamType: 'Discovery Team' as const,
+  },
   { id: 't2', displayName: 'Smith, A', teamType: 'Discovery Team' as const },
   { id: 't3', displayName: 'Okafor, B', teamType: 'Resource Team' as const },
 ];
@@ -83,6 +87,4 @@ export const Mixed = () => (
   />
 );
 
-export const Empty = () => (
-  <ProjectOutputListCard researchOutputs={[]} />
-);
+export const Empty = () => <ProjectOutputListCard researchOutputs={[]} />;

--- a/apps/storybook/src/ProjectOutputListCard.stories.tsx
+++ b/apps/storybook/src/ProjectOutputListCard.stories.tsx
@@ -1,5 +1,9 @@
 import { ProjectOutputListCard } from '@asap-hub/react-components';
-import { createResearchOutputResponse } from '@asap-hub/fixtures';
+import {
+  createListUserResponse,
+  createResearchOutputResponse,
+} from '@asap-hub/fixtures';
+import type { ProjectOutput } from '@asap-hub/react-components';
 
 import { number } from './knobs';
 
@@ -7,30 +11,78 @@ export default {
   title: 'Organisms / Project Outputs / List Card',
 };
 
-export const Normal = () => (
+const projectAlpha = {
+  id: 'p1',
+  title: 'Project Alpha',
+  href: '/projects/discovery/p1',
+};
+
+const teamPool = [
+  { id: 't1', displayName: 'Jakobsson, J', teamType: 'Discovery Team' as const },
+  { id: 't2', displayName: 'Smith, A', teamType: 'Discovery Team' as const },
+  { id: 't3', displayName: 'Okafor, B', teamType: 'Resource Team' as const },
+];
+
+const baseOutput = (i: number): ProjectOutput => ({
+  ...createResearchOutputResponse(i),
+  source: 'project',
+  teams: [],
+  projects: [projectAlpha],
+});
+
+export const ProjectBasedOnly = () => (
   <ProjectOutputListCard
     researchOutputs={Array.from({
       length: number('Outputs', 5, { min: 0, max: 20 }),
-    }).map((_, i) => ({
-      ...createResearchOutputResponse(i),
-      teams: [],
-      projects: [
-        { id: 'p1', title: 'Project Alpha', href: '/projects/p1' },
-      ],
-    }))}
+    }).map((_, i) => baseOutput(i))}
   />
 );
 
 export const Mixed = () => (
   <ProjectOutputListCard
-    researchOutputs={Array.from({
-      length: number('Outputs', 4, { min: 0, max: 20 }),
-    }).map((_, i) => ({
-      ...createResearchOutputResponse(i),
-      source: i % 2 === 0 ? 'project' as const : 'team' as const,
-      projects: [
-        { id: 'p1', title: 'Project Alpha', href: '/projects/p1' },
-      ],
-    }))}
+    researchOutputs={[
+      {
+        ...baseOutput(0),
+        title: 'Project-based: dataset shared across cohorts',
+        documentType: 'Dataset',
+        type: 'Genetic Data - RNA',
+        link: 'https://example.com/output-1',
+        authors: createListUserResponse(4).items,
+      },
+      {
+        ...baseOutput(1),
+        title: 'Team-based: antibody validation',
+        documentType: 'Lab Material',
+        type: 'Antibody',
+        source: 'team',
+        teams: teamPool,
+        authors: createListUserResponse(6).items,
+        link: 'https://example.com/output-2',
+      },
+      {
+        ...baseOutput(2),
+        title: 'Draft: in progress preprint',
+        documentType: 'Article',
+        type: 'Preprint',
+        published: false,
+        isInReview: false,
+        authors: createListUserResponse(2).items,
+      },
+      {
+        ...baseOutput(3),
+        title: 'In review: team protocol',
+        documentType: 'Protocol',
+        type: 'Sample Prep',
+        published: false,
+        isInReview: true,
+        source: 'team',
+        teams: teamPool.slice(0, 2),
+        authors: createListUserResponse(3).items,
+      },
+    ]}
   />
+);
+
+export const Empty = () => (
+  <ProjectOutputListCard researchOutputs={[]} />
 );

--- a/apps/storybook/src/ProjectOutputListCard.stories.tsx
+++ b/apps/storybook/src/ProjectOutputListCard.stories.tsx
@@ -14,6 +14,7 @@ export default {
 const projectAlpha = {
   id: 'p1',
   title: 'Project Alpha',
+  projectType: 'discovery' as const,
   href: '/projects/discovery/p1',
 };
 

--- a/apps/storybook/src/ProjectOutputListCard.stories.tsx
+++ b/apps/storybook/src/ProjectOutputListCard.stories.tsx
@@ -1,0 +1,36 @@
+import { ProjectOutputListCard } from '@asap-hub/react-components';
+import { createResearchOutputResponse } from '@asap-hub/fixtures';
+
+import { number } from './knobs';
+
+export default {
+  title: 'Organisms / Project Outputs / List Card',
+};
+
+export const Normal = () => (
+  <ProjectOutputListCard
+    researchOutputs={Array.from({
+      length: number('Outputs', 5, { min: 0, max: 20 }),
+    }).map((_, i) => ({
+      ...createResearchOutputResponse(i),
+      teams: [],
+      projects: [
+        { id: 'p1', title: 'Project Alpha', href: '/projects/p1' },
+      ],
+    }))}
+  />
+);
+
+export const Mixed = () => (
+  <ProjectOutputListCard
+    researchOutputs={Array.from({
+      length: number('Outputs', 4, { min: 0, max: 20 }),
+    }).map((_, i) => ({
+      ...createResearchOutputResponse(i),
+      source: i % 2 === 0 ? 'project' as const : 'team' as const,
+      projects: [
+        { id: 'p1', title: 'Project Alpha', href: '/projects/p1' },
+      ],
+    }))}
+  />
+);

--- a/packages/react-components/src/index.ts
+++ b/packages/react-components/src/index.ts
@@ -114,6 +114,7 @@ export {
   ProjectDuration,
   ProjectMemberCard,
   ProjectMembers,
+  ProjectOutputBody,
   ReminderItem,
   SearchField,
   StatusBadge,
@@ -192,6 +193,8 @@ export {
   ProjectContributors,
   ProjectDetailOverview,
   ProjectAims,
+  ProjectOutputCard,
+  ProjectOutputListCard,
   ProjectMilestonesTable,
   Aim,
   Milestone,
@@ -306,6 +309,7 @@ export {
   PasswordResetEmailSentPage,
   PersonalInfoModal,
   ProfileOutputs,
+  ProjectOutputList,
   ProjectDetailAbout,
   ProjectDetailHeader,
   ProjectDetailPage,
@@ -357,7 +361,12 @@ export {
 } from './utils';
 export { pixels, text, authTestUtils, utils, mail, ajvErrors, colors };
 export type { AccentVariant, SwitchProps } from './atoms';
-export type { ItemType, StatusType, ReminderEntity } from './molecules';
+export type {
+  ItemType,
+  StatusType,
+  ReminderEntity,
+  ProjectOutput,
+} from './molecules';
 export type {
   Association,
   AuthorOption,

--- a/packages/react-components/src/index.ts
+++ b/packages/react-components/src/index.ts
@@ -366,6 +366,7 @@ export type {
   StatusType,
   ReminderEntity,
   ProjectOutput,
+  ProjectOutputType,
 } from './molecules';
 export type {
   Association,

--- a/packages/react-components/src/molecules/AssociationList.tsx
+++ b/packages/react-components/src/molecules/AssociationList.tsx
@@ -9,6 +9,7 @@ import {
   WorkingGroupsIcon,
   ImpactIcon,
   CategoryIcon,
+  DiscoveryProjectIcon,
 } from '../icons';
 import { Avatar, Link } from '../atoms';
 import { rem } from '../pixels';
@@ -85,8 +86,15 @@ interface AssociationListProps {
     displayName: string;
     id: string;
     inactiveSince?: string;
+    href?: string;
   }>;
-  readonly type: 'Team' | 'Lab' | 'Working Group' | 'Impact' | 'Category';
+  readonly type:
+    | 'Team'
+    | 'Lab'
+    | 'Working Group'
+    | 'Impact'
+    | 'Category'
+    | 'Project';
   readonly inline?: boolean;
   readonly max?: number;
   readonly more?: number;
@@ -97,6 +105,7 @@ const icon: Record<AssociationListProps['type'], React.ReactElement> = {
   'Working Group': <WorkingGroupsIcon />,
   Impact: <ImpactIcon />,
   Category: <CategoryIcon />,
+  Project: <DiscoveryProjectIcon />,
 };
 const Indicator = ({ type }: { type: AssociationListProps['type'] }) => (
   <div css={iconStyles}>{icon[type]}</div>
@@ -129,7 +138,7 @@ const AssociationList: FC<AssociationListProps> = ({
     <div>
       {inline && <Indicator type={type} />}
       <ul css={[containerStyles, inline && inlineContainerStyles]}>
-        {associations.map(({ displayName, id, inactiveSince }) => (
+        {associations.map(({ displayName, id, inactiveSince, href }) => (
           <li key={id} css={[itemStyles, inline && inlineItemStyles]}>
             {inline || <Indicator type={type} />}
             {type === 'Team' && (
@@ -161,6 +170,8 @@ const AssociationList: FC<AssociationListProps> = ({
                 {displayName}
               </Link>
             )}
+            {type === 'Project' &&
+              (href ? <Link href={href}>{displayName}</Link> : displayName)}
             {inline && <span css={bulletStyles}>•</span>}
           </li>
         ))}

--- a/packages/react-components/src/molecules/AssociationList.tsx
+++ b/packages/react-components/src/molecules/AssociationList.tsx
@@ -9,7 +9,6 @@ import {
   WorkingGroupsIcon,
   ImpactIcon,
   CategoryIcon,
-  DiscoveryProjectIcon,
 } from '../icons';
 import { Avatar, Link } from '../atoms';
 import { rem } from '../pixels';
@@ -86,15 +85,8 @@ interface AssociationListProps {
     displayName: string;
     id: string;
     inactiveSince?: string;
-    href?: string;
   }>;
-  readonly type:
-    | 'Team'
-    | 'Lab'
-    | 'Working Group'
-    | 'Impact'
-    | 'Category'
-    | 'Project';
+  readonly type: 'Team' | 'Lab' | 'Working Group' | 'Impact' | 'Category';
   readonly inline?: boolean;
   readonly max?: number;
   readonly more?: number;
@@ -105,7 +97,6 @@ const icon: Record<AssociationListProps['type'], React.ReactElement> = {
   'Working Group': <WorkingGroupsIcon />,
   Impact: <ImpactIcon />,
   Category: <CategoryIcon />,
-  Project: <DiscoveryProjectIcon />,
 };
 const Indicator = ({ type }: { type: AssociationListProps['type'] }) => (
   <div css={iconStyles}>{icon[type]}</div>
@@ -138,7 +129,7 @@ const AssociationList: FC<AssociationListProps> = ({
     <div>
       {inline && <Indicator type={type} />}
       <ul css={[containerStyles, inline && inlineContainerStyles]}>
-        {associations.map(({ displayName, id, inactiveSince, href }) => (
+        {associations.map(({ displayName, id, inactiveSince }) => (
           <li key={id} css={[itemStyles, inline && inlineItemStyles]}>
             {inline || <Indicator type={type} />}
             {type === 'Team' && (
@@ -170,8 +161,6 @@ const AssociationList: FC<AssociationListProps> = ({
                 {displayName}
               </Link>
             )}
-            {type === 'Project' &&
-              (href ? <Link href={href}>{displayName}</Link> : displayName)}
             {inline && <span css={bulletStyles}>•</span>}
           </li>
         ))}

--- a/packages/react-components/src/molecules/ProjectOutputBody.tsx
+++ b/packages/react-components/src/molecules/ProjectOutputBody.tsx
@@ -239,7 +239,7 @@ const ProjectOutputBody: React.FC<ProjectOutputBodyProps> = ({
         href:
           'id' in author
             ? network({}).users({}).user({ userId: author.id }).$
-            : undefined,
+            : /* istanbul ignore next */ undefined,
       }))}
     />
     <div css={associationStyles}>

--- a/packages/react-components/src/molecules/ProjectOutputBody.tsx
+++ b/packages/react-components/src/molecules/ProjectOutputBody.tsx
@@ -1,0 +1,300 @@
+import { css } from '@emotion/react';
+import { ResearchOutputResponse } from '@asap-hub/model';
+import { network, sharedResearch } from '@asap-hub/routing';
+
+import { Anchor, Avatar, Caption, Headline2, Link, StateTag } from '../atoms';
+import ExternalLink from './ExternalLink';
+import LinkHeadline from './LinkHeadline';
+import PillList from './PillList';
+import TagList from './TagList';
+import UsersList from './UsersList';
+import { formatDate } from '../date';
+import { rem } from '../pixels';
+import {
+  DiscoveryProjectIcon,
+  TeamIcon,
+} from '../icons';
+
+const PROJECT_ICON = <DiscoveryProjectIcon />;
+const TEAM_ICON = <TeamIcon />;
+
+export type ProjectOutput = Pick<
+  ResearchOutputResponse,
+  | 'published'
+  | 'addedDate'
+  | 'authors'
+  | 'created'
+  | 'documentType'
+  | 'id'
+  | 'link'
+  | 'teams'
+  | 'title'
+  | 'type'
+  | 'isInReview'
+  | 'keywords'
+> & {
+  projects?: ReadonlyArray<{ id: string; title: string; href?: string }>;
+  lastModifiedDate?: string;
+  source?: 'team' | 'project';
+};
+
+const associationStyles = css({
+  display: 'flex',
+  flexDirection: 'column',
+  rowGap: rem(16),
+  marginTop: rem(16),
+});
+
+const metadataRowStyles = css({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  columnGap: rem(12),
+  height: rem(32),
+});
+
+const listTagContainerStyles = css({
+  marginTop: rem(24),
+});
+
+const listDatesStyles = css({
+  display: 'flex',
+  flexWrap: 'wrap',
+  columnGap: rem(12),
+  '& > *': {
+    lineHeight: rem(16),
+  },
+});
+
+const associationRowStyles = css({
+  display: 'flex',
+  flexWrap: 'wrap',
+  alignItems: 'center',
+  columnGap: rem(8),
+  rowGap: rem(8),
+});
+
+const associationIconStyles = css({
+  display: 'inline-flex',
+  alignItems: 'center',
+  height: rem(24),
+});
+
+const associationItemStyles = css({
+  display: 'inline-flex',
+  alignItems: 'center',
+  columnGap: rem(8),
+});
+
+const associationBulletStyles = css({
+  marginLeft: rem(8),
+});
+
+const counterStyles = css({
+  display: 'inline-flex',
+  alignItems: 'center',
+  columnGap: rem(8),
+  marginLeft: rem(8),
+});
+
+const counterAvatarStyles = css({
+  width: rem(24),
+  flex: 'none',
+});
+
+const titleStyles = css({
+  display: 'flex',
+  columnGap: rem(15),
+  flexWrap: 'wrap',
+  alignItems: 'center',
+  marginTop: rem(16),
+  marginBottom: rem(16),
+});
+
+const tagContainerStyles = css({
+  marginTop: rem(24),
+});
+
+const datesStyles = css({
+  display: 'flex',
+  flexWrap: 'wrap',
+  columnGap: rem(12),
+  marginTop: rem(24),
+  '& > *': {
+    lineHeight: rem(16),
+  },
+});
+
+const dateSeparatorStyles = css({
+  alignSelf: 'center',
+});
+
+type AssociationRowProps = {
+  icon: React.ReactNode;
+  items: ReadonlyArray<{ id: string; displayName: string; href?: string }>;
+  max: number;
+  label: 'Projects' | 'Teams';
+  separator?: string;
+};
+
+const AssociationRow: React.FC<AssociationRowProps> = ({
+  icon,
+  items,
+  max,
+  label,
+  separator,
+}) => {
+  const visible = items.slice(0, max);
+  const remaining = items.length - visible.length;
+  return (
+    <div css={associationRowStyles}>
+      <span css={associationIconStyles}>{icon}</span>
+      {visible.map((item, index) => (
+        <span key={item.id} css={associationItemStyles}>
+          {item.href ? (
+            <Link href={item.href}>{item.displayName}</Link>
+          ) : (
+            item.displayName
+          )}
+          {separator && index < visible.length - 1 && (
+            <span css={associationBulletStyles}>{separator}</span>
+          )}
+        </span>
+      ))}
+      {remaining > 0 && (
+        <span css={counterStyles}>
+          <span css={counterAvatarStyles}>
+            <Avatar placeholder={`+${remaining}`} />
+          </span>
+          <span>{label}</span>
+        </span>
+      )}
+    </div>
+  );
+};
+
+type ProjectOutputBodyProps = ProjectOutput & {
+  variant: 'card' | 'list';
+  showTags?: boolean;
+};
+
+const ProjectOutputBody: React.FC<ProjectOutputBodyProps> = ({
+  id: researchOutputId,
+  variant,
+  source = 'project',
+  created,
+  addedDate,
+  lastModifiedDate,
+  teams,
+  title,
+  authors,
+  type,
+  documentType,
+  link,
+  published,
+  isInReview,
+  keywords,
+  showTags = true,
+  projects,
+}) => (
+  <>
+    <div css={metadataRowStyles}>
+      <PillList
+        small
+        pills={[
+          'Project',
+          ...(documentType ? [documentType] : []),
+          ...(type ? [type] : []),
+        ]}
+      />
+      {link && (
+        <ExternalLink
+          href={link}
+          label="Access Output"
+          size="large"
+          noMargin
+        />
+      )}
+    </div>
+    <div css={titleStyles}>
+      {variant === 'card' ? (
+        <LinkHeadline
+          level={2}
+          styleAsHeading={4}
+          href={sharedResearch({}).researchOutput({ researchOutputId }).$}
+        >
+          {title}
+        </LinkHeadline>
+      ) : (
+        <Anchor
+          href={sharedResearch({}).researchOutput({ researchOutputId }).$}
+        >
+          <Headline2 styleAsHeading={5}>{title}</Headline2>
+        </Anchor>
+      )}
+      {!published && (
+        <StateTag
+          label={isInReview ? 'In Review' : 'Draft'}
+          accent={isInReview ? 'blue' : undefined}
+        />
+      )}
+    </div>
+    <UsersList
+      max={3}
+      noMargin
+      users={authors.map((author) => ({
+        ...author,
+        href:
+          'id' in author
+            ? network({}).users({}).user({ userId: author.id }).$
+            : undefined,
+      }))}
+    />
+    <div css={associationStyles}>
+      {projects && projects.length > 0 && (
+        <AssociationRow
+          icon={PROJECT_ICON}
+          max={1}
+          label="Projects"
+          items={projects.map(({ id, title: displayName, href }) => ({
+            id,
+            displayName,
+            href,
+          }))}
+        />
+      )}
+      {source === 'team' && teams.length > 0 && (
+        <AssociationRow
+          icon={TEAM_ICON}
+          max={3}
+          label="Teams"
+          separator="•"
+          items={teams.map(({ id, displayName }) => ({
+            id,
+            displayName: `Team ${displayName}`,
+            href: network({}).teams({}).team({ teamId: id }).$,
+          }))}
+        />
+      )}
+    </div>
+    {showTags && keywords.length > 0 && (
+      <div
+        css={variant === 'list' ? listTagContainerStyles : tagContainerStyles}
+      >
+        <TagList max={3} tags={keywords} />
+      </div>
+    )}
+    <div css={variant === 'list' ? listDatesStyles : datesStyles}>
+      <Caption accent={'lead'} asParagraph>
+        Date Added: {formatDate(new Date(addedDate || created))}
+      </Caption>
+      <Caption accent={'lead'} asParagraph>
+        <span css={dateSeparatorStyles}>• </span>
+        Last Updated:{' '}
+        {formatDate(new Date(lastModifiedDate || addedDate || created))}
+      </Caption>
+    </div>
+  </>
+);
+
+export default ProjectOutputBody;

--- a/packages/react-components/src/molecules/ProjectOutputBody.tsx
+++ b/packages/react-components/src/molecules/ProjectOutputBody.tsx
@@ -362,6 +362,7 @@ const ProjectOutputBody: React.FC<ProjectOutputBodyProps> = ({
   projects,
 }) => {
   const primaryProject = projects?.[0];
+  const firstTeam = teams[0];
 
   const externalLinkElement = link ? (
     <div css={externalLinkWrapperStyles}>
@@ -456,15 +457,17 @@ const ProjectOutputBody: React.FC<ProjectOutputBodyProps> = ({
               {teams.length > 1 ? (
                 <span css={associationItemStyles}>{teams.length} Teams</span>
               ) : (
-                <span css={associationItemStyles}>
-                  <Link
-                    href={
-                      network({}).teams({}).team({ teamId: teams[0]!.id }).$
-                    }
-                  >
-                    Team {teams[0]!.displayName}
-                  </Link>
-                </span>
+                firstTeam && (
+                  <span css={associationItemStyles}>
+                    <Link
+                      href={
+                        network({}).teams({}).team({ teamId: firstTeam.id }).$
+                      }
+                    >
+                      Team {firstTeam.displayName}
+                    </Link>
+                  </span>
+                )
               )}
             </div>
           </>

--- a/packages/react-components/src/molecules/ProjectOutputBody.tsx
+++ b/packages/react-components/src/molecules/ProjectOutputBody.tsx
@@ -182,6 +182,7 @@ const titleStyles = css({
   marginBottom: rem(4),
   [`@media (max-width: ${mobileScreen.max}px)`]: {
     marginTop: 0,
+    marginBottom: rem(16),
   },
 });
 
@@ -195,7 +196,7 @@ const datesStyles = css({
   columnGap: rem(12),
   marginTop: rem(24),
   color: neutral800.rgb,
-  '& > *': {
+  '& > *, & p': {
     lineHeight: rem(16),
   },
   [`@media (max-width: ${mobileScreen.max}px)`]: {
@@ -204,7 +205,6 @@ const datesStyles = css({
 });
 
 const dateSeparatorStyles = css({
-  alignSelf: 'center',
   [`@media (max-width: ${mobileScreen.max}px)`]: {
     display: 'none',
   },
@@ -484,8 +484,8 @@ const ProjectOutputBody: React.FC<ProjectOutputBodyProps> = ({
             Date Added: {formatDate(new Date(addedDate || created))}
           </Caption>
         </span>
+        <span css={dateSeparatorStyles}>•</span>
         <Caption asParagraph noMargin>
-          <span css={dateSeparatorStyles}>• </span>
           Last Updated:{' '}
           {formatDate(new Date(lastModifiedDate || addedDate || created))}
         </Caption>

--- a/packages/react-components/src/molecules/ProjectOutputBody.tsx
+++ b/packages/react-components/src/molecules/ProjectOutputBody.tsx
@@ -10,10 +10,22 @@ import TagList from './TagList';
 import UsersList from './UsersList';
 import { formatDate } from '../date';
 import { rem } from '../pixels';
-import { DiscoveryProjectIcon, TeamIcon } from '../icons';
+import {
+  DiscoveryProjectIcon,
+  ResourceProjectIcon,
+  TeamIcon,
+  TraineeProjectIcon,
+} from '../icons';
 
-const PROJECT_ICON = <DiscoveryProjectIcon />;
 const TEAM_ICON = <TeamIcon />;
+
+export type ProjectOutputType = 'discovery' | 'resource' | 'trainee';
+
+const PROJECT_ICONS: Record<ProjectOutputType, React.ReactElement> = {
+  discovery: <DiscoveryProjectIcon />,
+  resource: <ResourceProjectIcon />,
+  trainee: <TraineeProjectIcon />,
+};
 
 export type ProjectOutput = Pick<
   ResearchOutputResponse,
@@ -30,7 +42,12 @@ export type ProjectOutput = Pick<
   | 'isInReview'
   | 'keywords'
 > & {
-  projects?: ReadonlyArray<{ id: string; title: string; href?: string }>;
+  projects?: ReadonlyArray<{
+    id: string;
+    title: string;
+    projectType: ProjectOutputType;
+    href?: string;
+  }>;
   lastModifiedDate?: string;
   source?: 'team' | 'project';
 };
@@ -193,100 +210,109 @@ const ProjectOutputBody: React.FC<ProjectOutputBodyProps> = ({
   keywords,
   showTags = true,
   projects,
-}) => (
-  <>
-    <div css={metadataRowStyles}>
-      <PillList
-        small
-        pills={[
-          'Project',
-          ...(documentType ? [documentType] : []),
-          ...(type ? [type] : []),
-        ]}
-      />
-      {link && (
-        <ExternalLink href={link} label="Access Output" size="large" noMargin />
-      )}
-    </div>
-    <div css={titleStyles}>
-      {variant === 'card' ? (
-        <LinkHeadline
-          level={2}
-          styleAsHeading={4}
-          href={sharedResearch({}).researchOutput({ researchOutputId }).$}
-        >
-          {title}
-        </LinkHeadline>
-      ) : (
-        <Anchor
-          href={sharedResearch({}).researchOutput({ researchOutputId }).$}
-        >
-          <Headline2 styleAsHeading={5}>{title}</Headline2>
-        </Anchor>
-      )}
-      {!published && (
-        <StateTag
-          label={isInReview ? 'In Review' : 'Draft'}
-          accent={isInReview ? 'blue' : undefined}
+}) => {
+  const primaryProject = projects?.[0];
+
+  return (
+    <>
+      <div css={metadataRowStyles}>
+        <PillList
+          small
+          pills={[
+            'Project',
+            ...(documentType ? [documentType] : []),
+            ...(type ? [type] : []),
+          ]}
         />
-      )}
-    </div>
-    <UsersList
-      max={3}
-      noMargin
-      users={authors.map((author) => ({
-        ...author,
-        href:
-          'id' in author
-            ? network({}).users({}).user({ userId: author.id }).$
-            : /* istanbul ignore next */ undefined,
-      }))}
-    />
-    <div css={associationStyles}>
-      {projects && projects.length > 0 && (
-        <AssociationRow
-          icon={PROJECT_ICON}
-          max={1}
-          label="Projects"
-          items={projects.map(({ id, title: displayName, href }) => ({
-            id,
-            displayName,
-            href,
-          }))}
-        />
-      )}
-      {source === 'team' && teams.length > 0 && (
-        <AssociationRow
-          icon={TEAM_ICON}
-          max={3}
-          label="Teams"
-          separator="•"
-          items={teams.map(({ id, displayName }) => ({
-            id,
-            displayName: `Team ${displayName}`,
-            href: network({}).teams({}).team({ teamId: id }).$,
-          }))}
-        />
-      )}
-    </div>
-    {showTags && keywords.length > 0 && (
-      <div
-        css={variant === 'list' ? listTagContainerStyles : tagContainerStyles}
-      >
-        <TagList max={3} tags={keywords} />
+        {link && (
+          <ExternalLink
+            href={link}
+            label="Access Output"
+            size="large"
+            noMargin
+          />
+        )}
       </div>
-    )}
-    <div css={variant === 'list' ? listDatesStyles : datesStyles}>
-      <Caption accent={'lead'} asParagraph>
-        Date Added: {formatDate(new Date(addedDate || created))}
-      </Caption>
-      <Caption accent={'lead'} asParagraph>
-        <span css={dateSeparatorStyles}>• </span>
-        Last Updated:{' '}
-        {formatDate(new Date(lastModifiedDate || addedDate || created))}
-      </Caption>
-    </div>
-  </>
-);
+      <div css={titleStyles}>
+        {variant === 'card' ? (
+          <LinkHeadline
+            level={2}
+            styleAsHeading={4}
+            href={sharedResearch({}).researchOutput({ researchOutputId }).$}
+          >
+            {title}
+          </LinkHeadline>
+        ) : (
+          <Anchor
+            href={sharedResearch({}).researchOutput({ researchOutputId }).$}
+          >
+            <Headline2 styleAsHeading={5}>{title}</Headline2>
+          </Anchor>
+        )}
+        {!published && (
+          <StateTag
+            label={isInReview ? 'In Review' : 'Draft'}
+            accent={isInReview ? 'blue' : undefined}
+          />
+        )}
+      </div>
+      <UsersList
+        max={3}
+        noMargin
+        users={authors.map((author) => ({
+          ...author,
+          href:
+            'id' in author
+              ? network({}).users({}).user({ userId: author.id }).$
+              : /* istanbul ignore next */ undefined,
+        }))}
+      />
+      <div css={associationStyles}>
+        {primaryProject && (
+          <AssociationRow
+            icon={PROJECT_ICONS[primaryProject.projectType]}
+            max={1}
+            label="Projects"
+            items={(projects ?? []).map(({ id, title: displayName, href }) => ({
+              id,
+              displayName,
+              href,
+            }))}
+          />
+        )}
+        {source === 'team' && teams.length > 0 && (
+          <AssociationRow
+            icon={TEAM_ICON}
+            max={3}
+            label="Teams"
+            separator="•"
+            items={teams.map(({ id, displayName }) => ({
+              id,
+              displayName: `Team ${displayName}`,
+              href: network({}).teams({}).team({ teamId: id }).$,
+            }))}
+          />
+        )}
+      </div>
+      {showTags && keywords.length > 0 && (
+        <div
+          css={variant === 'list' ? listTagContainerStyles : tagContainerStyles}
+        >
+          <TagList max={3} tags={keywords} />
+        </div>
+      )}
+      <div css={variant === 'list' ? listDatesStyles : datesStyles}>
+        <Caption accent={'lead'} asParagraph>
+          Date Added: {formatDate(new Date(addedDate || created))}
+        </Caption>
+        <Caption accent={'lead'} asParagraph>
+          <span css={dateSeparatorStyles}>• </span>
+          Last Updated:{' '}
+          {formatDate(new Date(lastModifiedDate || addedDate || created))}
+        </Caption>
+      </div>
+    </>
+  );
+};
 
 export default ProjectOutputBody;

--- a/packages/react-components/src/molecules/ProjectOutputBody.tsx
+++ b/packages/react-components/src/molecules/ProjectOutputBody.tsx
@@ -190,7 +190,10 @@ const AuthorRow: React.FC<AuthorRowProps> = ({ authors, max }) => {
       {visible.map((author, index) => {
         const isInternal = 'firstName' in author;
         return (
-          <span key={isInternal ? author.id : `ext-${index}`} css={authorItemStyles}>
+          <span
+            key={isInternal ? author.id : `ext-${index}`}
+            css={authorItemStyles}
+          >
             <Avatar
               firstName={isInternal ? author.firstName : undefined}
               lastName={isInternal ? author.lastName : undefined}
@@ -326,7 +329,9 @@ const ProjectOutputBody: React.FC<ProjectOutputBodyProps> = ({
           <Anchor
             href={sharedResearch({}).researchOutput({ researchOutputId }).$}
           >
-            <Headline2 styleAsHeading={5} noMargin>{title}</Headline2>
+            <Headline2 styleAsHeading={5} noMargin>
+              {title}
+            </Headline2>
           </Anchor>
         )}
         {!published && (

--- a/packages/react-components/src/molecules/ProjectOutputBody.tsx
+++ b/packages/react-components/src/molecules/ProjectOutputBody.tsx
@@ -7,10 +7,10 @@ import ExternalLink from './ExternalLink';
 import LinkHeadline from './LinkHeadline';
 import PillList from './PillList';
 import TagList from './TagList';
-import UsersList from './UsersList';
 import { formatDate } from '../date';
 import { rem } from '../pixels';
 import {
+  alumniBadgeIcon,
   DiscoveryProjectIcon,
   ResourceProjectIcon,
   TeamIcon,
@@ -67,16 +67,21 @@ const metadataRowStyles = css({
   height: rem(32),
 });
 
-const listTagContainerStyles = css({
-  marginTop: rem(24),
-});
-
-const listDatesStyles = css({
+const externalLinkWrapperStyles = css({
   display: 'flex',
-  flexWrap: 'wrap',
-  columnGap: rem(12),
-  '& > *': {
-    lineHeight: rem(16),
+  alignItems: 'center',
+  height: rem(32),
+  '& > div': {
+    height: '100%',
+  },
+  '& a': {
+    display: 'flex',
+    alignItems: 'center',
+    height: '100%',
+  },
+  '& a > span': {
+    height: '100%',
+    boxSizing: 'border-box',
   },
 });
 
@@ -104,16 +109,22 @@ const associationBulletStyles = css({
   marginLeft: rem(8),
 });
 
-const counterStyles = css({
+const counterBaseStyles = css({
   display: 'inline-flex',
   alignItems: 'center',
   columnGap: rem(8),
-  marginLeft: rem(8),
+});
+
+const associationCounterStyles = css(counterBaseStyles, {
+  marginLeft: rem(32),
 });
 
 const counterAvatarStyles = css({
   width: rem(24),
   flex: 'none',
+  '& > p': {
+    margin: 0,
+  },
 });
 
 const titleStyles = css({
@@ -121,8 +132,8 @@ const titleStyles = css({
   columnGap: rem(15),
   flexWrap: 'wrap',
   alignItems: 'center',
-  marginTop: rem(16),
-  marginBottom: rem(16),
+  marginTop: rem(4),
+  marginBottom: rem(4),
 });
 
 const tagContainerStyles = css({
@@ -142,6 +153,73 @@ const datesStyles = css({
 const dateSeparatorStyles = css({
   alignSelf: 'center',
 });
+
+const authorRowStyles = css({
+  display: 'flex',
+  flexWrap: 'wrap',
+  alignItems: 'center',
+  columnGap: rem(40),
+  rowGap: rem(8),
+});
+
+const authorItemStyles = css({
+  display: 'inline-flex',
+  alignItems: 'center',
+  columnGap: rem(8),
+  '& > div:first-of-type': {
+    width: rem(24),
+    height: rem(24),
+    flex: 'none',
+    margin: 0,
+    '& > p': {
+      margin: 0,
+    },
+  },
+});
+
+type AuthorRowProps = {
+  authors: ProjectOutput['authors'];
+  max: number;
+};
+
+const AuthorRow: React.FC<AuthorRowProps> = ({ authors, max }) => {
+  const visible = authors.slice(0, max);
+  const remaining = authors.length - visible.length;
+  return (
+    <div css={authorRowStyles}>
+      {visible.map((author, index) => {
+        const isInternal = 'firstName' in author;
+        return (
+          <span key={isInternal ? author.id : `ext-${index}`} css={authorItemStyles}>
+            <Avatar
+              firstName={isInternal ? author.firstName : undefined}
+              lastName={isInternal ? author.lastName : undefined}
+              imageUrl={isInternal ? author.avatarUrl : undefined}
+            />
+            {isInternal ? (
+              <Link href={network({}).users({}).user({ userId: author.id }).$}>
+                {author.displayName}
+              </Link>
+            ) : (
+              author.displayName
+            )}
+            {isInternal && author.alumniSinceDate && (
+              <span css={{ display: 'inline-flex' }}>{alumniBadgeIcon}</span>
+            )}
+          </span>
+        );
+      })}
+      {remaining > 0 && (
+        <span css={counterBaseStyles}>
+          <span css={counterAvatarStyles}>
+            <Avatar placeholder={`+${remaining}`} />
+          </span>
+          <span>Authors</span>
+        </span>
+      )}
+    </div>
+  );
+};
 
 type AssociationRowProps = {
   icon: React.ReactNode;
@@ -176,7 +254,7 @@ const AssociationRow: React.FC<AssociationRowProps> = ({
         </span>
       ))}
       {remaining > 0 && (
-        <span css={counterStyles}>
+        <span css={associationCounterStyles}>
           <span css={counterAvatarStyles}>
             <Avatar placeholder={`+${remaining}`} />
           </span>
@@ -225,12 +303,14 @@ const ProjectOutputBody: React.FC<ProjectOutputBodyProps> = ({
           ]}
         />
         {link && (
-          <ExternalLink
-            href={link}
-            label="Access Output"
-            size="large"
-            noMargin
-          />
+          <div css={externalLinkWrapperStyles}>
+            <ExternalLink
+              href={link}
+              label="Access Output"
+              size="large"
+              noMargin
+            />
+          </div>
         )}
       </div>
       <div css={titleStyles}>
@@ -246,7 +326,7 @@ const ProjectOutputBody: React.FC<ProjectOutputBodyProps> = ({
           <Anchor
             href={sharedResearch({}).researchOutput({ researchOutputId }).$}
           >
-            <Headline2 styleAsHeading={5}>{title}</Headline2>
+            <Headline2 styleAsHeading={5} noMargin>{title}</Headline2>
           </Anchor>
         )}
         {!published && (
@@ -256,17 +336,7 @@ const ProjectOutputBody: React.FC<ProjectOutputBodyProps> = ({
           />
         )}
       </div>
-      <UsersList
-        max={3}
-        noMargin
-        users={authors.map((author) => ({
-          ...author,
-          href:
-            'id' in author
-              ? network({}).users({}).user({ userId: author.id }).$
-              : /* istanbul ignore next */ undefined,
-        }))}
-      />
+      <AuthorRow authors={authors} max={3} />
       <div css={associationStyles}>
         {primaryProject && (
           <AssociationRow
@@ -295,17 +365,15 @@ const ProjectOutputBody: React.FC<ProjectOutputBodyProps> = ({
         )}
       </div>
       {showTags && keywords.length > 0 && (
-        <div
-          css={variant === 'list' ? listTagContainerStyles : tagContainerStyles}
-        >
+        <div css={tagContainerStyles}>
           <TagList max={3} tags={keywords} />
         </div>
       )}
-      <div css={variant === 'list' ? listDatesStyles : datesStyles}>
-        <Caption accent={'lead'} asParagraph>
+      <div css={datesStyles}>
+        <Caption accent={'lead'} asParagraph noMargin>
           Date Added: {formatDate(new Date(addedDate || created))}
         </Caption>
-        <Caption accent={'lead'} asParagraph>
+        <Caption accent={'lead'} asParagraph noMargin>
           <span css={dateSeparatorStyles}>• </span>
           Last Updated:{' '}
           {formatDate(new Date(lastModifiedDate || addedDate || created))}

--- a/packages/react-components/src/molecules/ProjectOutputBody.tsx
+++ b/packages/react-components/src/molecules/ProjectOutputBody.tsx
@@ -2,13 +2,22 @@ import { css } from '@emotion/react';
 import { ResearchOutputResponse } from '@asap-hub/model';
 import { network, sharedResearch } from '@asap-hub/routing';
 
-import { Anchor, Avatar, Caption, Headline2, Link, StateTag } from '../atoms';
+import {
+  Anchor,
+  Avatar,
+  Caption,
+  Headline2,
+  Link,
+  Pill,
+  StateTag,
+} from '../atoms';
 import ExternalLink from './ExternalLink';
 import LinkHeadline from './LinkHeadline';
 import PillList from './PillList';
 import TagList from './TagList';
 import { formatDate } from '../date';
-import { rem } from '../pixels';
+import { neutral800 } from '../colors';
+import { mobileScreen, rem } from '../pixels';
 import {
   alumniBadgeIcon,
   DiscoveryProjectIcon,
@@ -52,6 +61,32 @@ export type ProjectOutput = Pick<
   source?: 'team' | 'project';
 };
 
+const mobileOnlyStyles = css({
+  display: 'none',
+  [`@media (max-width: ${mobileScreen.max}px)`]: {
+    display: 'flex',
+  },
+});
+
+const mobilePillStyles = css({
+  '& > span': {
+    margin: 0,
+  },
+});
+
+const mobilePillListStyles = css({
+  '& > ul': {
+    marginTop: rem(8),
+    marginBottom: 0,
+  },
+});
+
+const desktopOnlyStyles = css({
+  [`@media (max-width: ${mobileScreen.max}px)`]: {
+    display: 'none',
+  },
+});
+
 const associationStyles = css({
   display: 'flex',
   flexDirection: 'column',
@@ -65,6 +100,10 @@ const metadataRowStyles = css({
   justifyContent: 'space-between',
   columnGap: rem(12),
   height: rem(32),
+  [`@media (max-width: ${mobileScreen.max}px)`]: {
+    height: 'auto',
+    flexWrap: 'wrap',
+  },
 });
 
 const externalLinkWrapperStyles = css({
@@ -91,6 +130,9 @@ const associationRowStyles = css({
   alignItems: 'center',
   columnGap: rem(8),
   rowGap: rem(8),
+  [`@media (max-width: ${mobileScreen.max}px)`]: {
+    rowGap: rem(16),
+  },
 });
 
 const associationIconStyles = css({
@@ -117,6 +159,10 @@ const counterBaseStyles = css({
 
 const associationCounterStyles = css(counterBaseStyles, {
   marginLeft: rem(32),
+  [`@media (max-width: ${mobileScreen.max}px)`]: {
+    marginLeft: 0,
+    flexBasis: '100%',
+  },
 });
 
 const counterAvatarStyles = css({
@@ -134,6 +180,9 @@ const titleStyles = css({
   alignItems: 'center',
   marginTop: rem(4),
   marginBottom: rem(4),
+  [`@media (max-width: ${mobileScreen.max}px)`]: {
+    marginTop: 0,
+  },
 });
 
 const tagContainerStyles = css({
@@ -145,13 +194,28 @@ const datesStyles = css({
   flexWrap: 'wrap',
   columnGap: rem(12),
   marginTop: rem(24),
+  color: neutral800.rgb,
   '& > *': {
     lineHeight: rem(16),
+  },
+  [`@media (max-width: ${mobileScreen.max}px)`]: {
+    flexDirection: 'column',
   },
 });
 
 const dateSeparatorStyles = css({
   alignSelf: 'center',
+  [`@media (max-width: ${mobileScreen.max}px)`]: {
+    display: 'none',
+  },
+});
+
+const dateAddedStyles = css({
+  [`@media (max-width: ${mobileScreen.max}px)`]: {
+    '& > p::after': {
+      content: '"  •"',
+    },
+  },
 });
 
 const authorRowStyles = css({
@@ -160,6 +224,11 @@ const authorRowStyles = css({
   alignItems: 'center',
   columnGap: rem(40),
   rowGap: rem(8),
+  [`@media (max-width: ${mobileScreen.max}px)`]: {
+    flexDirection: 'column',
+    alignItems: 'flex-start',
+    rowGap: rem(16),
+  },
 });
 
 const authorItemStyles = css({
@@ -294,9 +363,15 @@ const ProjectOutputBody: React.FC<ProjectOutputBodyProps> = ({
 }) => {
   const primaryProject = projects?.[0];
 
+  const externalLinkElement = link ? (
+    <div css={externalLinkWrapperStyles}>
+      <ExternalLink href={link} label="Access Output" size="large" noMargin />
+    </div>
+  ) : null;
+
   return (
     <>
-      <div css={metadataRowStyles}>
+      <div css={[metadataRowStyles, desktopOnlyStyles]}>
         <PillList
           small
           pills={[
@@ -305,17 +380,23 @@ const ProjectOutputBody: React.FC<ProjectOutputBodyProps> = ({
             ...(type ? [type] : []),
           ]}
         />
-        {link && (
-          <div css={externalLinkWrapperStyles}>
-            <ExternalLink
-              href={link}
-              label="Access Output"
-              size="large"
-              noMargin
-            />
-          </div>
-        )}
+        {externalLinkElement}
       </div>
+      <div css={[metadataRowStyles, mobileOnlyStyles, mobilePillStyles]}>
+        <Pill small>Project</Pill>
+        {externalLinkElement}
+      </div>
+      {(documentType || type) && (
+        <div css={[mobileOnlyStyles, mobilePillListStyles]}>
+          <PillList
+            small
+            pills={[
+              ...(documentType ? [documentType] : []),
+              ...(type ? [type] : []),
+            ]}
+          />
+        </div>
+      )}
       <div css={titleStyles}>
         {variant === 'card' ? (
           <LinkHeadline
@@ -356,17 +437,37 @@ const ProjectOutputBody: React.FC<ProjectOutputBodyProps> = ({
           />
         )}
         {source === 'team' && teams.length > 0 && (
-          <AssociationRow
-            icon={TEAM_ICON}
-            max={3}
-            label="Teams"
-            separator="•"
-            items={teams.map(({ id, displayName }) => ({
-              id,
-              displayName: `Team ${displayName}`,
-              href: network({}).teams({}).team({ teamId: id }).$,
-            }))}
-          />
+          <>
+            <div css={desktopOnlyStyles}>
+              <AssociationRow
+                icon={TEAM_ICON}
+                max={3}
+                label="Teams"
+                separator="•"
+                items={teams.map(({ id, displayName }) => ({
+                  id,
+                  displayName: `Team ${displayName}`,
+                  href: network({}).teams({}).team({ teamId: id }).$,
+                }))}
+              />
+            </div>
+            <div css={[associationRowStyles, mobileOnlyStyles]}>
+              <span css={associationIconStyles}>{TEAM_ICON}</span>
+              {teams.length > 1 ? (
+                <span css={associationItemStyles}>{teams.length} Teams</span>
+              ) : (
+                <span css={associationItemStyles}>
+                  <Link
+                    href={
+                      network({}).teams({}).team({ teamId: teams[0]!.id }).$
+                    }
+                  >
+                    Team {teams[0]!.displayName}
+                  </Link>
+                </span>
+              )}
+            </div>
+          </>
         )}
       </div>
       {showTags && keywords.length > 0 && (
@@ -375,10 +476,12 @@ const ProjectOutputBody: React.FC<ProjectOutputBodyProps> = ({
         </div>
       )}
       <div css={datesStyles}>
-        <Caption accent={'lead'} asParagraph noMargin>
-          Date Added: {formatDate(new Date(addedDate || created))}
-        </Caption>
-        <Caption accent={'lead'} asParagraph noMargin>
+        <span css={dateAddedStyles}>
+          <Caption asParagraph noMargin>
+            Date Added: {formatDate(new Date(addedDate || created))}
+          </Caption>
+        </span>
+        <Caption asParagraph noMargin>
           <span css={dateSeparatorStyles}>• </span>
           Last Updated:{' '}
           {formatDate(new Date(lastModifiedDate || addedDate || created))}

--- a/packages/react-components/src/molecules/ProjectOutputBody.tsx
+++ b/packages/react-components/src/molecules/ProjectOutputBody.tsx
@@ -10,10 +10,7 @@ import TagList from './TagList';
 import UsersList from './UsersList';
 import { formatDate } from '../date';
 import { rem } from '../pixels';
-import {
-  DiscoveryProjectIcon,
-  TeamIcon,
-} from '../icons';
+import { DiscoveryProjectIcon, TeamIcon } from '../icons';
 
 const PROJECT_ICON = <DiscoveryProjectIcon />;
 const TEAM_ICON = <TeamIcon />;
@@ -208,12 +205,7 @@ const ProjectOutputBody: React.FC<ProjectOutputBodyProps> = ({
         ]}
       />
       {link && (
-        <ExternalLink
-          href={link}
-          label="Access Output"
-          size="large"
-          noMargin
-        />
+        <ExternalLink href={link} label="Access Output" size="large" noMargin />
       )}
     </div>
     <div css={titleStyles}>

--- a/packages/react-components/src/molecules/__tests__/AssociationList.test.tsx
+++ b/packages/react-components/src/molecules/__tests__/AssociationList.test.tsx
@@ -250,3 +250,34 @@ it('renders category associations', () => {
   expect(screen.getByText('Cat Two')).toBeInTheDocument();
   expect(screen.getByTitle('Category icon')).toBeInTheDocument();
 });
+
+describe('Projects', () => {
+  it('renders project name with link when href is provided', () => {
+    render(
+      <AssociationList
+        inline
+        type="Project"
+        associations={[
+          { displayName: 'Project Alpha', id: 'p1', href: '/projects/p1' },
+        ]}
+      />,
+    );
+    expect(
+      screen.getByRole('link', { name: 'Project Alpha' }),
+    ).toHaveAttribute('href', '/projects/p1');
+  });
+
+  it('renders project name as plain text when href is absent', () => {
+    render(
+      <AssociationList
+        inline
+        type="Project"
+        associations={[{ displayName: 'Project Alpha', id: 'p1' }]}
+      />,
+    );
+    expect(screen.getByText('Project Alpha')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: 'Project Alpha' }),
+    ).toBeNull();
+  });
+});

--- a/packages/react-components/src/molecules/__tests__/AssociationList.test.tsx
+++ b/packages/react-components/src/molecules/__tests__/AssociationList.test.tsx
@@ -250,33 +250,3 @@ it('renders category associations', () => {
   expect(screen.getByText('Cat Two')).toBeInTheDocument();
   expect(screen.getByTitle('Category icon')).toBeInTheDocument();
 });
-
-describe('Projects', () => {
-  it('renders project name with link when href is provided', () => {
-    render(
-      <AssociationList
-        inline
-        type="Project"
-        associations={[
-          { displayName: 'Project Alpha', id: 'p1', href: '/projects/p1' },
-        ]}
-      />,
-    );
-    expect(screen.getByRole('link', { name: 'Project Alpha' })).toHaveAttribute(
-      'href',
-      '/projects/p1',
-    );
-  });
-
-  it('renders project name as plain text when href is absent', () => {
-    render(
-      <AssociationList
-        inline
-        type="Project"
-        associations={[{ displayName: 'Project Alpha', id: 'p1' }]}
-      />,
-    );
-    expect(screen.getByText('Project Alpha')).toBeInTheDocument();
-    expect(screen.queryByRole('link', { name: 'Project Alpha' })).toBeNull();
-  });
-});

--- a/packages/react-components/src/molecules/__tests__/AssociationList.test.tsx
+++ b/packages/react-components/src/molecules/__tests__/AssociationList.test.tsx
@@ -262,9 +262,10 @@ describe('Projects', () => {
         ]}
       />,
     );
-    expect(
-      screen.getByRole('link', { name: 'Project Alpha' }),
-    ).toHaveAttribute('href', '/projects/p1');
+    expect(screen.getByRole('link', { name: 'Project Alpha' })).toHaveAttribute(
+      'href',
+      '/projects/p1',
+    );
   });
 
   it('renders project name as plain text when href is absent', () => {
@@ -276,8 +277,6 @@ describe('Projects', () => {
       />,
     );
     expect(screen.getByText('Project Alpha')).toBeInTheDocument();
-    expect(
-      screen.queryByRole('link', { name: 'Project Alpha' }),
-    ).toBeNull();
+    expect(screen.queryByRole('link', { name: 'Project Alpha' })).toBeNull();
   });
 });

--- a/packages/react-components/src/molecules/__tests__/ProjectOutputBody.test.tsx
+++ b/packages/react-components/src/molecules/__tests__/ProjectOutputBody.test.tsx
@@ -60,3 +60,86 @@ it('renders author overflow counter when authors exceed max', () => {
   expect(getByText('+2')).toBeVisible();
   expect(getByText('Authors')).toBeVisible();
 });
+
+it('renders list variant with headline style 5', () => {
+  const { getByRole } = render(
+    <ProjectOutputBody {...baseProps} variant="list" />,
+  );
+  expect(getByRole('heading', { level: 2 })).toBeVisible();
+});
+
+it('renders Draft state tag when not published', () => {
+  const { getByText } = render(
+    <ProjectOutputBody {...baseProps} published={false} isInReview={false} />,
+  );
+  expect(getByText('Draft')).toBeVisible();
+});
+
+it('renders In Review state tag when in review', () => {
+  const { getByText } = render(
+    <ProjectOutputBody {...baseProps} published={false} isInReview={true} />,
+  );
+  expect(getByText('In Review')).toBeVisible();
+});
+
+it('renders external link when link is provided', () => {
+  const { getAllByText } = render(
+    <ProjectOutputBody {...baseProps} link="https://example.com" />,
+  );
+  expect(getAllByText('Access Output').length).toBeGreaterThanOrEqual(1);
+});
+
+it('hides mobile pill list when documentType and type are absent', () => {
+  const { queryAllByText } = render(
+    <ProjectOutputBody
+      {...baseProps}
+      documentType={undefined as never}
+      type={undefined as never}
+    />,
+  );
+  expect(queryAllByText('Project')).toHaveLength(2);
+});
+
+it('hides teams section when source is project', () => {
+  const { queryByText } = render(
+    <ProjectOutputBody {...baseProps} source="project" />,
+  );
+  expect(queryByText(/Team Jakobsson/)).toBeNull();
+});
+
+it('renders multiple teams count on mobile layout', () => {
+  const { getByText } = render(
+    <ProjectOutputBody
+      {...baseProps}
+      teams={[
+        { id: 't1', displayName: 'Alpha', teamType: 'Discovery Team' },
+        { id: 't2', displayName: 'Beta', teamType: 'Discovery Team' },
+      ]}
+    />,
+  );
+  expect(getByText('2 Teams')).toBeInTheDocument();
+});
+
+it('renders project association row', () => {
+  const { getByText } = render(
+    <ProjectOutputBody
+      {...baseProps}
+      projects={[
+        {
+          id: 'p1',
+          title: 'My Project',
+          projectType: 'discovery',
+          href: '/projects/p1',
+        },
+      ]}
+    />,
+  );
+  expect(getByText('My Project')).toBeVisible();
+});
+
+it('hides tags when showTags is false', () => {
+  const { queryByText } = render(
+    <ProjectOutputBody {...baseProps} showTags={false} />,
+  );
+  expect(queryByText('Etag')).toBeNull();
+});

--- a/packages/react-components/src/molecules/__tests__/ProjectOutputBody.test.tsx
+++ b/packages/react-components/src/molecules/__tests__/ProjectOutputBody.test.tsx
@@ -1,0 +1,18 @@
+import { ComponentProps } from 'react';
+import { render } from '@testing-library/react';
+import { createResearchOutputResponse } from '@asap-hub/fixtures';
+
+import ProjectOutputBody from '../ProjectOutputBody';
+
+const baseProps: ComponentProps<typeof ProjectOutputBody> = {
+  ...createResearchOutputResponse(),
+  variant: 'card',
+  source: 'team',
+};
+
+it('defaults showTags to true when omitted', () => {
+  const { getByText } = render(
+    <ProjectOutputBody {...baseProps} keywords={['Etag']} />,
+  );
+  expect(getByText('Etag')).toBeVisible();
+});

--- a/packages/react-components/src/molecules/__tests__/ProjectOutputBody.test.tsx
+++ b/packages/react-components/src/molecules/__tests__/ProjectOutputBody.test.tsx
@@ -16,3 +16,47 @@ it('defaults showTags to true when omitted', () => {
   );
   expect(getByText('Etag')).toBeVisible();
 });
+
+it('renders external author display name', () => {
+  const { getByText } = render(
+    <ProjectOutputBody
+      {...baseProps}
+      authors={[{ id: 'ext-1', displayName: 'External Author' }]}
+    />,
+  );
+  expect(getByText('External Author')).toBeVisible();
+});
+
+it('renders alumni badge for internal authors with alumniSinceDate', () => {
+  const { getByTitle } = render(
+    <ProjectOutputBody
+      {...baseProps}
+      authors={[
+        {
+          id: 'u1',
+          firstName: 'John',
+          lastName: 'Doe',
+          displayName: 'John Doe',
+          avatarUrl: undefined,
+          alumniSinceDate: '2020-01-01',
+        },
+      ]}
+    />,
+  );
+  expect(getByTitle('Alumni Member')).toBeInTheDocument();
+});
+
+it('renders author overflow counter when authors exceed max', () => {
+  const authors = Array.from({ length: 5 }, (_, i) => ({
+    id: `u${i}`,
+    firstName: `First${i}`,
+    lastName: `Last${i}`,
+    displayName: `First${i} Last${i}`,
+    avatarUrl: undefined,
+  }));
+  const { getByText } = render(
+    <ProjectOutputBody {...baseProps} authors={authors} />,
+  );
+  expect(getByText('+2')).toBeVisible();
+  expect(getByText('Authors')).toBeVisible();
+});

--- a/packages/react-components/src/molecules/index.ts
+++ b/packages/react-components/src/molecules/index.ts
@@ -62,6 +62,8 @@ export { default as PillList } from './PillList';
 export { default as ProjectDuration } from './ProjectDuration';
 export { default as ProjectMemberCard } from './ProjectMemberCard';
 export { default as ProjectMembers } from './ProjectMembers';
+export { default as ProjectOutputBody } from './ProjectOutputBody';
+export type { ProjectOutput } from './ProjectOutputBody';
 export { default as ReminderItem } from './ReminderItem';
 export { default as SearchField } from './SearchField';
 export { default as SocialIcons } from './SocialIcons';

--- a/packages/react-components/src/molecules/index.ts
+++ b/packages/react-components/src/molecules/index.ts
@@ -63,7 +63,7 @@ export { default as ProjectDuration } from './ProjectDuration';
 export { default as ProjectMemberCard } from './ProjectMemberCard';
 export { default as ProjectMembers } from './ProjectMembers';
 export { default as ProjectOutputBody } from './ProjectOutputBody';
-export type { ProjectOutput } from './ProjectOutputBody';
+export type { ProjectOutput, ProjectOutputType } from './ProjectOutputBody';
 export { default as ReminderItem } from './ReminderItem';
 export { default as SearchField } from './SearchField';
 export { default as SocialIcons } from './SocialIcons';

--- a/packages/react-components/src/organisms/ProjectOutputCard.tsx
+++ b/packages/react-components/src/organisms/ProjectOutputCard.tsx
@@ -1,0 +1,18 @@
+import { Card } from '../atoms';
+import { ProjectOutputBody } from '../molecules';
+import type { ProjectOutput } from '../molecules';
+
+export type ProjectOutputCardProps = ProjectOutput & {
+  showTags?: boolean;
+};
+
+const ProjectOutputCard: React.FC<ProjectOutputCardProps> = ({
+  showTags = true,
+  ...output
+}) => (
+  <Card accent={output.published ? 'default' : 'neutral200'}>
+    <ProjectOutputBody variant="card" showTags={showTags} {...output} />
+  </Card>
+);
+
+export default ProjectOutputCard;

--- a/packages/react-components/src/organisms/ProjectOutputListCard.tsx
+++ b/packages/react-components/src/organisms/ProjectOutputListCard.tsx
@@ -43,11 +43,7 @@ const ProjectOutputListCard: React.FC<ProjectOutputListCardProps> = ({
             algoliaQueryId={algoliaQueryId}
             objectId={output.id}
           >
-            <ProjectOutputBody
-              variant="list"
-              showTags={showTags}
-              {...output}
-            />
+            <ProjectOutputBody variant="list" showTags={showTags} {...output} />
           </AlgoliaHit>
         </li>
       ))}

--- a/packages/react-components/src/organisms/ProjectOutputListCard.tsx
+++ b/packages/react-components/src/organisms/ProjectOutputListCard.tsx
@@ -1,0 +1,58 @@
+import { css } from '@emotion/react';
+
+import { Card } from '../atoms';
+import { ProjectOutputBody } from '../molecules';
+import type { ProjectOutput } from '../molecules';
+import { steel } from '../colors';
+import { paddingStyles } from '../card';
+import AlgoliaHit from '../atoms/AlgoliaHit';
+import { rem } from '../pixels';
+
+const containerStyles = css({
+  margin: 0,
+  padding: 0,
+  listStyle: 'none',
+});
+
+const itemStyles = css({
+  borderBottom: `1px solid ${steel.rgb}`,
+  display: 'grid',
+  rowGap: rem(12),
+  '&:last-of-type': {
+    borderBottom: 'none',
+  },
+});
+
+type ProjectOutputListCardProps = {
+  algoliaQueryId?: string;
+  researchOutputs: ReadonlyArray<ProjectOutput>;
+  showTags?: boolean;
+};
+
+const ProjectOutputListCard: React.FC<ProjectOutputListCardProps> = ({
+  researchOutputs,
+  algoliaQueryId,
+  showTags = true,
+}) => (
+  <Card padding={false}>
+    <ul css={containerStyles}>
+      {researchOutputs.map((output, index) => (
+        <li key={output.id} css={[itemStyles, paddingStyles]}>
+          <AlgoliaHit
+            index={index}
+            algoliaQueryId={algoliaQueryId}
+            objectId={output.id}
+          >
+            <ProjectOutputBody
+              variant="list"
+              showTags={showTags}
+              {...output}
+            />
+          </AlgoliaHit>
+        </li>
+      ))}
+    </ul>
+  </Card>
+);
+
+export default ProjectOutputListCard;

--- a/packages/react-components/src/organisms/__tests__/ProjectOutputCard.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/ProjectOutputCard.test.tsx
@@ -26,7 +26,14 @@ it('renders projects with clickable link when href present', () => {
   const { getByRole } = render(
     <ProjectOutputCard
       {...baseProps}
-      projects={[{ id: 'p1', title: 'My Project', href: '/projects/p1' }]}
+      projects={[
+        {
+          id: 'p1',
+          title: 'My Project',
+          projectType: 'discovery',
+          href: '/projects/p1',
+        },
+      ]}
     />,
   );
   const link = getByRole('link', { name: 'My Project' });
@@ -37,7 +44,9 @@ it('renders projects as plain text when href absent', () => {
   const { getByText, queryByRole } = render(
     <ProjectOutputCard
       {...baseProps}
-      projects={[{ id: 'p1', title: 'No-link Project' }]}
+      projects={[
+        { id: 'p1', title: 'No-link Project', projectType: 'discovery' },
+      ]}
     />,
   );
   expect(getByText('No-link Project')).toBeVisible();

--- a/packages/react-components/src/organisms/__tests__/ProjectOutputCard.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/ProjectOutputCard.test.tsx
@@ -75,6 +75,17 @@ it('omits Team association for project-based output even when teams present', ()
   expect(queryByText('Team Alpha')).toBeNull();
 });
 
+it('defaults source to project when not provided', () => {
+  const { source: _unused, ...propsWithoutSource } = baseProps;
+  const { queryByText } = render(
+    <ProjectOutputCard
+      {...propsWithoutSource}
+      teams={[{ id: 't1', displayName: 'Alpha', teamType: 'Discovery Team' }]}
+    />,
+  );
+  expect(queryByText('Team Alpha')).toBeNull();
+});
+
 it('displays Draft tag when not published', () => {
   const { getByText, queryByText, rerender } = render(
     <ProjectOutputCard {...baseProps} published={false} />,
@@ -137,16 +148,6 @@ it('falls back Last Updated to addedDate then created when lastModifiedDate abse
   expect(getByText(/Last Updated/).textContent).toContain('1st January 2019');
 });
 
-it('renders authors', () => {
-  const { getByText } = render(
-    <ProjectOutputCard
-      {...baseProps}
-      authors={[{ id: 'u1', displayName: 'Author One' }]}
-    />,
-  );
-  expect(getByText('Author One')).toBeVisible();
-});
-
 it('renders tags when showTags', () => {
   const { getByText, queryByText, rerender } = render(
     <ProjectOutputCard {...baseProps} keywords={['Etag']} showTags />,
@@ -157,4 +158,27 @@ it('renders tags when showTags', () => {
     <ProjectOutputCard {...baseProps} keywords={['Etag']} showTags={false} />,
   );
   expect(queryByText('Etag')).toBeNull();
+});
+
+it('omits the tags block when keywords are empty', () => {
+  const { queryByText } = render(
+    <ProjectOutputCard {...baseProps} keywords={[]} showTags />,
+  );
+  expect(queryByText('Etag')).toBeNull();
+});
+
+it('renders +N counter when teams exceed the visible limit', () => {
+  const { getByText } = render(
+    <ProjectOutputCard
+      {...baseProps}
+      teams={[
+        { id: 't1', displayName: 'A', teamType: 'Discovery Team' },
+        { id: 't2', displayName: 'B', teamType: 'Discovery Team' },
+        { id: 't3', displayName: 'C', teamType: 'Discovery Team' },
+        { id: 't4', displayName: 'D', teamType: 'Resource Team' },
+      ]}
+    />,
+  );
+  expect(getByText('+1')).toBeVisible();
+  expect(getByText('Teams')).toBeVisible();
 });

--- a/packages/react-components/src/organisms/__tests__/ProjectOutputCard.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/ProjectOutputCard.test.tsx
@@ -18,8 +18,8 @@ it('renders the title', () => {
 });
 
 it('renders Project pill', () => {
-  const { getByText } = render(<ProjectOutputCard {...baseProps} />);
-  expect(getByText('Project')).toBeVisible();
+  const { getAllByText } = render(<ProjectOutputCard {...baseProps} />);
+  expect(getAllByText('Project').length).toBeGreaterThanOrEqual(1);
 });
 
 it('renders projects with clickable link when href present', () => {
@@ -54,13 +54,16 @@ it('renders projects as plain text when href absent', () => {
 });
 
 it('renders Team association when teams present', () => {
-  const { getByText } = render(
+  const { getAllByText } = render(
     <ProjectOutputCard
       {...baseProps}
       teams={[{ id: 't1', displayName: 'Alpha', teamType: 'Discovery Team' }]}
     />,
   );
-  expect(getByText('Team Alpha').closest('a')).toHaveAttribute(
+  const matches = getAllByText('Team Alpha');
+  expect(matches.length).toBeGreaterThanOrEqual(1);
+  const linked = matches.find((el) => el.closest('a'));
+  expect(linked?.closest('a')).toHaveAttribute(
     'href',
     expect.stringMatching(/t1$/),
   );
@@ -113,10 +116,12 @@ it('displays In Review tag when not published and is in review', () => {
 });
 
 it('renders external link when link property present', () => {
-  const { getByTitle } = render(
+  const { getAllByTitle } = render(
     <ProjectOutputCard {...baseProps} link={'https://example.com'} />,
   );
-  expect(getByTitle('External Link').closest('a')).toHaveAttribute(
+  const matches = getAllByTitle('External Link');
+  expect(matches.length).toBeGreaterThanOrEqual(1);
+  expect(matches[0]?.closest('a')).toHaveAttribute(
     'href',
     'https://example.com',
   );

--- a/packages/react-components/src/organisms/__tests__/ProjectOutputCard.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/ProjectOutputCard.test.tsx
@@ -1,0 +1,164 @@
+import { ComponentProps } from 'react';
+import { render } from '@testing-library/react';
+import { createResearchOutputResponse } from '@asap-hub/fixtures';
+
+import ProjectOutputCard from '../ProjectOutputCard';
+
+const baseProps: ComponentProps<typeof ProjectOutputCard> = {
+  ...createResearchOutputResponse(),
+  source: 'team',
+};
+
+it('renders the title', () => {
+  const { getByRole } = render(
+    <ProjectOutputCard {...baseProps} title="output title" />,
+  );
+  expect(getByRole('heading').textContent).toEqual('output title');
+  expect(getByRole('heading').tagName).toEqual('H2');
+});
+
+it('renders Project pill', () => {
+  const { getByText } = render(<ProjectOutputCard {...baseProps} />);
+  expect(getByText('Project')).toBeVisible();
+});
+
+it('renders projects with clickable link when href present', () => {
+  const { getByRole } = render(
+    <ProjectOutputCard
+      {...baseProps}
+      projects={[{ id: 'p1', title: 'My Project', href: '/projects/p1' }]}
+    />,
+  );
+  const link = getByRole('link', { name: 'My Project' });
+  expect(link).toHaveAttribute('href', '/projects/p1');
+});
+
+it('renders projects as plain text when href absent', () => {
+  const { getByText, queryByRole } = render(
+    <ProjectOutputCard
+      {...baseProps}
+      projects={[{ id: 'p1', title: 'No-link Project' }]}
+    />,
+  );
+  expect(getByText('No-link Project')).toBeVisible();
+  expect(queryByRole('link', { name: 'No-link Project' })).toBeNull();
+});
+
+it('renders Team association when teams present', () => {
+  const { getByText } = render(
+    <ProjectOutputCard
+      {...baseProps}
+      teams={[{ id: 't1', displayName: 'Alpha', teamType: 'Discovery Team' }]}
+    />,
+  );
+  expect(getByText('Team Alpha').closest('a')).toHaveAttribute(
+    'href',
+    expect.stringMatching(/t1$/),
+  );
+});
+
+it('omits Team association when teams empty (team-based output)', () => {
+  const { queryByText } = render(
+    <ProjectOutputCard {...baseProps} teams={[]} />,
+  );
+  expect(queryByText(/^Team\s/)).toBeNull();
+});
+
+it('omits Team association for project-based output even when teams present', () => {
+  const { queryByText } = render(
+    <ProjectOutputCard
+      {...baseProps}
+      source="project"
+      teams={[{ id: 't1', displayName: 'Alpha', teamType: 'Discovery Team' }]}
+    />,
+  );
+  expect(queryByText('Team Alpha')).toBeNull();
+});
+
+it('displays Draft tag when not published', () => {
+  const { getByText, queryByText, rerender } = render(
+    <ProjectOutputCard {...baseProps} published={false} />,
+  );
+  expect(getByText('Draft')).toBeVisible();
+
+  rerender(<ProjectOutputCard {...baseProps} published={true} />);
+  expect(queryByText('Draft')).toBeNull();
+});
+
+it('displays In Review tag when not published and is in review', () => {
+  const { getByText } = render(
+    <ProjectOutputCard {...baseProps} published={false} isInReview={true} />,
+  );
+  expect(getByText('In Review')).toBeVisible();
+});
+
+it('renders external link when link property present', () => {
+  const { getByTitle } = render(
+    <ProjectOutputCard {...baseProps} link={'https://example.com'} />,
+  );
+  expect(getByTitle('External Link').closest('a')).toHaveAttribute(
+    'href',
+    'https://example.com',
+  );
+});
+
+it('displays Date Added and Last Updated using lastModifiedDate', () => {
+  const { getByText } = render(
+    <ProjectOutputCard
+      {...baseProps}
+      addedDate={new Date(2020, 3, 3).toISOString()}
+      lastModifiedDate={new Date(2021, 5, 10).toISOString()}
+      created={new Date(2019, 0, 1).toISOString()}
+    />,
+  );
+  expect(getByText(/Date Added/).textContent).toContain('3rd April 2020');
+  expect(getByText(/Last Updated/).textContent).toContain('10th June 2021');
+});
+
+it('falls back Last Updated to addedDate then created when lastModifiedDate absent', () => {
+  const { getByText, rerender } = render(
+    <ProjectOutputCard
+      {...baseProps}
+      addedDate={new Date(2020, 3, 3).toISOString()}
+      lastModifiedDate={undefined}
+      created={new Date(2019, 0, 1).toISOString()}
+    />,
+  );
+  expect(getByText(/Last Updated/).textContent).toContain('3rd April 2020');
+
+  rerender(
+    <ProjectOutputCard
+      {...baseProps}
+      addedDate={undefined}
+      lastModifiedDate={undefined}
+      created={new Date(2019, 0, 1).toISOString()}
+    />,
+  );
+  expect(getByText(/Last Updated/).textContent).toContain('1st January 2019');
+});
+
+it('renders authors', () => {
+  const { getByText } = render(
+    <ProjectOutputCard
+      {...baseProps}
+      authors={[{ id: 'u1', displayName: 'Author One' }]}
+    />,
+  );
+  expect(getByText('Author One')).toBeVisible();
+});
+
+it('renders tags when showTags', () => {
+  const { getByText, queryByText, rerender } = render(
+    <ProjectOutputCard {...baseProps} keywords={['Etag']} showTags />,
+  );
+  expect(getByText('Etag')).toBeVisible();
+
+  rerender(
+    <ProjectOutputCard
+      {...baseProps}
+      keywords={['Etag']}
+      showTags={false}
+    />,
+  );
+  expect(queryByText('Etag')).toBeNull();
+});

--- a/packages/react-components/src/organisms/__tests__/ProjectOutputCard.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/ProjectOutputCard.test.tsx
@@ -154,11 +154,7 @@ it('renders tags when showTags', () => {
   expect(getByText('Etag')).toBeVisible();
 
   rerender(
-    <ProjectOutputCard
-      {...baseProps}
-      keywords={['Etag']}
-      showTags={false}
-    />,
+    <ProjectOutputCard {...baseProps} keywords={['Etag']} showTags={false} />,
   );
   expect(queryByText('Etag')).toBeNull();
 });

--- a/packages/react-components/src/organisms/__tests__/ProjectOutputListCard.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/ProjectOutputListCard.test.tsx
@@ -1,0 +1,44 @@
+import { ComponentProps } from 'react';
+import { render } from '@testing-library/react';
+import { createResearchOutputResponse } from '@asap-hub/fixtures';
+
+import ProjectOutputListCard from '../ProjectOutputListCard';
+
+const baseProps: ComponentProps<typeof ProjectOutputListCard> = {
+  researchOutputs: [],
+};
+
+it('renders one entry per research output', () => {
+  const { getAllByRole } = render(
+    <ProjectOutputListCard
+      {...baseProps}
+      researchOutputs={[
+        { ...createResearchOutputResponse(0), source: 'team', title: 'Output 1' },
+        { ...createResearchOutputResponse(1), source: 'team', title: 'Output 2' },
+      ]}
+    />,
+  );
+  expect(
+    getAllByRole('heading').map(({ textContent }) => textContent),
+  ).toEqual(['Output 1', 'Output 2']);
+});
+
+it('links each title to the research output detail page', () => {
+  const { getByRole } = render(
+    <ProjectOutputListCard
+      {...baseProps}
+      researchOutputs={[
+        {
+          ...createResearchOutputResponse(0),
+          source: 'team',
+          title: 'Output 1',
+          id: '123',
+        },
+      ]}
+    />,
+  );
+  expect(getByRole('heading').closest('a')).toHaveAttribute(
+    'href',
+    expect.stringMatching(/123/i),
+  );
+});

--- a/packages/react-components/src/organisms/__tests__/ProjectOutputListCard.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/ProjectOutputListCard.test.tsx
@@ -13,14 +13,22 @@ it('renders one entry per research output', () => {
     <ProjectOutputListCard
       {...baseProps}
       researchOutputs={[
-        { ...createResearchOutputResponse(0), source: 'team', title: 'Output 1' },
-        { ...createResearchOutputResponse(1), source: 'team', title: 'Output 2' },
+        {
+          ...createResearchOutputResponse(0),
+          source: 'team',
+          title: 'Output 1',
+        },
+        {
+          ...createResearchOutputResponse(1),
+          source: 'team',
+          title: 'Output 2',
+        },
       ]}
     />,
   );
-  expect(
-    getAllByRole('heading').map(({ textContent }) => textContent),
-  ).toEqual(['Output 1', 'Output 2']);
+  expect(getAllByRole('heading').map(({ textContent }) => textContent)).toEqual(
+    ['Output 1', 'Output 2'],
+  );
 });
 
 it('links each title to the research output detail page', () => {

--- a/packages/react-components/src/organisms/index.ts
+++ b/packages/react-components/src/organisms/index.ts
@@ -99,6 +99,8 @@ export {
   SharedOutputDropdownBase,
   SharedOutputDropdownWrapper,
 } from './SharedOutputDropdown';
+export { default as ProjectOutputCard } from './ProjectOutputCard';
+export { default as ProjectOutputListCard } from './ProjectOutputListCard';
 export { default as SharedResearchAdditionalInformationCard } from './SharedResearchAdditionalInformationCard';
 export { default as SharedResearchCard } from './SharedResearchCard';
 export { default as SharedResearchDetailsTagsCard } from './SharedResearchDetailsTagsCard';

--- a/packages/react-components/src/templates/ProjectDetailHeader.tsx
+++ b/packages/react-components/src/templates/ProjectDetailHeader.tsx
@@ -133,6 +133,8 @@ type ProjectDetailHeaderProps = ProjectDetail & {
   readonly milestonesHref: string;
   readonly outputsHref?: string;
   readonly draftOutputsHref?: string;
+  readonly outputsCount?: number;
+  readonly draftOutputsCount?: number;
 };
 
 export const getTeamIcon = (project: ProjectDetail) => {
@@ -161,6 +163,8 @@ const ProjectDetailHeader = (project: ProjectDetailHeaderProps) => {
     milestonesHref,
     outputsHref,
     draftOutputsHref,
+    outputsCount,
+    draftOutputsCount,
   } = project;
   const { isEnabled } = useFlags();
   const isProjectMilestonesEnabled = isEnabled('PROJECT_AIMS_AND_MILESTONES');
@@ -197,10 +201,16 @@ const ProjectDetailHeader = (project: ProjectDetailHeaderProps) => {
                 <TabLink href={workspaceHref}>Workspace</TabLink>
               ) : null}
               {isProjectOutputsEnabled && outputsHref ? (
-                <TabLink href={outputsHref}>Outputs</TabLink>
+                <TabLink href={outputsHref}>
+                  Outputs
+                  {outputsCount !== undefined && ` (${outputsCount})`}
+                </TabLink>
               ) : null}
               {isProjectOutputsEnabled && draftOutputsHref ? (
-                <TabLink href={draftOutputsHref}>Draft Outputs</TabLink>
+                <TabLink href={draftOutputsHref}>
+                  Draft Outputs
+                  {draftOutputsCount !== undefined && ` (${draftOutputsCount})`}
+                </TabLink>
               ) : null}
             </TabNav>
           }

--- a/packages/react-components/src/templates/ProjectDetailPage.tsx
+++ b/packages/react-components/src/templates/ProjectDetailPage.tsx
@@ -9,6 +9,8 @@ type ProjectDetailPageProps = ProjectDetail & {
   readonly milestonesHref: string;
   readonly outputsHref?: string;
   readonly draftOutputsHref?: string;
+  readonly outputsCount?: number;
+  readonly draftOutputsCount?: number;
   readonly children?: React.ReactNode;
 };
 
@@ -20,6 +22,8 @@ const ProjectDetailPage: React.FC<ProjectDetailPageProps> = ({
   milestonesHref,
   outputsHref,
   draftOutputsHref,
+  outputsCount,
+  draftOutputsCount,
   ...project
 }) => (
   <article>
@@ -31,6 +35,8 @@ const ProjectDetailPage: React.FC<ProjectDetailPageProps> = ({
       milestonesHref={milestonesHref}
       outputsHref={outputsHref}
       draftOutputsHref={draftOutputsHref}
+      outputsCount={outputsCount}
+      draftOutputsCount={draftOutputsCount}
     />
     <PageConstraints as="main">{children}</PageConstraints>
   </article>

--- a/packages/react-components/src/templates/ProjectOutputList.tsx
+++ b/packages/react-components/src/templates/ProjectOutputList.tsx
@@ -1,0 +1,52 @@
+import { ComponentProps } from 'react';
+import AlgoliaHit from '../atoms/AlgoliaHit';
+
+import {
+  ResultList,
+  ProjectOutputCard,
+  ProjectOutputListCard,
+} from '../organisms';
+import type { ProjectOutput } from '../molecules';
+import { LibraryIcon } from '../icons';
+import { charcoal } from '../colors';
+
+const RESULT_LIST_ICON = <LibraryIcon color={charcoal.rgb} />;
+
+type ProjectOutputListProps = Omit<
+  ComponentProps<typeof ResultList>,
+  'children'
+> & {
+  readonly researchOutputs: ReadonlyArray<ProjectOutput>;
+  readonly listViewHref: string;
+  readonly cardViewHref: string;
+  showTags?: boolean;
+} & Pick<ComponentProps<typeof AlgoliaHit>, 'algoliaQueryId'>;
+
+const ProjectOutputList: React.FC<ProjectOutputListProps> = ({
+  researchOutputs,
+  algoliaQueryId,
+  showTags = true,
+  ...cardListProps
+}) => (
+  <ResultList icon={RESULT_LIST_ICON} {...cardListProps}>
+    {cardListProps.isListView ? (
+      <ProjectOutputListCard
+        algoliaQueryId={algoliaQueryId}
+        researchOutputs={researchOutputs}
+        showTags={showTags}
+      />
+    ) : (
+      researchOutputs.map((output, index) => (
+        <AlgoliaHit
+          key={output.id}
+          index={index}
+          algoliaQueryId={algoliaQueryId}
+          objectId={output.id}
+        >
+          <ProjectOutputCard {...output} showTags={showTags} />
+        </AlgoliaHit>
+      ))
+    )}
+  </ResultList>
+);
+export default ProjectOutputList;

--- a/packages/react-components/src/templates/__tests__/ProjectDetailHeader.test.tsx
+++ b/packages/react-components/src/templates/__tests__/ProjectDetailHeader.test.tsx
@@ -785,6 +785,20 @@ describe('ProjectDetailHeader', () => {
       );
       expect(screen.queryByText('Outputs')).not.toBeInTheDocument();
     });
+
+    it('renders Outputs tab with count when outputsCount is provided', () => {
+      mockIsEnabled.mockReturnValue(true);
+      render(
+        <ProjectDetailHeader
+          {...mockDiscoveryProject}
+          aboutHref="/projects/discovery/1/about"
+          milestonesHref="/projects/discovery/1/milestones"
+          outputsHref="/projects/discovery/1/outputs"
+          outputsCount={12}
+        />,
+      );
+      expect(screen.getByText('Outputs (12)')).toBeInTheDocument();
+    });
   });
 
   describe('Draft Outputs tab', () => {
@@ -824,6 +838,20 @@ describe('ProjectDetailHeader', () => {
         />,
       );
       expect(screen.queryByText('Draft Outputs')).not.toBeInTheDocument();
+    });
+
+    it('renders Draft Outputs tab with count when draftOutputsCount is provided', () => {
+      mockIsEnabled.mockReturnValue(true);
+      render(
+        <ProjectDetailHeader
+          {...mockDiscoveryProject}
+          aboutHref="/projects/discovery/1/about"
+          milestonesHref="/projects/discovery/1/milestones"
+          draftOutputsHref="/projects/discovery/1/draft-outputs"
+          draftOutputsCount={5}
+        />,
+      );
+      expect(screen.getByText('Draft Outputs (5)')).toBeInTheDocument();
     });
   });
 });

--- a/packages/react-components/src/templates/__tests__/ProjectOutputList.test.tsx
+++ b/packages/react-components/src/templates/__tests__/ProjectOutputList.test.tsx
@@ -1,0 +1,43 @@
+import { ComponentProps } from 'react';
+import { createListResearchOutputResponse } from '@asap-hub/fixtures';
+import { render } from '@testing-library/react';
+import { StaticRouter } from 'react-router';
+
+import ProjectOutputList from '../ProjectOutputList';
+
+const props: Omit<ComponentProps<typeof ProjectOutputList>, 'children'> = {
+  researchOutputs: createListResearchOutputResponse(2).items.map((item) => ({
+    ...item,
+    source: 'team' as const,
+  })),
+  listViewHref: '/list',
+  cardViewHref: '/card',
+  numberOfItems: 2,
+  numberOfPages: 1,
+  currentPageIndex: 0,
+  renderPageHref: (index) => `#${index}`,
+};
+
+it('renders multiple outputs in card view', () => {
+  const { queryAllByRole, getByRole } = render(
+    <StaticRouter location="/">
+      <ProjectOutputList {...props} isListView={false} />
+    </StaticRouter>,
+  );
+  expect(getByRole('button').closest('span')).toHaveTextContent(/card/i);
+  expect(
+    queryAllByRole('heading').map(({ textContent }) => textContent),
+  ).toEqual(['Output 1', 'Output 2']);
+});
+
+it('renders multiple outputs in list view', () => {
+  const { queryAllByRole, getByRole } = render(
+    <StaticRouter location="/">
+      <ProjectOutputList {...props} isListView />
+    </StaticRouter>,
+  );
+  expect(getByRole('button').closest('span')).toHaveTextContent(/list/i);
+  expect(
+    queryAllByRole('heading').map(({ textContent }) => textContent),
+  ).toEqual(['Output 1', 'Output 2']);
+});

--- a/packages/react-components/src/templates/index.ts
+++ b/packages/react-components/src/templates/index.ts
@@ -70,6 +70,7 @@ export { default as OpenQuestionsModal } from './OpenQuestionsModal';
 export { default as PasswordResetEmailSentPage } from './PasswordResetEmailSentPage';
 export { default as PersonalInfoModal } from './PersonalInfoModal';
 export { default as ProfileOutputs } from './ProfileOutputs';
+export { default as ProjectOutputList } from './ProjectOutputList';
 export { default as ResearchOutputForm } from './ResearchOutputForm';
 export { default as ResearchOutputsSearch } from './ResearchOutputsSearch';
 export { default as RoleModal } from './RoleModal';


### PR DESCRIPTION
### Changes

* Created the Project Output elements to compose a `ProjectOutputList`.
* Created the `ProjectOutputList` and then used mocked data to render this
component on the Project page. These changes are guarded by a feature flag
(`ASAP_PROJECT_OUTPUTS=true`). Also added the missing output counts to the
tabs which was missed from the previous PR.

### Screenshots

#### Outputs tab - Card view

<img width="961" height="542" alt="Screenshot 2026-05-21 at 15 01 40" src="https://github.com/user-attachments/assets/5fe4868d-6960-4a43-8100-4e4cacaccc6f" />

<img width="961" height="543" alt="Screenshot 2026-05-21 at 15 02 01" src="https://github.com/user-attachments/assets/b1879f6a-a7be-46b5-9d7e-fd215c74a106" />

#### Outputs tab - List view
<!-- drop screenshot here -->

<img width="961" height="539" alt="Screenshot 2026-05-21 at 15 02 53" src="https://github.com/user-attachments/assets/117cefd4-0f44-4983-aa12-4f3003097a34" />

<img width="964" height="541" alt="Screenshot 2026-05-21 at 15 03 08" src="https://github.com/user-attachments/assets/36e4c44d-f746-43de-a3a9-cb602d58c20b" />


#### Draft Outputs tab
<!-- drop screenshot here -->

<img width="961" height="540" alt="Screenshot 2026-05-21 at 15 02 22" src="https://github.com/user-attachments/assets/e3d9839e-a19f-4378-814c-13a6579952f6" />

### How to preview

1. Enable the flag (DevTools > Application > Cookies):
   `ASAP_PROJECT_OUTPUTS=true`, then reload.
2. Open any project(resource, discovery).
3. Tabs show counts: `Outputs (12)` / `Draft Outputs (5)` from the mocks.
4. Toggle Card <-> List via the header.