### PR TITLE
ASAP-1530 Display User-Based Manuscript when Team is Collaborator

### DIFF
--- a/apps/crn-frontend/src/projects/__tests__/ProjectDetail.test.tsx
+++ b/apps/crn-frontend/src/projects/__tests__/ProjectDetail.test.tsx
@@ -314,6 +314,29 @@ const renderProjectDetail = async (
   });
 };
 
+const getWorkspaceRoute = (routeKeyword: string, projectId: string) => {
+  const base = projects({});
+  switch (routeKeyword) {
+    case 'discovery':
+      return base
+        .discoveryProjects({})
+        .discoveryProject({ projectId })
+        .workspace({});
+    case 'resource':
+      return base
+        .resourceProjects({})
+        .resourceProject({ projectId })
+        .workspace({});
+    case 'trainee':
+      return base
+        .traineeProjects({})
+        .traineeProject({ projectId })
+        .workspace({});
+    default:
+      throw new Error(`Unknown route keyword: ${routeKeyword}`);
+  }
+};
+
 // --- Test variants ---
 
 type TestVariant = {
@@ -747,57 +770,48 @@ describe.each(variants)(
       );
       expect(await screen.findByText('Supplement')).toBeInTheDocument();
     });
+
+    it('builds correct manuscript hrefs from workspace callbacks', async () => {
+      enable('PROJECT_WORKSPACE');
+      await renderProjectDetail(
+        Component,
+        routeKeyword,
+        mainProjectId,
+        memberUser,
+        'workspace',
+      );
+      await screen.findByRole('heading', { name: 'Compliance Review' });
+
+      const getEditManuscriptHref =
+        lastWorkspaceProps.getEditManuscriptHref as (
+          manuscriptId: string,
+        ) => string;
+      const getResubmitManuscriptHref =
+        lastWorkspaceProps.getResubmitManuscriptHref as (
+          manuscriptId: string,
+        ) => string;
+      const getCreateComplianceReportHref =
+        lastWorkspaceProps.getCreateComplianceReportHref as (
+          manuscriptId: string,
+        ) => string;
+
+      const manuscriptId = 'manuscript-1';
+      const workspaceRoute = getWorkspaceRoute(routeKeyword, mainProjectId);
+
+      expect(getEditManuscriptHref(manuscriptId)).toBe(
+        workspaceRoute.editManuscript({ manuscriptId }).$,
+      );
+      expect(getResubmitManuscriptHref(manuscriptId)).toBe(
+        workspaceRoute.resubmitManuscript({ manuscriptId }).$,
+      );
+      expect(getCreateComplianceReportHref(manuscriptId)).toBe(
+        workspaceRoute.createComplianceReport({ manuscriptId }).$,
+      );
+    });
   },
 );
 
 // --- Variant-specific tests ---
-
-describe('Workspace href callbacks', () => {
-  it('builds edit, resubmit, and create-compliance-report hrefs from manuscriptId', async () => {
-    const memberUser = {
-      id: 'user-team',
-      projects: [],
-      teams: [{ id: 'team-1', role: 'Project Manager' }],
-      role: 'Grantee',
-    };
-    enable('PROJECT_WORKSPACE');
-    await renderProjectDetail(
-      DiscoveryProjectDetail,
-      'discovery',
-      'discovery-1',
-      memberUser,
-      'workspace',
-    );
-    await screen.findByRole('heading', { name: 'Compliance Review' });
-
-    const getEditManuscriptHref = lastWorkspaceProps.getEditManuscriptHref as (
-      manuscriptId: string,
-    ) => string;
-    const getResubmitManuscriptHref =
-      lastWorkspaceProps.getResubmitManuscriptHref as (
-        manuscriptId: string,
-      ) => string;
-    const getCreateComplianceReportHref =
-      lastWorkspaceProps.getCreateComplianceReportHref as (
-        manuscriptId: string,
-      ) => string;
-
-    const workspaceRoute = projects({})
-      .discoveryProjects({})
-      .discoveryProject({ projectId: 'discovery-1' })
-      .workspace({});
-
-    expect(getEditManuscriptHref('ms-1')).toBe(
-      workspaceRoute.editManuscript({ manuscriptId: 'ms-1' }).$,
-    );
-    expect(getResubmitManuscriptHref('ms-1')).toBe(
-      workspaceRoute.resubmitManuscript({ manuscriptId: 'ms-1' }).$,
-    );
-    expect(getCreateComplianceReportHref('ms-1')).toBe(
-      workspaceRoute.createComplianceReport({ manuscriptId: 'ms-1' }).$,
-    );
-  });
-});
 
 describe('DiscoveryProjectDetail - specific', () => {
   it('passes manuscripts and collaborationManuscripts to ProjectWorkspace', async () => {

--- a/apps/crn-frontend/src/projects/projectDetailConfig.ts
+++ b/apps/crn-frontend/src/projects/projectDetailConfig.ts
@@ -1,16 +1,10 @@
 import type { ProjectDetail, ProjectType } from '@asap-hub/model';
-import { projects } from '@asap-hub/routing';
+import { projectRouteByType } from '@asap-hub/routing';
 
 export type ProjectDetailConfig = {
   projectType: ProjectType;
   projectTypeKey: 'discovery' | 'resource' | 'trainee';
-  getRoute: (
-    projectId: string,
-  ) => ReturnType<
-    ReturnType<
-      ReturnType<typeof projects>['discoveryProjects']
-    >['discoveryProject']
-  >;
+  getRoute: (typeof projectRouteByType)[ProjectType];
   getIsTeamBased: (projectDetail: ProjectDetail) => boolean;
   getContactName: (projectDetail: ProjectDetail) => string | undefined;
 };
@@ -18,8 +12,7 @@ export type ProjectDetailConfig = {
 export const discoveryConfig: ProjectDetailConfig = {
   projectType: 'Discovery Project',
   projectTypeKey: 'discovery',
-  getRoute: (projectId) =>
-    projects({}).discoveryProjects({}).discoveryProject({ projectId }),
+  getRoute: projectRouteByType['Discovery Project'],
   getIsTeamBased: () => true,
   getContactName: (pd) =>
     pd.projectType === 'Discovery Project'
@@ -30,8 +23,7 @@ export const discoveryConfig: ProjectDetailConfig = {
 export const resourceConfig: ProjectDetailConfig = {
   projectType: 'Resource Project',
   projectTypeKey: 'resource',
-  getRoute: (projectId) =>
-    projects({}).resourceProjects({}).resourceProject({ projectId }),
+  getRoute: projectRouteByType['Resource Project'],
   getIsTeamBased: (pd) =>
     pd.projectType === 'Resource Project' ? pd.isTeamBased : true,
   getContactName: (pd) =>
@@ -44,8 +36,7 @@ export const resourceConfig: ProjectDetailConfig = {
 export const traineeConfig: ProjectDetailConfig = {
   projectType: 'Trainee Project',
   projectTypeKey: 'trainee',
-  getRoute: (projectId) =>
-    projects({}).traineeProjects({}).traineeProject({ projectId }),
+  getRoute: projectRouteByType['Trainee Project'],
   getIsTeamBased: () => false,
   getContactName: (pd) =>
     pd.projectType === 'Trainee Project'

--- a/apps/crn-server/src/data-providers/contentful/manuscript.data-provider.ts
+++ b/apps/crn-server/src/data-providers/contentful/manuscript.data-provider.ts
@@ -711,6 +711,10 @@ const parseGraphQLManuscript = (
   const projectId = resolvedProject?.project.projectId || '';
   const grantId = resolvedProject?.project.grantId || '';
   const count = manuscript.count || 1;
+  const rawProjectType = resolvedProject?.project.projectType;
+  const projectType = isProjectType(rawProjectType)
+    ? rawProjectType
+    : undefined;
   return {
     id: manuscript.sys.id,
     count,
@@ -718,6 +722,7 @@ const parseGraphQLManuscript = (
     url: manuscript.url || undefined,
     teamId: isProjectManuscript ? undefined : teamData?.sys.id,
     projectId: isProjectManuscript ? manuscript.project?.sys.id : undefined,
+    projectType: isProjectManuscript ? projectType : undefined,
     status: manuscriptMapStatus(manuscript.status) || undefined,
     discussions: parseGraphQLManuscriptDiscussions(
       manuscript.discussionsCollection?.items,

--- a/packages/model/src/manuscript.ts
+++ b/packages/model/src/manuscript.ts
@@ -351,6 +351,7 @@ export type ManuscriptDataObject = {
   status?: ManuscriptStatus;
   teamId?: string;
   projectId?: string;
+  projectType?: ProjectType;
   versions: ManuscriptVersion[];
   count: number;
   assignedUsers: ManuscriptAssignedUser[];

--- a/packages/react-components/src/organisms/ManuscriptCard.tsx
+++ b/packages/react-components/src/organisms/ManuscriptCard.tsx
@@ -11,7 +11,7 @@ import {
   statusButtonOptions,
   TeamManuscript,
 } from '@asap-hub/model';
-import { network } from '@asap-hub/routing';
+import { network, projectRouteByType } from '@asap-hub/routing';
 import { css, Theme } from '@emotion/react';
 import { ComponentProps, useEffect, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router';
@@ -267,6 +267,23 @@ const ManuscriptCard: React.FC<ManuscriptCardProps> = ({
   >(isTargetManuscript ? targetTabFromUrl : 'manuscripts-and-reports');
   const [manuscript, setManuscript] = useManuscriptById(id);
   const { title, status, versions } = manuscript ?? { versions: [] };
+
+  const projectWorkspaceRoute =
+    manuscript?.projectId && manuscript.projectType
+      ? projectRouteByType[manuscript.projectType](
+          manuscript.projectId,
+        ).workspace({})
+      : undefined;
+
+  const teamWorkspaceRoute = network({})
+    .teams({})
+    .team({ teamId })
+    .workspace({});
+
+  const resolvedGetEditManuscriptHref = (manuscriptId: string): string =>
+    projectWorkspaceRoute?.editManuscript({ manuscriptId }).$ ??
+    getEditManuscriptHref?.(manuscriptId) ??
+    teamWorkspaceRoute.editManuscript({ manuscriptId }).$;
   const [displayConfirmStatusChangeModal, setDisplayConfirmStatusChangeModal] =
     useState(false);
   const targetManuscriptRef = useRef<HTMLDivElement>(null);
@@ -307,21 +324,15 @@ const ManuscriptCard: React.FC<ManuscriptCardProps> = ({
     if (expandedState) syncUrl(true, next);
   };
 
-  const complianceReportRoute = getCreateComplianceReportHref
-    ? getCreateComplianceReportHref(id)
-    : network({})
-        .teams({})
-        .team({ teamId })
-        .workspace({})
-        .createComplianceReport({ manuscriptId: id }).$;
+  const complianceReportRoute =
+    projectWorkspaceRoute?.createComplianceReport({ manuscriptId: id }).$ ??
+    getCreateComplianceReportHref?.(id) ??
+    teamWorkspaceRoute.createComplianceReport({ manuscriptId: id }).$;
 
-  const resubmitManuscriptRoute = getResubmitManuscriptHref
-    ? getResubmitManuscriptHref(id)
-    : network({})
-        .teams({})
-        .team({ teamId })
-        .workspace({})
-        .resubmitManuscript({ manuscriptId: id }).$;
+  const resubmitManuscriptRoute =
+    projectWorkspaceRoute?.resubmitManuscript({ manuscriptId: id }).$ ??
+    getResubmitManuscriptHref?.(id) ??
+    teamWorkspaceRoute.resubmitManuscript({ manuscriptId: id }).$;
 
   const handleShareComplianceReport = () => {
     void navigate(complianceReportRoute, { state: { fromButton: true } });
@@ -583,7 +594,7 @@ const ManuscriptCard: React.FC<ManuscriptCardProps> = ({
                         categories={manuscript?.categories || []}
                         impact={manuscript?.impact}
                         showTeamName={showTeamName}
-                        getEditManuscriptHref={getEditManuscriptHref}
+                        getEditManuscriptHref={resolvedGetEditManuscriptHref}
                       />
                     ))}
                   {versions.length > VERSION_LIMIT && (

--- a/packages/react-components/src/organisms/__tests__/ManuscriptCard.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/ManuscriptCard.test.tsx
@@ -4,10 +4,14 @@ import {
   manuscriptAuthor,
 } from '@asap-hub/fixtures';
 import { User } from '@asap-hub/auth';
-import { ManuscriptDiscussion, ManuscriptVersion } from '@asap-hub/model';
+import {
+  ManuscriptDataObject,
+  ManuscriptDiscussion,
+  ManuscriptVersion,
+} from '@asap-hub/model';
 import { cleanup, render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { ComponentProps, useEffect } from 'react';
+import { ComponentProps, Dispatch, SetStateAction, useEffect } from 'react';
 import { MemoryRouter, Route, Routes, useLocation } from 'react-router';
 import ManuscriptCard from '../ManuscriptCard';
 
@@ -28,13 +32,28 @@ const LocationCapture = () => {
   return null;
 };
 
+const createTestManuscript = (
+  overrides: Partial<ManuscriptDataObject> = {},
+): ManuscriptDataObject => ({
+  ...createManuscriptResponse(),
+  id: 'manuscript_0',
+  title: 'Mock Manuscript Title',
+  status: 'Waiting for Report',
+  ...overrides,
+});
+
+const mockUseManuscriptById = (
+  overrides: Partial<ManuscriptDataObject> = {},
+): ComponentProps<typeof ManuscriptCard>['useManuscriptById'] =>
+  jest.fn(
+    (): [
+      ManuscriptDataObject,
+      Dispatch<SetStateAction<ManuscriptDataObject | undefined>>,
+    ] => [createTestManuscript(overrides), jest.fn()],
+  );
+
 const useManuscriptById = jest.fn().mockImplementation(() => {
-  const manuscript = {
-    id: 'manuscript_0',
-    title: 'Mock Manuscript Title',
-    status: 'Waiting for Report',
-    versions: [],
-  };
+  const manuscript = createTestManuscript();
 
   const setManuscript = jest.fn((newData) => {
     Object.assign(manuscript, newData);
@@ -120,12 +139,7 @@ const user: User = {
 beforeEach(() => {
   currentLocation = null;
   useManuscriptById.mockImplementation(() => {
-    const manuscript = {
-      id: 'manuscript_0',
-      title: 'Mock Manuscript Title',
-      status: 'Waiting for Report',
-      versions: [mockVersion],
-    };
+    const manuscript = createTestManuscript({ versions: [mockVersion] });
 
     const setManuscript = jest.fn((newData) => {
       Object.assign(manuscript, newData);
@@ -134,12 +148,9 @@ beforeEach(() => {
     return [manuscript, setManuscript];
   });
   useManuscriptByIdWithReport.mockImplementation(() => {
-    const manuscript = {
-      id: 'manuscript_0',
-      title: 'Mock Manuscript Title',
-      status: 'Waiting for Report',
+    const manuscript = createTestManuscript({
       versions: [mockVersionWithReport],
-    };
+    });
 
     const setManuscript = jest.fn((newData) => {
       Object.assign(manuscript, newData);
@@ -497,6 +508,236 @@ it('uses override getResubmitManuscriptHref for the resubmit manuscript button',
   );
   expect(currentLocation?.pathname).toBe(
     `/projects/discovery/project-1/workspace/resubmit-manuscript/${props.id}`,
+  );
+});
+
+it.each([
+  ['Discovery Project', 'discovery'],
+  ['Resource Project', 'resource'],
+  ['Trainee Project', 'trainee'],
+] as const)(
+  'uses %s project route for edit when manuscript.projectId is set',
+  async (projectType, routeSegment) => {
+    const userActions = userEvent.setup({ delay: null });
+    const { getByRole, getByTestId } = render(
+      <MemoryRouter>
+        <Routes>
+          <Route
+            path="*"
+            element={
+              <>
+                <LocationCapture />
+                <ManuscriptCard
+                  {...props}
+                  useManuscriptById={mockUseManuscriptById({
+                    versions: [{ ...mockVersion, firstAuthors: [user] }],
+                    projectId: 'proj-1',
+                    projectType,
+                  })}
+                />
+              </>
+            }
+          />
+        </Routes>
+      </MemoryRouter>,
+    );
+    await userActions.click(getByTestId('collapsible-button'));
+    await userActions.click(getByRole('button', { name: 'Edit' }));
+    expect(currentLocation?.pathname).toBe(
+      `/projects/${routeSegment}/proj-1/workspace/edit-manuscript/${props.id}`,
+    );
+  },
+);
+
+it.each([
+  ['Discovery Project', 'discovery'],
+  ['Resource Project', 'resource'],
+  ['Trainee Project', 'trainee'],
+] as const)(
+  'uses %s project route for compliance report when manuscript.projectId is set',
+  async (projectType, routeSegment) => {
+    const userActions = userEvent.setup({ delay: null });
+    const { getByRole, getByTestId } = render(
+      <MemoryRouter>
+        <Routes>
+          <Route
+            path="*"
+            element={
+              <>
+                <LocationCapture />
+                <ManuscriptCard
+                  {...props}
+                  isComplianceReviewer
+                  useManuscriptById={mockUseManuscriptById({
+                    versions: [],
+                    projectId: 'proj-1',
+                    projectType,
+                  })}
+                />
+              </>
+            }
+          />
+        </Routes>
+      </MemoryRouter>,
+    );
+    await userActions.click(getByTestId('collapsible-button'));
+    await userActions.click(
+      getByRole('button', { name: /Share Compliance Report Icon/i }),
+    );
+    expect(currentLocation?.pathname).toBe(
+      `/projects/${routeSegment}/proj-1/workspace/create-compliance-report/${props.id}`,
+    );
+  },
+);
+
+it.each([
+  ['Discovery Project', 'discovery'],
+  ['Resource Project', 'resource'],
+  ['Trainee Project', 'trainee'],
+] as const)(
+  'uses %s project route for resubmit when manuscript.projectId is set',
+  async (projectType, routeSegment) => {
+    const userActions = userEvent.setup({ delay: null });
+    const { getByRole, getByTestId } = render(
+      <MemoryRouter>
+        <Routes>
+          <Route
+            path="*"
+            element={
+              <>
+                <LocationCapture />
+                <ManuscriptCard
+                  {...props}
+                  useManuscriptById={mockUseManuscriptById({
+                    versions: [
+                      { ...mockVersionWithReport, firstAuthors: [user] },
+                    ],
+                    projectId: 'proj-1',
+                    projectType,
+                  })}
+                />
+              </>
+            }
+          />
+        </Routes>
+      </MemoryRouter>,
+    );
+    await userActions.click(getByTestId('collapsible-button'));
+    await userActions.click(
+      getByRole('button', { name: /Resubmit Manuscript Icon/i }),
+    );
+    expect(currentLocation?.pathname).toBe(
+      `/projects/${routeSegment}/proj-1/workspace/resubmit-manuscript/${props.id}`,
+    );
+  },
+);
+
+it('project route takes precedence over injected getEditManuscriptHref when manuscript.projectId is set', async () => {
+  const userActions = userEvent.setup({ delay: null });
+  const { getByRole, getByTestId } = render(
+    <MemoryRouter>
+      <Routes>
+        <Route
+          path="*"
+          element={
+            <>
+              <LocationCapture />
+              <ManuscriptCard
+                {...props}
+                getEditManuscriptHref={() =>
+                  `/network/teams/${props.teamId}/workspace/edit-manuscript/${props.id}`
+                }
+                useManuscriptById={mockUseManuscriptById({
+                  versions: [{ ...mockVersion, firstAuthors: [user] }],
+                  projectId: 'proj-1',
+                  projectType: 'Discovery Project',
+                })}
+              />
+            </>
+          }
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+  await userActions.click(getByTestId('collapsible-button'));
+  await userActions.click(getByRole('button', { name: 'Edit' }));
+  expect(currentLocation?.pathname).toBe(
+    `/projects/discovery/proj-1/workspace/edit-manuscript/${props.id}`,
+  );
+});
+
+it('project route takes precedence over injected getCreateComplianceReportHref when manuscript.projectId is set', async () => {
+  const userActions = userEvent.setup({ delay: null });
+  const { getByRole, getByTestId } = render(
+    <MemoryRouter>
+      <Routes>
+        <Route
+          path="*"
+          element={
+            <>
+              <LocationCapture />
+              <ManuscriptCard
+                {...props}
+                isComplianceReviewer
+                getCreateComplianceReportHref={() =>
+                  `/network/teams/${props.teamId}/workspace/create-compliance-report/${props.id}`
+                }
+                useManuscriptById={mockUseManuscriptById({
+                  versions: [],
+                  projectId: 'proj-1',
+                  projectType: 'Discovery Project',
+                })}
+              />
+            </>
+          }
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+  await userActions.click(getByTestId('collapsible-button'));
+  await userActions.click(
+    getByRole('button', { name: /Share Compliance Report Icon/i }),
+  );
+  expect(currentLocation?.pathname).toBe(
+    `/projects/discovery/proj-1/workspace/create-compliance-report/${props.id}`,
+  );
+});
+
+it('project route takes precedence over injected getResubmitManuscriptHref when manuscript.projectId is set', async () => {
+  const userActions = userEvent.setup({ delay: null });
+  const { getByRole, getByTestId } = render(
+    <MemoryRouter>
+      <Routes>
+        <Route
+          path="*"
+          element={
+            <>
+              <LocationCapture />
+              <ManuscriptCard
+                {...props}
+                getResubmitManuscriptHref={() =>
+                  `/network/teams/${props.teamId}/workspace/resubmit-manuscript/${props.id}`
+                }
+                useManuscriptById={mockUseManuscriptById({
+                  versions: [
+                    { ...mockVersionWithReport, firstAuthors: [user] },
+                  ],
+                  projectId: 'proj-1',
+                  projectType: 'Discovery Project',
+                })}
+              />
+            </>
+          }
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+  await userActions.click(getByTestId('collapsible-button'));
+  await userActions.click(
+    getByRole('button', { name: /Resubmit Manuscript Icon/i }),
+  );
+  expect(currentLocation?.pathname).toBe(
+    `/projects/discovery/proj-1/workspace/resubmit-manuscript/${props.id}`,
   );
 });
 

--- a/packages/routing/src/index.ts
+++ b/packages/routing/src/index.ts
@@ -11,7 +11,7 @@ export { default as logout } from './logout';
 export { default as network } from './network';
 export type { OutputDocumentTypeParameter } from './network';
 export { default as news } from './news';
-export { default as projects } from './projects';
+export { default as projects, projectRouteByType } from './projects';
 export { default as sharedResearch } from './shared-research';
 export { default as staticPages } from './static-pages';
 export { default as welcome } from './welcome';

--- a/packages/routing/src/projects.ts
+++ b/packages/routing/src/projects.ts
@@ -55,4 +55,13 @@ const projects = route(
   { discoveryProjects, resourceProjects, traineeProjects },
 );
 
+export const projectRouteByType = {
+  'Discovery Project': (projectId: string) =>
+    projects({}).discoveryProjects({}).discoveryProject({ projectId }),
+  'Resource Project': (projectId: string) =>
+    projects({}).resourceProjects({}).resourceProject({ projectId }),
+  'Trainee Project': (projectId: string) =>
+    projects({}).traineeProjects({}).traineeProject({ projectId }),
+} as const;
+
 export default projects;


### PR DESCRIPTION
Jira: https://asaphub.atlassian.net/browse/ASAP-1530

--- 

### Problem
When a user-based project manuscript was displayed through a team-based workspace's collaboration section, it was being opened as if it were a team-based manuscript. This caused the "Teams" field to appear as required in the contributors section, even though that field is not required for user-based projects.
The root cause was how the URL path was being calculated inside ManuscriptCard. When the card was rendered in a team-based workspace collaboration section, it used the surrounding team's project ID to build the route, instead of the manuscript's own projectId and projectType. So the manuscript form opened in the wrong project context.

### Solution
Fixed the URL path calculation in ManuscriptCard so that when a manuscript has its own projectId and projectType, those take precedence over the hrefs injected by the surrounding workspace. This applies to the edit, resubmit, and compliance report routes.
As part of this, the route-building logic was extracted into a projectRouteByType map in @asap-hub/routing, which removed the repeated if-chains and also simplified the getRoute type in projectDetailConfig.
I'm not a fan of putting this kind of logic inside a component, but moving it up to ProjectDetail would require fetching extra data upfront and duplicating the fix across both the project and team workspaces, so keeping it in ManuscriptCard felt better in this case.