### PR TITLE
[ASAP-1554] - Close Contact Details and Open Questions modals on save

### DIFF
--- a/packages/react-components/src/templates/ContactInfoModal.tsx
+++ b/packages/react-components/src/templates/ContactInfoModal.tsx
@@ -2,6 +2,7 @@ import { UserPatchRequest, UserResponse } from '@asap-hub/model';
 import { urlExpression, USER_SOCIAL_RESEARCHER_ID } from '@asap-hub/validation';
 import { css } from '@emotion/react';
 import { FunctionComponent, useState } from 'react';
+import { useNavigate } from 'react-router';
 
 import { Link } from '../atoms';
 import { charcoal, lead } from '../colors';
@@ -68,6 +69,7 @@ const ContactInfoModal: React.FC<ContactInfoModalProps> = ({
   backHref,
   onSave = noop,
 }) => {
+  const navigate = useNavigate();
   const [newEmail, setNewEmail] = useState(email);
   const [newWebsite1, setNewWebsite1] = useState(website1);
   const [newWebsite2, setNewWebsite2] = useState(website2);
@@ -85,8 +87,8 @@ const ContactInfoModal: React.FC<ContactInfoModalProps> = ({
       backHref={backHref}
       title="Contact Details"
       dirty={newEmail !== email}
-      onSave={() =>
-        onSave({
+      onSave={async () => {
+        await onSave({
           contactEmail: newEmail || undefined,
           social: {
             twitter: formatUserSocial(newTwitter, 'twitter') || undefined,
@@ -101,8 +103,9 @@ const ContactInfoModal: React.FC<ContactInfoModalProps> = ({
             website1: newWebsite1 || undefined,
             website2: newWebsite2 || undefined,
           },
-        })
-      }
+        });
+        void navigate(backHref);
+      }}
     >
       {({ isSaving }) => (
         <FormSection>

--- a/packages/react-components/src/templates/OpenQuestionsModal.tsx
+++ b/packages/react-components/src/templates/OpenQuestionsModal.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useNavigate } from 'react-router';
 import { UserPatchRequest, UserResponse } from '@asap-hub/model';
 import deepEqual from 'fast-deep-equal';
 
@@ -16,6 +17,7 @@ const OpenQuestionsModal: React.FC<OpenQuestionsModalProps> = ({
   onSave = noop,
   backHref,
 }) => {
+  const navigate = useNavigate();
   const [newQuestions, setNewQuestions] = useState<string[]>(questions);
 
   return (
@@ -24,11 +26,12 @@ const OpenQuestionsModal: React.FC<OpenQuestionsModalProps> = ({
       description="Share questions that drive your work or get you out of bed in the morning. Help other ASAP researchers get to know you and spark discussions and collaborations in the Network!"
       dirty={!deepEqual(newQuestions, questions)}
       backHref={backHref}
-      onSave={() =>
-        onSave({
+      onSave={async () => {
+        await onSave({
           questions: newQuestions.filter((item) => item.trim() !== ''),
-        })
-      }
+        });
+        void navigate(backHref);
+      }}
     >
       {({ isSaving }) => (
         <>


### PR DESCRIPTION
ref: https://asaphub.atlassian.net/browse/ASAP-1554

**Contact Info**

Before: 

https://github.com/user-attachments/assets/e88679db-0e9e-4322-98a9-035be8471c6a

After:

https://github.com/user-attachments/assets/b30a4711-87be-41b8-80dd-34d30ea23ae4

While fixing it, I noticed the same wrong behavior was being reproduced on the Open Questions modal.

**Open Questions**

Before:

https://github.com/user-attachments/assets/97468ba2-f0c8-4796-aef8-46caf9920780

After:

https://github.com/user-attachments/assets/11889c89-ac13-42b4-b3a4-55ca66ac980e
