### PR TITLE
[ASAP-1491] - [Auth0] Share user roles details with DataSeer

### DIFF
--- a/apps/auth0/src/__tests__/post-login-add-metadata.test.ts
+++ b/apps/auth0/src/__tests__/post-login-add-metadata.test.ts
@@ -114,7 +114,7 @@ describe('For an ASAP KR-Sync login', () => {
 
     expect(nock.isDone()).toBe(true);
     expect(apiBase.idToken.setCustomClaim).toHaveBeenCalledWith(
-      'http://example.com/user',
+      `${apiUrl}/user`,
       {
         teams: [
           {
@@ -124,6 +124,7 @@ describe('For an ASAP KR-Sync login', () => {
             roles: ['Lead PI (Core Leadership)'],
           },
         ],
+        role: 'Grantee',
         openScienceTeamMember: true,
       },
     );
@@ -149,7 +150,7 @@ describe('For an ASAP KR-Sync login', () => {
     await onExecutePostLogin(krSyncEvent, apiBase);
 
     expect(apiBase.idToken.setCustomClaim).toHaveBeenCalledWith(
-      'http://example.com/user',
+      `${apiUrl}/user`,
       expect.objectContaining({
         teams: [
           {
@@ -207,18 +208,6 @@ describe('For an ASAP KR-Sync login', () => {
       'Response code 404 (Not Found)',
     );
     expect(apiBase.idToken.setCustomClaim).not.toHaveBeenCalled();
-  });
-
-  it('denies access if redirect_uri is missing', async () => {
-    await onExecutePostLogin(
-      {
-        ...krSyncEvent,
-        request: { ...krSyncEvent.request, query: {}, body: {} },
-      },
-      apiBase,
-    );
-
-    expect(apiBase.access.deny).toHaveBeenCalledWith('Missing redirect_uri');
   });
 
   it('does not set claims for non-CRN (GP2) users', async () => {

--- a/apps/auth0/src/__tests__/post-login-add-metadata.test.ts
+++ b/apps/auth0/src/__tests__/post-login-add-metadata.test.ts
@@ -79,14 +79,88 @@ describe('For an ASAP KR-Sync login', () => {
     },
   };
 
-  it('verifies the user against the webhook without setting custom claims', async () => {
-    nock(apiUrl).get(`/webhook/users/${user.user_id}`).reply(200, { id: '42' });
+  const baseUser: UserMetadataResponse = {
+    onboarded: true,
+    displayName: 'Joao Tiago',
+    firstName: 'Joao',
+    lastName: 'Tiago',
+    email: 'joao.tiago@yld.io',
+    id: 'myRandomId123',
+    lastModifiedDate: '2020-08-21T14:23:31.924Z',
+    createdDate: '2020-08-21T14:23:31.924Z',
+    teams: [
+      {
+        id: 'team-1',
+        displayName: 'Team 1',
+        role: 'Lead PI (Core Leadership)',
+      },
+    ],
+    tags: [],
+    questions: [],
+    workingGroups: [],
+    interestGroups: [],
+    projects: [],
+    role: 'Grantee',
+    openScienceTeamMember: false,
+    algoliaApiKey: 'test-api-key',
+  };
+
+  it('sets team and openScienceTeamMember claims for CRN users', async () => {
+    nock(apiUrl)
+      .get(`/webhook/users/${user.user_id}`)
+      .reply(200, { ...baseUser, id: '42', openScienceTeamMember: true });
 
     await onExecutePostLogin(krSyncEvent, apiBase);
 
     expect(nock.isDone()).toBe(true);
-    expect(apiBase.idToken.setCustomClaim).not.toHaveBeenCalled();
+    expect(apiBase.idToken.setCustomClaim).toHaveBeenCalledWith(
+      'http://example.com/user',
+      {
+        teams: [
+          {
+            id: 'team-1',
+            displayName: 'Team 1',
+            inactiveSinceDate: undefined,
+            roles: ['Lead PI (Core Leadership)'],
+          },
+        ],
+        openScienceTeamMember: true,
+      },
+    );
     expect(apiBase.access.deny).not.toHaveBeenCalled();
+  });
+
+  it('groups multiple roles in the same team into one entry', async () => {
+    nock(apiUrl)
+      .get(`/webhook/users/${user.user_id}`)
+      .reply(200, {
+        ...baseUser,
+        id: '42',
+        teams: [
+          {
+            id: 'team-1',
+            displayName: 'Team 1',
+            role: 'Lead PI (Core Leadership)',
+          },
+          { id: 'team-1', displayName: 'Team 1', role: 'Project Manager' },
+        ],
+      });
+
+    await onExecutePostLogin(krSyncEvent, apiBase);
+
+    expect(apiBase.idToken.setCustomClaim).toHaveBeenCalledWith(
+      'http://example.com/user',
+      expect.objectContaining({
+        teams: [
+          {
+            id: 'team-1',
+            displayName: 'Team 1',
+            inactiveSinceDate: undefined,
+            roles: ['Lead PI (Core Leadership)', 'Project Manager'],
+          },
+        ],
+      }),
+    );
   });
 
   it('passes the AUTH0_SHARED_SECRET as a basic auth token', async () => {
@@ -95,7 +169,7 @@ describe('For an ASAP KR-Sync login', () => {
       reqheaders: { authorization: `Basic ${token}` },
     })
       .get(`/webhook/users/${user.user_id}`)
-      .reply(200, { id: '42' });
+      .reply(200, { ...baseUser, id: '42' });
 
     await onExecutePostLogin(
       {
@@ -109,11 +183,12 @@ describe('For an ASAP KR-Sync login', () => {
   });
 
   it('denies access for alumni users', async () => {
-    nock(apiUrl).get(`/webhook/users/${user.user_id}`).reply(200, {
-      id: '42',
-      teams: [],
-      alumniSinceDate: '2024-01-01',
-    });
+    nock(apiUrl)
+      .get(`/webhook/users/${user.user_id}`)
+      .reply(200, {
+        ...baseUser,
+        alumniSinceDate: '2024-01-01',
+      });
 
     await onExecutePostLogin(krSyncEvent, apiBase);
 
@@ -134,7 +209,19 @@ describe('For an ASAP KR-Sync login', () => {
     expect(apiBase.idToken.setCustomClaim).not.toHaveBeenCalled();
   });
 
-  it('allows non-alumni GP2 users (no teams field on response)', async () => {
+  it('denies access if redirect_uri is missing', async () => {
+    await onExecutePostLogin(
+      {
+        ...krSyncEvent,
+        request: { ...krSyncEvent.request, query: {}, body: {} },
+      },
+      apiBase,
+    );
+
+    expect(apiBase.access.deny).toHaveBeenCalledWith('Missing redirect_uri');
+  });
+
+  it('does not set claims for non-CRN (GP2) users', async () => {
     nock(apiUrl)
       .get(`/webhook/users/${user.user_id}`)
       .reply(200, { id: '42', role: 'Trainee' });

--- a/apps/auth0/src/post-login-add-metadata.ts
+++ b/apps/auth0/src/post-login-add-metadata.ts
@@ -119,12 +119,12 @@ const parseUserMetadata = ({
 
 const parseKRSyncMetadata = ({
   teams,
-  openScienceTeamMember,
   role,
+  openScienceTeamMember,
 }: UserMetadataResponse) => ({
   teams: groupTeams(teams),
-  openScienceTeamMember,
   role,
+  openScienceTeamMember,
 });
 const extractUser = (response: Auth0UserResponse): User | gp2Auth.User => ({
   ...parseCommonUserMetadata(response),
@@ -177,13 +177,6 @@ export const onExecutePostLogin = async (
   try {
     if (event.client.name === 'ASAP KR-Sync') {
       const apiUrl = event.secrets.API_URL ?? '##API_URL##';
-      const queryRedirectUri = new URLSearchParams(event.request.query).get(
-        'redirect_uri',
-      );
-      const redirect_uri = queryRedirectUri ?? event.request.body.redirect_uri;
-      if (!redirect_uri) {
-        throw new Error('Missing redirect_uri');
-      }
       const response = await fetchUserMetadata(apiUrl, event);
 
       if (isUserMetadataResponse(response) && response.alumniSinceDate) {
@@ -194,7 +187,7 @@ export const onExecutePostLogin = async (
       if (isUserMetadataResponse(response)) {
         const dataSeerUser = parseKRSyncMetadata(response);
         api.idToken.setCustomClaim(
-          new URL('/user', redirect_uri).toString(),
+          new URL('/user', apiUrl).toString(),
           dataSeerUser,
         );
         console.log(

--- a/apps/auth0/src/post-login-add-metadata.ts
+++ b/apps/auth0/src/post-login-add-metadata.ts
@@ -116,6 +116,14 @@ const parseUserMetadata = ({
   role,
   openScienceTeamMember,
 });
+
+const parseKRSyncMetadata = ({
+  teams,
+  openScienceTeamMember,
+}: UserMetadataResponse) => ({
+  teams: groupTeams(teams),
+  openScienceTeamMember,
+});
 const extractUser = (response: Auth0UserResponse): User | gp2Auth.User => ({
   ...parseCommonUserMetadata(response),
   ...(isUserMetadataResponse(response)
@@ -167,6 +175,13 @@ export const onExecutePostLogin = async (
   try {
     if (event.client.name === 'ASAP KR-Sync') {
       const apiUrl = event.secrets.API_URL ?? '##API_URL##';
+      const queryRedirectUri = new URLSearchParams(event.request.query).get(
+        'redirect_uri',
+      );
+      const redirect_uri = queryRedirectUri ?? event.request.body.redirect_uri;
+      if (!redirect_uri) {
+        throw new Error('Missing redirect_uri');
+      }
       const response = await fetchUserMetadata(apiUrl, event);
 
       if (isUserMetadataResponse(response) && response.alumniSinceDate) {
@@ -174,7 +189,18 @@ export const onExecutePostLogin = async (
         return api.access.deny('alumni-user-access-denied');
       }
 
-      console.log('Successfully verified KR-Sync user');
+      if (isUserMetadataResponse(response)) {
+        const dataSeerUser = parseKRSyncMetadata(response);
+        api.idToken.setCustomClaim(
+          new URL('/user', redirect_uri).toString(),
+          dataSeerUser,
+        );
+        console.log(
+          `KR-Sync user metadata set: ${JSON.stringify(dataSeerUser)}`,
+        );
+      } else {
+        console.log('Successfully verified KR-Sync user');
+      }
       return true;
     }
     const [apiUrl, redirect_uri] = getApiUrls(event);

--- a/apps/auth0/src/post-login-add-metadata.ts
+++ b/apps/auth0/src/post-login-add-metadata.ts
@@ -120,9 +120,11 @@ const parseUserMetadata = ({
 const parseKRSyncMetadata = ({
   teams,
   openScienceTeamMember,
+  role,
 }: UserMetadataResponse) => ({
   teams: groupTeams(teams),
   openScienceTeamMember,
+  role,
 });
 const extractUser = (response: Auth0UserResponse): User | gp2Auth.User => ({
   ...parseCommonUserMetadata(response),


### PR DESCRIPTION
[ASAP-1491](https://asaphub.atlassian.net/browse/ASAP-1491)

The real test for this is through Dataseer platform when they add roles in, for now to confirm that we are sending the correct data I had to do it through terminal by sending a `POST` request to auth0 pr env using credentials of one of my users:

<img width="1185" height="646" alt="image" src="https://github.com/user-attachments/assets/24377c3e-9384-4348-9375-ee2e6a2103d9" />


here is the decoded version of `id_token`:

<img width="1310" height="762" alt="image" src="https://github.com/user-attachments/assets/32ebd78e-ab3f-4df1-a352-7dd5afd0c788" />


_

> PS: No worries about the id_token and access_token being exposed, they are short lived tokens and I already invalidated them

_ 

[ASAP-1491]: https://asaphub.atlassian.net/browse/ASAP-1491?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ