### PR TITLE
ASAP-1575 Fix scroll to manuscript card

### DIFF
--- a/apps/crn-frontend/src/compliance/ManuscriptWorkspaceRedirect.tsx
+++ b/apps/crn-frontend/src/compliance/ManuscriptWorkspaceRedirect.tsx
@@ -20,7 +20,9 @@ const ManuscriptWorkspaceRedirect: FC = () => {
     return <ManuscriptWorkspaceUnavailablePage />;
   }
 
-  return <Navigate to={workspaceUrl.url} replace />;
+  return (
+    <Navigate to={workspaceUrl.url} replace state={{ scrollToHash: true }} />
+  );
 };
 
 export default ManuscriptWorkspaceRedirect;

--- a/apps/crn-frontend/src/network/ProfileSwitch.tsx
+++ b/apps/crn-frontend/src/network/ProfileSwitch.tsx
@@ -31,7 +31,7 @@ type ProfileSwitchProps = {
   DraftOutputs?: ReactElement;
   paths: Record<RequiredPaths, string> & Partial<Record<OptionalPaths, string>>;
   type: ComponentProps<typeof NoEvents>['type'];
-  Workspace?: FC;
+  Workspace?: ReactElement;
   Compliance?: ReactElement;
 };
 
@@ -82,11 +82,7 @@ const ProfileSwitch: FC<ProfileSwitchProps> = ({
         {Workspace && (
           <Route
             path={`${paths.workspace}/*`}
-            element={
-              <Frame title="Workspace">
-                <Workspace />
-              </Frame>
-            }
+            element={<Frame title="Workspace">{Workspace}</Frame>}
           />
         )}
         {Compliance && (

--- a/apps/crn-frontend/src/network/teams/TeamProfile.tsx
+++ b/apps/crn-frontend/src/network/teams/TeamProfile.tsx
@@ -274,11 +274,11 @@ const TeamProfile: FC<TeamProfileProps> = ({ currentTime }) => {
                       }
                       paths={paths}
                       type="team"
-                      Workspace={() => (
+                      Workspace={
                         <Workspace
                           team={{ ...team, tools: team.tools ?? [] }}
                         />
-                      )}
+                      }
                       {...(canDisplayCompliancePage
                         ? { Compliance: <Compliance /> }
                         : {})}

--- a/packages/react-components/src/__tests__/routing.test.tsx
+++ b/packages/react-components/src/__tests__/routing.test.tsx
@@ -343,28 +343,100 @@ describe('usePushFromHere', () => {
 });
 
 describe('useScrollToHash', () => {
+  const createTargetElement = ({
+    id = 'section',
+    append = true,
+    scrollIntoView = jest.fn(),
+    getBoundingClientRect,
+  }: {
+    id?: string;
+    append?: boolean;
+    scrollIntoView?: HTMLElement['scrollIntoView'];
+    getBoundingClientRect?: HTMLElement['getBoundingClientRect'];
+  } = {}) => {
+    const element = document.createElement('div');
+    element.id = id;
+    element.scrollIntoView = scrollIntoView;
+    if (getBoundingClientRect) {
+      element.getBoundingClientRect = getBoundingClientRect;
+    }
+    if (append) {
+      document.body.appendChild(element);
+    }
+    return element;
+  };
+
+  const renderScrollToHash = (route: string) => {
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <MemoryRouter initialEntries={[route]}>{children}</MemoryRouter>
+    );
+    return renderHook(() => useScrollToHash(), { wrapper });
+  };
+
   it('scrolls to element when hash is present in URL', async () => {
-    // Create target element with mocked scrollIntoView
-    const targetElement = document.createElement('div');
-    targetElement.id = 'section';
-    targetElement.scrollIntoView = jest.fn();
+    const targetElement = createTargetElement();
+
+    renderScrollToHash('/page#section');
+
+    await waitFor(() => {
+      expect(targetElement.scrollIntoView).toHaveBeenCalledWith({
+        behavior: 'smooth',
+        block: 'start',
+      });
+    });
+
+    document.body.removeChild(targetElement);
+  });
+
+  it('scrolls once the target eventually renders', async () => {
+    renderScrollToHash('/page#late-section');
+
+    // simulate the target only appearing after data has loaded
+    const targetElement = createTargetElement({
+      id: 'late-section',
+      append: false,
+    });
+    expect(targetElement.scrollIntoView).not.toHaveBeenCalled();
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 100);
+    });
     document.body.appendChild(targetElement);
 
-    const wrapper = ({ children }: { children: ReactNode }) => (
-      <MemoryRouter initialEntries={['/page#section']}>{children}</MemoryRouter>
-    );
+    await waitFor(() => {
+      expect(targetElement.scrollIntoView).toHaveBeenCalledWith({
+        behavior: 'smooth',
+        block: 'start',
+      });
+    });
 
-    renderHook(() => useScrollToHash(), { wrapper });
+    document.body.removeChild(targetElement);
+  });
 
-    // Wait for the setTimeout to complete (100ms delay in the hook)
+  it('re-scrolls when late-loading content pushes the target out of view', async () => {
+    let top = 900;
+    let reads = 0;
+    const targetElement = createTargetElement({
+      scrollIntoView: jest.fn(() => {
+        top = 0;
+      }),
+      getBoundingClientRect: jest.fn(() => {
+        reads += 1;
+        // Simulate late-loading content above the target pushing it
+        // below the viewport (jsdom window.innerHeight is 768)
+        if (reads === 10) {
+          top = 800;
+        }
+        return { top, bottom: top + 50, width: 100, height: 50 } as DOMRect;
+      }),
+    });
+
+    renderScrollToHash('/page#section');
+
     await waitFor(
       () => {
-        expect(targetElement.scrollIntoView).toHaveBeenCalledWith({
-          behavior: 'smooth',
-          block: 'start',
-        });
+        expect(targetElement.scrollIntoView).toHaveBeenCalledTimes(2);
       },
-      { timeout: 200 },
+      { timeout: 3000 },
     );
 
     document.body.removeChild(targetElement);
@@ -372,16 +444,9 @@ describe('useScrollToHash', () => {
 
   it('does not scroll when no hash is present', async () => {
     // Create element just to verify scrollIntoView is NOT called
-    const targetElement = document.createElement('div');
-    targetElement.id = 'section';
-    targetElement.scrollIntoView = jest.fn();
-    document.body.appendChild(targetElement);
+    const targetElement = createTargetElement();
 
-    const wrapper = ({ children }: { children: ReactNode }) => (
-      <MemoryRouter initialEntries={['/page']}>{children}</MemoryRouter>
-    );
-
-    renderHook(() => useScrollToHash(), { wrapper });
+    renderScrollToHash('/page');
 
     // Wait a bit and verify it was NOT called
     await new Promise<void>((resolve) => {
@@ -394,14 +459,8 @@ describe('useScrollToHash', () => {
   });
 
   it('does not throw if element does not exist', async () => {
-    const wrapper = ({ children }: { children: ReactNode }) => (
-      <MemoryRouter initialEntries={['/page#nonexistent']}>
-        {children}
-      </MemoryRouter>
-    );
-
     // This should not throw even if element doesn't exist
-    const { result } = renderHook(() => useScrollToHash(), { wrapper });
+    const { result } = renderScrollToHash('/page#nonexistent');
 
     // Wait for the timeout to complete
     await new Promise<void>((resolve) => {
@@ -410,5 +469,98 @@ describe('useScrollToHash', () => {
 
     // Verify hook completed without throwing (result should be undefined as hook returns void)
     expect(result.current).toBeUndefined();
+  });
+
+  describe('animation frame lifecycle', () => {
+    let rafCallbacks: FrameRequestCallback[];
+    let rafId: number;
+    let now: number;
+
+    const flushFrames = (count: number) => {
+      act(() => {
+        for (let i = 0; i < count; i += 1) {
+          const callbacks = [...rafCallbacks];
+          rafCallbacks = [];
+          const frameTime = now;
+          callbacks.forEach((cb) => {
+            cb(frameTime);
+          });
+        }
+      });
+    };
+
+    const settleLayout = () => flushFrames(6);
+    const finishSmoothScroll = () => flushFrames(10);
+    const settleHoldingPosition = () => flushFrames(1);
+
+    beforeEach(() => {
+      rafCallbacks = [];
+      rafId = 0;
+      now = 0;
+
+      jest.spyOn(performance, 'now').mockImplementation(() => now);
+      jest.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+        rafId += 1;
+        rafCallbacks.push(cb);
+        return rafId;
+      });
+      jest.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {
+        rafCallbacks = [];
+      });
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('stops polling once scroll animation has settled in view', () => {
+      const top = 0;
+      const targetElement = createTargetElement({
+        getBoundingClientRect: jest.fn(
+          () =>
+            ({
+              top,
+              bottom: top + 50,
+              width: 100,
+              height: 50,
+            }) as DOMRect,
+        ),
+      });
+
+      const cancelAnimationFrameSpy = jest.spyOn(
+        window,
+        'cancelAnimationFrame',
+      );
+
+      renderScrollToHash('/page#section');
+
+      settleLayout();
+      expect(targetElement.scrollIntoView).toHaveBeenCalled();
+
+      finishSmoothScroll();
+      settleHoldingPosition();
+
+      expect(cancelAnimationFrameSpy).toHaveBeenCalled();
+      expect(rafCallbacks).toHaveLength(0);
+
+      document.body.removeChild(targetElement);
+    });
+
+    it('stops polling after the give-up timeout', () => {
+      const cancelAnimationFrameSpy = jest.spyOn(
+        window,
+        'cancelAnimationFrame',
+      );
+
+      renderScrollToHash('/page#missing');
+
+      flushFrames(1);
+
+      now = 10001;
+      flushFrames(1);
+
+      expect(cancelAnimationFrameSpy).toHaveBeenCalled();
+      expect(rafCallbacks).toHaveLength(0);
+    });
   });
 });

--- a/packages/react-components/src/__tests__/routing.test.tsx
+++ b/packages/react-components/src/__tests__/routing.test.tsx
@@ -458,6 +458,102 @@ describe('useScrollToHash', () => {
     document.body.removeChild(targetElement);
   });
 
+  it('does not scroll when the hash changes via a replace navigation', async () => {
+    navigateToPath = null;
+    const targetElement = createTargetElement();
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <MemoryRouter initialEntries={['/page']}>
+        <NavigationHelper />
+        {children}
+      </MemoryRouter>
+    );
+
+    renderHook(() => useScrollToHash(), { wrapper });
+
+    await waitFor(() => {
+      expect(navigateToPath).not.toBeNull();
+    });
+
+    act(() => {
+      void navigateToPath?.('/page#section', { replace: true });
+    });
+
+    // Give the hook time to (not) scroll
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 150);
+    });
+
+    expect(targetElement.scrollIntoView).not.toHaveBeenCalled();
+
+    document.body.removeChild(targetElement);
+  });
+
+  it('scrolls on a replace navigation that requests it via state', async () => {
+    navigateToPath = null;
+    const targetElement = createTargetElement();
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <MemoryRouter initialEntries={['/page']}>
+        <NavigationHelper />
+        {children}
+      </MemoryRouter>
+    );
+
+    renderHook(() => useScrollToHash(), { wrapper });
+
+    await waitFor(() => {
+      expect(navigateToPath).not.toBeNull();
+    });
+
+    act(() => {
+      void navigateToPath?.('/page#section', {
+        replace: true,
+        state: { scrollToHash: true },
+      });
+    });
+
+    await waitFor(() => {
+      expect(targetElement.scrollIntoView).toHaveBeenCalledWith({
+        behavior: 'smooth',
+        block: 'start',
+      });
+    });
+
+    document.body.removeChild(targetElement);
+  });
+
+  it('scrolls when navigating to a hash via a push', async () => {
+    navigateToPath = null;
+    const targetElement = createTargetElement();
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <MemoryRouter initialEntries={['/page']}>
+        <NavigationHelper />
+        {children}
+      </MemoryRouter>
+    );
+
+    renderHook(() => useScrollToHash(), { wrapper });
+
+    await waitFor(() => {
+      expect(navigateToPath).not.toBeNull();
+    });
+
+    act(() => {
+      void navigateToPath?.('/page#section');
+    });
+
+    await waitFor(() => {
+      expect(targetElement.scrollIntoView).toHaveBeenCalledWith({
+        behavior: 'smooth',
+        block: 'start',
+      });
+    });
+
+    document.body.removeChild(targetElement);
+  });
+
   it('does not throw if element does not exist', async () => {
     // This should not throw even if element doesn't exist
     const { result } = renderScrollToHash('/page#nonexistent');
@@ -513,7 +609,7 @@ describe('useScrollToHash', () => {
       jest.restoreAllMocks();
     });
 
-    it('stops polling once scroll animation has settled in view', () => {
+    it('stops polling once the scroll animation has settled in view', () => {
       const top = 0;
       const targetElement = createTargetElement({
         getBoundingClientRect: jest.fn(
@@ -534,14 +630,17 @@ describe('useScrollToHash', () => {
 
       renderScrollToHash('/page#section');
 
+      // once the layout has been still long enough, it scrolls exactly once
       settleLayout();
-      expect(targetElement.scrollIntoView).toHaveBeenCalled();
+      expect(targetElement.scrollIntoView).toHaveBeenCalledTimes(1);
 
+      // the scroll animation finishes and one more settled frame stops polling
       finishSmoothScroll();
       settleHoldingPosition();
 
       expect(cancelAnimationFrameSpy).toHaveBeenCalled();
       expect(rafCallbacks).toHaveLength(0);
+      expect(targetElement.scrollIntoView).toHaveBeenCalledTimes(1);
 
       document.body.removeChild(targetElement);
     });

--- a/packages/react-components/src/organisms/ManuscriptCard.tsx
+++ b/packages/react-components/src/organisms/ManuscriptCard.tsx
@@ -286,10 +286,15 @@ const ManuscriptCard: React.FC<ManuscriptCardProps> = ({
     teamWorkspaceRoute.editManuscript({ manuscriptId }).$;
   const [displayConfirmStatusChangeModal, setDisplayConfirmStatusChangeModal] =
     useState(false);
-  const targetManuscriptRef = useRef<HTMLDivElement>(null);
-
   const [expandedState, setExpandedState] = useState(isTargetManuscript);
   const [showMore, setShowMore] = useState(false);
+
+  useEffect(() => {
+    if (isTargetManuscript) {
+      setExpandedState(true);
+      setInternalActiveTab(targetTabFromUrl);
+    }
+  }, [isTargetManuscript, targetTabFromUrl]);
 
   const [newSelectedStatus, setNewSelectedStatus] =
     useState<ManuscriptStatus>();
@@ -375,36 +380,6 @@ const ManuscriptCard: React.FC<ManuscriptCardProps> = ({
       ? manuscript?.discussions.some((discussion) => !discussion.read)
       : false;
 
-  // scroll only once per page load when the URL pointed at this card.
-  // wait until the manuscript data is loaded so the layout is stable; never
-  // re-scroll on later expand/collapse cycles or tab switches.
-  const hasAutoScrolledRef = useRef(false);
-  const initialTabRef = useRef(activeTab);
-  /* istanbul ignore next */
-  useEffect(() => {
-    if (!isTargetManuscript || hasAutoScrolledRef.current || !manuscript) {
-      return undefined;
-    }
-
-    // give the layout one paint to settle (refs attach, tab content mounts)
-    // before measuring, then scroll to the target.
-    const timer = setTimeout(() => {
-      const scrollTarget =
-        initialTabRef.current === 'discussions' && discussionTabRef.current
-          ? discussionTabRef.current
-          : targetManuscriptRef.current;
-
-      if (scrollTarget) {
-        scrollTarget.scrollIntoView({ behavior: 'smooth', block: 'start' });
-        hasAutoScrolledRef.current = true;
-      }
-    }, 100);
-
-    return () => clearTimeout(timer);
-    // intentionally only re-evaluates on isTargetManuscript flips or manuscript
-    // arriving; the ref guard prevents repeat scrolls after the first success.
-  }, [isTargetManuscript, manuscript]);
-
   return (
     <>
       {displayConfirmStatusChangeModal && newSelectedStatus && (
@@ -414,7 +389,9 @@ const ManuscriptCard: React.FC<ManuscriptCardProps> = ({
           newStatus={newSelectedStatus}
         />
       )}
-      <div css={manuscriptContainerStyles} ref={targetManuscriptRef}>
+      {/* the DOM id makes the card a real #<manuscriptId> anchor target;
+          useScrollToHash (mounted in Layout) owns scrolling to it */}
+      <div id={id} css={manuscriptContainerStyles}>
         <div css={[toastStyles]}>
           <span css={[iconStyles]}>
             <Button

--- a/packages/react-components/src/organisms/__tests__/ManuscriptCard.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/ManuscriptCard.test.tsx
@@ -1133,6 +1133,32 @@ describe('Tabs', () => {
       ).not.toHaveClass('active');
     });
 
+    it('expands and opens the Discussions tab when the card becomes the target after mount', () => {
+      const { getByRole, queryByRole, rerender } = render(
+        <MemoryRouter
+          initialEntries={['/workspace?tab=discussions#manuscript_0']}
+        >
+          <ManuscriptCard {...props} />
+        </MemoryRouter>,
+      );
+
+      expect(
+        queryByRole('button', { name: 'Discussions' }),
+      ).not.toBeInTheDocument();
+
+      rerender(
+        <MemoryRouter
+          initialEntries={['/workspace?tab=discussions#manuscript_0']}
+        >
+          <ManuscriptCard {...props} isTargetManuscript />
+        </MemoryRouter>,
+      );
+
+      expect(getByRole('button', { name: 'Discussions' })).toHaveClass(
+        'active',
+      );
+    });
+
     it('keeps the default tab when isTargetManuscript but tab query is missing', () => {
       const { getByRole } = render(
         <MemoryRouter initialEntries={['/workspace#manuscript_0']}>

--- a/packages/react-components/src/routing.ts
+++ b/packages/react-components/src/routing.ts
@@ -1,5 +1,10 @@
 import { searchQueryParam } from '@asap-hub/routing';
-import { useNavigate, useLocation, NavigateFunction } from 'react-router';
+import {
+  useNavigate,
+  useLocation,
+  useNavigationType,
+  NavigateFunction,
+} from 'react-router';
 import { useRef, useEffect } from 'react';
 
 const GIVE_UP_AFTER_MS = 10000;
@@ -16,10 +21,22 @@ const isWithinViewport = (rect: DOMRect): boolean =>
 type ScrollPhase = 'awaiting-settle' | 'animating-scroll' | 'holding-position';
 
 export const useScrollToHash = (): void => {
-  const { hash, pathname } = useLocation();
+  const { hash, pathname, state } = useLocation();
+  const navigationType = useNavigationType();
+
+  const scrollRequestedByState =
+    (state as { scrollToHash?: boolean } | null)?.scrollToHash === true;
 
   useEffect(() => {
     if (!hash) {
+      return undefined;
+    }
+
+    // Only scroll when the user actually arrives at this URL by
+    // - opening a deep link (POP)
+    // - following a link (PUSH)
+    // The exception is when it is requested by the state (ManuscriptWorkspaceRedirect)
+    if (navigationType === 'REPLACE' && !scrollRequestedByState) {
       return undefined;
     }
 
@@ -30,11 +47,9 @@ export const useScrollToHash = (): void => {
     let framesUnchanged = 0;
     let firstSeenAt: number | undefined;
     let phase: ScrollPhase = 'awaiting-settle';
-
     const stop = () => {
       window.cancelAnimationFrame(rafId);
     };
-
     const startSmoothScroll = (element: HTMLElement) => {
       element.scrollIntoView({ behavior: 'smooth', block: 'start' });
       phase = 'animating-scroll';
@@ -64,10 +79,13 @@ export const useScrollToHash = (): void => {
           }
         } else if (phase === 'awaiting-settle') {
           const waitedLongEnough = now - firstSeenAt > SCROLL_ANYWAY_AFTER_MS;
+
           if (layoutHasQuieted || waitedLongEnough) {
             startSmoothScroll(element);
           }
         } else if (isMeasurable(rect) && !isWithinViewport(rect)) {
+          // holding-position: late-loading content pushed the target out of
+          // view, so chase it back.
           startSmoothScroll(element);
         } else if (scrollAnimationFinished) {
           return false;
@@ -93,7 +111,7 @@ export const useScrollToHash = (): void => {
     scheduleNextFrame();
 
     return stop;
-  }, [hash, pathname]);
+  }, [hash, pathname, navigationType, scrollRequestedByState]);
 };
 
 export const queryParamString = (searchQuery: string | undefined): string => {

--- a/packages/react-components/src/routing.ts
+++ b/packages/react-components/src/routing.ts
@@ -2,22 +2,97 @@ import { searchQueryParam } from '@asap-hub/routing';
 import { useNavigate, useLocation, NavigateFunction } from 'react-router';
 import { useRef, useEffect } from 'react';
 
+const GIVE_UP_AFTER_MS = 10000;
+const FRAMES_STILL_BEFORE_SCROLL = 5;
+const FRAMES_STILL_UNTIL_SETTLED = 10;
+const SCROLL_ANYWAY_AFTER_MS = 1000;
+
+const isMeasurable = (rect: DOMRect): boolean =>
+  rect.width > 0 || rect.height > 0;
+
+const isWithinViewport = (rect: DOMRect): boolean =>
+  rect.bottom > 0 && rect.top < window.innerHeight;
+
+type ScrollPhase = 'awaiting-settle' | 'animating-scroll' | 'holding-position';
+
 export const useScrollToHash = (): void => {
   const { hash, pathname } = useLocation();
 
   useEffect(() => {
-    if (hash) {
-      // Delay to allow React to render the target element
-      const timeoutId = setTimeout(() => {
-        const element = document.getElementById(hash.slice(1));
-        if (element) {
-          element.scrollIntoView({ behavior: 'smooth', block: 'start' });
-        }
-      }, 100);
-
-      return () => clearTimeout(timeoutId);
+    if (!hash) {
+      return undefined;
     }
-    return undefined;
+
+    const targetId = decodeURIComponent(hash.slice(1));
+    const giveUpAt = performance.now() + GIVE_UP_AFTER_MS;
+    let rafId = 0;
+    let previousTop: number | undefined;
+    let framesUnchanged = 0;
+    let firstSeenAt: number | undefined;
+    let phase: ScrollPhase = 'awaiting-settle';
+
+    const stop = () => {
+      window.cancelAnimationFrame(rafId);
+    };
+
+    const startSmoothScroll = (element: HTMLElement) => {
+      element.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      phase = 'animating-scroll';
+      framesUnchanged = 0;
+    };
+
+    const scheduleNextFrame = () => {
+      rafId = requestAnimationFrame(step);
+    };
+
+    const processFrame = (): boolean => {
+      const element = document.getElementById(targetId);
+      if (element) {
+        const now = performance.now();
+        firstSeenAt = firstSeenAt ?? now;
+        const rect = element.getBoundingClientRect();
+        framesUnchanged = rect.top === previousTop ? framesUnchanged + 1 : 0;
+        previousTop = rect.top;
+
+        const layoutHasQuieted = framesUnchanged >= FRAMES_STILL_BEFORE_SCROLL;
+        const scrollAnimationFinished =
+          framesUnchanged >= FRAMES_STILL_UNTIL_SETTLED;
+
+        if (phase === 'animating-scroll') {
+          if (scrollAnimationFinished) {
+            phase = 'holding-position';
+          }
+        } else if (phase === 'awaiting-settle') {
+          const waitedLongEnough = now - firstSeenAt > SCROLL_ANYWAY_AFTER_MS;
+          if (layoutHasQuieted || waitedLongEnough) {
+            startSmoothScroll(element);
+          }
+        } else if (isMeasurable(rect) && !isWithinViewport(rect)) {
+          startSmoothScroll(element);
+        } else if (scrollAnimationFinished) {
+          return false;
+        }
+      }
+      return true;
+    };
+
+    const step = () => {
+      const shouldContinue = processFrame();
+      if (!shouldContinue) {
+        stop();
+        return;
+      }
+
+      if (performance.now() < giveUpAt) {
+        scheduleNextFrame();
+      } else {
+        stop();
+      }
+    };
+
+    scheduleNextFrame();
+
+    return stop;
   }, [hash, pathname]);
 };
 

--- a/packages/react-components/src/templates/ProjectProfileWorkspace.tsx
+++ b/packages/react-components/src/templates/ProjectProfileWorkspace.tsx
@@ -333,6 +333,9 @@ const ProjectProfileWorkspace: React.FC<ProjectProfileWorkspaceProps> = ({
                             getCreateComplianceReportHref={
                               getCreateComplianceReportHref
                             }
+                            {...(manuscriptId === targetManuscriptId
+                              ? { isTargetManuscript: true }
+                              : {})}
                           />
                         </div>
                       ))}

--- a/packages/react-components/src/templates/__tests__/ProjectProfileWorkspace.test.tsx
+++ b/packages/react-components/src/templates/__tests__/ProjectProfileWorkspace.test.tsx
@@ -601,6 +601,22 @@ describe('ProjectProfileWorkspace', () => {
     expect(screen.getByTestId('team-manuscripts')).toBeInTheDocument();
   });
 
+  it('expands the target manuscript in the collaborator submission list', () => {
+    jest.spyOn(console, 'error').mockImplementation();
+    renderWithRouter(
+      <ProjectProfileWorkspace
+        {...defaultProps}
+        manuscripts={[]}
+        collaborationManuscripts={['manuscript-collab-1']}
+        targetManuscriptId="manuscript-collab-1"
+      />,
+    );
+    // the tab buttons only render when the target card starts expanded
+    expect(
+      screen.getByRole('button', { name: 'Manuscripts and Reports' }),
+    ).toBeInTheDocument();
+  });
+
   describe('Tool actions', () => {
     it('calls onDeleteTool with correct index when delete is clicked', async () => {
       jest.spyOn(console, 'error').mockImplementation();

--- a/packages/react-context/src/Auth0SpaProvider.tsx
+++ b/packages/react-context/src/Auth0SpaProvider.tsx
@@ -10,7 +10,7 @@ import {
   Auth0ClientOptions,
   RedirectLoginResult,
 } from '@auth0/auth0-spa-js';
-import { Context, useCallback, useEffect, useState } from 'react';
+import { Context, useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router';
 
 interface Auth0SpaProviderProps<TUser> extends Auth0ClientOptions {
@@ -131,25 +131,29 @@ export const Auth0SpaProvider = <TUser,>(
     setUser(await auth0Client.getUser());
   };
 
-  const auth0: Auth0<TUser> = {
-    isAuthenticated,
-    user,
-    refreshUser,
-    loading,
-    popupOpen,
-    loginWithPopup,
-    handleRedirectCallback,
-    getTokenSilently:
-      getSafeAuth0ClientProperty('getTokenSilently').bind(auth0Client),
-    getIdTokenClaims:
-      getSafeAuth0ClientProperty('getIdTokenClaims').bind(auth0Client),
-    loginWithRedirect:
-      getSafeAuth0ClientProperty('loginWithRedirect').bind(auth0Client),
-    getTokenWithPopup:
-      getSafeAuth0ClientProperty('getTokenWithPopup').bind(auth0Client),
-    logout: getSafeAuth0ClientProperty('logout').bind(auth0Client),
-    checkSession,
-  };
+  const auth0: Auth0<TUser> = useMemo(
+    () => ({
+      isAuthenticated,
+      user,
+      refreshUser,
+      loading,
+      popupOpen,
+      loginWithPopup,
+      handleRedirectCallback,
+      getTokenSilently:
+        getSafeAuth0ClientProperty('getTokenSilently').bind(auth0Client),
+      getIdTokenClaims:
+        getSafeAuth0ClientProperty('getIdTokenClaims').bind(auth0Client),
+      loginWithRedirect:
+        getSafeAuth0ClientProperty('loginWithRedirect').bind(auth0Client),
+      getTokenWithPopup:
+        getSafeAuth0ClientProperty('getTokenWithPopup').bind(auth0Client),
+      logout: getSafeAuth0ClientProperty('logout').bind(auth0Client),
+      checkSession,
+    }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [isAuthenticated, user, loading, popupOpen, auth0Client],
+  );
 
   return (
     <ContextProvider.Provider value={auth0}>


### PR DESCRIPTION
Sometimes scrolling to the Manuscript Card didn’t work properly because the element’s position changed while the page was still loading. In order to fix that, this PR reuses `useScrollToHash` mounted in Layout and refactors the hook so that:
* it keeps checking every animation frame until the element stops changing position before scrolling
* if more than 1 second passes, it scrolls anyway
* after scrolling, it keeps checking in case the layout shifts again and the element moves out of view
* if more than 10 seconds pass, it gives up
