### PR TITLE
[FIX][CI] - crn-sls-package build failing due to OOM - temporary

### DIFF
--- a/.github/actions/sls-package/action.yml
+++ b/.github/actions/sls-package/action.yml
@@ -136,7 +136,9 @@ runs:
         CURRENT_REVISION: ${{ github.sha }}
         HOSTNAME: ${{ inputs.hostname }}
         NODE_ENV: 'production'
-        NODE_OPTIONS: '--max-old-space-size=8192'
+        # Leave headroom for the esbuild native process (not bound by this
+        # flag) — an 8GB heap cap starved it and got it OOM-killed
+        NODE_OPTIONS: '--max-old-space-size=6144'
         OPENAI_API_KEY: ${{ inputs.openai-api-key }}
         POSTMARK_SERVER_TOKEN: ${{ inputs.postmark-server-token }}
         SENTRY_DSN_API: ${{ inputs.sentry-dsn-api }}

--- a/apps/crn-server/serverless.ts
+++ b/apps/crn-server/serverless.ts
@@ -459,12 +459,13 @@ const serverlessConfig: AWS = {
       platform: 'node',
       target: 'node24',
       bundle: true,
-      // Lower than gp2: crn has ~50 handlers and parallel esbuild workers
-      // intermittently OOM the esbuild service ("The service was stopped")
-      // on the CI runner 4 was still flaky, so throttle further; the esbuild
-      //  native process is not bound by
-      // NODE_OPTIONS --max-old-space-size.
-      concurrency: 2,
+      // Lower than gp2: crn has ~50 handlers (more on production, which adds
+      // the isProd-gated compliance handlers) and parallel esbuild workers
+      // OOM the esbuild service ("The service was stopped") on the CI runner;
+      // the esbuild native process is not bound by NODE_OPTIONS
+      // --max-old-space-size. 4 and then 2 still failed on production, so
+      // build serially until the packaging job gets more memory.
+      concurrency: 1,
     },
     'serverless-offline-ssm': {
       stages: ['local'],


### PR DESCRIPTION
Our stack on cloudformation is getting too big, we're hitting the limit of memory on deploys/builds way too often, it's the sixth attempt of me rerunning the build step on production but still fails (dev passed after the 3rd one), we really need to find a solution for this soon :disappointed_relieved:
my current ideas:
- Temporary fix:
  - --max-old-space-size=6144 --> Node takes less of the machine
  - concurrency: 1 --> esbuild needs less of the machine (one bundle in memory at a time instead of two)
- Larger github-hosted runner (surely means spending money on it)
- Split crn-server into two serverless services (needs a roadmap and probably will take time):
  - API Stack
  - async/event-handler stack
I'm going with the temporary fix for now, but we need to plan this soon, otherwise we will find ourselves obliged to pay for a bigger runner, the total memory demand is still growing every time a handler or dependency is added to crn-server, and we're running out of throttling options, concurrency can't go below 1, when the issue surfaces again the only solution would be to pay for a stronger machine.

https://github.com/yldio/asap-hub/actions/runs/29244104042/job/86810850802

<img width="1901" height="951" alt="image" src="https://github.com/user-attachments/assets/ebb03dba-b980-4145-a753-c28998278924" />

