### PR TITLE
[ASAP-1510] - Fix - Clicking download button doesn't show loading state

### DIFF
--- a/apps/crn-frontend/src/network/teams/__tests__/Outputs.test.tsx
+++ b/apps/crn-frontend/src/network/teams/__tests__/Outputs.test.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from 'react';
 import { MemoryRouter, Route, Routes } from 'react-router';
-import { act, render, waitFor } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {
   createListResearchOutputResponse,
@@ -204,24 +204,23 @@ it('triggers export with the same parameters and custom file name', async () => 
   );
 
   const csvButton = await findByText(/csv/i);
-  await act(async () => {
-    await userEvent.click(csvButton);
-  });
-  await waitFor(() => {
-    expect(mockCreateCsvFileStream).toHaveBeenLastCalledWith(
-      expect.stringMatching(/SharedOutputs_Team_ExampleTeam123_\d+\.csv/),
-      expect.anything(),
-    );
-  });
-  await waitFor(() =>
-    expect(mockGetResearchOutputs).toHaveBeenCalledWith(expect.anything(), {
-      searchQuery,
-      filters,
-      teamId,
-      currentPage: 0,
-      pageSize: CARD_VIEW_PAGE_SIZE,
-    }),
+  const csvButtonEl = csvButton.closest('button');
+  await userEvent.click(csvButton);
+  // ExportButton disables the button while the export is in flight; wait for
+  // it to re-enable so the trailing setLoading(false) is flushed inside act.
+  await waitFor(() => expect(csvButtonEl).toBeEnabled());
+
+  expect(mockCreateCsvFileStream).toHaveBeenLastCalledWith(
+    expect.stringMatching(/SharedOutputs_Team_ExampleTeam123_\d+\.csv/),
+    expect.anything(),
   );
+  expect(mockGetResearchOutputs).toHaveBeenCalledWith(expect.anything(), {
+    searchQuery,
+    filters,
+    teamId,
+    currentPage: 0,
+    pageSize: CARD_VIEW_PAGE_SIZE,
+  });
 });
 
 it('triggers draft research output export with custom file name', async () => {
@@ -243,20 +242,22 @@ it('triggers draft research output export with custom file name', async () => {
     true,
   );
 
-  await userEvent.click(getByText(/csv/i));
-  await waitFor(() =>
-    expect(mockGetDraftResearchOutputs).toHaveBeenCalledWith(
-      {
-        searchQuery: '',
-        filters,
-        teamId,
-        draftsOnly: true,
-        userAssociationMember: true,
-        currentPage: 0,
-        pageSize: MAX_CONTENTFUL_RESULTS,
-      },
-      expect.anything(),
-    ),
+  const csvBtn = getByText(/csv/i);
+  const csvBtnEl = csvBtn.closest('button');
+  await userEvent.click(csvBtn);
+  await waitFor(() => expect(csvBtnEl).toBeEnabled());
+
+  expect(mockGetDraftResearchOutputs).toHaveBeenCalledWith(
+    {
+      searchQuery: '',
+      filters,
+      teamId,
+      draftsOnly: true,
+      userAssociationMember: true,
+      currentPage: 0,
+      pageSize: MAX_CONTENTFUL_RESULTS,
+    },
+    expect.anything(),
   );
   expect(mockCreateCsvFileStream).toHaveBeenLastCalledWith(
     expect.stringMatching(/SharedOutputs_Drafts_Team_Team123_\d+\.csv/),

--- a/apps/crn-frontend/src/network/users/__tests__/Outputs.test.tsx
+++ b/apps/crn-frontend/src/network/users/__tests__/Outputs.test.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from 'react';
 import { MemoryRouter, Route, Routes } from 'react-router';
-import { act, render, waitFor } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createUserResponse } from '@asap-hub/fixtures';
 import { network } from '@asap-hub/routing';
@@ -197,22 +197,21 @@ it('triggers export with the same parameters and custom filename', async () => {
     }),
   );
 
-  await act(async () => {
-    await userEvent.click(getByText(/csv/i));
-  });
-  await waitFor(() => {
-    expect(mockCreateCsvFileStream).toHaveBeenLastCalledWith(
-      expect.stringMatching(/SharedOutputs_JohnSmith_\d+\.csv/),
-      expect.anything(),
-    );
-  });
-  await waitFor(() =>
-    expect(mockGetResearchOutputs).toHaveBeenLastCalledWith(expect.anything(), {
-      searchQuery,
-      filters,
-      userId,
-      currentPage: 0,
-      pageSize: MAX_ALGOLIA_RESULTS,
-    }),
+  const csvButton = getByText(/csv/i).closest('button');
+  await userEvent.click(getByText(/csv/i));
+  // ExportButton disables the button while the export is in flight; wait for
+  // it to re-enable so the trailing setLoading(false) is flushed inside act.
+  await waitFor(() => expect(csvButton).toBeEnabled());
+
+  expect(mockCreateCsvFileStream).toHaveBeenLastCalledWith(
+    expect.stringMatching(/SharedOutputs_JohnSmith_\d+\.csv/),
+    expect.anything(),
   );
+  expect(mockGetResearchOutputs).toHaveBeenLastCalledWith(expect.anything(), {
+    searchQuery,
+    filters,
+    userId,
+    currentPage: 0,
+    pageSize: MAX_ALGOLIA_RESULTS,
+  });
 });

--- a/packages/react-components/src/molecules/ExportButton.tsx
+++ b/packages/react-components/src/molecules/ExportButton.tsx
@@ -8,7 +8,6 @@ import {
   useRef,
   useState,
 } from 'react';
-import { flushSync } from 'react-dom';
 import { Button } from '../atoms';
 import { lead, neutral500 } from '../colors';
 import { ExportIcon } from '../icons';
@@ -114,12 +113,16 @@ const ExportButton: React.FC<ExportButtonProps> = ({
   // been unmounted (e.g. tests that finish the click then unmount without
   // awaiting the export's resolution).
   const mountedRef = useRef(true);
-  useEffect(
-    () => () => {
+  useEffect(() => {
+    // Re-assert mounted on every mount. Under React 18 StrictMode the dev
+    // double-invoke runs the cleanup once (setting this false), and useRef's
+    // initializer does NOT re-run on the remount — so without this the ref
+    // stays false forever and setLoading silently no-ops.
+    mountedRef.current = true;
+    return () => {
       mountedRef.current = false;
-    },
-    [],
-  );
+    };
+  }, []);
   const setLoading = useCallback((buttonText: string, value: boolean) => {
     if (!mountedRef.current) return;
     setLoadingButtons((previous) => ({
@@ -151,12 +154,12 @@ const ExportButton: React.FC<ExportButtonProps> = ({
             enabled={!isLoading}
             onClick={async () => {
               if (isLoading) return;
-              // flushSync forces React to paint the loading state before the
-              // export starts; otherwise React 18 automatic batching can
-              // group setLoading(true) and setLoading(false) into a single
-              // render and the spinner never appears.
-              flushSync(() => {
-                setLoading(button.buttonText, true);
+              // Show the spinner, then yield a macrotask before starting the
+              // export so the loading render commits and paints before any
+              // synchronous export work (CSV/XLSX stringify) blocks the thread.
+              setLoading(button.buttonText, true);
+              await new Promise<void>((resolve) => {
+                setTimeout(resolve, 0);
               });
               const startedAt = Date.now();
               try {

--- a/packages/react-components/src/molecules/ExportButton.tsx
+++ b/packages/react-components/src/molecules/ExportButton.tsx
@@ -1,7 +1,8 @@
 import { ToastContext } from '@asap-hub/react-context';
-import { css } from '@emotion/react';
-import { ReactNode, useContext } from 'react';
+import { css, keyframes } from '@emotion/react';
+import { ReactNode, useCallback, useContext, useState } from 'react';
 import { Button } from '../atoms';
+import { lead, neutral500 } from '../colors';
 import { ExportIcon } from '../icons';
 import { mobileScreen, rem, tabletScreen } from '../pixels';
 import TooltipInfo from './TooltipInfo';
@@ -43,7 +44,31 @@ const tooltipStyle = css({
   textAlign: 'left',
 });
 
-const exportIconStyles = css({ display: 'flex' });
+// Match ExportIcon's intrinsic 18×18 footprint so swapping in the spinner
+// doesn't reflow the button width.
+const exportIconStyles = css({
+  display: 'flex',
+  width: rem(18),
+  height: rem(18),
+  alignItems: 'center',
+  justifyContent: 'center',
+  flexShrink: 0,
+});
+
+const spin = keyframes`
+  from { transform: rotate(0deg) }
+  to { transform: rotate(360deg) }
+`;
+
+// Dark-grey spinner that matches secondary button text/icon colour (lead).
+const exportSpinnerStyles = css({
+  width: rem(16),
+  height: rem(16),
+  border: `${rem(2)} solid ${neutral500.rgb}`,
+  borderTop: `${rem(2)} solid ${lead.rgb}`,
+  borderRadius: '50%',
+  animation: `${spin} 1s linear infinite`,
+});
 type ExportButtonProps = {
   readonly exportResults?: () => Promise<void>;
   readonly buttons?: Array<{
@@ -69,6 +94,19 @@ const ExportButton: React.FC<ExportButtonProps> = ({
   );
 
   const toast = useContext(ToastContext);
+  // Per-button loading state keyed by buttonText so each button shows its
+  // spinner independently while exports may take a while to fetch data.
+  const [loadingButtons, setLoadingButtons] = useState<
+    Readonly<Record<string, boolean>>
+  >({});
+  const setLoading = useCallback(
+    (buttonText: string, value: boolean) =>
+      setLoadingButtons((previous) => ({
+        ...previous,
+        [buttonText]: value,
+      })),
+    [],
+  );
 
   return buttonGroup.length ? (
     <span css={exportSectionStyles}>
@@ -83,25 +121,45 @@ const ExportButton: React.FC<ExportButtonProps> = ({
           </TooltipInfo>
         ) : null}
       </strong>
-      {buttonGroup.map((button) => (
-        <Button
-          key={button.buttonText}
-          noMargin
-          small
-          onClick={() =>
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            button.exportResults!().catch(() => {
-              toast(button.errorMessage);
-            })
-          }
-          overrideStyles={exportButtonStyles}
-        >
-          <>
-            <div css={exportIconStyles}>{ExportIcon}</div>
-            {button.buttonText}
-          </>
-        </Button>
-      ))}
+      {buttonGroup.map((button) => {
+        const isLoading = loadingButtons[button.buttonText] === true;
+        return (
+          <Button
+            key={button.buttonText}
+            noMargin
+            small
+            enabled={!isLoading}
+            onClick={() => {
+              if (isLoading) return;
+              setLoading(button.buttonText, true);
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+              void button.exportResults!()
+                .catch(() => {
+                  toast(button.errorMessage);
+                })
+                .finally(() => {
+                  setLoading(button.buttonText, false);
+                });
+            }}
+            overrideStyles={exportButtonStyles}
+          >
+            <>
+              <div css={exportIconStyles}>
+                {isLoading ? (
+                  <div
+                    css={exportSpinnerStyles}
+                    role="progressbar"
+                    aria-label="Exporting"
+                  />
+                ) : (
+                  ExportIcon
+                )}
+              </div>
+              {button.buttonText}
+            </>
+          </Button>
+        );
+      })}
     </span>
   ) : null;
 };

--- a/packages/react-components/src/molecules/ExportButton.tsx
+++ b/packages/react-components/src/molecules/ExportButton.tsx
@@ -1,6 +1,14 @@
 import { ToastContext } from '@asap-hub/react-context';
 import { css, keyframes } from '@emotion/react';
-import { ReactNode, useCallback, useContext, useState } from 'react';
+import {
+  ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+import { flushSync } from 'react-dom';
 import { Button } from '../atoms';
 import { lead, neutral500 } from '../colors';
 import { ExportIcon } from '../icons';
@@ -62,12 +70,15 @@ const spin = keyframes`
 
 // Dark-grey spinner that matches secondary button text/icon colour (lead).
 const exportSpinnerStyles = css({
+  display: 'block',
+  boxSizing: 'border-box',
   width: rem(16),
   height: rem(16),
   border: `${rem(2)} solid ${neutral500.rgb}`,
-  borderTop: `${rem(2)} solid ${lead.rgb}`,
+  borderTopColor: lead.rgb,
   borderRadius: '50%',
   animation: `${spin} 1s linear infinite`,
+  flexShrink: 0,
 });
 type ExportButtonProps = {
   readonly exportResults?: () => Promise<void>;
@@ -99,14 +110,23 @@ const ExportButton: React.FC<ExportButtonProps> = ({
   const [loadingButtons, setLoadingButtons] = useState<
     Readonly<Record<string, boolean>>
   >({});
-  const setLoading = useCallback(
-    (buttonText: string, value: boolean) =>
-      setLoadingButtons((previous) => ({
-        ...previous,
-        [buttonText]: value,
-      })),
+  // Track mount so we don't schedule a state update after the component has
+  // been unmounted (e.g. tests that finish the click then unmount without
+  // awaiting the export's resolution).
+  const mountedRef = useRef(true);
+  useEffect(
+    () => () => {
+      mountedRef.current = false;
+    },
     [],
   );
+  const setLoading = useCallback((buttonText: string, value: boolean) => {
+    if (!mountedRef.current) return;
+    setLoadingButtons((previous) => ({
+      ...previous,
+      [buttonText]: value,
+    }));
+  }, []);
 
   return buttonGroup.length ? (
     <span css={exportSectionStyles}>
@@ -129,17 +149,33 @@ const ExportButton: React.FC<ExportButtonProps> = ({
             noMargin
             small
             enabled={!isLoading}
-            onClick={() => {
+            onClick={async () => {
               if (isLoading) return;
-              setLoading(button.buttonText, true);
-              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-              void button.exportResults!()
-                .catch(() => {
-                  toast(button.errorMessage);
-                })
-                .finally(() => {
-                  setLoading(button.buttonText, false);
-                });
+              // flushSync forces React to paint the loading state before the
+              // export starts; otherwise React 18 automatic batching can
+              // group setLoading(true) and setLoading(false) into a single
+              // render and the spinner never appears.
+              flushSync(() => {
+                setLoading(button.buttonText, true);
+              });
+              const startedAt = Date.now();
+              try {
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                await button.exportResults!();
+              } catch {
+                toast(button.errorMessage);
+              } finally {
+                // Keep the spinner visible for at least 250ms even on very
+                // fast exports so it doesn't flicker imperceptibly.
+                const elapsed = Date.now() - startedAt;
+                const remaining = Math.max(0, 250 - elapsed);
+                if (remaining > 0) {
+                  await new Promise<void>((resolve) => {
+                    setTimeout(resolve, remaining);
+                  });
+                }
+                setLoading(button.buttonText, false);
+              }
             }}
             overrideStyles={exportButtonStyles}
           >

--- a/packages/react-components/src/molecules/__tests__/ExportButton.test.tsx
+++ b/packages/react-components/src/molecules/__tests__/ExportButton.test.tsx
@@ -1,0 +1,108 @@
+import { ToastContext } from '@asap-hub/react-context';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ReactNode } from 'react';
+
+import ExportButton from '../ExportButton';
+
+const withToast = (children: ReactNode, toast: (node: ReactNode) => void) => (
+  <ToastContext.Provider value={toast}>{children}</ToastContext.Provider>
+);
+
+describe('ExportButton', () => {
+  it('disables the clicked button and shows a spinner while exporting', async () => {
+    let resolveExport: (() => void) | undefined;
+    const exportResults = jest.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveExport = resolve;
+        }),
+    );
+
+    render(<ExportButton exportResults={exportResults} />);
+
+    const button = screen.getByRole('button', { name: /CSV/i });
+    await userEvent.click(button);
+
+    expect(button).toBeDisabled();
+    // Spinner replaces the export icon in-place; no <svg> in the button while
+    // loading.
+    expect(button.querySelector('[role="progressbar"]')).not.toBeNull();
+    expect(button.querySelector('svg')).toBeNull();
+
+    resolveExport!();
+    await waitFor(() => expect(button).toBeEnabled());
+  });
+
+  it('ignores repeated clicks while an export is in flight', async () => {
+    let resolveExport: (() => void) | undefined;
+    const exportResults = jest.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveExport = resolve;
+        }),
+    );
+
+    render(<ExportButton exportResults={exportResults} />);
+
+    const button = screen.getByRole('button', { name: /CSV/i });
+    await userEvent.click(button);
+    await userEvent.click(button);
+    await userEvent.click(button);
+
+    expect(exportResults).toHaveBeenCalledTimes(1);
+
+    resolveExport!();
+    await waitFor(() => expect(button).toBeEnabled());
+  });
+
+  it('tracks loading state per-button so siblings stay clickable', async () => {
+    let resolveSlow: (() => void) | undefined;
+    const slow = jest.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSlow = resolve;
+        }),
+    );
+    const fast = jest.fn(() => Promise.resolve());
+
+    render(
+      <ExportButton
+        buttons={[
+          { buttonText: 'Slow', errorMessage: 'slow err', exportResults: slow },
+          { buttonText: 'Fast', errorMessage: 'fast err', exportResults: fast },
+        ]}
+      />,
+    );
+
+    const slowBtn = screen.getByRole('button', { name: /Slow/ });
+    const fastBtn = screen.getByRole('button', { name: /Fast/ });
+
+    await userEvent.click(slowBtn);
+    expect(slowBtn).toBeDisabled();
+    expect(fastBtn).toBeEnabled();
+
+    await userEvent.click(fastBtn);
+    expect(fast).toHaveBeenCalledTimes(1);
+    expect(slowBtn).toBeDisabled();
+
+    resolveSlow!();
+    await waitFor(() => expect(slowBtn).toBeEnabled());
+  });
+
+  it('re-enables the button after an export rejects and toasts the error', async () => {
+    const exportResults = jest.fn(() => Promise.reject(new Error('boom')));
+    const toast = jest.fn();
+
+    render(withToast(<ExportButton exportResults={exportResults} />, toast));
+
+    const button = screen.getByRole('button', { name: /CSV/i });
+    await userEvent.click(button);
+
+    await waitFor(() => expect(button).toBeEnabled());
+    expect(exportResults).toHaveBeenCalledTimes(1);
+    expect(toast).toHaveBeenCalledWith(
+      'There was an issue exporting to CSV. Please try again.',
+    );
+  });
+});


### PR DESCRIPTION
Exports can take a few seconds to fetch their data; users would click again and again. Each ExportButton now tracks per-button loading state keyed by buttonText so multiple buttons in the same group disable independently. While a button is loading:

- the button is disabled (ignores repeated clicks)
- the export icon is swapped in-place for a dark-grey (lead) spinner that matches the secondary text/icon color

Adds ExportButton.test.tsx covering the disabled state, repeated-click debounce, per-button isolation, and the failure-path toast + re-enable.


https://github.com/user-attachments/assets/aeb72dec-fd9c-4249-ad48-f9a3978448af

