### PR TITLE
[ASAP-1544] - Show "No articles associated" empty state on Aims and Milestones

### DIFF
--- a/packages/react-components/src/molecules/ArticlesList.tsx
+++ b/packages/react-components/src/molecules/ArticlesList.tsx
@@ -16,6 +16,7 @@ import {
   articlesListStyles,
   articlesListWrapperStyles,
   articlesTitleStyles,
+  noArticlesTextStyles,
 } from '../organisms/shared-aim-milestones-styles';
 
 export type ArticlesListProps = {
@@ -52,6 +53,14 @@ const ArticlesList: FC<ArticlesListProps> = ({
   }, [aimId, initiallyExpanded, fetchArticles]);
 
   const displayedCount = hasFetched ? articles.length : articlesCount;
+
+  if (displayedCount === 0) {
+    return (
+      <div css={articlesHeaderStyles}>
+        <span css={noArticlesTextStyles}>No articles associated</span>
+      </div>
+    );
+  }
 
   return (
     <div>

--- a/packages/react-components/src/molecules/__tests__/ArticlesList.test.tsx
+++ b/packages/react-components/src/molecules/__tests__/ArticlesList.test.tsx
@@ -22,7 +22,21 @@ describe('ArticlesList', () => {
       fetchArticles: mockFetchArticles,
     } as unknown as ArticlesListProps;
     render(<ArticlesList {...props} />);
-    expect(screen.getByText('Articles (0)')).toBeInTheDocument();
+    expect(screen.getByText('No articles associated')).toBeInTheDocument();
+  });
+
+  it('displays empty state and no expand button when count is 0', () => {
+    render(
+      <ArticlesList
+        aimId="aim-1"
+        articlesCount={0}
+        fetchArticles={mockFetchArticles}
+      />,
+    );
+    expect(screen.getByText('No articles associated')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Expand articles' }),
+    ).not.toBeInTheDocument();
   });
 
   it('displays the article count in the header', () => {

--- a/packages/react-components/src/organisms/Milestone.tsx
+++ b/packages/react-components/src/organisms/Milestone.tsx
@@ -179,7 +179,7 @@ const Milestone: FC<MilestoneProps> = ({
         <div css={articlesWrapperStyles}>
           {articleCount === 0 ? (
             <div css={articlesHeaderStyles}>
-              <span css={noArticlesTextStyles}>No articles added</span>
+              <span css={noArticlesTextStyles}>No articles associated</span>
               {isLead && (
                 <>
                   <span css={articlesSeparatorStyles}>•</span>

--- a/packages/react-components/src/organisms/__tests__/Aim.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/Aim.test.tsx
@@ -1,9 +1,11 @@
 import { render, screen, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { Aim as AimType, AimStatus } from '@asap-hub/model';
+import { Aim as AimType, AimStatus, ArticleItem } from '@asap-hub/model';
 import Aim, { getAimStatusAccent } from '../Aim';
 
-const mockFetchArticles = jest.fn(() => Promise.resolve([]));
+const mockFetchArticles = jest.fn(
+  (): Promise<ReadonlyArray<ArticleItem>> => Promise.resolve([]),
+);
 
 const mockAim: AimType = {
   id: '1',
@@ -39,6 +41,11 @@ const mockClientHeight = (element: HTMLElement, clientHeight: number) => {
 };
 
 describe('Aim', () => {
+  beforeEach(() => {
+    mockFetchArticles.mockClear();
+    mockFetchArticles.mockResolvedValue([]);
+  });
+
   it('renders aim description', () => {
     render(<Aim aim={mockAim} {...defaultAimProps} />);
     expect(screen.getByText(mockAim.description)).toBeInTheDocument();
@@ -54,9 +61,12 @@ describe('Aim', () => {
     expect(screen.getByText('Complete')).toBeInTheDocument();
   });
 
-  it('shows ArticlesList with count 0 when articleCount is 0', () => {
+  it('shows empty state when articleCount is 0', () => {
     render(<Aim aim={mockAim} {...defaultAimProps} />);
-    expect(screen.getByText('Articles (0)')).toBeInTheDocument();
+    expect(screen.getByText('No articles associated')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Expand articles' }),
+    ).not.toBeInTheDocument();
     expect(
       screen.queryByRole('button', { name: 'Edit' }),
     ).not.toBeInTheDocument();
@@ -74,6 +84,9 @@ describe('Aim', () => {
   });
 
   it('toggles articles section on click', async () => {
+    mockFetchArticles.mockResolvedValueOnce([
+      { id: 'a1', title: 'Article one', href: '/articles/a1' },
+    ]);
     render(<Aim aim={longAim} {...defaultAimProps} />);
 
     const articlesButton = screen.getByRole('button', {

--- a/packages/react-components/src/organisms/__tests__/Milestone.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/Milestone.test.tsx
@@ -239,7 +239,7 @@ describe('Milestone', () => {
       Promise.resolve(sampleArticles),
     );
 
-    it('displays "No articles added" when no related articles', () => {
+    it('displays "No articles associated" when no related articles', () => {
       render(
         <Milestone
           milestone={mockMilestone}
@@ -249,7 +249,7 @@ describe('Milestone', () => {
           onSaveArticles={mockOnSaveArticles}
         />,
       );
-      expect(screen.getByText('No articles added')).toBeInTheDocument();
+      expect(screen.getByText('No articles associated')).toBeInTheDocument();
     });
 
     it('displays article count with expand button when articles exist', () => {


### PR DESCRIPTION
ref: https://asaphub.atlassian.net/browse/ASAP-1544

**Aims section:**

<img width="1512" height="838" alt="Screenshot 2026-06-18 at 16 20 11" src="https://github.com/user-attachments/assets/e804f846-4e8e-479a-a625-9beed2e1acd0" />
 
**Listing Milestones:**
<img width="1512" height="835" alt="Screenshot 2026-06-18 at 16 20 26" src="https://github.com/user-attachments/assets/55eed16f-bdb9-4190-b829-cc67a6960c36" />

**Milestones when removing/adding an article:**

https://github.com/user-attachments/assets/893b0961-9af4-42b9-9c4e-13962bd8660d

