### PR TITLE
[ASAP-1574] - Fix Publish Date Timezone

### DIFF
--- a/packages/react-components/src/molecules/LabeledDateField.tsx
+++ b/packages/react-components/src/molecules/LabeledDateField.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { parseISO } from 'date-fns';
+import { format, parseISO } from 'date-fns';
 import { ComponentProps } from 'react';
 
 import { Label, Paragraph, TextField } from '../atoms';
@@ -29,7 +29,7 @@ const descriptionStyles = css({
   color: lead.rgb,
 });
 
-// publishDate is a date-only value stored at UTC midnight; format it in UTC so the
+// The value is a date-only field stored at UTC midnight; format it in UTC so the
 // calendar day does not shift for viewers in timezones behind UTC.
 export const parseDateToString = (date?: Date): string => {
   try {
@@ -65,7 +65,9 @@ const LabeledDateField: React.FC<LabeledDateFieldProps> = ({
               newDate ? parseISO(`${newDate}T00:00:00.000Z`) : undefined,
             );
           }}
-          max={max ? parseDateToString(max) : undefined}
+          // max is a "today" selection ceiling that the user reasons about in their
+          // local calendar, so it stays in local time (unlike the UTC-anchored value).
+          max={max ? format(max, 'yyyy-MM-dd') : undefined}
         />
       )}
     >

--- a/packages/react-components/src/molecules/LabeledDateField.tsx
+++ b/packages/react-components/src/molecules/LabeledDateField.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { format, formatISO, parseISO } from 'date-fns';
+import { parseISO } from 'date-fns';
 import { ComponentProps } from 'react';
 
 import { Label, Paragraph, TextField } from '../atoms';
@@ -29,10 +29,12 @@ const descriptionStyles = css({
   color: lead.rgb,
 });
 
+// publishDate is a date-only value stored at UTC midnight; format it in UTC so the
+// calendar day does not shift for viewers in timezones behind UTC.
 export const parseDateToString = (date?: Date): string => {
   try {
     if (date) {
-      return formatISO(date, { representation: 'date' });
+      return date.toISOString().slice(0, 10);
     }
     throw new Error('Date is undefined');
   } catch {
@@ -59,9 +61,11 @@ const LabeledDateField: React.FC<LabeledDateFieldProps> = ({
           id={id}
           value={parseDateToString(value)}
           onChange={(newDate) => {
-            onChange(newDate ? parseISO(newDate) : undefined);
+            onChange(
+              newDate ? parseISO(`${newDate}T00:00:00.000Z`) : undefined,
+            );
           }}
-          max={max ? format(max, 'yyyy-MM-dd') : undefined}
+          max={max ? parseDateToString(max) : undefined}
         />
       )}
     >

--- a/packages/react-components/src/molecules/__tests__/LabeledDateField.test.tsx
+++ b/packages/react-components/src/molecules/__tests__/LabeledDateField.test.tsx
@@ -1,4 +1,4 @@
-import { formatISO, startOfTomorrow } from 'date-fns';
+import { startOfTomorrow } from 'date-fns';
 import { render, fireEvent, screen, waitFor } from '@testing-library/react';
 
 import LabeledDateField, { parseDateToString } from '../LabeledDateField';
@@ -59,9 +59,7 @@ it('reports changes as date objects', async () => {
 
   expect(handleChange).toHaveBeenCalled();
   const [newDate] = handleChange.mock.calls.slice(-1)[0]!;
-  expect(formatISO(newDate as Date, { representation: 'date' })).toBe(
-    '2019-02-01',
-  );
+  expect((newDate as Date).toISOString().slice(0, 10)).toBe('2019-02-01');
 });
 
 it('handles clearing the date field', () => {
@@ -91,5 +89,10 @@ describe('Tests that the parseDateTostring function returns', () => {
   });
   it('the stringified date when the date is defined', () => {
     expect(parseDateToString(new Date('2020-01-01'))).toBe('2020-01-01');
+  });
+  it('the same calendar day for a UTC-midnight instant', () => {
+    expect(parseDateToString(new Date('2026-04-01T00:00:00.000Z'))).toBe(
+      '2026-04-01',
+    );
   });
 });


### PR DESCRIPTION
ref: https://asaphub.atlassian.net/browse/ASAP-1574

Publish date is a date-only value stored at UTC midnight, but the picker formatted/parsed it in local time -> one day earlier in timezones behind UTC. The CSV export was already correct (it uses the raw string).


https://github.com/user-attachments/assets/f740257e-0e6a-48b3-a8df-8b6b52337bbe
<img width="547" height="184" alt="Screenshot 2026-07-03 at 18 28 18" src="https://github.com/user-attachments/assets/69ef6f55-1a40-46ae-83fc-93e69a48e54d" />

_On the left is the older version, and on the right is the newer version._