### PR TITLE
ASAP-1527 Refactoring Modals inside Research Output Form

### DIFF
--- a/apps/crn-frontend/src/network/teams/TeamOutput.tsx
+++ b/apps/crn-frontend/src/network/teams/TeamOutput.tsx
@@ -185,7 +185,11 @@ const TeamOutput: React.FC<TeamOutputProps> = ({
     published,
     isImportedFromManuscript,
     isDuplicate,
-    hasResearchOutputId: !!researchOutputData?.id,
+    // When importing an already-published manuscript whose preprint was
+    // never shared as an output, the backend auto-creates the preprint
+    // output and updatedOutput gains its id at runtime, turning this
+    // import into an add-version flow.
+    hasResearchOutputId: !!(updatedOutput?.id || researchOutputData?.id),
   });
   const availableActions = resolveResearchOutputAvailableActions({
     flowId,

--- a/apps/crn-frontend/src/network/teams/TeamOutput.tsx
+++ b/apps/crn-frontend/src/network/teams/TeamOutput.tsx
@@ -18,20 +18,17 @@ import {
   Toast,
   usePrevious,
 } from '@asap-hub/react-components';
-import { InnerToastContext } from '@asap-hub/react-context';
+import {
+  InnerToastContext,
+  resolveResearchOutputAvailableActions,
+} from '@asap-hub/react-context';
 import {
   network,
   OutputDocumentTypeParameter,
   sharedResearch,
   useRouteParams,
 } from '@asap-hub/routing';
-import React, {
-  ComponentProps,
-  ReactNode,
-  useCallback,
-  useEffect,
-  useState,
-} from 'react';
+import React, { ReactNode, useCallback, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router';
 import {
   mapManuscriptVersionToResearchOutput,
@@ -73,16 +70,12 @@ type TeamOutputProps = {
   latestManuscriptVersion?: ManuscriptVersionResponse;
   versionAction?: 'create' | 'edit';
   isDuplicate?: boolean;
-} & Pick<
-  ComponentProps<typeof ResearchOutputForm>,
-  'descriptionUnchangedWarning'
->;
+};
 
 const TeamOutput: React.FC<TeamOutputProps> = ({
   teamId,
   researchOutputData,
   latestManuscriptVersion,
-  descriptionUnchangedWarning,
   versionAction: versionActionProp,
   isDuplicate = false,
 }) => {
@@ -162,6 +155,7 @@ const TeamOutput: React.FC<TeamOutputProps> = ({
 
   const getImpactSuggestions = useImpactSuggestions();
   const getCategorySuggestions = useCategorySuggestions();
+  const getShortDescriptionFromDescription = useGeneratedContent();
   const getLabSuggestions = useLabSuggestions();
   const getAuthorSuggestions = useAuthorSuggestions();
   const getTeamSuggestions = useTeamSuggestions();
@@ -193,7 +187,11 @@ const TeamOutput: React.FC<TeamOutputProps> = ({
     isDuplicate,
     hasResearchOutputId: !!researchOutputData?.id,
   });
-  const getShortDescriptionFromDescription = useGeneratedContent();
+  const availableActions = resolveResearchOutputAvailableActions({
+    flowId,
+    permissions,
+  });
+
   const researchSuggestions = researchTags
     .filter((tag) => tag.category === 'Keyword')
     .map((keyword) => keyword.name);
@@ -408,7 +406,6 @@ const TeamOutput: React.FC<TeamOutputProps> = ({
               )}
               published={published}
               permissions={permissions}
-              descriptionUnchangedWarning={descriptionUnchangedWarning}
               isImportedFromManuscript={isImportedFromManuscript}
               onSave={(output) =>
                 updatedOutput?.id
@@ -447,6 +444,7 @@ const TeamOutput: React.FC<TeamOutputProps> = ({
                     }).catch(handleError(['/link', '/title'], setErrors))
               }
               flowId={flowId}
+              availableActions={availableActions}
             />
           </InnerToastContext.Provider>
         </Frame>

--- a/apps/crn-frontend/src/network/teams/TeamProfile.tsx
+++ b/apps/crn-frontend/src/network/teams/TeamProfile.tsx
@@ -69,7 +69,6 @@ const DuplicateOutput: FC = () => {
           link: undefined,
           title: `Copy of ${output.title}`,
         }}
-        descriptionUnchangedWarning
         isDuplicate
         teamId={output.teams[0].id}
       />

--- a/apps/crn-frontend/src/network/teams/__tests__/TeamOutput.test.tsx
+++ b/apps/crn-frontend/src/network/teams/__tests__/TeamOutput.test.tsx
@@ -1031,7 +1031,7 @@ describe('manuscript outputs flow', () => {
       await user.click(screen.getByRole('button', { name: /Publish/i }));
 
       const button = screen.getByRole('button', {
-        name: 'Publish Output',
+        name: /Publish new version/i,
       });
 
       await user.click(button);

--- a/apps/crn-frontend/src/network/teams/__tests__/TeamOutput.test.tsx
+++ b/apps/crn-frontend/src/network/teams/__tests__/TeamOutput.test.tsx
@@ -270,6 +270,7 @@ it('displays the save button for existing research outputs', async () => {
     teamId: '42',
     outputDocumentType: 'bioinformatics',
     researchOutputData: baseResearchOutput,
+    versionAction: 'edit',
   });
 
   expect(screen.getByRole('button', { name: /Save/i })).toBeInTheDocument();
@@ -473,6 +474,7 @@ it('can edit a research output', async () => {
     teamId: '42',
     outputDocumentType: 'article',
     researchOutputData: { ...baseResearchOutput, doi },
+    versionAction: 'edit',
   });
 
   const user = userEvent.setup({ delay: null });
@@ -788,6 +790,7 @@ it('will toast server side errors for unknown errors in edit mode', async () => 
     teamId: '42',
     outputDocumentType: 'article',
     researchOutputData: { ...baseResearchOutput, doi },
+    versionAction: 'edit',
   });
 
   const user = userEvent.setup({ delay: null });
@@ -1028,7 +1031,7 @@ describe('manuscript outputs flow', () => {
       await user.click(screen.getByRole('button', { name: /Publish/i }));
 
       const button = screen.getByRole('button', {
-        name: /Publish new version/i,
+        name: 'Publish Output',
       });
 
       await user.click(button);

--- a/apps/crn-frontend/src/network/working-groups/WorkingGroupOutput.tsx
+++ b/apps/crn-frontend/src/network/working-groups/WorkingGroupOutput.tsx
@@ -13,15 +13,12 @@ import {
   Toast,
   usePrevious,
 } from '@asap-hub/react-components';
-import { InnerToastContext } from '@asap-hub/react-context';
+import {
+  InnerToastContext,
+  resolveResearchOutputAvailableActions,
+} from '@asap-hub/react-context';
 import { network, useRouteParams } from '@asap-hub/routing';
-import React, {
-  ComponentProps,
-  ReactNode,
-  useCallback,
-  useEffect,
-  useState,
-} from 'react';
+import React, { ReactNode, useCallback, useEffect, useState } from 'react';
 import { resolveResearchOutputFlowId } from '../../shared-research/util';
 import { useResearchOutputPermissions } from '../../shared-research/state';
 import {
@@ -45,15 +42,13 @@ type WorkingGroupOutputProps = {
   workingGroupId: string;
   researchOutputData?: ResearchOutputResponse;
   versionAction?: 'create' | 'edit';
-} & Pick<
-  ComponentProps<typeof ResearchOutputForm>,
-  'descriptionUnchangedWarning'
->;
+  isDuplicate?: boolean;
+};
 const WorkingGroupOutput: React.FC<WorkingGroupOutputProps> = ({
   workingGroupId,
   researchOutputData,
-  descriptionUnchangedWarning,
   versionAction,
+  isDuplicate = false,
 }) => {
   const route = network({})
     .workingGroups({})
@@ -111,7 +106,11 @@ const WorkingGroupOutput: React.FC<WorkingGroupOutputProps> = ({
     versionAction,
     published,
     hasResearchOutputId: !!researchOutputData?.id,
-    isDuplicate: !!descriptionUnchangedWarning,
+    isDuplicate,
+  });
+  const availableActions = resolveResearchOutputAvailableActions({
+    flowId,
+    permissions,
   });
 
   const researchSuggestions = researchTags
@@ -201,7 +200,6 @@ const WorkingGroupOutput: React.FC<WorkingGroupOutputProps> = ({
             authorsRequired
             published={published}
             permissions={permissions}
-            descriptionUnchangedWarning={descriptionUnchangedWarning}
             onSave={(output) =>
               researchOutputData?.id
                 ? updateAndPublishResearchOutput(researchOutputData.id, {
@@ -234,6 +232,7 @@ const WorkingGroupOutput: React.FC<WorkingGroupOutputProps> = ({
                   }).catch(handleError(['/link', '/title'], setErrors))
             }
             flowId={flowId}
+            availableActions={availableActions}
           />
         </InnerToastContext.Provider>
       </Frame>

--- a/apps/crn-frontend/src/network/working-groups/WorkingGroupProfile.tsx
+++ b/apps/crn-frontend/src/network/working-groups/WorkingGroupProfile.tsx
@@ -50,7 +50,7 @@ const DuplicateOutput: FC = () => {
           title: `Copy of ${output.title}`,
         }}
         workingGroupId={output.workingGroups[0].id}
-        descriptionUnchangedWarning
+        isDuplicate
       />
     );
   }

--- a/apps/crn-frontend/src/network/working-groups/__tests__/WorkingGroupOutput.test.tsx
+++ b/apps/crn-frontend/src/network/working-groups/__tests__/WorkingGroupOutput.test.tsx
@@ -632,7 +632,8 @@ it.each([
     status: 'published',
     buttonName: 'Save',
     published: true,
-    shouldPublish: false,
+    shouldPublish: true,
+    versionAction: 'edit',
   },
   {
     status: 'draft',
@@ -642,7 +643,7 @@ it.each([
   },
 ])(
   'can edit a $status working group research output',
-  async ({ buttonName, published, shouldPublish }) => {
+  async ({ buttonName, published, shouldPublish, versionAction }) => {
     const user = userEvent.setup({ delay: null });
     const id = 'RO-ID';
     const workingGroupId = 'wg1';
@@ -677,6 +678,7 @@ it.each([
           .workingGroup({ workingGroupId })
           .createOutput({ outputDocumentType }).$,
       ],
+      versionAction: versionAction as 'create' | 'edit' | undefined,
     });
 
     const button = screen.getByRole('button', { name: buttonName });

--- a/apps/crn-frontend/src/network/working-groups/__tests__/WorkingGroupOutputFlows.test.tsx
+++ b/apps/crn-frontend/src/network/working-groups/__tests__/WorkingGroupOutputFlows.test.tsx
@@ -63,14 +63,14 @@ async function renderPage({
   outputDocumentType = 'article',
   researchOutputData,
   versionAction,
-  descriptionUnchangedWarning,
+  isDuplicate,
 }: {
   user?: UserResponse;
   workingGroupId: string;
   versionAction?: 'create' | 'edit';
   outputDocumentType?: OutputDocumentTypeParameter;
   researchOutputData?: ResearchOutputResponse;
-  descriptionUnchangedWarning?: boolean;
+  isDuplicate?: boolean;
 }) {
   const path =
     network.template +
@@ -98,7 +98,7 @@ async function renderPage({
                       workingGroupId={workingGroupId}
                       researchOutputData={researchOutputData}
                       versionAction={versionAction}
-                      descriptionUnchangedWarning={descriptionUnchangedWarning}
+                      isDuplicate={isDuplicate}
                     />
                   }
                 />
@@ -169,7 +169,7 @@ it('passes WORKING_GROUP_DUPLICATE when duplicating a research output', async ()
       ...baseResearchOutput,
       published: false,
     },
-    descriptionUnchangedWarning: true,
+    isDuplicate: true,
   });
 
   expect(getFlowId()).toBe(RESEARCH_OUTPUT_FLOW_IDS.WORKING_GROUP_DUPLICATE);

--- a/apps/crn-frontend/src/projects/ProjectDetail.tsx
+++ b/apps/crn-frontend/src/projects/ProjectDetail.tsx
@@ -109,7 +109,6 @@ const DuplicateOutput: FC = () => {
           link: undefined,
           title: `Copy of ${output.title}`,
         }}
-        descriptionUnchangedWarning
         isDuplicate
         teamId={output.teams[0].id}
       />

--- a/apps/crn-frontend/src/projects/ProjectOutput.tsx
+++ b/apps/crn-frontend/src/projects/ProjectOutput.tsx
@@ -28,13 +28,7 @@ import {
   sharedResearch,
   useRouteParams,
 } from '@asap-hub/routing';
-import React, {
-  ComponentProps,
-  ReactNode,
-  useCallback,
-  useEffect,
-  useState,
-} from 'react';
+import React, { ReactNode, useCallback, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router';
 import {
   mapManuscriptVersionToResearchOutput,
@@ -76,16 +70,12 @@ type ProjectOutputProps = {
   latestManuscriptVersion?: ManuscriptVersionResponse;
   versionAction?: 'create' | 'edit';
   isDuplicate?: boolean;
-} & Pick<
-  ComponentProps<typeof ResearchOutputForm>,
-  'descriptionUnchangedWarning'
->;
+};
 
 const ProjectOutput: React.FC<ProjectOutputProps> = ({
   teamId,
   researchOutputData,
   latestManuscriptVersion,
-  descriptionUnchangedWarning,
   versionAction: versionActionProp,
   isDuplicate = false,
 }) => {
@@ -194,7 +184,9 @@ const ProjectOutput: React.FC<ProjectOutputProps> = ({
     published,
     isImportedFromManuscript,
     isDuplicate,
-    hasResearchOutputId: !!researchOutputData?.id,
+    // updatedOutput covers outputs that gain an id at runtime, e.g. the
+    // auto-created preprint that turns the import flow into add-version
+    hasResearchOutputId: !!(updatedOutput?.id || researchOutputData?.id),
   });
   const availableActions = resolveResearchOutputAvailableActions({
     flowId,
@@ -416,7 +408,6 @@ const ProjectOutput: React.FC<ProjectOutputProps> = ({
               )}
               published={published}
               permissions={permissions}
-              descriptionUnchangedWarning={descriptionUnchangedWarning}
               isImportedFromManuscript={isImportedFromManuscript}
               onSave={(output) =>
                 updatedOutput?.id
@@ -454,7 +445,6 @@ const ProjectOutput: React.FC<ProjectOutputProps> = ({
                       published: false,
                     }).catch(handleError(['/link', '/title'], setErrors))
               }
-              behaviorMode="flow"
               flowId={flowId}
               availableActions={availableActions}
             />

--- a/apps/storybook/src/ResearchOutputForm.stories.tsx
+++ b/apps/storybook/src/ResearchOutputForm.stories.tsx
@@ -17,6 +17,8 @@ export default {
 
 const researchOutputFormProps: ComponentProps<typeof ResearchOutputForm> = {
   displayChangelog: false,
+  flowId: 'team-create-manual',
+  availableActions: { canSaveDraft: true },
   permissions: {
     canEditResearchOutput: true,
     canPublishResearchOutput: true,

--- a/packages/model/src/research-output.ts
+++ b/packages/model/src/research-output.ts
@@ -532,41 +532,119 @@ export const RESEARCH_OUTPUT_FLOW_IDS = {
 export type ResearchOutputFlowId =
   (typeof RESEARCH_OUTPUT_FLOW_IDS)[keyof typeof RESEARCH_OUTPUT_FLOW_IDS];
 
-export const FLOW_REGISTRY = {
+export type ResearchOutputFlowDescriptor = {
+  entity: 'team' | 'working-group';
+  action: 'create' | 'edit' | 'add-version' | 'duplicate';
+  origin: 'manual' | 'manuscript';
+  startsPublished: boolean;
+};
+
+export const FLOW_DEFINITIONS = {
   [RESEARCH_OUTPUT_FLOW_IDS.TEAM_CREATE_MANUAL]: {
-    supportsDrafts: true,
+    entity: 'team',
+    action: 'create',
+    origin: 'manual',
+    startsPublished: false,
   },
   [RESEARCH_OUTPUT_FLOW_IDS.TEAM_CREATE_IMPORTED_FROM_MANUSCRIPT]: {
-    supportsDrafts: false,
-  },
-  [RESEARCH_OUTPUT_FLOW_IDS.TEAM_ADD_VERSION]: {
-    supportsDrafts: false,
+    entity: 'team',
+    action: 'create',
+    origin: 'manuscript',
+    startsPublished: false,
   },
   [RESEARCH_OUTPUT_FLOW_IDS.TEAM_EDIT_DRAFT]: {
-    supportsDrafts: true,
+    entity: 'team',
+    action: 'edit',
+    origin: 'manual',
+    startsPublished: false,
   },
   [RESEARCH_OUTPUT_FLOW_IDS.TEAM_EDIT_PUBLISHED]: {
-    supportsDrafts: false,
+    entity: 'team',
+    action: 'edit',
+    origin: 'manual',
+    startsPublished: true,
+  },
+  [RESEARCH_OUTPUT_FLOW_IDS.TEAM_ADD_VERSION]: {
+    entity: 'team',
+    action: 'add-version',
+    origin: 'manual',
+    startsPublished: true,
   },
   [RESEARCH_OUTPUT_FLOW_IDS.TEAM_ADD_VERSION_FROM_MANUSCRIPT]: {
-    supportsDrafts: false,
+    entity: 'team',
+    action: 'add-version',
+    origin: 'manuscript',
+    startsPublished: true,
   },
   [RESEARCH_OUTPUT_FLOW_IDS.TEAM_DUPLICATE]: {
-    supportsDrafts: true,
+    entity: 'team',
+    action: 'duplicate',
+    origin: 'manual',
+    startsPublished: false,
   },
   [RESEARCH_OUTPUT_FLOW_IDS.WORKING_GROUP_CREATE]: {
-    supportsDrafts: true,
+    entity: 'working-group',
+    action: 'create',
+    origin: 'manual',
+    startsPublished: false,
   },
   [RESEARCH_OUTPUT_FLOW_IDS.WORKING_GROUP_EDIT_DRAFT]: {
-    supportsDrafts: true,
+    entity: 'working-group',
+    action: 'edit',
+    origin: 'manual',
+    startsPublished: false,
   },
   [RESEARCH_OUTPUT_FLOW_IDS.WORKING_GROUP_EDIT_PUBLISHED]: {
-    supportsDrafts: false,
+    entity: 'working-group',
+    action: 'edit',
+    origin: 'manual',
+    startsPublished: true,
   },
   [RESEARCH_OUTPUT_FLOW_IDS.WORKING_GROUP_ADD_VERSION]: {
-    supportsDrafts: false,
+    entity: 'working-group',
+    action: 'add-version',
+    origin: 'manual',
+    startsPublished: true,
   },
   [RESEARCH_OUTPUT_FLOW_IDS.WORKING_GROUP_DUPLICATE]: {
-    supportsDrafts: true,
+    entity: 'working-group',
+    action: 'duplicate',
+    origin: 'manual',
+    startsPublished: false,
   },
+} as const satisfies Record<ResearchOutputFlowId, ResearchOutputFlowDescriptor>;
+
+const supportsDrafts = (flow: ResearchOutputFlowDescriptor): boolean =>
+  flow.origin !== 'manuscript' &&
+  flow.action !== 'add-version' &&
+  !flow.startsPublished;
+
+const requiresAddVersionConfirm = (
+  flow: ResearchOutputFlowDescriptor,
+): boolean => flow.action === 'add-version';
+
+const requiresPublishConfirm = (flow: ResearchOutputFlowDescriptor): boolean =>
+  !flow.startsPublished;
+
+const requiresDescriptionConfirm = (
+  flow: ResearchOutputFlowDescriptor,
+): boolean => flow.action === 'duplicate';
+
+export type ResearchOutputFlowBehavior = {
+  supportsDrafts: boolean;
+  requiresAddVersionConfirm: boolean;
+  requiresPublishConfirm: boolean;
+  requiresSameDescriptionConfirm: boolean;
+};
+
+export const getResearchOutputFlowBehavior = (
+  flowId: ResearchOutputFlowId,
+): ResearchOutputFlowBehavior => {
+  const flow = FLOW_DEFINITIONS[flowId];
+  return {
+    supportsDrafts: supportsDrafts(flow),
+    requiresAddVersionConfirm: requiresAddVersionConfirm(flow),
+    requiresPublishConfirm: requiresPublishConfirm(flow),
+    requiresSameDescriptionConfirm: requiresDescriptionConfirm(flow),
+  };
 };

--- a/packages/model/test/research-output.test.ts
+++ b/packages/model/test/research-output.test.ts
@@ -1,7 +1,9 @@
 import {
   convertBooleanToDecision,
   convertDecisionToBoolean,
+  FLOW_DEFINITIONS,
   getProjectResearchOutputDisplaySource,
+  getResearchOutputFlowBehavior,
   isResearchOutputDocumentType,
   isResearchOutputType,
   researchOutputMapType,
@@ -39,6 +41,15 @@ describe('Research Output Model', () => {
         }),
       ).toBe('project');
     });
+
+    it('treats outputs with working groups but no project as team-based', () => {
+      expect(
+        getProjectResearchOutputDisplaySource({
+          project: undefined,
+          workingGroups: [{ id: 'wg1', title: 'Working Group' }],
+        }),
+      ).toBe('team');
+    });
   });
 
   describe('Types', () => {
@@ -56,6 +67,11 @@ describe('Research Output Model', () => {
 
     it('should return null on not known type', () => {
       expect(researchOutputMapType('NotACloningType')).toBeNull();
+    });
+
+    it('should return null when type is undefined or null', () => {
+      expect(researchOutputMapType(undefined)).toBeNull();
+      expect(researchOutputMapType(null)).toBeNull();
     });
   });
 });
@@ -79,5 +95,76 @@ describe('convertDecisionToBoolean', () => {
     ${'returns undefined when Not Sure'} | ${'Not Sure'} | ${undefined}
   `('$description', ({ given, expected }) => {
     expect(convertDecisionToBoolean(given)).toEqual(expected);
+  });
+});
+
+describe('getResearchOutputFlowBehavior', () => {
+  test.each`
+    flowId                                    | supportsDrafts | requiresAddVersionConfirm | requiresPublishConfirm | requiresSameDescriptionConfirm
+    ${'team-create-manual'}                   | ${true}        | ${false}                  | ${true}                | ${false}
+    ${'team-create-imported-from-manuscript'} | ${false}       | ${false}                  | ${true}                | ${false}
+    ${'team-edit-draft'}                      | ${true}        | ${false}                  | ${true}                | ${false}
+    ${'team-edit-published'}                  | ${false}       | ${false}                  | ${false}               | ${false}
+    ${'team-add-version'}                     | ${false}       | ${true}                   | ${false}               | ${false}
+    ${'team-add-version-from-manuscript'}     | ${false}       | ${true}                   | ${false}               | ${false}
+    ${'team-duplicate'}                       | ${true}        | ${false}                  | ${true}                | ${true}
+    ${'working-group-create'}                 | ${true}        | ${false}                  | ${true}                | ${false}
+    ${'working-group-edit-draft'}             | ${true}        | ${false}                  | ${true}                | ${false}
+    ${'working-group-edit-published'}         | ${false}       | ${false}                  | ${false}               | ${false}
+    ${'working-group-add-version'}            | ${false}       | ${true}                   | ${false}               | ${false}
+    ${'working-group-duplicate'}              | ${true}        | ${false}                  | ${true}                | ${true}
+  `(
+    '$flowId supports drafts: $supportsDrafts, requires add version confirm: $requiresAddVersionConfirm, requires publish confirm: $requiresPublishConfirm, requires same description confirm: $requiresSameDescriptionConfirm',
+    ({
+      flowId,
+      supportsDrafts,
+      requiresAddVersionConfirm,
+      requiresPublishConfirm,
+      requiresSameDescriptionConfirm,
+    }) => {
+      expect(getResearchOutputFlowBehavior(flowId)).toEqual({
+        supportsDrafts,
+        requiresAddVersionConfirm,
+        requiresPublishConfirm,
+        requiresSameDescriptionConfirm,
+      });
+    },
+  );
+
+  it('never requires add version confirm on a flow that supports drafts', () => {
+    Object.keys(FLOW_DEFINITIONS).forEach((flowId) => {
+      const behavior = getResearchOutputFlowBehavior(
+        flowId as keyof typeof FLOW_DEFINITIONS,
+      );
+      expect(
+        behavior.supportsDrafts && behavior.requiresAddVersionConfirm,
+      ).toBe(false);
+    });
+  });
+
+  it('never requires both add version and publish confirm on the same flow', () => {
+    Object.keys(FLOW_DEFINITIONS).forEach((flowId) => {
+      const behavior = getResearchOutputFlowBehavior(
+        flowId as keyof typeof FLOW_DEFINITIONS,
+      );
+      expect(
+        behavior.requiresAddVersionConfirm && behavior.requiresPublishConfirm,
+      ).toBe(false);
+    });
+  });
+
+  it('only requires same description confirm on duplicate flows', () => {
+    Object.entries(FLOW_DEFINITIONS).forEach(([flowId, flow]) => {
+      const behavior = getResearchOutputFlowBehavior(
+        flowId as keyof typeof FLOW_DEFINITIONS,
+      );
+      expect(behavior.requiresSameDescriptionConfirm).toBe(
+        flow.action === 'duplicate',
+      );
+    });
+  });
+
+  it('covers every registered flow', () => {
+    expect(Object.keys(FLOW_DEFINITIONS)).toHaveLength(12);
   });
 });

--- a/packages/react-components/src/index.ts
+++ b/packages/react-components/src/index.ts
@@ -219,6 +219,7 @@ export {
   ResearchOutputHeader,
   ResearchOutputRelatedEventsCard,
   ResearchOutputRelatedResearchCard,
+  ResearchOutputConfirmModal,
   ResultList,
   RichText,
   RichTextCard,
@@ -382,6 +383,7 @@ export type {
   AuthorOption,
   UserCollaborationMetric,
   TeamCollaborationMetric,
+  ResearchOutputConfirmModalType,
 } from './organisms';
 export type { ResearchOutputOption } from './utils';
 export type {

--- a/packages/react-components/src/organisms/ResearchOutputConfirmModal.tsx
+++ b/packages/react-components/src/organisms/ResearchOutputConfirmModal.tsx
@@ -1,0 +1,117 @@
+import { ResearchOutputResponse } from '@asap-hub/model';
+import { Dispatch, SetStateAction } from 'react';
+import { Link } from '../atoms';
+import { mailToSupport, TECH_SUPPORT_EMAIL } from '../mail';
+import ConfirmModal from './ConfirmModal';
+
+export type SeenModalType = 'description-change' | 'version';
+
+export type ResearchOutputConfirmModalType =
+  | 'description-draft'
+  | 'description-publish'
+  | 'version'
+  | 'confirm-publish'
+  | null;
+
+type ResearchOutputConfirmModalProps = {
+  modal: ResearchOutputConfirmModalType;
+  save: (draftSave?: boolean) => Promise<void | ResearchOutputResponse>;
+  onCancel: () => void;
+  setAlreadySeenModals: Dispatch<SetStateAction<Set<SeenModalType>>>;
+};
+
+const ResearchOutputConfirmModal: React.FC<ResearchOutputConfirmModalProps> = ({
+  modal,
+  save,
+  onCancel,
+  setAlreadySeenModals,
+}) => {
+  const markModalAsSeen = (type: SeenModalType) => {
+    setAlreadySeenModals((prev) => {
+      const next = new Set(prev);
+      next.add(type);
+      return next;
+    });
+  };
+
+  const getModalConfig = () => {
+    switch (modal) {
+      case 'version':
+        return {
+          title: 'Publish new version for the whole hub?',
+          confirmText: 'Publish new version',
+          description: (
+            <>
+              Once published this output version will be available to all Hub
+              members and reminders will be issued to all associated
+              contributors. If you have any issues with this output version
+              after it has been published, please contact{' '}
+              <Link href={mailToSupport()}>{TECH_SUPPORT_EMAIL}</Link>.
+            </>
+          ),
+          onSave: async () => {
+            markModalAsSeen('version');
+            const result = await save(false);
+
+            if (!result) {
+              onCancel();
+            }
+          },
+        };
+
+      case 'description-draft':
+      case 'description-publish':
+        return {
+          title: 'Keep the same description?',
+          confirmText: `Keep and ${
+            modal === 'description-draft' ? 'save' : 'publish'
+          }`,
+          description:
+            'We noticed that you kept the same description as your previous output. ASAP encourages users to provide specific context for each output.',
+          onSave: async () => {
+            markModalAsSeen('description-change');
+
+            const result = await save(modal === 'description-draft');
+
+            if (!result) {
+              onCancel();
+            }
+          },
+        };
+
+      case 'confirm-publish':
+      default:
+        return {
+          title: 'Publish output for the whole hub?',
+          confirmText: 'Publish Output',
+          description: (
+            <>
+              Once published this output will be available to all Hub members
+              and reminders will be issued to all associated contributors. If
+              you have any issues with the output after it has been published,
+              please contact{' '}
+              <Link href={mailToSupport()}>{TECH_SUPPORT_EMAIL}</Link>.
+            </>
+          ),
+          onSave: async () => {
+            await save(false);
+            onCancel();
+          },
+        };
+    }
+  };
+
+  const modalConfig = getModalConfig();
+  return (
+    <ConfirmModal
+      title={modalConfig.title}
+      cancelText="Cancel"
+      onCancel={onCancel}
+      confirmText={modalConfig.confirmText}
+      description={modalConfig.description}
+      onSave={modalConfig.onSave}
+    />
+  );
+};
+
+export default ResearchOutputConfirmModal;

--- a/packages/react-components/src/organisms/index.ts
+++ b/packages/react-components/src/organisms/index.ts
@@ -88,6 +88,7 @@ export { default as RepresentationOfPresentersTable } from './RepresentationOfPr
 export { default as ResearchOutputExtraInformationCard } from './ResearchOutputExtraInformationCard';
 export { default as ResearchOutputFormSharingCard } from './ResearchOutputFormSharingCard';
 export { default as ResearchOutputPublishingCard } from './ResearchOutputPublishingCard';
+export { default as ResearchOutputConfirmModal } from './ResearchOutputConfirmModal';
 export { default as ResearchOutputHeader } from './ResearchOutputHeader';
 export { default as ResearchOutputRelatedEventsCard } from './ResearchOutputRelatedEventsCard';
 export { default as ResearchOutputRelatedResearchCard } from './ResearchOutputRelatedResearchCard';
@@ -146,3 +147,7 @@ export { default as WorkingGroupsTabbedCard } from './WorkingGroupsTabbedCard';
 export type { Association } from './SharedOutputDropdown';
 export type { TeamCollaborationMetric } from './TeamCollaborationTable';
 export type { UserCollaborationMetric } from './UserCollaborationTable';
+export type {
+  ResearchOutputConfirmModalType,
+  SeenModalType,
+} from './ResearchOutputConfirmModal';

--- a/packages/react-components/src/templates/ResearchOutputForm.tsx
+++ b/packages/react-components/src/templates/ResearchOutputForm.tsx
@@ -1,6 +1,7 @@
 import {
   DecisionOption,
   EventResponse,
+  getResearchOutputFlowBehavior,
   ResearchOutputDocumentType,
   ResearchOutputFlowId,
   ResearchOutputIdentifierType,
@@ -21,12 +22,12 @@ import { useMatch, useNavigate } from 'react-router';
 
 import { OptionsType } from '../select';
 
-import { Button, Link, MultiSelectOptionsType } from '../atoms';
+import { Button, MultiSelectOptionsType } from '../atoms';
 import { defaultPageLayoutPaddingStyle } from '../layout';
-import { mailToSupport, TECH_SUPPORT_EMAIL } from '../mail';
 import {
-  ConfirmModal,
   Form,
+  ResearchOutputConfirmModal,
+  ResearchOutputConfirmModalType,
   ResearchOutputExtraInformationCard,
   ResearchOutputFormSharingCard,
   ResearchOutputPublishingCard,
@@ -47,6 +48,7 @@ import {
   noop,
 } from '../utils';
 import { richTextToMarkdown } from '../utils/parsing';
+import { SeenModalType } from '../organisms/ResearchOutputConfirmModal';
 
 type ResearchOutputFormProps = Pick<
   ComponentProps<typeof ResearchOutputFormSharingCard>,
@@ -92,11 +94,9 @@ type ResearchOutputFormProps = Pick<
     researchOutputData?: ResearchOutputResponse;
     tagSuggestions: string[];
     permissions: ResearchOutputPermissions;
-    descriptionUnchangedWarning?: boolean;
     isImportedFromManuscript?: boolean;
-    flowId?: ResearchOutputFlowId;
-    behaviorMode?: 'legacy' | 'flow';
-    availableActions?: ResearchOutputAvailableActions;
+    flowId: ResearchOutputFlowId;
+    availableActions: ResearchOutputAvailableActions;
   };
 
 const mainStyles = css({
@@ -175,7 +175,6 @@ const ResearchOutputForm: React.FC<ResearchOutputFormProps> = ({
   authorsRequired = false,
   typeOptions,
   selectedTeams,
-  descriptionUnchangedWarning = false,
   getLabSuggestions = noop,
   getTeamSuggestions = noop,
   getAuthorSuggestions = noop,
@@ -192,17 +191,14 @@ const ResearchOutputForm: React.FC<ResearchOutputFormProps> = ({
   versionAction,
   isImportedFromManuscript,
   flowId,
-  behaviorMode = 'legacy',
   availableActions,
 }) => {
   const navigate = useNavigate();
-  const { canShareResearchOutput, canPublishResearchOutput } = permissions;
+  const { canPublishResearchOutput } = permissions;
 
-  const useFlowMode = behaviorMode === 'flow' && !!availableActions;
+  const behavior = getResearchOutputFlowBehavior(flowId);
 
-  const showSaveDraftButton = useFlowMode
-    ? availableActions.canSaveDraft
-    : !isImportedFromManuscript && !published && canShareResearchOutput;
+  const showSaveDraftButton = availableActions.canSaveDraft;
 
   const showPublishButton = canPublishResearchOutput;
   const displayThreeButtons = showSaveDraftButton && showPublishButton;
@@ -312,24 +308,33 @@ const ResearchOutputForm: React.FC<ResearchOutputFormProps> = ({
   const [changelog, setChangelog] = useState<
     ResearchOutputPostRequest['changelog']
   >(versionAction === 'create' ? '' : researchOutputData?.changelog || '');
-  const [
-    dismissedDescriptionChangePrompt,
-    setDismissedDescriptionChangePrompt,
-  ] = useState(false);
+
+  const [alreadySeenModals, setAlreadySeenModals] = useState<
+    Set<SeenModalType>
+  >(() => new Set());
+
+  const isModalAlreadySeen = (modal: SeenModalType) =>
+    alreadySeenModals.has(modal);
 
   const promptDescriptionChange =
     descriptionMD === researchOutputData?.descriptionMD &&
-    descriptionUnchangedWarning &&
-    !dismissedDescriptionChangePrompt;
-  const [showDescriptionChangePrompt, setShowDescriptionChangePrompt] =
-    useState<false | 'draft' | 'publish'>(false);
+    behavior.requiresSameDescriptionConfirm &&
+    !isModalAlreadySeen('description-change');
 
-  const [dismissedVersionPrompt, setDismissedVersionPrompt] = useState(false);
-  const [showVersionPrompt, setShowVersionPrompt] = useState(false);
   const promptNewVersion =
-    versionAction === 'create' && !dismissedVersionPrompt;
+    behavior.requiresAddVersionConfirm && !isModalAlreadySeen('version');
 
-  const [showConfirmPublish, setShowConfirmPublish] = useState<boolean>(false);
+  const [modal, setModal] = useState<ResearchOutputConfirmModalType>(null);
+
+  const getDraftModal: () => ResearchOutputConfirmModalType = () =>
+    promptDescriptionChange ? 'description-draft' : null;
+
+  const getPublishModal: () => ResearchOutputConfirmModalType = () => {
+    if (promptDescriptionChange) return 'description-publish';
+    if (promptNewVersion) return 'version';
+    if (behavior.requiresPublishConfirm) return 'confirm-publish';
+    return null;
+  };
 
   const [link, setLink] = useState<ResearchOutputPostRequest['link']>(
     researchOutputData?.link || '',
@@ -520,74 +525,42 @@ const ResearchOutputForm: React.FC<ResearchOutputFormProps> = ({
               }
               return researchOutput;
             })();
-          const confirmDescriptionText = `Keep and ${
-            showDescriptionChangePrompt === 'draft' ? 'save' : 'publish'
-          }`;
+
+          const handleAction = async (
+            actionType: 'draft' | 'publish',
+            getModal: () => ResearchOutputConfirmModalType,
+            action: () => Promise<void | ResearchOutputResponse>,
+          ) => {
+            setIsFormSubmitted(true);
+
+            const nextModal = getModal();
+            if (nextModal) {
+              setModal(nextModal);
+              return;
+            }
+
+            setSavingAction(actionType);
+            try {
+              await action();
+            } finally {
+              setSavingAction(null);
+            }
+          };
+
+          const handleSaveDraft = () =>
+            handleAction('draft', getDraftModal, () => save(true));
+
+          const handlePublish = () =>
+            handleAction('publish', getPublishModal, () => save(false));
+
           return (
             <>
-              {showVersionPrompt && (
-                <ConfirmModal
-                  title="Publish new version for the whole hub?"
-                  cancelText="Cancel"
-                  onCancel={() => setShowVersionPrompt(false)}
-                  confirmText="Publish new version"
-                  onSave={async () => {
-                    setDismissedVersionPrompt(true);
-                    const result = await save(false);
-                    if (!result) {
-                      setShowVersionPrompt(false);
-                    }
-                  }}
-                  description={
-                    <>
-                      Once published this output version will be available to
-                      all Hub members and reminders will be issued to all
-                      associated contributors. If you have any issues with this
-                      output version after it has been published, please contact{' '}
-                      {<Link href={mailToSupport()}>{TECH_SUPPORT_EMAIL}</Link>}
-                      .
-                    </>
-                  }
-                />
-              )}
-
-              {showDescriptionChangePrompt && (
-                <ConfirmModal
-                  title="Keep the same description?"
-                  cancelText="Cancel"
-                  onCancel={() => setShowDescriptionChangePrompt(false)}
-                  confirmText={confirmDescriptionText}
-                  onSave={async () => {
-                    setDismissedDescriptionChangePrompt(true);
-                    const result = await save(
-                      showDescriptionChangePrompt === 'draft',
-                    );
-                    if (!result) {
-                      setShowDescriptionChangePrompt(false);
-                    }
-                  }}
-                  description="We noticed that you kept the same description as your previous output. ASAP encourages users to provide specific context for each output."
-                />
-              )}
-              {showConfirmPublish && (
-                <ConfirmModal
-                  title="Publish output for the whole hub?"
-                  cancelText="Cancel"
-                  onCancel={() => setShowConfirmPublish(false)}
-                  confirmText="Publish Output"
-                  onSave={async () => {
-                    await save(false);
-                    setShowConfirmPublish(false);
-                  }}
-                  description={
-                    <>
-                      Once published this output will be available to all Hub
-                      members and reminders will be issued to all associated
-                      contributors. If you have any issues with the output after
-                      it has been published, please contact{' '}
-                      <Link href={mailToSupport()}>{TECH_SUPPORT_EMAIL}</Link>.
-                    </>
-                  }
+              {modal && (
+                <ResearchOutputConfirmModal
+                  modal={modal}
+                  onCancel={() => setModal(null)}
+                  save={save}
+                  setAlreadySeenModals={setAlreadySeenModals}
                 />
               )}
               <div css={contentStyles} data-flow-id={flowId}>
@@ -733,19 +706,7 @@ const ResearchOutputForm: React.FC<ResearchOutputFormProps> = ({
                         enabled={!isSaving}
                         loading={isSaving && savingAction === 'draft'}
                         fullWidth
-                        onClick={async () => {
-                          setIsFormSubmitted(true);
-                          if (promptDescriptionChange) {
-                            setShowDescriptionChangePrompt('draft');
-                          } else {
-                            setSavingAction('draft');
-                            try {
-                              await save(true);
-                            } finally {
-                              setSavingAction(null);
-                            }
-                          }
-                        }}
+                        onClick={handleSaveDraft}
                         primary={showSaveDraftButton && !showPublishButton}
                         noMargin
                       >
@@ -759,24 +720,7 @@ const ResearchOutputForm: React.FC<ResearchOutputFormProps> = ({
                         fullWidth
                         primary
                         noMargin
-                        onClick={async () => {
-                          setIsFormSubmitted(true);
-
-                          if (promptDescriptionChange) {
-                            setShowDescriptionChangePrompt('publish');
-                          } else if (promptNewVersion) {
-                            setShowVersionPrompt(true);
-                          } else if (!published) {
-                            setShowConfirmPublish(true);
-                          } else {
-                            setSavingAction('publish');
-                            try {
-                              await save(false);
-                            } finally {
-                              setSavingAction(null);
-                            }
-                          }
-                        }}
+                        onClick={handlePublish}
                       >
                         {published ? 'Save' : 'Publish'}
                       </Button>

--- a/packages/react-components/src/templates/__tests__/ResearchOutputForm/ConfirmationModals.test.tsx
+++ b/packages/react-components/src/templates/__tests__/ResearchOutputForm/ConfirmationModals.test.tsx
@@ -1,0 +1,243 @@
+import userEvent from '@testing-library/user-event';
+
+import { createResearchOutputResponse } from '@asap-hub/fixtures';
+import { ResearchOutputFlowId, ResearchOutputResponse } from '@asap-hub/model';
+import { screen, waitFor } from '@testing-library/react';
+import { renderPrefilledForm } from '../../test-utils/research-output-form';
+import { mockActErrorsInConsole } from '../../../test-utils';
+
+describe('ResearchOutputForm confirmation modals', () => {
+  const id = '42';
+  const saveFn = jest.fn();
+  let consoleMock: ReturnType<typeof mockActErrorsInConsole>;
+
+  beforeEach(() => {
+    saveFn.mockResolvedValue({ id } as ResearchOutputResponse);
+
+    consoleMock = mockActErrorsInConsole();
+  });
+
+  afterEach(() => {
+    consoleMock.mockRestore();
+    jest.resetAllMocks();
+  });
+
+  const renderFormWithSave = (
+    propOverride: Parameters<typeof renderPrefilledForm>[0] = {},
+  ) =>
+    renderPrefilledForm({
+      onSave: saveFn,
+      ...propOverride,
+    });
+
+  describe('general modal behavior', () => {
+    it('is cancelable', async () => {
+      renderFormWithSave({
+        flowId: 'team-duplicate',
+        researchOutputData: createResearchOutputResponse(),
+      });
+      await userEvent.click(screen.getByRole('button', { name: /Publish/i }));
+      expect(screen.getByText(/Keep the same description/i)).toBeVisible();
+      await userEvent.click(
+        screen.getAllByRole('button', { name: /Cancel/i })[0]!,
+      );
+      expect(screen.queryByText(/Keep the same description/i)).toBeNull();
+      expect(saveFn).not.toHaveBeenCalled();
+    });
+
+    it('is dismissed if there are errors on the form', async () => {
+      renderFormWithSave({
+        flowId: 'team-add-version',
+        availableActions: { canSaveDraft: false },
+        researchOutputData: {
+          ...createResearchOutputResponse(),
+          link: '',
+        },
+      });
+      await userEvent.click(screen.getByRole('button', { name: /Publish/i }));
+      expect(
+        screen.getByText(/Publish new version for the whole hub?/i),
+      ).toBeVisible();
+      await userEvent.click(
+        screen.getByRole('button', { name: /Publish new version/i }),
+      );
+      await waitFor(() => {
+        expect(
+          screen.queryByText(/Publish new version for the whole hub?/i),
+        ).toBeNull();
+        expect(screen.getByText(/Please enter a valid URL/i)).toBeVisible();
+      });
+    });
+  });
+
+  describe('same description confirmation', () => {
+    it.each(['team-duplicate', 'working-group-duplicate'])(
+      'shows the save variant when saving a draft of a duplicate with an unchanged description and the flow is %s',
+      async (flowId) => {
+        renderFormWithSave({
+          flowId: flowId as ResearchOutputFlowId,
+          researchOutputData: createResearchOutputResponse(),
+        });
+        await userEvent.click(
+          screen.getByRole('button', { name: /Save Draft/i }),
+        );
+        expect(screen.getByText(/Keep the same description/i)).toBeVisible();
+        expect(
+          screen.getByRole('button', { name: /Keep and save/i }),
+        ).toBeVisible();
+      },
+    );
+
+    it.each(['team-duplicate', 'working-group-duplicate'])(
+      'shows the publish variant when publishing a duplicate with an unchanged description and the flow is %s',
+      async (flowId) => {
+        renderFormWithSave({
+          flowId: flowId as ResearchOutputFlowId,
+          researchOutputData: createResearchOutputResponse(),
+        });
+        await userEvent.click(screen.getByRole('button', { name: /Publish/i }));
+        expect(screen.getByText(/Keep the same description/i)).toBeVisible();
+        expect(
+          screen.getByRole('button', { name: /Keep and publish/i }),
+        ).toBeVisible();
+      },
+    );
+
+    it('does not show on a flow that does not require the confirmation', async () => {
+      renderFormWithSave({
+        flowId: 'team-edit-published',
+        availableActions: { canSaveDraft: false },
+        researchOutputData: createResearchOutputResponse(),
+        published: true,
+      });
+      await userEvent.click(screen.getByRole('button', { name: /Save/i }));
+      expect(screen.queryByText(/Keep the same description/i)).toBeNull();
+    });
+
+    it('does not show on a create flow even with an unchanged description', async () => {
+      renderFormWithSave({
+        flowId: 'team-create-manual',
+        availableActions: { canSaveDraft: false },
+        researchOutputData: createResearchOutputResponse(),
+      });
+      await userEvent.click(screen.getByRole('button', { name: /Publish/i }));
+      expect(screen.queryByText(/Keep the same description/i)).toBeNull();
+      expect(
+        screen.getByText(/Publish output for the whole hub?/i),
+      ).toBeVisible();
+    });
+
+    it('will not reappear once dismissed', async () => {
+      renderFormWithSave({
+        flowId: 'team-duplicate',
+        researchOutputData: {
+          ...createResearchOutputResponse(),
+          link: '',
+        },
+      });
+      await userEvent.click(screen.getByRole('button', { name: /Publish/i }));
+      expect(screen.getByText(/Keep the same description/i)).toBeVisible();
+      await userEvent.click(
+        screen.getByRole('button', { name: /Keep and publish/i }),
+      );
+      await waitFor(() => {
+        expect(screen.queryByText(/Keep the same description/i)).toBeNull();
+        expect(screen.getByText(/Please enter a valid URL/i)).toBeVisible();
+      });
+      await userEvent.click(screen.getByRole('button', { name: /Publish/i }));
+      expect(screen.queryByText(/Keep the same description/i)).toBeNull();
+    });
+  });
+
+  describe('new version confirmation', () => {
+    it.each([
+      'team-add-version',
+      'working-group-add-version',
+      'team-add-version-from-manuscript',
+    ])('shows on %s flow regardless of versionAction', async (flowId) => {
+      renderFormWithSave({
+        flowId: flowId as ResearchOutputFlowId,
+        availableActions: { canSaveDraft: false },
+      });
+      await userEvent.click(screen.getByRole('button', { name: /Publish/i }));
+      expect(
+        screen.getByText(/Publish new version for the whole hub?/i),
+      ).toBeVisible();
+      expect(
+        screen.getByRole('button', { name: /Publish new version/i }),
+      ).toBeVisible();
+    });
+
+    it('does not show on a create flow even when versionAction is set', async () => {
+      renderFormWithSave({
+        flowId: 'team-create-manual',
+        availableActions: { canSaveDraft: false },
+        versionAction: 'create',
+      });
+      await userEvent.click(screen.getByRole('button', { name: /Publish/i }));
+      expect(
+        screen.queryByText(/Publish new version for the whole hub?/i),
+      ).toBeNull();
+      expect(
+        screen.getByText(/Publish output for the whole hub?/i),
+      ).toBeVisible();
+    });
+
+    it('will not reappear once dismissed', async () => {
+      renderFormWithSave({
+        flowId: 'team-add-version',
+        availableActions: { canSaveDraft: false },
+        researchOutputData: {
+          ...createResearchOutputResponse(),
+          link: '',
+        },
+      });
+      await userEvent.click(screen.getByRole('button', { name: /Publish/i }));
+      expect(
+        screen.getByText(/Publish new version for the whole hub?/i),
+      ).toBeVisible();
+      await userEvent.click(
+        screen.getByRole('button', { name: /Publish new version/i }),
+      );
+      await waitFor(() => {
+        expect(
+          screen.queryByText(/Publish new version for the whole hub?/i),
+        ).toBeNull();
+        expect(screen.getByText(/Please enter a valid URL/i)).toBeVisible();
+      });
+      await userEvent.click(screen.getByRole('button', { name: /Publish/i }));
+      expect(
+        screen.queryByText(/Publish new version for the whole hub?/i),
+      ).toBeNull();
+    });
+  });
+
+  describe('publish confirmation', () => {
+    it('shows on a create flow that has not been published yet', async () => {
+      renderFormWithSave({
+        flowId: 'team-create-manual',
+        published: false,
+      });
+      await userEvent.click(screen.getByRole('button', { name: /Publish/i }));
+      expect(
+        screen.getByText(/Publish output for the whole hub?/i),
+      ).toBeVisible();
+      expect(
+        screen.getByRole('button', { name: /Publish Output/i }),
+      ).toBeVisible();
+    });
+
+    it('does not show on an edit-published flow', async () => {
+      renderFormWithSave({
+        flowId: 'team-edit-published',
+        availableActions: { canSaveDraft: false },
+        published: true,
+        researchOutputData: createResearchOutputResponse(),
+      });
+      await userEvent.click(screen.getByRole('button', { name: /Save/i }));
+      expect(
+        screen.queryByText(/Publish output for the whole hub?/i),
+      ).toBeNull();
+    });
+  });
+});

--- a/packages/react-components/src/templates/__tests__/ResearchOutputForm/ResearchOutputForm.2.test.tsx
+++ b/packages/react-components/src/templates/__tests__/ResearchOutputForm/ResearchOutputForm.2.test.tsx
@@ -204,7 +204,13 @@ describe('on submit', () => {
   });
 
   it('can update a published form with minimum data', async () => {
-    await setupForm({ propOverride: { published: true } });
+    await setupForm({
+      propOverride: {
+        published: true,
+        flowId: 'team-edit-published',
+        availableActions: { canSaveDraft: false },
+      },
+    });
     await saveForm();
     expect(saveFn).toHaveBeenLastCalledWith({
       ...expectedRequest,

--- a/packages/react-components/src/templates/__tests__/ResearchOutputForm/ResearchOutputForm.flowMode.test.tsx
+++ b/packages/react-components/src/templates/__tests__/ResearchOutputForm/ResearchOutputForm.flowMode.test.tsx
@@ -1,4 +1,6 @@
-import { render } from '@testing-library/react';
+import { InnerToastContext } from '@asap-hub/react-context';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { StaticRouter } from 'react-router';
 import ResearchOutputForm from '../../ResearchOutputForm';
 import { defaultProps } from '../../test-utils/research-output-form';
@@ -7,12 +9,11 @@ beforeEach(() => {
   jest.spyOn(console, 'error').mockImplementation();
 });
 
-it('displays Save Draft button in flow mode when canSaveDraft action is available', () => {
+it('displays Save Draft button when canSaveDraft action is available', () => {
   const { getByRole, queryByRole, rerender } = render(
     <StaticRouter location="/">
       <ResearchOutputForm
         {...defaultProps}
-        behaviorMode={'flow'}
         availableActions={{ canSaveDraft: false }}
       />
     </StaticRouter>,
@@ -24,10 +25,42 @@ it('displays Save Draft button in flow mode when canSaveDraft action is availabl
     <StaticRouter location="/">
       <ResearchOutputForm
         {...defaultProps}
-        behaviorMode={'flow'}
         availableActions={{ canSaveDraft: true }}
       />
     </StaticRouter>,
   );
   expect(getByRole('button', { name: /Save Draft/i })).toBeVisible();
+});
+
+describe('new version confirmation', () => {
+  const renderFlowForm = (
+    props: Partial<React.ComponentProps<typeof ResearchOutputForm>>,
+  ) =>
+    render(
+      <InnerToastContext.Provider value={jest.fn()}>
+        <StaticRouter location="/">
+          <ResearchOutputForm
+            {...defaultProps}
+            availableActions={{ canSaveDraft: false }}
+            {...props}
+          />
+        </StaticRouter>
+      </InnerToastContext.Provider>,
+    );
+
+  it('shows the confirmation on an add-version flow without relying on versionAction', async () => {
+    renderFlowForm({ flowId: 'team-add-version' });
+    await userEvent.click(screen.getByRole('button', { name: /Publish/i }));
+    expect(
+      screen.getByText(/Publish new version for the whole hub?/i),
+    ).toBeVisible();
+  });
+
+  it('does not show the confirmation when the flow does not require it, even with versionAction set', async () => {
+    renderFlowForm({ flowId: 'team-create-manual', versionAction: 'create' });
+    await userEvent.click(screen.getByRole('button', { name: /Publish/i }));
+    expect(
+      screen.queryByText(/Publish new version for the whole hub?/i),
+    ).toBeNull();
+  });
 });

--- a/packages/react-components/src/templates/__tests__/ResearchOutputForm/ResearchOutputForm.formButtons.test.tsx
+++ b/packages/react-components/src/templates/__tests__/ResearchOutputForm/ResearchOutputForm.formButtons.test.tsx
@@ -1,15 +1,18 @@
-import userEvent from '@testing-library/user-event';
 import { ComponentProps } from 'react';
 import { MemoryRouter } from 'react-router';
-import { InnerToastContext } from '@asap-hub/react-context';
+import {
+  InnerToastContext,
+  resolveResearchOutputAvailableActions,
+} from '@asap-hub/react-context';
 
-import { createResearchOutputResponse } from '@asap-hub/fixtures';
 import {
   researchOutputDocumentTypeToType,
   ResearchOutputResponse,
   ResearchTagResponse,
 } from '@asap-hub/model';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createResearchOutputResponse } from '@asap-hub/fixtures';
 import ResearchOutputForm from '../../ResearchOutputForm';
 import { fern, paper } from '../../../colors';
 import { getDefaultProps } from '../../test-utils/research-output-form';
@@ -47,10 +50,10 @@ describe('form buttons', () => {
       published = false,
       documentType = 'Article',
       researchTags = [{ id: '1', name: 'research tag 1' }],
-      descriptionUnchangedWarning = false,
       researchOutputData = undefined,
       versionAction = undefined,
       isImportedFromManuscript = false,
+      flowId = 'team-create-manual',
     }: {
       canEditResearchOutput?: boolean;
       canPublishResearchOutput?: boolean;
@@ -61,20 +64,23 @@ describe('form buttons', () => {
         typeof ResearchOutputForm
       >['versionAction'];
       researchTags?: ResearchTagResponse[];
-      descriptionUnchangedWarning?: ComponentProps<
-        typeof ResearchOutputForm
-      >['descriptionUnchangedWarning'];
       researchOutputData?: ComponentProps<
         typeof ResearchOutputForm
       >['researchOutputData'];
       isImportedFromManuscript?: ComponentProps<
         typeof ResearchOutputForm
       >['isImportedFromManuscript'];
+      flowId?: ComponentProps<typeof ResearchOutputForm>['flowId'];
     } = {
       documentType: 'Article',
       researchTags: [],
     },
   ) => {
+    const permissions = {
+      canEditResearchOutput,
+      canPublishResearchOutput,
+      canShareResearchOutput: true,
+    };
     render(
       <InnerToastContext.Provider value={jest.fn()}>
         <MemoryRouter>
@@ -82,7 +88,6 @@ describe('form buttons', () => {
             {...getDefaultProps()}
             versionAction={versionAction}
             researchOutputData={researchOutputData}
-            descriptionUnchangedWarning={descriptionUnchangedWarning}
             selectedTeams={[{ value: 'TEAMID', label: 'Example Team' }]}
             documentType={documentType}
             typeOptions={Array.from(
@@ -95,11 +100,12 @@ describe('form buttons', () => {
             researchTags={researchTags}
             published={published}
             isImportedFromManuscript={isImportedFromManuscript}
-            permissions={{
-              canEditResearchOutput,
-              canPublishResearchOutput,
-              canShareResearchOutput: true,
-            }}
+            flowId={flowId}
+            availableActions={resolveResearchOutputAvailableActions({
+              flowId,
+              permissions,
+            })}
+            permissions={permissions}
           />
         </MemoryRouter>
       </InnerToastContext.Provider>,
@@ -138,6 +144,7 @@ describe('form buttons', () => {
       canEditResearchOutput: true,
       canPublishResearchOutput: true,
       published: true,
+      flowId: 'team-edit-published',
     });
 
     expect(
@@ -158,6 +165,7 @@ describe('form buttons', () => {
       isImportedFromManuscript: true,
       canPublishResearchOutput: true,
       published: true,
+      flowId: 'team-edit-published',
     });
 
     expect(
@@ -181,6 +189,7 @@ describe('form buttons', () => {
       isImportedFromManuscript: true,
       canPublishResearchOutput: true,
       published: false,
+      flowId: 'team-create-imported-from-manuscript',
     });
 
     expect(
@@ -231,6 +240,7 @@ describe('form buttons', () => {
           }),
       );
       await setupForm({
+        flowId: 'team-edit-published',
         canEditResearchOutput: true,
         canPublishResearchOutput: true,
         published: true,
@@ -268,188 +278,6 @@ describe('form buttons', () => {
       expect(await screen.findByRole('progressbar')).toBeInTheDocument();
       expect(screen.getByRole('button', { name: /Cancel/i })).toBeDisabled();
       reportValidity.mockRestore();
-    });
-  });
-
-  describe('descriptionUnchangedWarning', () => {
-    it('Shows correct button for draft save warning', async () => {
-      await setupForm({
-        descriptionUnchangedWarning: true,
-        canEditResearchOutput: true,
-        canPublishResearchOutput: true,
-        published: false,
-        researchOutputData: createResearchOutputResponse(),
-      });
-      await userEvent.click(
-        screen.getByRole('button', { name: /Save Draft/i }),
-      );
-      expect(screen.getByText(/Keep the same description/i)).toBeVisible();
-      expect(screen.getByText(/Keep and save/i)).toBeVisible();
-    });
-    it('Shows correct button for publish save warning', async () => {
-      await setupForm({
-        descriptionUnchangedWarning: true,
-        canEditResearchOutput: true,
-        canPublishResearchOutput: true,
-        researchOutputData: createResearchOutputResponse(),
-        published: false,
-      });
-      await userEvent.click(screen.getByRole('button', { name: /Publish/i }));
-      expect(screen.getByText(/Keep the same description/i)).toBeVisible();
-      expect(screen.getByText(/Keep and publish/i)).toBeVisible();
-    });
-    it('is cancelable', async () => {
-      await setupForm({
-        descriptionUnchangedWarning: true,
-        canEditResearchOutput: true,
-        canPublishResearchOutput: true,
-        researchOutputData: createResearchOutputResponse(),
-        published: false,
-      });
-      await userEvent.click(screen.getByRole('button', { name: /Publish/i }));
-      expect(screen.getByText(/Keep the same description/i)).toBeVisible();
-      await userEvent.click(
-        screen.getAllByRole('button', { name: /Cancel/i })[0]!,
-      );
-      expect(screen.queryByText(/Keep the same description/i)).toBeNull();
-    });
-
-    it('Will be dismissed if there are errors on the form', async () => {
-      await setupForm({
-        descriptionUnchangedWarning: true,
-        canEditResearchOutput: true,
-        canPublishResearchOutput: true,
-
-        researchOutputData: {
-          ...createResearchOutputResponse(),
-          link: '',
-        },
-        published: false,
-      });
-      await userEvent.click(screen.getByRole('button', { name: /Publish/i }));
-      expect(screen.getByText(/Keep the same description/i)).toBeVisible();
-      await userEvent.click(
-        screen.getByRole('button', { name: /Keep and publish/i }),
-      );
-      await waitFor(() => {
-        expect(screen.queryByText(/Keep the same description/i)).toBeNull();
-        expect(screen.getByText(/Please enter a valid URL/i)).toBeVisible();
-      });
-    });
-    it('Will not reappear once dismissed', async () => {
-      await setupForm({
-        descriptionUnchangedWarning: true,
-        canEditResearchOutput: true,
-        canPublishResearchOutput: true,
-
-        researchOutputData: {
-          ...createResearchOutputResponse(),
-          link: '',
-        },
-        published: false,
-      });
-      await userEvent.click(screen.getByRole('button', { name: /Publish/i }));
-      expect(screen.getByText(/Keep the same description/i)).toBeVisible();
-      await userEvent.click(
-        screen.getByRole('button', { name: /Keep and publish/i }),
-      );
-      await waitFor(() => {
-        expect(screen.queryByText(/Keep the same description/i)).toBeNull();
-        expect(screen.getByText(/Please enter a valid URL/i)).toBeVisible();
-      });
-      await userEvent.click(screen.getByRole('button', { name: /Publish/i }));
-      expect(screen.queryByText(/Keep the same description/i)).toBeNull();
-    });
-  });
-
-  describe('Create Version Warning', () => {
-    it('Shows warning', async () => {
-      await setupForm({
-        versionAction: 'create',
-        canEditResearchOutput: true,
-        canPublishResearchOutput: true,
-        researchOutputData: createResearchOutputResponse(),
-      });
-      await userEvent.click(screen.getByRole('button', { name: /Publish/i }));
-      expect(
-        screen.getByText(/Publish new version for the whole hub?/i),
-      ).toBeVisible();
-      expect(
-        screen.getByRole('button', { name: /Publish new version/i }),
-      ).toBeVisible();
-    });
-
-    it('is cancelable', async () => {
-      await setupForm({
-        versionAction: 'create',
-        canEditResearchOutput: true,
-        canPublishResearchOutput: true,
-        researchOutputData: createResearchOutputResponse(),
-      });
-      await userEvent.click(screen.getByRole('button', { name: /Publish/i }));
-      expect(
-        screen.getByText(/Publish new version for the whole hub?/i),
-      ).toBeVisible();
-      await userEvent.click(
-        screen.getAllByRole('button', { name: /Cancel/i })[0]!,
-      );
-      expect(
-        screen.queryByText(/Publish new version for the whole hub?/i),
-      ).toBeNull();
-    });
-
-    it('Will be dismissed if there are errors on the form', async () => {
-      await setupForm({
-        versionAction: 'create',
-        canEditResearchOutput: true,
-        canPublishResearchOutput: true,
-        researchOutputData: {
-          ...createResearchOutputResponse(),
-          link: '',
-        },
-      });
-      await userEvent.click(screen.getByRole('button', { name: /Publish/i }));
-      expect(
-        screen.getByText(/Publish new version for the whole hub?/i),
-      ).toBeVisible();
-      await userEvent.click(
-        screen.getByRole('button', { name: /Publish new version/i }),
-      );
-      await waitFor(() => {
-        expect(
-          screen.queryByText(/Publish new version for the whole hub?/i),
-        ).toBeNull();
-        expect(screen.getByText(/Please enter a valid URL/i)).toBeVisible();
-      });
-    });
-    it('Will not reappear once dismissed', async () => {
-      await setupForm({
-        versionAction: 'create',
-        canEditResearchOutput: true,
-        canPublishResearchOutput: true,
-
-        researchOutputData: {
-          ...createResearchOutputResponse(),
-          link: '',
-        },
-      });
-      await userEvent.click(screen.getByRole('button', { name: /Publish/i }));
-      expect(
-        screen.getByText(/Publish new version for the whole hub?/i),
-      ).toBeVisible();
-      await userEvent.click(
-        screen.getByRole('button', { name: /Publish new version/i }),
-      );
-      await waitFor(() => {
-        expect(
-          screen.queryByText(/Publish new version for the whole hub?/i),
-        ).toBeNull();
-        expect(screen.getByText(/Please enter a valid URL/i)).toBeVisible();
-      });
-      await userEvent.click(screen.getByRole('button', { name: /Publish/i }));
-      expect(
-        screen.queryByText(/Publish new version for the whole hub?/i),
-      ).toBeNull();
     });
   });
 

--- a/packages/react-components/src/templates/test-utils/research-output-form.tsx
+++ b/packages/react-components/src/templates/test-utils/research-output-form.tsx
@@ -1,8 +1,13 @@
+/* istanbul ignore file */
+import { InnerToastContext } from '@asap-hub/react-context';
+import { MemoryRouter } from 'react-router';
 import {
   researchOutputDocumentTypeToType,
   ResearchOutputPostRequest,
 } from '@asap-hub/model';
 import { ComponentProps } from 'react';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { render } from '@testing-library/react';
 import ResearchOutputForm from '../ResearchOutputForm';
 
 export const getDefaultProps = (): ComponentProps<
@@ -16,6 +21,8 @@ export const getDefaultProps = (): ComponentProps<
   researchTags: [],
   documentType: 'Article',
   selectedTeams: [],
+  flowId: 'team-create-manual',
+  availableActions: { canSaveDraft: true },
   typeOptions: Array.from(researchOutputDocumentTypeToType.Article.values()),
   permissions: {
     canEditResearchOutput: true,
@@ -92,3 +99,25 @@ export const initialResearchOutputData = {
   link: 'http://example.com',
   type: 'Code' as const,
 };
+
+export const renderForm = (
+  propOverride: Partial<ComponentProps<typeof ResearchOutputForm>> = {},
+) =>
+  render(
+    <InnerToastContext.Provider value={jest.fn()}>
+      <MemoryRouter>
+        <ResearchOutputForm {...getDefaultProps()} {...propOverride} />
+      </MemoryRouter>
+    </InnerToastContext.Provider>,
+  );
+
+export const renderPrefilledForm = (
+  propOverride: Partial<ComponentProps<typeof ResearchOutputForm>> = {},
+) =>
+  renderForm({
+    researchOutputData: initialResearchOutputData,
+    documentType: 'Bioinformatics',
+    typeOptions: Array.from(researchOutputDocumentTypeToType.Bioinformatics),
+    selectedTeams: [{ value: 'TEAMID', label: 'Example Team' }],
+    ...propOverride,
+  });

--- a/packages/react-context/src/permissions/research-output.ts
+++ b/packages/react-context/src/permissions/research-output.ts
@@ -1,4 +1,7 @@
-import { FLOW_REGISTRY, ResearchOutputFlowId } from '@asap-hub/model';
+import {
+  getResearchOutputFlowBehavior,
+  ResearchOutputFlowId,
+} from '@asap-hub/model';
 import { createContext, useContext } from 'react';
 
 export type ResearchOutputPermissions = {
@@ -44,9 +47,9 @@ export const resolveResearchOutputAvailableActions = ({
   flowId: ResearchOutputFlowId;
   permissions: ResearchOutputPermissions;
 }): ResearchOutputAvailableActions => {
-  const flow = FLOW_REGISTRY[flowId];
+  const { supportsDrafts } = getResearchOutputFlowBehavior(flowId);
   return {
-    canSaveDraft: flow.supportsDrafts && !!permissions.canShareResearchOutput,
+    canSaveDraft: supportsDrafts && !!permissions.canShareResearchOutput,
   };
 };
 


### PR DESCRIPTION
This PR adds 3 new conditions to `getResearchOutputFlowBehavior`:
* `requiresAddVersionConfirm`
* `requiresPublishConfirm`
* `requiresSameDescriptionConfirm`

These conditions control whether the confirmation modals are shown when the user saves or publishes an output. They are derived from the flow descriptor, since in this PR `FLOW_REGISTRY` was reworked into `FLOW_DEFINITIONS`, where each flow is described by its entity, action, origin and startsPublished. This makes the flow registry the single source of truth for this behavior.

In this PR the modals were also moved to a separate component. The two states that tracked whether a modal had already been dismissed were grouped into a single `alreadySeenModals` state, and the states that controlled which modal is open were grouped into a single modal state.

I also ended up removing the `behaviorMode` ('legacy' | 'flow') flag, since I think it would be difficult to maintain both paths at once. As a result, flowId and availableActions are now required props and the descriptionUnchangedWarning prop was removed.


---

## Modals

### Same description

<img width="746" height="268" alt="Screenshot 2026-07-14 at 06 35 40" src="https://github.com/user-attachments/assets/4b191cf1-c65a-4455-8433-c944de07ec82" />

Only appears when duplicating an output. 
Variations:
- Button Copy: “Keep and publish” → when publishing
- Button Copy: “Keep and save” → when saving a draft

If user presses “Keep and (publish|save)” once, the modal won’t appear again.

### Publish new version

<img width="746" height="291" alt="Screenshot 2026-07-14 at 06 35 19" src="https://github.com/user-attachments/assets/693be398-b072-4c07-8e24-5bc139d734db" />

Only appears when adding a new version.
If user presses “Publish new version” once, the modal won’t appear again.

### Publish output
<img width="765" height="306" alt="Screenshot 2026-07-14 at 06 33 32" src="https://github.com/user-attachments/assets/5ab9cd21-605c-40d8-b9e5-a08ff0289c7a" />

Appears when publishing an output that is not a version.
It does not have the same rules as the other modals that once seen it doesn’t appear again.
