### PR TITLE
[ASAP-1513] - Filter people by membership status

### DIFF
--- a/apps/gp2-frontend/src/users/UserDirectory.tsx
+++ b/apps/gp2-frontend/src/users/UserDirectory.tsx
@@ -1,6 +1,6 @@
 import { createCsvFileStream } from '@asap-hub/frontend-utils';
 import { UsersPageList } from '@asap-hub/gp2-components';
-import { useCurrentUserGP2 } from '@asap-hub/react-context';
+import { useCurrentUserGP2, useFlags } from '@asap-hub/react-context';
 import { gp2 } from '@asap-hub/routing';
 import { ComponentProps, FC } from 'react';
 import { useRecoilValue } from 'recoil';
@@ -21,6 +21,7 @@ type UserDirectoryProps = Pick<
 
 const UserDirectory: FC<UserDirectoryProps> = ({ displayFilters = false }) => {
   const { users } = gp2;
+  const { isEnabled } = useFlags();
   const {
     changeLocation,
     filters,
@@ -33,7 +34,7 @@ const UserDirectory: FC<UserDirectoryProps> = ({ displayFilters = false }) => {
     'tags',
     'projects',
     'workingGroups',
-    'membershipStatus',
+    ...(isEnabled('STAGING_MODE') ? (['membershipStatus'] as const) : []),
   ]);
   const currentUser = useCurrentUserGP2();
   const isAdministrator = currentUser?.role === 'Administrator';

--- a/apps/gp2-frontend/src/users/UserDirectory.tsx
+++ b/apps/gp2-frontend/src/users/UserDirectory.tsx
@@ -28,7 +28,13 @@ const UserDirectory: FC<UserDirectoryProps> = ({ displayFilters = false }) => {
     setSearchQuery,
     debouncedSearchQuery,
     updateFilters,
-  } = useSearch(['regions', 'tags', 'projects', 'workingGroups']);
+  } = useSearch([
+    'regions',
+    'tags',
+    'projects',
+    'workingGroups',
+    'membershipStatus',
+  ]);
   const currentUser = useCurrentUserGP2();
   const isAdministrator = currentUser?.role === 'Administrator';
 

--- a/apps/gp2-frontend/src/users/UserList.tsx
+++ b/apps/gp2-frontend/src/users/UserList.tsx
@@ -18,6 +18,7 @@ const UserList: React.FC<UserListProps> = ({ searchQuery, filters }) => {
     regions: filters.regions,
     projects: filters.projects,
     workingGroups: filters.workingGroups,
+    membershipStatus: filters.membershipStatus,
   });
 
   const { numberOfPages, renderPageHref } = usePagination(

--- a/apps/gp2-frontend/src/users/__tests__/UserDirectory.test.tsx
+++ b/apps/gp2-frontend/src/users/__tests__/UserDirectory.test.tsx
@@ -150,6 +150,7 @@ it.each`
       tags: [],
       projects: [],
       workingGroups: [],
+      membershipStatus: [],
       [name]: [value],
     });
   },

--- a/apps/gp2-frontend/src/users/__tests__/UserList.test.tsx
+++ b/apps/gp2-frontend/src/users/__tests__/UserList.test.tsx
@@ -49,6 +49,7 @@ const renderUserList = async ({
       tags: [],
       projects: [],
       workingGroups: [],
+      membershipStatus: [],
       ...filters,
     },
     updateFilters: mockUpdateFilter,
@@ -97,7 +98,13 @@ const renderUserList = async ({
 beforeEach(jest.resetAllMocks);
 it('fetches the user information', async () => {
   await renderUserList({
-    filters: { regions: [], tags: [], projects: [], workingGroups: [] },
+    filters: {
+      regions: [],
+      tags: [],
+      projects: [],
+      workingGroups: [],
+      membershipStatus: ['Alumni Member'],
+    },
   });
 
   await waitFor(() =>
@@ -108,6 +115,7 @@ it('fetches the user information', async () => {
         tags: [],
         projects: [],
         workingGroups: [],
+        membershipStatus: ['Alumni Member'],
         searchQuery: '',
         currentPage: 0,
         pageSize: 10,

--- a/apps/gp2-frontend/src/users/__tests__/api.test.tsx
+++ b/apps/gp2-frontend/src/users/__tests__/api.test.tsx
@@ -1,4 +1,5 @@
 import { AlgoliaSearchClient, ClientSearchResponse } from '@asap-hub/algolia';
+import { disable, enable, reset } from '@asap-hub/flags';
 import { gp2 as gp2Fixtures } from '@asap-hub/fixtures';
 import { GetListOptions } from '@asap-hub/frontend-utils';
 import { gp2 as gp2Model } from '@asap-hub/model';
@@ -26,7 +27,13 @@ type Search = () => Promise<
   ClientSearchResponse<'gp2', 'user' | 'external-user'>
 >;
 
-beforeEach(() => nock.cleanAll());
+beforeEach(() => {
+  nock.cleanAll();
+  enable('STAGING_MODE');
+});
+afterEach(() => {
+  reset();
+});
 describe('getUser', () => {
   afterEach(() => {
     expect(nock.isDone()).toBe(true);
@@ -268,6 +275,22 @@ describe('getAlgoliaUsers', () => {
     );
   });
 
+  it('omits the membershipStatus filter when STAGING_MODE is disabled', async () => {
+    disable('STAGING_MODE');
+    await getAlgoliaUsers(mockAlgoliaSearchClient, {
+      ...options,
+      membershipStatus: ['Alumni Member'],
+      currentPage: 1,
+      pageSize: 20,
+    });
+
+    expect(mockAlgoliaSearchClient.search).toHaveBeenLastCalledWith(
+      ['user'],
+      '',
+      expect.objectContaining({ filters: '' }),
+    );
+  });
+
   it('builds a multiple filter query', async () => {
     await getAlgoliaUsers(mockAlgoliaSearchClient, {
       ...options,
@@ -426,6 +449,14 @@ describe('createUserApiUrl', () => {
       expect(url.searchParams.get('filter[onlyOnboarded]')).toEqual('false');
     },
   );
+
+  it('omits the membershipStatus filter from REST URL when STAGING_MODE is disabled', () => {
+    disable('STAGING_MODE');
+    const url = createUserApiUrl({
+      filter: { membershipStatus: ['Alumni Member'], onlyOnboarded: false },
+    });
+    expect(url.searchParams.getAll('filter[membershipStatus]')).toEqual([]);
+  });
 });
 
 describe('postUserAvatar', () => {

--- a/apps/gp2-frontend/src/users/__tests__/api.test.tsx
+++ b/apps/gp2-frontend/src/users/__tests__/api.test.tsx
@@ -171,7 +171,7 @@ describe('getAlgoliaUsers', () => {
     expect(mockAlgoliaSearchClient.search).toHaveBeenLastCalledWith(
       ['user'],
       '',
-      expect.objectContaining({ filters: 'region:"Europe"' }),
+      expect.objectContaining({ filters: '(region:"Europe")' }),
     );
   });
 
@@ -187,7 +187,7 @@ describe('getAlgoliaUsers', () => {
       ['user'],
       '',
       expect.objectContaining({
-        filters: 'region:"Europe" OR region:"Asia"',
+        filters: '(region:"Europe" OR region:"Asia")',
       }),
     );
   });
@@ -207,7 +207,7 @@ describe('getAlgoliaUsers', () => {
     expect(mockAlgoliaSearchClient.search).toHaveBeenLastCalledWith(
       ['user'],
       '',
-      expect.objectContaining({ filters: `${expected}:"42"` }),
+      expect.objectContaining({ filters: `(${expected}:"42")` }),
     );
   });
 
@@ -228,7 +228,42 @@ describe('getAlgoliaUsers', () => {
       ['user'],
       '',
       expect.objectContaining({
-        filters: `${expected}:"42" OR ${expected}:"11"`,
+        filters: `(${expected}:"42" OR ${expected}:"11")`,
+      }),
+    );
+  });
+
+  it('builds a single membershipStatus filter query', async () => {
+    await getAlgoliaUsers(mockAlgoliaSearchClient, {
+      ...options,
+      membershipStatus: ['Alumni Member'],
+      currentPage: 1,
+      pageSize: 20,
+    });
+
+    expect(mockAlgoliaSearchClient.search).toHaveBeenLastCalledWith(
+      ['user'],
+      '',
+      expect.objectContaining({
+        filters: '(membershipStatus:"Alumni Member")',
+      }),
+    );
+  });
+
+  it('builds a multiple membershipStatus filter query', async () => {
+    await getAlgoliaUsers(mockAlgoliaSearchClient, {
+      ...options,
+      membershipStatus: ['GP2 Member', 'Alumni Member'],
+      currentPage: 1,
+      pageSize: 20,
+    });
+
+    expect(mockAlgoliaSearchClient.search).toHaveBeenLastCalledWith(
+      ['user'],
+      '',
+      expect.objectContaining({
+        filters:
+          '(membershipStatus:"GP2 Member" OR membershipStatus:"Alumni Member")',
       }),
     );
   });
@@ -240,6 +275,7 @@ describe('getAlgoliaUsers', () => {
       tags: ['7'],
       projects: ['11'],
       workingGroups: ['23'],
+      membershipStatus: ['Alumni Member'],
       currentPage: 1,
       pageSize: 20,
     });
@@ -249,7 +285,7 @@ describe('getAlgoliaUsers', () => {
       '',
       expect.objectContaining({
         filters:
-          'region:"Europe" AND tagIds:"7" AND projectIds:"11" AND workingGroupIds:"23"',
+          '(region:"Europe") AND (tagIds:"7") AND (projectIds:"11") AND (workingGroupIds:"23") AND (membershipStatus:"Alumni Member")',
       }),
     );
   });
@@ -374,11 +410,12 @@ describe('createUserApiUrl', () => {
   });
 
   it.each`
-    name               | value
-    ${'regions'}       | ${['Africa', 'Asia']}
-    ${'tags'}          | ${['Cohort', 'BLAAC-PD']}
-    ${'projects'}      | ${['a project', 'another project']}
-    ${'workingGroups'} | ${['a working group', 'another working group']}
+    name                  | value
+    ${'regions'}          | ${['Africa', 'Asia']}
+    ${'tags'}             | ${['Cohort', 'BLAAC-PD']}
+    ${'projects'}         | ${['a project', 'another project']}
+    ${'workingGroups'}    | ${['a working group', 'another working group']}
+    ${'membershipStatus'} | ${['GP2 Member', 'Alumni Member']}
   `(
     'handles requests with filters for $name - new',
     async ({ name, value }) => {

--- a/apps/gp2-frontend/src/users/api.ts
+++ b/apps/gp2-frontend/src/users/api.ts
@@ -23,6 +23,7 @@ export const createUserApiUrl = ({
   addFilter('tags', filter?.tags);
   addFilter('projects', filter?.projects);
   addFilter('workingGroups', filter?.workingGroups);
+  addFilter('membershipStatus', filter?.membershipStatus);
 
   if (typeof filter?.onlyOnboarded === 'boolean') {
     url.searchParams.set(
@@ -39,6 +40,7 @@ const getAllFilters = ({
   workingGroups,
   regions,
   tags,
+  membershipStatus,
 }: gp2.FetchUsersFilter) => {
   const addFilter = ({
     name,
@@ -46,13 +48,17 @@ const getAllFilters = ({
   }: {
     name: string;
     items?: string[];
-  }) => items?.map((item) => `${name}:"${item}"`).join(' OR ');
+  }) => {
+    const inner = items.map((item) => `${name}:"${item}"`).join(' OR ');
+    return inner ? `(${inner})` : '';
+  };
 
   return [
     { name: 'region', items: regions },
     { name: 'tagIds', items: tags },
     { name: 'projectIds', items: projects },
     { name: 'workingGroupIds', items: workingGroups },
+    { name: 'membershipStatus', items: membershipStatus },
   ]
     .map(addFilter)
     .filter(Boolean)

--- a/apps/gp2-frontend/src/users/api.ts
+++ b/apps/gp2-frontend/src/users/api.ts
@@ -1,4 +1,5 @@
 import { AlgoliaClient } from '@asap-hub/algolia';
+import { isEnabled } from '@asap-hub/flags';
 import { createSentryHeaders, GetListOptions } from '@asap-hub/frontend-utils';
 import { gp2 } from '@asap-hub/model';
 import { API_BASE_URL } from '../config';
@@ -23,7 +24,9 @@ export const createUserApiUrl = ({
   addFilter('tags', filter?.tags);
   addFilter('projects', filter?.projects);
   addFilter('workingGroups', filter?.workingGroups);
-  addFilter('membershipStatus', filter?.membershipStatus);
+  if (isEnabled('STAGING_MODE')) {
+    addFilter('membershipStatus', filter?.membershipStatus);
+  }
 
   if (typeof filter?.onlyOnboarded === 'boolean') {
     url.searchParams.set(
@@ -58,7 +61,9 @@ const getAllFilters = ({
     { name: 'tagIds', items: tags },
     { name: 'projectIds', items: projects },
     { name: 'workingGroupIds', items: workingGroups },
-    { name: 'membershipStatus', items: membershipStatus },
+    ...(isEnabled('STAGING_MODE')
+      ? [{ name: 'membershipStatus', items: membershipStatus }]
+      : []),
   ]
     .map(addFilter)
     .filter(Boolean)

--- a/apps/gp2-server/scripts/export-entity.ts
+++ b/apps/gp2-server/scripts/export-entity.ts
@@ -1,5 +1,5 @@
 import { EntityResponses } from '@asap-hub/algolia';
-import { ListResponse } from '@asap-hub/model';
+import { gp2 as gp2Model, ListResponse } from '@asap-hub/model';
 import { promises as fs } from 'fs';
 import Events from '../src/controllers/event.controller';
 import ExternalUsers from '../src/controllers/external-user.controller';
@@ -127,7 +127,10 @@ const getController = (entity: keyof EntityResponsesGP2) => {
   return controllerMap[entity];
 };
 
-const transformRecords = <T extends EntityResponsesGP2, K extends keyof T>(
+export const transformRecords = <
+  T extends EntityResponsesGP2,
+  K extends keyof T,
+>(
   record: T[K] extends EntityResponsesGP2[keyof EntityResponsesGP2]
     ? T[K] & { id: string }
     : never,
@@ -139,6 +142,11 @@ const transformRecords = <T extends EntityResponsesGP2, K extends keyof T>(
     __meta: {
       type,
     },
+    ...(type === 'user' && {
+      membershipStatus: (record as gp2Model.UserResponse).alumniSinceDate
+        ? 'Alumni Member'
+        : 'GP2 Member',
+    }),
   };
 
   if ('tags' in record) {

--- a/apps/gp2-server/src/data-providers/user.data-provider.ts
+++ b/apps/gp2-server/src/data-providers/user.data-provider.ts
@@ -406,6 +406,7 @@ const generateFetchQueryFilter = (
     orcidLastSyncDate,
     hidden = true,
     email,
+    membershipStatus,
   } = filter || {};
 
   const filterCode: gp2Contentful.UsersFilter = code
@@ -428,6 +429,16 @@ const generateFetchQueryFilter = (
   const filterUserId =
     userIdFilter.length > 0 ? { sys: { id_in: userIdFilter } } : {};
   const filterEmail = email ? { email } : {};
+  const filterMembershipStatus: gp2Contentful.UsersFilter =
+    membershipStatus?.length
+      ? {
+          OR: membershipStatus.map((status) =>
+            status === 'Alumni Member'
+              ? { alumniSinceDate_exists: true }
+              : { alumniSinceDate_exists: false },
+          ),
+        }
+      : {};
   return {
     ...filterUserId,
     ...filterCode,
@@ -438,6 +449,7 @@ const generateFetchQueryFilter = (
     ...filterOrcidLastSyncDate,
     ...searchFilter,
     ...filterEmail,
+    ...filterMembershipStatus,
   };
 };
 

--- a/apps/gp2-server/src/handlers/user/algolia-index-handler.ts
+++ b/apps/gp2-server/src/handlers/user/algolia-index-handler.ts
@@ -34,6 +34,9 @@ export const indexUserHandler =
           const data = {
             ...user,
             _tags: getTagsNames(user.tags),
+            membershipStatus: user.alumniSinceDate
+              ? 'Alumni Member'
+              : 'GP2 Member',
           };
 
           await algoliaClient.save({

--- a/apps/gp2-server/src/handlers/user/algolia-index-handler.ts
+++ b/apps/gp2-server/src/handlers/user/algolia-index-handler.ts
@@ -31,12 +31,12 @@ export const indexUserHandler =
         log.debug(`Fetched user ${user.id}`);
 
         if (user.onboarded && user.role !== 'Hidden') {
+          const membershipStatus: gp2Model.UserMembershipStatus =
+            user.alumniSinceDate ? 'Alumni Member' : 'GP2 Member';
           const data = {
             ...user,
             _tags: getTagsNames(user.tags),
-            membershipStatus: user.alumniSinceDate
-              ? 'Alumni Member'
-              : 'GP2 Member',
+            membershipStatus,
           };
 
           await algoliaClient.save({

--- a/apps/gp2-server/test/data-providers/user.data-provider.test.ts
+++ b/apps/gp2-server/test/data-providers/user.data-provider.test.ts
@@ -931,6 +931,56 @@ describe('User data provider', () => {
       },
     );
 
+    test.each`
+      values                                 | expected
+      ${['Alumni Member']}                   | ${[{ alumniSinceDate_exists: true }]}
+      ${['GP2 Member']}                      | ${[{ alumniSinceDate_exists: false }]}
+      ${['Alumni Member', 'GP2 Member']}     | ${[{ alumniSinceDate_exists: true }, { alumniSinceDate_exists: false }]}
+    `(
+      'Should translate membershipStatus $values to alumniSinceDate_exists OR clauses',
+      async ({ values, expected }) => {
+        contentfulGraphqlClientMock.request.mockResolvedValueOnce(
+          getContentfulUsersGraphqlResponse(),
+        );
+        const fetchOptions: gp2Model.FetchUsersOptions = {
+          take: 12,
+          skip: 2,
+          filter: {
+            membershipStatus: values,
+          },
+        };
+        await userDataProvider.fetch(fetchOptions);
+
+        expect(contentfulGraphqlClientMock.request).toHaveBeenCalledWith(
+          gp2Contentful.FETCH_USERS,
+          expect.objectContaining({
+            where: expect.objectContaining({
+              OR: expected,
+            }),
+          }),
+        );
+      },
+    );
+
+    test('Should not add membershipStatus filter when array is empty', async () => {
+      contentfulGraphqlClientMock.request.mockResolvedValueOnce(
+        getContentfulUsersGraphqlResponse(),
+      );
+      const fetchOptions: gp2Model.FetchUsersOptions = {
+        take: 12,
+        skip: 2,
+        filter: { membershipStatus: [] },
+      };
+      await userDataProvider.fetch(fetchOptions);
+
+      expect(contentfulGraphqlClientMock.request).toHaveBeenCalledWith(
+        gp2Contentful.FETCH_USERS,
+        expect.objectContaining({
+          where: expect.not.objectContaining({ OR: expect.anything() }),
+        }),
+      );
+    });
+
     describe('projects filter', () => {
       test('it should return empty when no members', async () => {
         const projectId = '140f5e15-922d-4cbf-9d39-35dd39225b03';

--- a/apps/gp2-server/test/data-providers/user.data-provider.test.ts
+++ b/apps/gp2-server/test/data-providers/user.data-provider.test.ts
@@ -932,10 +932,10 @@ describe('User data provider', () => {
     );
 
     test.each`
-      values                                 | expected
-      ${['Alumni Member']}                   | ${[{ alumniSinceDate_exists: true }]}
-      ${['GP2 Member']}                      | ${[{ alumniSinceDate_exists: false }]}
-      ${['Alumni Member', 'GP2 Member']}     | ${[{ alumniSinceDate_exists: true }, { alumniSinceDate_exists: false }]}
+      values                             | expected
+      ${['Alumni Member']}               | ${[{ alumniSinceDate_exists: true }]}
+      ${['GP2 Member']}                  | ${[{ alumniSinceDate_exists: false }]}
+      ${['Alumni Member', 'GP2 Member']} | ${[{ alumniSinceDate_exists: true }, { alumniSinceDate_exists: false }]}
     `(
       'Should translate membershipStatus $values to alumniSinceDate_exists OR clauses',
       async ({ values, expected }) => {

--- a/apps/gp2-server/test/handlers/user/algolia-index-handler.test.ts
+++ b/apps/gp2-server/test/handlers/user/algolia-index-handler.test.ts
@@ -39,7 +39,35 @@ describe('User index handler', () => {
       data: {
         ...userResponse,
         _tags: expect.arrayContaining(['user tag']),
+        membershipStatus: 'Alumni Member',
       },
+      type: 'user',
+    });
+  });
+
+  test('Should set membershipStatus to "GP2 Member" when alumniSinceDate is undefined', async () => {
+    const userResponse = { ...getUserResponse(), alumniSinceDate: undefined };
+    userControllerMock.fetchById.mockResolvedValueOnce(userResponse);
+
+    await indexHandler(publishedEvent('42'));
+
+    expect(algoliaSearchClientMock.save).toHaveBeenCalledWith({
+      data: expect.objectContaining({ membershipStatus: 'GP2 Member' }),
+      type: 'user',
+    });
+  });
+
+  test('Should set membershipStatus to "Alumni Member" when alumniSinceDate is set', async () => {
+    const userResponse = {
+      ...getUserResponse(),
+      alumniSinceDate: '2025-01-01',
+    };
+    userControllerMock.fetchById.mockResolvedValueOnce(userResponse);
+
+    await indexHandler(publishedEvent('42'));
+
+    expect(algoliaSearchClientMock.save).toHaveBeenCalledWith({
+      data: expect.objectContaining({ membershipStatus: 'Alumni Member' }),
       type: 'user',
     });
   });

--- a/apps/gp2-server/test/routes/user.route.test.ts
+++ b/apps/gp2-server/test/routes/user.route.test.ts
@@ -113,13 +113,15 @@ describe('/users/ route', () => {
       });
 
       test.each`
-        name               | value
-        ${'regions'}       | ${['Africa']}
-        ${'projects'}      | ${['a project']}
-        ${'workingGroups'} | ${['a working group']}
-        ${'regions'}       | ${['Africa', 'Asia']}
-        ${'projects'}      | ${['a project', 'another project']}
-        ${'workingGroups'} | ${['a working group', 'another working group']}
+        name                  | value
+        ${'regions'}          | ${['Africa']}
+        ${'projects'}         | ${['a project']}
+        ${'workingGroups'}    | ${['a working group']}
+        ${'regions'}          | ${['Africa', 'Asia']}
+        ${'projects'}         | ${['a project', 'another project']}
+        ${'workingGroups'}    | ${['a working group', 'another working group']}
+        ${'membershipStatus'} | ${['GP2 Member']}
+        ${'membershipStatus'} | ${['GP2 Member', 'Alumni Member']}
       `(
         'Should return the results correctly when a filter is used for $name',
         async ({ name, value }) => {
@@ -134,6 +136,16 @@ describe('/users/ route', () => {
           expect(response.status).toBe(200);
         },
       );
+
+      test('Should reject an invalid membershipStatus value', async () => {
+        const response = await supertest(app)
+          .get('/users')
+          .query({
+            filter: { membershipStatus: ['not a member'] },
+          });
+
+        expect(response.status).toBe(400);
+      });
 
       test('Should return 200 when an administrator asks for non-onboarded users', async () => {
         userControllerMock.fetch.mockResolvedValueOnce(fetchExpectation);

--- a/apps/gp2-server/test/scripts/export-entity.test.ts
+++ b/apps/gp2-server/test/scripts/export-entity.test.ts
@@ -1,0 +1,42 @@
+import { transformRecords } from '../../scripts/export-entity';
+import { getUserResponse } from '../fixtures/user.fixtures';
+
+describe('transformRecords', () => {
+  it('derives membershipStatus="Alumni Member" when alumniSinceDate is set', () => {
+    const user = { ...getUserResponse(), alumniSinceDate: '2024-01-01' };
+
+    const result = transformRecords(user, 'user');
+
+    expect(result).toMatchObject({
+      objectID: user.id,
+      __meta: { type: 'user' },
+      membershipStatus: 'Alumni Member',
+    });
+  });
+
+  it('derives membershipStatus="GP2 Member" when alumniSinceDate is absent', () => {
+    const user = { ...getUserResponse(), alumniSinceDate: undefined };
+
+    const result = transformRecords(user, 'user');
+
+    expect(result).toMatchObject({
+      objectID: user.id,
+      __meta: { type: 'user' },
+      membershipStatus: 'GP2 Member',
+    });
+  });
+
+  it('flattens tags into _tags for tagged entities', () => {
+    const user = {
+      ...getUserResponse(),
+      tags: [
+        { id: 't1', name: 'tag-one' },
+        { id: 't2', name: 'tag-two' },
+      ],
+    };
+
+    const result = transformRecords(user, 'user');
+
+    expect(result).toMatchObject({ _tags: ['tag-one', 'tag-two'] });
+  });
+});

--- a/packages/algolia/schema/gp2/algolia-reverse-timestamp-schema.json
+++ b/packages/algolia/schema/gp2/algolia-reverse-timestamp-schema.json
@@ -10,6 +10,7 @@
     "authors.id",
     "documentType",
     "eventTypes",
+    "membershipStatus",
     "project.id",
     "projects.id",
     "projectIds",

--- a/packages/algolia/schema/gp2/algolia-schema.json
+++ b/packages/algolia/schema/gp2/algolia-schema.json
@@ -44,6 +44,7 @@
     "documentType",
     "eventTypes",
     "id",
+    "membershipStatus",
     "project.id",
     "projects.id",
     "projectIds",

--- a/packages/gp2-components/src/molecules/FilterModalFooter.tsx
+++ b/packages/gp2-components/src/molecules/FilterModalFooter.tsx
@@ -1,8 +1,20 @@
 import { Button, pixels } from '@asap-hub/react-components';
 import { css } from '@emotion/react';
-import { footerStyles, mobileQuery, padding24Styles } from '../layout';
+import colors from '../templates/colors';
+import { mobileQuery, padding24Styles } from '../layout';
 
 const { rem } = pixels;
+
+const footerStyles = css({
+  display: 'flex',
+  gap: rem(24),
+  justifyContent: 'space-between',
+  borderTop: `1px solid ${colors.neutral500.rgb}`,
+  [mobileQuery]: {
+    display: 'flex',
+    flexDirection: 'column-reverse',
+  },
+});
 
 type FilterModalFooterProps = {
   onReset: () => void;

--- a/packages/gp2-components/src/organisms/FilterPills.tsx
+++ b/packages/gp2-components/src/organisms/FilterPills.tsx
@@ -1,5 +1,6 @@
 import { gp2 as gp2Model } from '@asap-hub/model';
 import { pixels, Tag } from '@asap-hub/react-components';
+import { useFlags } from '@asap-hub/react-context';
 import { css } from '@emotion/react';
 import { useMemo } from 'react';
 
@@ -46,6 +47,7 @@ const FilterPills: React.FC<FilterPillsProps> = ({
   tags,
   onRemove,
 }) => {
+  const { isEnabled } = useFlags();
   const lookupTag = useMemo(
     () => getArrayLookup(tags.map(({ id, name }) => ({ id, title: name }))),
     [tags],
@@ -89,14 +91,15 @@ const FilterPills: React.FC<FilterPillsProps> = ({
           {lookupProject(filter)}
         </Tag>
       ))}
-      {filters.membershipStatus?.map((filter: string) => (
-        <Tag
-          key={`filter-pill-${filter}`}
-          onRemove={() => onRemove(filter, 'membershipStatus')}
-        >
-          {filter}
-        </Tag>
-      ))}
+      {isEnabled('STAGING_MODE') &&
+        filters.membershipStatus?.map((filter: string) => (
+          <Tag
+            key={`filter-pill-${filter}`}
+            onRemove={() => onRemove(filter, 'membershipStatus')}
+          >
+            {filter}
+          </Tag>
+        ))}
     </div>
   );
 };

--- a/packages/gp2-components/src/organisms/FilterPills.tsx
+++ b/packages/gp2-components/src/organisms/FilterPills.tsx
@@ -7,7 +7,7 @@ const { rem } = pixels;
 
 type FiltersType = Pick<
   gp2Model.FetchUsersFilter,
-  'tags' | 'regions' | 'workingGroups' | 'projects'
+  'tags' | 'regions' | 'workingGroups' | 'projects' | 'membershipStatus'
 >;
 
 type FilterType = keyof FiltersType;
@@ -87,6 +87,14 @@ const FilterPills: React.FC<FilterPillsProps> = ({
           onRemove={() => onRemove(filter, 'projects')}
         >
           {lookupProject(filter)}
+        </Tag>
+      ))}
+      {filters.membershipStatus?.map((filter: string) => (
+        <Tag
+          key={`filter-pill-${filter}`}
+          onRemove={() => onRemove(filter, 'membershipStatus')}
+        >
+          {filter}
         </Tag>
       ))}
     </div>

--- a/packages/gp2-components/src/organisms/FiltersModal.tsx
+++ b/packages/gp2-components/src/organisms/FiltersModal.tsx
@@ -7,6 +7,7 @@ import {
   Paragraph,
   pixels,
 } from '@asap-hub/react-components';
+import { useFlags } from '@asap-hub/react-context';
 import { css } from '@emotion/react';
 
 import { useState } from 'react';
@@ -68,6 +69,7 @@ const FiltersModal: React.FC<FiltersModalProps> = ({
   workingGroups,
   tags,
 }) => {
+  const { isEnabled } = useFlags();
   const entityToSelect = <T extends { title: string; id: string }>({
     title,
     id,
@@ -166,34 +168,36 @@ const FiltersModal: React.FC<FiltersModalProps> = ({
               setSelectedProjects([...newValues]);
             }}
           />
-          <div css={membershipStatusSectionStyles}>
-            <Paragraph noMargin styles={membershipStatusTitleStyles}>
-              <strong>Type of Users</strong>
-            </Paragraph>
-            <div css={membershipStatusRowStyles}>
-              {userMembershipStatus.map((value) => (
-                <div key={value} css={membershipStatusItemStyles}>
-                  <LabeledCheckbox
-                    wrapLabel={false}
-                    groupName="membershipStatus"
-                    title={value}
-                    checked={selectedMembershipStatus.has(value)}
-                    onSelect={() =>
-                      setSelectedMembershipStatus((prev) => {
-                        const next = new Set(prev);
-                        if (next.has(value)) {
-                          next.delete(value);
-                        } else {
-                          next.add(value);
-                        }
-                        return next;
-                      })
-                    }
-                  />
-                </div>
-              ))}
+          {isEnabled('STAGING_MODE') && (
+            <div css={membershipStatusSectionStyles}>
+              <Paragraph noMargin styles={membershipStatusTitleStyles}>
+                <strong>Type of Users</strong>
+              </Paragraph>
+              <div css={membershipStatusRowStyles}>
+                {userMembershipStatus.map((value) => (
+                  <div key={value} css={membershipStatusItemStyles}>
+                    <LabeledCheckbox
+                      wrapLabel={false}
+                      groupName="membershipStatus"
+                      title={value}
+                      checked={selectedMembershipStatus.has(value)}
+                      onSelect={() =>
+                        setSelectedMembershipStatus((prev) => {
+                          const next = new Set(prev);
+                          if (next.has(value)) {
+                            next.delete(value);
+                          } else {
+                            next.add(value);
+                          }
+                          return next;
+                        })
+                      }
+                    />
+                  </div>
+                ))}
+              </div>
             </div>
-          </div>
+          )}
           <FilterModalFooter
             onApply={() => {
               onApplyClick({

--- a/packages/gp2-components/src/organisms/FiltersModal.tsx
+++ b/packages/gp2-components/src/organisms/FiltersModal.tsx
@@ -1,5 +1,6 @@
 import { gp2 as gp2Model } from '@asap-hub/model';
 import {
+  CheckboxGroup,
   LabeledMultiSelect,
   Modal,
   FormCard,
@@ -8,7 +9,7 @@ import {
 import { useState } from 'react';
 import FilterModalFooter from '../molecules/FilterModalFooter';
 
-const { userRegions } = gp2Model;
+const { userRegions, userMembershipStatus } = gp2Model;
 
 type FiltersModalProps = {
   onBackClick: () => void;
@@ -65,18 +66,23 @@ const FiltersModal: React.FC<FiltersModalProps> = ({
       .filter(({ id }) => filters.workingGroups?.includes(id))
       .map(entityToSelect),
   );
+  const [selectedMembershipStatus, setSelectedMembershipStatus] = useState<
+    Set<gp2Model.UserMembershipStatus>
+  >(new Set(filters.membershipStatus ?? []));
   const resetFilters = () => {
     setSelectedRegions([]);
     setSelectedExpertise([]);
     setSelectedProjects([]);
     setSelectedWorkingGroups([]);
+    setSelectedMembershipStatus(new Set());
   };
 
   const numberOfFilter =
     selectedRegions.length +
     selectedExpertise.length +
     selectedProjects.length +
-    selectedWorkingGroups.length;
+    selectedWorkingGroups.length +
+    selectedMembershipStatus.size;
 
   const ModalDescription = () => (
     <>
@@ -134,6 +140,20 @@ const FiltersModal: React.FC<FiltersModalProps> = ({
               setSelectedProjects([...newValues]);
             }}
           />
+          <CheckboxGroup<gp2Model.UserMembershipStatus>
+            options={[
+              { title: 'Type of Users' },
+              ...userMembershipStatus.map((value) => ({ value, label: value })),
+            ]}
+            values={selectedMembershipStatus}
+            onChange={(value) =>
+              setSelectedMembershipStatus((prev) => {
+                const next = new Set(prev);
+                next.has(value) ? next.delete(value) : next.add(value);
+                return next;
+              })
+            }
+          />
           <FilterModalFooter
             onApply={() => {
               onApplyClick({
@@ -141,6 +161,7 @@ const FiltersModal: React.FC<FiltersModalProps> = ({
                 tags: selectedExpertise.map(({ value }) => value),
                 projects: selectedProjects.map(({ value }) => value),
                 workingGroups: selectedWorkingGroups.map(({ value }) => value),
+                membershipStatus: [...selectedMembershipStatus],
               });
             }}
             onClose={onBackClick}

--- a/packages/gp2-components/src/organisms/FiltersModal.tsx
+++ b/packages/gp2-components/src/organisms/FiltersModal.tsx
@@ -1,15 +1,41 @@
 import { gp2 as gp2Model } from '@asap-hub/model';
 import {
-  CheckboxGroup,
+  LabeledCheckbox,
   LabeledMultiSelect,
   Modal,
   FormCard,
+  Paragraph,
+  pixels,
 } from '@asap-hub/react-components';
+import { css } from '@emotion/react';
 
 import { useState } from 'react';
+import { mobileQuery } from '../layout';
 import FilterModalFooter from '../molecules/FilterModalFooter';
 
+const { rem } = pixels;
 const { userRegions, userMembershipStatus } = gp2Model;
+
+const membershipStatusTitleStyles = css({ paddingBottom: rem(14) });
+
+const membershipStatusSectionStyles = css({
+  marginBottom: rem(-24),
+});
+
+const membershipStatusRowStyles = css({
+  display: 'flex',
+  gap: rem(24),
+  '& p': { margin: 0 },
+  '& input[type="checkbox"]': { marginTop: 0, marginBottom: 0 },
+  [mobileQuery]: {
+    flexDirection: 'column',
+    gap: rem(16),
+  },
+});
+
+const membershipStatusItemStyles = css({
+  flex: 1,
+});
 
 type FiltersModalProps = {
   onBackClick: () => void;
@@ -68,7 +94,7 @@ const FiltersModal: React.FC<FiltersModalProps> = ({
   );
   const [selectedMembershipStatus, setSelectedMembershipStatus] = useState<
     Set<gp2Model.UserMembershipStatus>
-  >(new Set(filters.membershipStatus ?? []));
+  >(new Set(filters.membershipStatus));
   const resetFilters = () => {
     setSelectedRegions([]);
     setSelectedExpertise([]);
@@ -140,20 +166,34 @@ const FiltersModal: React.FC<FiltersModalProps> = ({
               setSelectedProjects([...newValues]);
             }}
           />
-          <CheckboxGroup<gp2Model.UserMembershipStatus>
-            options={[
-              { title: 'Type of Users' },
-              ...userMembershipStatus.map((value) => ({ value, label: value })),
-            ]}
-            values={selectedMembershipStatus}
-            onChange={(value) =>
-              setSelectedMembershipStatus((prev) => {
-                const next = new Set(prev);
-                next.has(value) ? next.delete(value) : next.add(value);
-                return next;
-              })
-            }
-          />
+          <div css={membershipStatusSectionStyles}>
+            <Paragraph noMargin styles={membershipStatusTitleStyles}>
+              <strong>Type of Users</strong>
+            </Paragraph>
+            <div css={membershipStatusRowStyles}>
+              {userMembershipStatus.map((value) => (
+                <div key={value} css={membershipStatusItemStyles}>
+                  <LabeledCheckbox
+                    wrapLabel={false}
+                    groupName="membershipStatus"
+                    title={value}
+                    checked={selectedMembershipStatus.has(value)}
+                    onSelect={() =>
+                      setSelectedMembershipStatus((prev) => {
+                        const next = new Set(prev);
+                        if (next.has(value)) {
+                          next.delete(value);
+                        } else {
+                          next.add(value);
+                        }
+                        return next;
+                      })
+                    }
+                  />
+                </div>
+              ))}
+            </div>
+          </div>
           <FilterModalFooter
             onApply={() => {
               onApplyClick({

--- a/packages/gp2-components/src/organisms/__tests__/FilterPills.test.tsx
+++ b/packages/gp2-components/src/organisms/__tests__/FilterPills.test.tsx
@@ -10,6 +10,7 @@ describe('FilterPills', () => {
       regions: ['Asia'],
       projects: ['project-1'],
       workingGroups: ['working-group-1'],
+      membershipStatus: ['Alumni Member'],
     } as ComponentProps<typeof FilterPills>['filters'],
     projects: [{ id: 'project-1', title: 'Project 1' }],
     workingGroups: [{ id: 'working-group-1', title: 'Working Group 1' }],
@@ -22,6 +23,7 @@ describe('FilterPills', () => {
     expect(screen.getByText('Asia')).toBeVisible();
     expect(screen.getByText('Project 1')).toBeVisible();
     expect(screen.getByText('Working Group 1')).toBeVisible();
+    expect(screen.getByText('Alumni Member')).toBeVisible();
   });
   it('calls the onRemove function for every pill with their respective id and type of filter', async () => {
     render(<FilterPills {...props} />);
@@ -31,11 +33,14 @@ describe('FilterPills', () => {
       screen.getByText('Project 1').nextElementSibling!;
     const onRemoveWorkingGroupButton =
       screen.getByText('Working Group 1').nextElementSibling!;
+    const onRemoveMembershipStatusButton =
+      screen.getByText('Alumni Member').nextElementSibling!;
 
     expect(onRemoveTagButton).toBeVisible();
     expect(onRemoveRegionButton).toBeVisible();
     expect(onRemoveProjectButton).toBeVisible();
     expect(onRemoveWorkingGroupButton).toBeVisible();
+    expect(onRemoveMembershipStatusButton).toBeVisible();
 
     await userEvent.click(onRemoveTagButton);
     expect(props.onRemove).toHaveBeenCalledWith('tag-1', 'tags');
@@ -50,6 +55,12 @@ describe('FilterPills', () => {
     expect(props.onRemove).toHaveBeenCalledWith(
       'working-group-1',
       'workingGroups',
+    );
+
+    await userEvent.click(onRemoveMembershipStatusButton);
+    expect(props.onRemove).toHaveBeenCalledWith(
+      'Alumni Member',
+      'membershipStatus',
     );
   });
 });

--- a/packages/gp2-components/src/organisms/__tests__/FilterPills.test.tsx
+++ b/packages/gp2-components/src/organisms/__tests__/FilterPills.test.tsx
@@ -1,9 +1,17 @@
+import { disable, enable, reset } from '@asap-hub/flags';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ComponentProps } from 'react';
 import FilterPills from '../FilterPills';
 
 describe('FilterPills', () => {
+  beforeEach(() => {
+    enable('STAGING_MODE');
+  });
+  afterEach(() => {
+    reset();
+  });
+
   const props = {
     filters: {
       tags: ['tag-1'],
@@ -62,5 +70,10 @@ describe('FilterPills', () => {
       'Alumni Member',
       'membershipStatus',
     );
+  });
+  it('does not render the membership status pill when STAGING_MODE is disabled', () => {
+    disable('STAGING_MODE');
+    render(<FilterPills {...props} />);
+    expect(screen.queryByText('Alumni Member')).not.toBeInTheDocument();
   });
 });

--- a/packages/gp2-components/src/organisms/__tests__/FiltersModal.test.tsx
+++ b/packages/gp2-components/src/organisms/__tests__/FiltersModal.test.tsx
@@ -1,3 +1,4 @@
+import { disable, enable, reset } from '@asap-hub/flags';
 import { gp2 as gp2Model } from '@asap-hub/model';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -7,6 +8,13 @@ import FiltersModal from '../FiltersModal';
 const { userRegions } = gp2Model;
 
 describe('FiltersModal', () => {
+  beforeEach(() => {
+    enable('STAGING_MODE');
+  });
+  afterEach(() => {
+    reset();
+  });
+
   const defaultProps = {
     onBackClick: jest.fn(),
     onApplyClick: jest.fn(),
@@ -214,6 +222,18 @@ describe('FiltersModal', () => {
     expect(
       screen.getByRole('checkbox', { name: 'Alumni Member' }),
     ).toBeInTheDocument();
+  });
+
+  it('does not render the Type of Users section when STAGING_MODE is disabled', () => {
+    disable('STAGING_MODE');
+    render(<FiltersModal {...defaultProps} />);
+    expect(screen.queryByText('Type of Users')).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('checkbox', { name: 'GP2 Member' }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('checkbox', { name: 'Alumni Member' }),
+    ).not.toBeInTheDocument();
   });
 
   it('toggling a membership status updates the filter count', async () => {

--- a/packages/gp2-components/src/organisms/__tests__/FiltersModal.test.tsx
+++ b/packages/gp2-components/src/organisms/__tests__/FiltersModal.test.tsx
@@ -162,6 +162,7 @@ describe('FiltersModal', () => {
       tags: [],
       projects: [],
       workingGroups: [],
+      membershipStatus: [],
     });
   });
   it('calls the onApplyClick function with correct expertise filters', async () => {
@@ -174,6 +175,7 @@ describe('FiltersModal', () => {
       tags: [tags[0]!.id],
       projects: [],
       workingGroups: [],
+      membershipStatus: [],
     });
   });
   it('calls the onApplyClick function with correct project filters', async () => {
@@ -186,6 +188,7 @@ describe('FiltersModal', () => {
       tags: [],
       projects: [projects[0]!.id],
       workingGroups: [],
+      membershipStatus: [],
     });
   });
   it('calls the onApplyClick function with correct working group filters', async () => {
@@ -198,7 +201,95 @@ describe('FiltersModal', () => {
       tags: [],
       projects: [],
       workingGroups: [workingGroups[0]!.id],
+      membershipStatus: [],
     });
+  });
+
+  it('renders the Type of Users checkboxes', () => {
+    render(<FiltersModal {...defaultProps} />);
+    expect(screen.getByText('Type of Users')).toBeVisible();
+    expect(
+      screen.getByRole('checkbox', { name: 'GP2 Member' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('checkbox', { name: 'Alumni Member' }),
+    ).toBeInTheDocument();
+  });
+
+  it('toggling a membership status updates the filter count', async () => {
+    render(<FiltersModal {...defaultProps} />);
+    expect(
+      screen.getByText(/Apply filters to narrow down your search results.*/i)
+        .textContent,
+    ).toContain('0 filters');
+    await userEvent.click(
+      screen.getByRole('checkbox', { name: 'Alumni Member' }),
+    );
+    expect(
+      screen.getByText(/Apply filters to narrow down your search results.*/i)
+        .textContent,
+    ).toContain('1 filter');
+    await userEvent.click(
+      screen.getByRole('checkbox', { name: 'GP2 Member' }),
+    );
+    expect(
+      screen.getByText(/Apply filters to narrow down your search results.*/i)
+        .textContent,
+    ).toContain('2 filters');
+    await userEvent.click(
+      screen.getByRole('checkbox', { name: 'Alumni Member' }),
+    );
+    expect(
+      screen.getByText(/Apply filters to narrow down your search results.*/i)
+        .textContent,
+    ).toContain('1 filter');
+  });
+
+  it('calls onApplyClick with correct membershipStatus selection', async () => {
+    render(<FiltersModal {...defaultProps} />);
+    await userEvent.click(
+      screen.getByRole('checkbox', { name: 'Alumni Member' }),
+    );
+    await userEvent.click(getApplyButton());
+    expect(defaultProps.onApplyClick).toHaveBeenCalledWith({
+      regions: [],
+      tags: [],
+      projects: [],
+      workingGroups: [],
+      membershipStatus: ['Alumni Member'],
+    });
+  });
+
+  it('pre-checks membershipStatus values from filters prop', () => {
+    render(
+      <FiltersModal
+        {...defaultProps}
+        filters={{ membershipStatus: ['GP2 Member'] }}
+      />,
+    );
+    expect(screen.getByRole('checkbox', { name: 'GP2 Member' })).toBeChecked();
+    expect(
+      screen.getByRole('checkbox', { name: 'Alumni Member' }),
+    ).not.toBeChecked();
+  });
+
+  it('resets membershipStatus on Reset', async () => {
+    render(<FiltersModal {...defaultProps} />);
+    await userEvent.click(
+      screen.getByRole('checkbox', { name: 'Alumni Member' }),
+    );
+    expect(
+      screen.getByText(/Apply filters to narrow down your search results.*/i)
+        .textContent,
+    ).toContain('1 filter');
+    await userEvent.click(screen.getByRole('button', { name: 'Reset' }));
+    expect(
+      screen.getByText(/Apply filters to narrow down your search results.*/i)
+        .textContent,
+    ).toContain('0 filters');
+    expect(
+      screen.getByRole('checkbox', { name: 'Alumni Member' }),
+    ).not.toBeChecked();
   });
 
   it.each`

--- a/packages/gp2-components/src/organisms/__tests__/FiltersModal.test.tsx
+++ b/packages/gp2-components/src/organisms/__tests__/FiltersModal.test.tsx
@@ -229,9 +229,7 @@ describe('FiltersModal', () => {
       screen.getByText(/Apply filters to narrow down your search results.*/i)
         .textContent,
     ).toContain('1 filter');
-    await userEvent.click(
-      screen.getByRole('checkbox', { name: 'GP2 Member' }),
-    );
+    await userEvent.click(screen.getByRole('checkbox', { name: 'GP2 Member' }));
     expect(
       screen.getByText(/Apply filters to narrow down your search results.*/i)
         .textContent,

--- a/packages/gp2-components/src/templates/__tests__/UsersPageList.test.tsx
+++ b/packages/gp2-components/src/templates/__tests__/UsersPageList.test.tsx
@@ -96,6 +96,7 @@ describe('UsersPageList', () => {
         tags: [],
         projects: [],
         workingGroups: [],
+        membershipStatus: [],
         [name]: [value],
       });
     },

--- a/packages/model/src/gp2/user.ts
+++ b/packages/model/src/gp2/user.ts
@@ -45,6 +45,9 @@ export const userRegions = [
   'South America',
 ] as const;
 
+export const userMembershipStatus = ['GP2 Member', 'Alumni Member'] as const;
+export type UserMembershipStatus = (typeof userMembershipStatus)[number];
+
 export type UserOutput = Pick<
   OutputResponse,
   'id' | 'title' | 'shortDescription' | 'gp2Supported' | 'sharingStatus'
@@ -245,6 +248,7 @@ export type FetchUsersSearchFilter = {
   workingGroups?: string[];
   regions?: UserRegion[];
   tags?: string[];
+  membershipStatus?: UserMembershipStatus[];
 };
 export type FetchUsersFilter = FetchUsersSearchFilter & {
   code?: string;

--- a/packages/server-common/src/validation/validation.ts
+++ b/packages/server-common/src/validation/validation.ts
@@ -121,6 +121,11 @@ export const fetchUsersOptionsValidationSchema: JSONSchemaType<gp2.FetchUsersApi
           onlyOnboarded: { type: 'boolean', nullable: true, default: true },
           hidden: { type: 'boolean', nullable: true },
           email: { type: 'string', nullable: true },
+          membershipStatus: {
+            type: 'array',
+            items: { type: 'string', enum: gp2.userMembershipStatus },
+            nullable: true,
+          },
         },
         nullable: true,
       },


### PR DESCRIPTION
ref: https://asaphub.atlassian.net/browse/ASAP-1513

Adds a **Type of Users** filter (GP2 Member / Alumni Member) to the GP2 People List, mirroring CRN's `UserMembershipStatus`. Membership is derived from `alumniSinceDate` at write time, both in the EventBridge indexer and in the bulk `export-entity.ts` script, so both write paths stay consistent.

Algolia gains a `membershipStatus` facet. The Algolia filter builder now wraps each group in parentheses so multi-value groups combine correctly. The REST `/users` endpoint translates `filter[membershipStatus]` into `OR { alumniSinceDate_exists }` for the CSV export.

The new section is rendered with `LabeledCheckbox` in a flex row — 2 columns on desktop, stacked with 16 px gap on mobile.

## Deploy

After merge, trigger **Sync GP2 Algolia** (`entity: users`) so existing records get the `membershipStatus` field; without this the filter returns empty values.

## See it in action

https://github.com/user-attachments/assets/d4e6f43e-2bf9-4356-bb60-45660bb64fe6

