### PR TITLE
[ASAP-1569] Event Speakers component

### DIFF
--- a/apps/storybook/src/EventSpeakers.stories.tsx
+++ b/apps/storybook/src/EventSpeakers.stories.tsx
@@ -1,0 +1,168 @@
+import {
+  EventSpeakers,
+  EventSpeakerTeamRow,
+  EventSpeakerExternalRow,
+} from '@asap-hub/react-components';
+import { Meta, StoryObj } from '@storybook/react-vite';
+import { StaticRouter } from 'react-router';
+
+import { CenterDecorator } from './layout';
+
+const noop = () => undefined;
+
+const roles = ['Data Manager', 'Multiple roles', 'Lead PI', 'Project Manager'];
+
+const buildTeams = (
+  numberOfTeams: number,
+  membersPerTeam: number,
+  teamsSharingFindings: number,
+): EventSpeakerTeamRow[] =>
+  Array.from({ length: numberOfTeams }, (_, teamIndex) => ({
+    teamId: `team-${teamIndex}`,
+    teamName: `Team ${teamIndex + 1}`,
+    teamType:
+      teamIndex % 2 === 0 ? ('discovery' as const) : ('resource' as const),
+    isTeamInactive: teamIndex === 2,
+    // The first N teams share findings — drives the preliminary-findings %.
+    sharedPreliminaryFindings: teamIndex < teamsSharingFindings,
+    members: Array.from({ length: membersPerTeam }, (_m, memberIndex) => ({
+      id: `user-${teamIndex}-${memberIndex}`,
+      firstName: 'John',
+      lastName: 'Doe',
+      displayName: `John Doe ${teamIndex + 1}.${memberIndex + 1}`,
+      role: roles[memberIndex % roles.length] as string,
+      isAlumni: memberIndex === 1,
+    })),
+  }));
+
+const buildExternalUsers = (
+  numberOfExternalUsers: number,
+  externalSharedFindings: boolean,
+): EventSpeakerExternalRow | undefined =>
+  numberOfExternalUsers > 0
+    ? {
+        sharedPreliminaryFindings: externalSharedFindings,
+        members: Array.from({ length: numberOfExternalUsers }, (_, index) => ({
+          name: `External user ${index + 1}`,
+        })),
+      }
+    : undefined;
+
+type ControlArgs = {
+  numberOfTeams: number;
+  membersPerTeam: number;
+  teamsSharingFindings: number;
+  numberOfExternalUsers: number;
+  externalSharedFindings: boolean;
+  isEditor: boolean;
+  hasFinished: boolean;
+};
+
+const meta: Meta<ControlArgs> = {
+  title: 'Organisms / Events / Speakers',
+  decorators: [
+    (Story) => (
+      <StaticRouter location="/">
+        <Story />
+      </StaticRouter>
+    ),
+    CenterDecorator,
+  ],
+  argTypes: {
+    numberOfTeams: { control: { type: 'range', min: 0, max: 20, step: 1 } },
+    membersPerTeam: { control: { type: 'range', min: 0, max: 8, step: 1 } },
+    teamsSharingFindings: {
+      control: { type: 'range', min: 0, max: 20, step: 1 },
+      description:
+        'How many teams shared preliminary findings — drives the circle % (teams sharing ÷ number of teams). Set equal to "number of teams" for 100% (green), 0 for 0% (purple).',
+    },
+    numberOfExternalUsers: {
+      control: { type: 'range', min: 0, max: 6, step: 1 },
+    },
+    externalSharedFindings: {
+      control: 'boolean',
+      description: 'Tick/cross on the External Users row',
+    },
+    isEditor: {
+      control: 'boolean',
+      description: 'PM/editor — shows Download & Edit actions',
+    },
+    hasFinished: {
+      control: 'boolean',
+      description: 'Whether the event has already taken place',
+    },
+  },
+  render: ({
+    numberOfTeams,
+    membersPerTeam,
+    teamsSharingFindings,
+    numberOfExternalUsers,
+    externalSharedFindings,
+    isEditor,
+    hasFinished,
+  }) => (
+    <EventSpeakers
+      teams={buildTeams(numberOfTeams, membersPerTeam, teamsSharingFindings)}
+      externalUsers={buildExternalUsers(
+        numberOfExternalUsers,
+        externalSharedFindings,
+      )}
+      hasFinished={hasFinished}
+      onEdit={isEditor ? noop : undefined}
+      onExport={isEditor ? noop : undefined}
+      onAddSpeaker={isEditor ? noop : undefined}
+    />
+  ),
+};
+
+export default meta;
+
+type Story = StoryObj<ControlArgs>;
+
+export const Playground: Story = {
+  args: {
+    numberOfTeams: 3,
+    membersPerTeam: 3,
+    teamsSharingFindings: 2,
+    numberOfExternalUsers: 2,
+    externalSharedFindings: false,
+    isEditor: true,
+    hasFinished: true,
+  },
+};
+
+export const NonAdmin: Story = {
+  args: { ...Playground.args, isEditor: false },
+};
+
+export const Overflow: Story = {
+  args: { ...Playground.args, numberOfTeams: 14, teamsSharingFindings: 9 },
+};
+
+export const FindingsFull: Story = {
+  args: { ...Playground.args, numberOfTeams: 5, teamsSharingFindings: 5 },
+};
+
+export const FindingsNone: Story = {
+  args: { ...Playground.args, teamsSharingFindings: 0 },
+};
+
+export const EmptyEditorUpcoming: Story = {
+  args: {
+    numberOfTeams: 0,
+    membersPerTeam: 0,
+    teamsSharingFindings: 0,
+    numberOfExternalUsers: 0,
+    externalSharedFindings: false,
+    isEditor: true,
+    hasFinished: false,
+  },
+};
+
+export const EmptyEditorPast: Story = {
+  args: { ...EmptyEditorUpcoming.args, hasFinished: true },
+};
+
+export const EmptyReadOnly: Story = {
+  args: { ...EmptyEditorUpcoming.args, isEditor: false },
+};

--- a/apps/storybook/src/EventSpeakers.stories.tsx
+++ b/apps/storybook/src/EventSpeakers.stories.tsx
@@ -135,6 +135,10 @@ export const NonAdmin: Story = {
   args: { ...Playground.args, isEditor: false },
 };
 
+export const Upcoming: Story = {
+  args: { ...Playground.args, hasFinished: false },
+};
+
 export const Overflow: Story = {
   args: { ...Playground.args, numberOfTeams: 14, teamsSharingFindings: 9 },
 };

--- a/apps/storybook/src/EventSpeakers.stories.tsx
+++ b/apps/storybook/src/EventSpeakers.stories.tsx
@@ -22,7 +22,9 @@ const buildTeams = (
     teamId: `team-${teamIndex}`,
     teamName: `Team ${teamIndex + 1}`,
     teamType:
-      teamIndex % 2 === 0 ? ('discovery' as const) : ('resource' as const),
+      teamIndex % 2 === 0
+        ? ('Discovery Team' as const)
+        : ('Resource Team' as const),
     isTeamInactive: hasInactiveTeam && teamIndex === 2,
     // The first N teams share findings — drives the preliminary-findings %.
     sharedPreliminaryFindings: teamIndex < teamsSharingFindings,

--- a/apps/storybook/src/EventSpeakers.stories.tsx
+++ b/apps/storybook/src/EventSpeakers.stories.tsx
@@ -16,13 +16,14 @@ const buildTeams = (
   numberOfTeams: number,
   membersPerTeam: number,
   teamsSharingFindings: number,
+  hasInactiveTeam: boolean,
 ): EventSpeakerTeamRow[] =>
   Array.from({ length: numberOfTeams }, (_, teamIndex) => ({
     teamId: `team-${teamIndex}`,
     teamName: `Team ${teamIndex + 1}`,
     teamType:
       teamIndex % 2 === 0 ? ('discovery' as const) : ('resource' as const),
-    isTeamInactive: teamIndex === 2,
+    isTeamInactive: hasInactiveTeam && teamIndex === 2,
     // The first N teams share findings — drives the preliminary-findings %.
     sharedPreliminaryFindings: teamIndex < teamsSharingFindings,
     members: Array.from({ length: membersPerTeam }, (_m, memberIndex) => ({
@@ -56,6 +57,8 @@ type ControlArgs = {
   externalSharedFindings: boolean;
   isEditor: boolean;
   hasFinished: boolean;
+  longTeamNameExample: boolean;
+  hasInactiveTeam: boolean;
 };
 
 const meta: Meta<ControlArgs> = {
@@ -91,6 +94,15 @@ const meta: Meta<ControlArgs> = {
       control: 'boolean',
       description: 'Whether the event has already taken place',
     },
+    longTeamNameExample: {
+      control: 'boolean',
+      description:
+        'Rename the first team to a long single word to demo the horizontal-scroll + "Preliminary Findings" header behaviour',
+    },
+    hasInactiveTeam: {
+      control: 'boolean',
+      description: 'Mark the third team as inactive (shows the inactive badge)',
+    },
   },
   render: ({
     numberOfTeams,
@@ -100,19 +112,32 @@ const meta: Meta<ControlArgs> = {
     externalSharedFindings,
     isEditor,
     hasFinished,
-  }) => (
-    <EventSpeakers
-      teams={buildTeams(numberOfTeams, membersPerTeam, teamsSharingFindings)}
-      externalUsers={buildExternalUsers(
-        numberOfExternalUsers,
-        externalSharedFindings,
-      )}
-      hasFinished={hasFinished}
-      onEdit={isEditor ? noop : undefined}
-      onExport={isEditor ? noop : undefined}
-      onAddSpeaker={isEditor ? noop : undefined}
-    />
-  ),
+    longTeamNameExample,
+    hasInactiveTeam,
+  }) => {
+    const teams = buildTeams(
+      numberOfTeams,
+      membersPerTeam,
+      teamsSharingFindings,
+      hasInactiveTeam,
+    );
+    if (longTeamNameExample && teams[0]) {
+      teams[0] = { ...teams[0], teamName: 'Sundaravadivelu' };
+    }
+    return (
+      <EventSpeakers
+        teams={teams}
+        externalUsers={buildExternalUsers(
+          numberOfExternalUsers,
+          externalSharedFindings,
+        )}
+        hasFinished={hasFinished}
+        onEdit={isEditor ? noop : undefined}
+        onExport={isEditor ? noop : undefined}
+        onAddSpeaker={isEditor ? noop : undefined}
+      />
+    );
+  },
 };
 
 export default meta;
@@ -128,6 +153,8 @@ export const Playground: Story = {
     externalSharedFindings: false,
     isEditor: true,
     hasFinished: true,
+    longTeamNameExample: false,
+    hasInactiveTeam: false,
   },
 };
 
@@ -140,7 +167,12 @@ export const Upcoming: Story = {
 };
 
 export const Overflow: Story = {
-  args: { ...Playground.args, numberOfTeams: 14, teamsSharingFindings: 9 },
+  args: {
+    ...Playground.args,
+    numberOfTeams: 14,
+    teamsSharingFindings: 9,
+    longTeamNameExample: true,
+  },
 };
 
 export const FindingsFull: Story = {

--- a/packages/react-components/src/index.ts
+++ b/packages/react-components/src/index.ts
@@ -173,6 +173,7 @@ export {
   EventConversation,
   EventMaterials,
   EventSearch,
+  EventSpeakers,
   ExportAnalyticsModal,
   Filter,
   Form,
@@ -397,6 +398,10 @@ export type {
   UserCollaborationMetric,
   TeamCollaborationMetric,
   ResearchOutputConfirmModalType,
+  EventSpeakerTeamRow,
+  EventSpeakerExternalRow,
+  EventSpeakerExternalMember,
+  EventSpeakerMember,
 } from './organisms';
 export type { ResearchOutputOption } from './utils';
 export type {

--- a/packages/react-components/src/molecules/EventAttendanceMetric.tsx
+++ b/packages/react-components/src/molecules/EventAttendanceMetric.tsx
@@ -1,51 +1,17 @@
 import { css } from '@emotion/react';
 
 import { ProgressBar, ProgressWheel } from '../atoms';
-import { charcoal, ember, fern, lead, pearl, steel } from '../colors';
-import { rem, tabletScreen } from '../pixels';
-import { headlineStyles } from '../text';
+import { ember, fern } from '../colors';
+import { rem } from '../pixels';
 
-const containerStyles = css({
-  boxSizing: 'border-box',
-  padding: rem(24),
-
-  backgroundColor: pearl.rgb,
-  border: `1px solid ${steel.rgb}`,
-  borderRadius: rem(8),
-});
-
-const labelStyles = css({
-  margin: 0,
-  color: lead.rgb,
-  fontSize: rem(17),
-  lineHeight: rem(24),
-});
-
-const valueStyles = css(headlineStyles[1], {
-  margin: 0,
-  color: charcoal.rgb,
-});
-
-const progressRowStyles = css({
-  display: 'flex',
-  alignItems: 'center',
-  gap: rem(24),
-});
-
-const wheelStyles = css({
-  display: 'none',
-  flexShrink: 0,
-  [`@media (min-width: ${tabletScreen.min}px)`]: {
-    display: 'flex',
-  },
-});
-
-const barStyles = css({
-  marginTop: rem(16),
-  [`@media (min-width: ${tabletScreen.min}px)`]: {
-    display: 'none',
-  },
-});
+import {
+  metricBarStyles,
+  metricContainerStyles,
+  metricLabelStyles,
+  metricProgressRowStyles,
+  metricValueStyles,
+  metricWheelStyles,
+} from './shared-metric-card-styles';
 
 const deltaRowStyles = css({
   display: 'flex',
@@ -89,10 +55,10 @@ const EventAttendanceMetric: React.FC<EventAttendanceMetricProps> = (props) => {
 
   if (props.variant === 'delta') {
     return (
-      <div css={containerStyles}>
-        <p css={labelStyles}>{label}</p>
+      <div css={metricContainerStyles}>
+        <p css={metricLabelStyles}>{label}</p>
         <div css={deltaRowStyles}>
-          <p css={valueStyles}>
+          <p css={metricValueStyles}>
             {`${props.direction === 'up' ? '+' : '-'} ${value}`}
           </p>
           <span
@@ -103,24 +69,24 @@ const EventAttendanceMetric: React.FC<EventAttendanceMetricProps> = (props) => {
             <span css={arrowStyles(props.direction)} />
           </span>
         </div>
-        <p css={labelStyles}>{caption}</p>
+        <p css={metricLabelStyles}>{caption}</p>
       </div>
     );
   }
 
   return (
-    <div css={containerStyles}>
-      <div css={progressRowStyles}>
-        <span css={wheelStyles}>
+    <div css={metricContainerStyles}>
+      <div css={metricProgressRowStyles}>
+        <span css={metricWheelStyles}>
           <ProgressWheel percentage={value} color={props.color} />
         </span>
         <div>
-          <p css={labelStyles}>{label}</p>
-          <p css={valueStyles}>{value}%</p>
-          <p css={labelStyles}>{caption}</p>
+          <p css={metricLabelStyles}>{label}</p>
+          <p css={metricValueStyles}>{value}%</p>
+          <p css={metricLabelStyles}>{caption}</p>
         </div>
       </div>
-      <div css={barStyles}>
+      <div css={metricBarStyles}>
         <ProgressBar percentage={value} color={props.color} />
       </div>
     </div>

--- a/packages/react-components/src/molecules/shared-metric-card-styles.ts
+++ b/packages/react-components/src/molecules/shared-metric-card-styles.ts
@@ -1,0 +1,46 @@
+import { css } from '@emotion/react';
+
+import { charcoal, lead, pearl, steel } from '../colors';
+import { rem, tabletScreen } from '../pixels';
+import { headlineStyles } from '../text';
+
+export const metricContainerStyles = css({
+  boxSizing: 'border-box',
+  padding: rem(24),
+  backgroundColor: pearl.rgb,
+  border: `1px solid ${steel.rgb}`,
+  borderRadius: rem(8),
+});
+
+export const metricLabelStyles = css({
+  margin: 0,
+  color: lead.rgb,
+  fontSize: rem(17),
+  lineHeight: rem(24),
+});
+
+export const metricValueStyles = css(headlineStyles[1], {
+  margin: 0,
+  color: charcoal.rgb,
+});
+
+export const metricProgressRowStyles = css({
+  display: 'flex',
+  alignItems: 'center',
+  gap: rem(24),
+});
+
+export const metricWheelStyles = css({
+  display: 'none',
+  flexShrink: 0,
+  [`@media (min-width: ${tabletScreen.min}px)`]: {
+    display: 'flex',
+  },
+});
+
+export const metricBarStyles = css({
+  marginTop: rem(16),
+  [`@media (min-width: ${tabletScreen.min}px)`]: {
+    display: 'none',
+  },
+});

--- a/packages/react-components/src/organisms/EditEventAttendanceModal.tsx
+++ b/packages/react-components/src/organisms/EditEventAttendanceModal.tsx
@@ -35,11 +35,9 @@ import {
 import { Modal } from '../molecules';
 import { mobileScreen, rem } from '../pixels';
 import { noop } from '../utils';
-import {
-  EventAttendanceTeam,
-  iconButtonStyles,
-  teamIcon,
-} from './EventAttendance';
+import { EventAttendanceTeam } from './EventAttendance';
+import { teamIcon } from './shared-event-card';
+import { iconButtonStyles } from './shared-event-card-styles';
 
 export type AttendanceSearchOption = MultiSelectOptionsType &
   (

--- a/packages/react-components/src/organisms/EventAttendance.tsx
+++ b/packages/react-components/src/organisms/EventAttendance.tsx
@@ -1,93 +1,48 @@
-import { TeamType } from '@asap-hub/model';
 import { network } from '@asap-hub/routing';
 import { css } from '@emotion/react';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 import { Button, Card, Headline3, Link, Paragraph } from '../atoms';
-import { charcoal, fern, neutral1000, steel, tin, warning500 } from '../colors';
+import { fern, neutral1000, steel, warning500 } from '../colors';
 import {
-  DiscoveryTeamIcon,
   ExportIcon,
   InactiveBadgeIcon,
   invalidTickIcon,
   PencilIcon,
   plusIcon,
-  ResourceTeamIcon,
-  TeamIcon,
   tickInCircleIcon,
 } from '../icons';
 import { EventAttendanceMetric } from '../molecules';
-import { mobileScreen, rem, tabletScreen } from '../pixels';
+import { rem, tabletScreen } from '../pixels';
 
-const defaultVisibleTeams = 10;
+import {
+  defaultVisibleTeams,
+  EventTeamType,
+  teamIcon,
+} from './shared-event-card';
+import {
+  actionsStyles,
+  cellStyles,
+  contentStyles,
+  contentWithFooterStyles,
+  editIconButtonStyles,
+  emptyStateStyles,
+  headerCellStyles,
+  headerStyles,
+  iconButtonStyles,
+  metricsStyles,
+  statusCellStyles,
+  statusIconStyles,
+  tableWrapperStyles,
+  teamInfoStyles,
+  viewMoreStyles,
+} from './shared-event-card-styles';
 
 // Attendance below this threshold colours the progress amber, otherwise green.
 // (A lower "red" tier may be added once design confirms it.)
 const attendanceAmberThreshold = 60;
 const getAttendanceColor = (percentage: number): string =>
   percentage < attendanceAmberThreshold ? warning500.rgb : fern.rgb;
-
-const contentStyles = css({
-  padding: `${rem(32)} ${rem(24)}`,
-});
-
-const contentWithFooterStyles = css({
-  paddingBottom: 0,
-});
-
-const headerStyles = css({
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'space-between',
-  gap: rem(15),
-});
-
-const actionsStyles = css({
-  display: 'flex',
-  gap: rem(12),
-});
-
-export const iconButtonStyles = css({
-  flexGrow: 0,
-  width: rem(40),
-  height: rem(40),
-  alignItems: 'center',
-  borderColor: tin.rgb,
-  ':hover, :focus': {
-    borderColor: tin.rgb,
-  },
-  [`@media (max-width: ${mobileScreen.max}px)`]: {
-    flexGrow: 0,
-    minWidth: rem(40),
-  },
-});
-
-const editIconButtonStyles = css([
-  iconButtonStyles,
-  {
-    '> svg': {
-      width: rem(24),
-      height: rem(24),
-      padding: 0,
-    },
-  },
-]);
-
-const metricsStyles = css({
-  display: 'grid',
-  gridTemplateColumns: '1fr',
-  gap: rem(24),
-  marginTop: rem(24),
-
-  [`@media (min-width: ${tabletScreen.min}px)`]: {
-    gridTemplateColumns: '1fr 1fr',
-  },
-});
-
-const tableWrapperStyles = css({
-  marginTop: rem(40),
-  overflowX: 'auto',
-});
 
 const tableStyles = css({
   width: '100%',
@@ -98,22 +53,12 @@ const tableStyles = css({
   'tbody tr:last-child': {
     borderBottom: 'none',
   },
-});
-
-const headerCellStyles = css({
-  textAlign: 'left',
-  color: charcoal.rgb,
-  fontSize: rem(17),
-  fontWeight: 'bold',
-  lineHeight: rem(24),
-  letterSpacing: rem(0.1),
-});
-
-const cellStyles = css({
-  // 16px top + 16px bottom → 32px (16 + 16) between rows around the separator,
-  // and a 16px gap between the header and the first row.
-  padding: `${rem(16)} 0`,
-  verticalAlign: 'middle',
+  // on mobile the Attendance column (header + icons) centers.
+  [`@media (max-width: ${tabletScreen.min}px)`]: {
+    'th:last-child, td:last-child': {
+      textAlign: 'center',
+    },
+  },
 });
 
 const teamCellStyles = css([
@@ -124,55 +69,7 @@ const teamCellStyles = css([
   },
 ]);
 
-const teamInnerStyles = css({
-  display: 'flex',
-  alignItems: 'center',
-  gap: rem(8),
-});
-
-const teamInfoNoWrapStyles = css({
-  whiteSpace: 'nowrap',
-  '> svg': { flexShrink: 0 },
-});
-
-const horizontalScrollGutter = css({ paddingBottom: rem(8) });
-
-const attendanceColStyles = css({ width: '1%' });
-
-const statusCellStyles = css([
-  cellStyles,
-  {
-    // collapse the line box so the 24x24 icon container centers via the cell's
-    // middle vertical-align instead of sitting on the text baseline.
-    lineHeight: 0,
-  },
-]);
-
-const statusIconStyles = css({
-  display: 'inline-flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  width: rem(24),
-  height: rem(24),
-  verticalAlign: 'middle',
-});
-
-const viewMoreStyles = css({
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  height: rem(56),
-  borderTop: `1px solid ${steel.rgb}`,
-});
-
-const emptyStateStyles = css({
-  display: 'flex',
-  flexDirection: 'column',
-  alignItems: 'flex-start',
-  gap: rem(24),
-});
-
-export type EventAttendanceTeamType = TeamType;
+export type EventAttendanceTeamType = EventTeamType;
 
 export type EventAttendanceTeam = {
   teamId: string;
@@ -182,39 +79,11 @@ export type EventAttendanceTeam = {
   isTeamInactive?: boolean;
 };
 
-export const teamIcon = (teamType?: EventAttendanceTeamType) => {
-  switch (teamType) {
-    case 'Discovery Team':
-      return <DiscoveryTeamIcon />;
-    case 'Resource Team':
-      return <ResourceTeamIcon />;
-    default:
-      return <TeamIcon />;
-  }
-};
-
 export type EventAttendanceSinceLastEvent = {
   // signed change in attending teams versus the previous event.
   count: number;
   teamsAttended: number;
   teamsTotal: number;
-};
-
-const useHorizontalOverflow = () => {
-  const [element, setElement] = useState<HTMLElement | null>(null);
-  const [overflowing, setOverflowing] = useState(false);
-  useEffect(() => {
-    if (!element) {
-      return undefined;
-    }
-    const measure = () =>
-      setOverflowing(element.scrollWidth > element.clientWidth);
-    measure();
-    const observer = new ResizeObserver(measure);
-    observer.observe(element);
-    return () => observer.disconnect();
-  }, [element]);
-  return [setElement, overflowing] as const;
 };
 
 type EventAttendanceProps = {
@@ -238,8 +107,7 @@ const EventAttendance: React.FC<EventAttendanceProps> = ({
   onAddAttendance,
 }) => {
   const [expanded, setExpanded] = useState(false);
-  const [tableRef, teamsOverflowing] = useHorizontalOverflow();
-  const hasMoreRows = teams.length > defaultVisibleTeams;
+  const showFooter = !expanded && teams.length > defaultVisibleTeams;
   const visibleTeams = expanded ? teams : teams.slice(0, defaultVisibleTeams);
   const attendancePercentage =
     teamsTotal > 0 ? Math.round((teamsAttended / teamsTotal) * 100) : 0;
@@ -270,7 +138,7 @@ const EventAttendance: React.FC<EventAttendanceProps> = ({
 
   return (
     <Card padding={false}>
-      <div css={[contentStyles, hasMoreRows && contentWithFooterStyles]}>
+      <div css={[contentStyles, showFooter && contentWithFooterStyles]}>
         <div css={headerStyles}>
           <Headline3 noMargin>Attendance</Headline3>
           <div css={actionsStyles}>
@@ -314,10 +182,7 @@ const EventAttendance: React.FC<EventAttendanceProps> = ({
           )}
         </div>
 
-        <div
-          css={[tableWrapperStyles, teamsOverflowing && horizontalScrollGutter]}
-          ref={tableRef}
-        >
+        <div css={tableWrapperStyles}>
           <table
             css={[
               tableStyles,
@@ -325,14 +190,14 @@ const EventAttendance: React.FC<EventAttendanceProps> = ({
               // the card's bottom padding.
               {
                 'tbody tr:last-child td': {
-                  paddingBottom: hasMoreRows ? rem(32) : 0,
+                  paddingBottom: showFooter ? rem(32) : 0,
                 },
               },
             ]}
           >
             <colgroup>
               <col />
-              <col css={attendanceColStyles} />
+              <col css={{ width: rem(204) }} />
             </colgroup>
             <thead>
               <tr>
@@ -348,7 +213,7 @@ const EventAttendance: React.FC<EventAttendanceProps> = ({
               {visibleTeams.map((team) => (
                 <tr key={team.teamId}>
                   <td css={teamCellStyles}>
-                    <span css={[teamInnerStyles, teamInfoNoWrapStyles]}>
+                    <span css={teamInfoStyles}>
                       {teamIcon(team.teamType)}
                       <Link
                         href={
@@ -376,10 +241,10 @@ const EventAttendance: React.FC<EventAttendanceProps> = ({
         </div>
       </div>
 
-      {hasMoreRows && (
+      {showFooter && (
         <div css={viewMoreStyles}>
-          <Button linkStyle onClick={() => setExpanded((current) => !current)}>
-            {expanded ? 'View Less Attendees' : 'View More Attendees'}
+          <Button linkStyle onClick={() => setExpanded(true)}>
+            View More Attendees
           </Button>
         </div>
       )}

--- a/packages/react-components/src/organisms/EventAttendance.tsx
+++ b/packages/react-components/src/organisms/EventAttendance.tsx
@@ -1,6 +1,7 @@
+import { TeamType } from '@asap-hub/model';
 import { network } from '@asap-hub/routing';
 import { css } from '@emotion/react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { Button, Card, Headline3, Link, Paragraph } from '../atoms';
 import { fern, neutral1000, steel, warning500 } from '../colors';
@@ -13,13 +14,9 @@ import {
   tickInCircleIcon,
 } from '../icons';
 import { EventAttendanceMetric } from '../molecules';
-import { rem, tabletScreen } from '../pixels';
+import { rem } from '../pixels';
 
-import {
-  defaultVisibleTeams,
-  EventTeamType,
-  teamIcon,
-} from './shared-event-card';
+import { defaultVisibleTeams, teamIcon } from './shared-event-card';
 import {
   actionsStyles,
   cellStyles,
@@ -29,12 +26,13 @@ import {
   emptyStateStyles,
   headerCellStyles,
   headerStyles,
+  horizontalScrollGutter,
   iconButtonStyles,
   metricsStyles,
   statusCellStyles,
   statusIconStyles,
   tableWrapperStyles,
-  teamInfoStyles,
+  teamInfoNoWrapStyles,
   viewMoreStyles,
 } from './shared-event-card-styles';
 
@@ -53,12 +51,6 @@ const tableStyles = css({
   'tbody tr:last-child': {
     borderBottom: 'none',
   },
-  // on mobile the Attendance column (header + icons) centers.
-  [`@media (max-width: ${tabletScreen.min}px)`]: {
-    'th:last-child, td:last-child': {
-      textAlign: 'center',
-    },
-  },
 });
 
 const teamCellStyles = css([
@@ -69,7 +61,15 @@ const teamCellStyles = css([
   },
 ]);
 
-export type EventAttendanceTeamType = EventTeamType;
+const teamInnerStyles = css({
+  display: 'flex',
+  alignItems: 'center',
+  gap: rem(8),
+});
+
+const attendanceColStyles = css({ width: '1%' });
+
+export type EventAttendanceTeamType = TeamType;
 
 export type EventAttendanceTeam = {
   teamId: string;
@@ -84,6 +84,23 @@ export type EventAttendanceSinceLastEvent = {
   count: number;
   teamsAttended: number;
   teamsTotal: number;
+};
+
+const useHorizontalOverflow = () => {
+  const [element, setElement] = useState<HTMLElement | null>(null);
+  const [overflowing, setOverflowing] = useState(false);
+  useEffect(() => {
+    if (!element) {
+      return undefined;
+    }
+    const measure = () =>
+      setOverflowing(element.scrollWidth > element.clientWidth);
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [element]);
+  return [setElement, overflowing] as const;
 };
 
 type EventAttendanceProps = {
@@ -107,7 +124,8 @@ const EventAttendance: React.FC<EventAttendanceProps> = ({
   onAddAttendance,
 }) => {
   const [expanded, setExpanded] = useState(false);
-  const showFooter = !expanded && teams.length > defaultVisibleTeams;
+  const [tableRef, teamsOverflowing] = useHorizontalOverflow();
+  const hasMoreRows = teams.length > defaultVisibleTeams;
   const visibleTeams = expanded ? teams : teams.slice(0, defaultVisibleTeams);
   const attendancePercentage =
     teamsTotal > 0 ? Math.round((teamsAttended / teamsTotal) * 100) : 0;
@@ -138,7 +156,7 @@ const EventAttendance: React.FC<EventAttendanceProps> = ({
 
   return (
     <Card padding={false}>
-      <div css={[contentStyles, showFooter && contentWithFooterStyles]}>
+      <div css={[contentStyles, hasMoreRows && contentWithFooterStyles]}>
         <div css={headerStyles}>
           <Headline3 noMargin>Attendance</Headline3>
           <div css={actionsStyles}>
@@ -182,7 +200,10 @@ const EventAttendance: React.FC<EventAttendanceProps> = ({
           )}
         </div>
 
-        <div css={tableWrapperStyles}>
+        <div
+          css={[tableWrapperStyles, teamsOverflowing && horizontalScrollGutter]}
+          ref={tableRef}
+        >
           <table
             css={[
               tableStyles,
@@ -190,14 +211,14 @@ const EventAttendance: React.FC<EventAttendanceProps> = ({
               // the card's bottom padding.
               {
                 'tbody tr:last-child td': {
-                  paddingBottom: showFooter ? rem(32) : 0,
+                  paddingBottom: hasMoreRows ? rem(32) : 0,
                 },
               },
             ]}
           >
             <colgroup>
               <col />
-              <col css={{ width: rem(204) }} />
+              <col css={attendanceColStyles} />
             </colgroup>
             <thead>
               <tr>
@@ -213,7 +234,7 @@ const EventAttendance: React.FC<EventAttendanceProps> = ({
               {visibleTeams.map((team) => (
                 <tr key={team.teamId}>
                   <td css={teamCellStyles}>
-                    <span css={teamInfoStyles}>
+                    <span css={[teamInnerStyles, teamInfoNoWrapStyles]}>
                       {teamIcon(team.teamType)}
                       <Link
                         href={
@@ -241,10 +262,10 @@ const EventAttendance: React.FC<EventAttendanceProps> = ({
         </div>
       </div>
 
-      {showFooter && (
+      {hasMoreRows && (
         <div css={viewMoreStyles}>
-          <Button linkStyle onClick={() => setExpanded(true)}>
-            View More Attendees
+          <Button linkStyle onClick={() => setExpanded((current) => !current)}>
+            {expanded ? 'View Less Attendees' : 'View More Attendees'}
           </Button>
         </div>
       )}

--- a/packages/react-components/src/organisms/EventSpeakers.tsx
+++ b/packages/react-components/src/organisms/EventSpeakers.tsx
@@ -62,6 +62,9 @@ const mobileQuery = `@media (max-width: ${tabletScreen.min}px)`;
 const speakerTableStyles = css({
   width: '100%',
   borderCollapse: 'collapse',
+});
+
+const findingsCenterMobileStyles = css({
   [mobileQuery]: {
     'th:nth-of-type(2), tbody td:nth-of-type(2)': {
       textAlign: 'center',
@@ -242,6 +245,7 @@ const findingsIcon = (shared: boolean) => (
 const SpeakerRow: React.FC<{
   info: React.ReactNode;
   sharedPreliminaryFindings: boolean;
+  showFindings: boolean;
   expanded: boolean;
   onToggle: () => void;
   label: string;
@@ -250,6 +254,7 @@ const SpeakerRow: React.FC<{
 }> = ({
   info,
   sharedPreliminaryFindings,
+  showFindings,
   expanded,
   onToggle,
   label,
@@ -266,9 +271,11 @@ const SpeakerRow: React.FC<{
         <td css={[cellStyles, collapsedBottom]}>
           <span css={teamInfoStyles}>{info}</span>
         </td>
-        <td css={[statusCellStyles, collapsedBottom]}>
-          {findingsIcon(sharedPreliminaryFindings)}
-        </td>
+        {showFindings && (
+          <td css={[statusCellStyles, collapsedBottom]}>
+            {findingsIcon(sharedPreliminaryFindings)}
+          </td>
+        )}
         <td css={[statusCellStyles, chevronCellStyles, collapsedBottom]}>
           <button
             type="button"
@@ -283,7 +290,7 @@ const SpeakerRow: React.FC<{
       </tr>
       {expanded && (
         <tr>
-          <td colSpan={3} css={membersCellStyles}>
+          <td colSpan={showFindings ? 3 : 2} css={membersCellStyles}>
             {children}
           </td>
         </tr>
@@ -309,6 +316,9 @@ const EventSpeakers: React.FC<EventSpeakersProps> = ({
     () => new Set(),
   );
   const [showAll, setShowAll] = useState(false);
+
+  // Preliminary findings are only shared once the event has taken place.
+  const showFindings = hasFinished;
 
   const externalCount = externalUsers?.members.length ?? 0;
   const hasExternal = externalCount > 0;
@@ -412,32 +422,41 @@ const EventSpeakers: React.FC<EventSpeakersProps> = ({
             value={totalSpeakers}
             caption={`${teamMemberCount} from teams • ${externalCount} non-CRN`}
           />
-          <FindingsMetric
-            label="Preliminary findings"
-            value={findingsPercentage}
-            caption={`${teamsShared} of ${teamsTotal} teams`}
-          />
+          {showFindings && (
+            <FindingsMetric
+              label="Preliminary findings"
+              value={findingsPercentage}
+              caption={`${teamsShared} of ${teamsTotal} teams`}
+            />
+          )}
         </div>
 
         <div css={tableWrapperStyles}>
-          <table css={speakerTableStyles}>
+          <table
+            css={[
+              speakerTableStyles,
+              showFindings && findingsCenterMobileStyles,
+            ]}
+          >
             <colgroup>
               <col />
-              <col css={findingsColStyles} />
+              {showFindings && <col css={findingsColStyles} />}
               <col css={chevronColStyles} />
             </colgroup>
-            <thead>
-              <tr>
-                <th css={headerCellStyles} scope="col">
-                  Speakers
-                </th>
-                <th css={headerCellStyles} scope="col">
-                  <span css={fullFindingsLabel}>Preliminary Findings</span>
-                  <span css={shortFindingsLabel}>P. Findings</span>
-                </th>
-                <th css={headerCellStyles} />
-              </tr>
-            </thead>
+            {showFindings && (
+              <thead>
+                <tr>
+                  <th css={headerCellStyles} scope="col">
+                    Speakers
+                  </th>
+                  <th css={headerCellStyles} scope="col">
+                    <span css={fullFindingsLabel}>Preliminary Findings</span>
+                    <span css={shortFindingsLabel}>P. Findings</span>
+                  </th>
+                  <th css={headerCellStyles} />
+                </tr>
+              </thead>
+            )}
 
             {visibleTeams.map((team, index) => {
               const bottomOverride = lastRowPadding(
@@ -448,6 +467,7 @@ const EventSpeakers: React.FC<EventSpeakersProps> = ({
                   key={team.teamId}
                   label={team.teamName}
                   sharedPreliminaryFindings={team.sharedPreliminaryFindings}
+                  showFindings={showFindings}
                   expanded={expandedRows.has(team.teamId)}
                   onToggle={() => toggleRow(team.teamId)}
                   collapsedBottomPadding={bottomOverride}
@@ -512,6 +532,7 @@ const EventSpeakers: React.FC<EventSpeakersProps> = ({
                 sharedPreliminaryFindings={
                   externalUsers.sharedPreliminaryFindings
                 }
+                showFindings={showFindings}
                 expanded={expandedRows.has('external')}
                 onToggle={() => toggleRow('external')}
                 collapsedBottomPadding={0}

--- a/packages/react-components/src/organisms/EventSpeakers.tsx
+++ b/packages/react-components/src/organisms/EventSpeakers.tsx
@@ -1,0 +1,552 @@
+import { network } from '@asap-hub/routing';
+import { css } from '@emotion/react';
+import { useState } from 'react';
+
+import {
+  Avatar,
+  Button,
+  Card,
+  Headline3,
+  Link,
+  Paragraph,
+  Pill,
+} from '../atoms';
+import { lead, neutral1000, steel } from '../colors';
+import {
+  alumniBadgeIcon,
+  chevronDownIcon,
+  chevronUpIcon,
+  ExportIcon,
+  InactiveBadgeIcon,
+  invalidTickIcon,
+  PencilIcon,
+  plusIcon,
+  tickInCircleIcon,
+} from '../icons';
+import {
+  metricBarStyles,
+  metricContainerStyles,
+  metricLabelStyles,
+  metricProgressRowStyles,
+  metricValueStyles,
+  metricWheelStyles,
+} from '../molecules/shared-metric-card-styles';
+import { rem, tabletScreen } from '../pixels';
+
+import { ProgressBar, ProgressWheel } from './PreliminaryFindingsChart';
+import {
+  defaultVisibleTeams,
+  EventTeamType,
+  teamIcon,
+} from './shared-event-card';
+import {
+  actionsStyles,
+  cellStyles,
+  contentStyles,
+  contentWithFooterStyles,
+  editIconButtonStyles,
+  emptyStateStyles,
+  headerCellStyles,
+  headerStyles,
+  iconButtonStyles,
+  metricsStyles,
+  statusCellStyles,
+  statusIconStyles,
+  tableWrapperStyles,
+  teamInfoStyles,
+  viewMoreStyles,
+} from './shared-event-card-styles';
+
+const mobileQuery = `@media (max-width: ${tabletScreen.min}px)`;
+
+const speakerTableStyles = css({
+  width: '100%',
+  borderCollapse: 'collapse',
+  [mobileQuery]: {
+    'th:nth-of-type(2), tbody td:nth-of-type(2)': {
+      textAlign: 'center',
+    },
+  },
+});
+
+const findingsColStyles = css({ width: '33%' });
+const chevronColStyles = css({ width: rem(40) });
+
+const fullFindingsLabel = css({
+  [mobileQuery]: { display: 'none' },
+});
+
+const shortFindingsLabel = css({
+  display: 'none',
+  [mobileQuery]: { display: 'inline' },
+});
+
+const teamGroupStyles = css({
+  borderBottom: `1px solid ${steel.rgb}`,
+  '&:last-of-type': {
+    borderBottom: 'none',
+  },
+});
+
+const chevronCellStyles = css({
+  textAlign: 'right',
+});
+
+const membersCellStyles = css({
+  padding: 0,
+});
+
+const leadTextStyles = css({
+  color: lead.rgb,
+});
+
+const chevronButtonStyles = css({
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  padding: 0,
+  border: 'none',
+  background: 'none',
+  cursor: 'pointer',
+});
+
+const membersListStyles = css({
+  listStyle: 'none',
+  margin: 0,
+  padding: `0 0 ${rem(12 + 16)} ${rem(32)}`,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: rem(16),
+  [mobileQuery]: {
+    gap: rem(24),
+    paddingLeft: rem(12),
+  },
+});
+
+const memberRowStyles = css({
+  display: 'flex',
+  alignItems: 'center',
+  gap: rem(8),
+  [mobileQuery]: {
+    flexDirection: 'column',
+    alignItems: 'flex-start',
+  },
+});
+
+const memberMainStyles = css({
+  display: 'flex',
+  alignItems: 'center',
+  gap: rem(8),
+});
+
+const memberAvatarStyles = css({
+  width: rem(24),
+  height: rem(24),
+  flexShrink: 0,
+});
+
+const alumniStyles = css({
+  display: 'inline-flex',
+  alignItems: 'center',
+});
+
+const MetricCard: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <div css={metricContainerStyles}>{children}</div>
+);
+
+const SpeakerCountMetric: React.FC<{
+  label: string;
+  value: number;
+  caption: string;
+}> = ({ label, value, caption }) => (
+  <MetricCard>
+    <p css={metricLabelStyles}>{label}</p>
+    <p css={metricValueStyles}>{value}</p>
+    <p css={metricLabelStyles}>{caption}</p>
+  </MetricCard>
+);
+
+const FindingsMetric: React.FC<{
+  label: string;
+  value: number;
+  caption: string;
+}> = ({ label, value, caption }) => (
+  <MetricCard>
+    <div css={metricProgressRowStyles}>
+      <span css={metricWheelStyles}>
+        <ProgressWheel percentage={value} />
+      </span>
+      <div>
+        <p css={metricLabelStyles}>{label}</p>
+        <p css={metricValueStyles}>{value}%</p>
+        <p css={metricLabelStyles}>{caption}</p>
+      </div>
+    </div>
+    <div css={metricBarStyles}>
+      <ProgressBar percentage={value} />
+    </div>
+  </MetricCard>
+);
+
+export type EventSpeakerMember = {
+  id: string;
+  displayName: string;
+  firstName?: string;
+  lastName?: string;
+  avatarUrl?: string;
+  role: string;
+  isAlumni?: boolean;
+};
+
+export type EventSpeakerTeamType = EventTeamType;
+
+export type EventSpeakerTeamRow = {
+  teamId: string;
+  teamName: string;
+  teamType?: EventSpeakerTeamType;
+  isTeamInactive?: boolean;
+  sharedPreliminaryFindings: boolean;
+  members: EventSpeakerMember[];
+};
+
+export type EventSpeakerExternalMember = {
+  name: string;
+};
+
+export type EventSpeakerExternalRow = {
+  sharedPreliminaryFindings: boolean;
+  members: EventSpeakerExternalMember[];
+};
+
+type EventSpeakersProps = {
+  teams: EventSpeakerTeamRow[];
+  externalUsers?: EventSpeakerExternalRow;
+  hasFinished?: boolean;
+  onExport?: () => void;
+  onEdit?: () => void;
+  onAddSpeaker?: () => void;
+};
+
+const findingsIcon = (shared: boolean) => (
+  <span
+    css={statusIconStyles}
+    role="img"
+    aria-label={
+      shared ? 'Shared preliminary findings' : 'No preliminary findings'
+    }
+  >
+    {shared ? tickInCircleIcon : invalidTickIcon}
+  </span>
+);
+
+const SpeakerRow: React.FC<{
+  info: React.ReactNode;
+  sharedPreliminaryFindings: boolean;
+  expanded: boolean;
+  onToggle: () => void;
+  label: string;
+  collapsedBottomPadding?: string | number;
+  children?: React.ReactNode;
+}> = ({
+  info,
+  sharedPreliminaryFindings,
+  expanded,
+  onToggle,
+  label,
+  collapsedBottomPadding,
+  children,
+}) => {
+  const collapsedBottom =
+    !expanded && collapsedBottomPadding !== undefined
+      ? { paddingBottom: collapsedBottomPadding }
+      : undefined;
+  return (
+    <tbody css={teamGroupStyles}>
+      <tr>
+        <td css={[cellStyles, collapsedBottom]}>
+          <span css={teamInfoStyles}>{info}</span>
+        </td>
+        <td css={[statusCellStyles, collapsedBottom]}>
+          {findingsIcon(sharedPreliminaryFindings)}
+        </td>
+        <td css={[statusCellStyles, chevronCellStyles, collapsedBottom]}>
+          <button
+            type="button"
+            css={chevronButtonStyles}
+            onClick={onToggle}
+            aria-expanded={expanded}
+            aria-label={expanded ? `Collapse ${label}` : `Expand ${label}`}
+          >
+            {expanded ? chevronUpIcon : chevronDownIcon}
+          </button>
+        </td>
+      </tr>
+      {expanded && (
+        <tr>
+          <td colSpan={3} css={membersCellStyles}>
+            {children}
+          </td>
+        </tr>
+      )}
+    </tbody>
+  );
+};
+
+const editorEmptyMessage = (hasFinished: boolean): string =>
+  hasFinished
+    ? 'Add the people who presented at this event, then mark who shared preliminary findings.'
+    : 'Add the speakers for this event. Marking who shared preliminary findings becomes available after the event.';
+
+const EventSpeakers: React.FC<EventSpeakersProps> = ({
+  teams,
+  externalUsers,
+  hasFinished = false,
+  onExport,
+  onEdit,
+  onAddSpeaker,
+}) => {
+  const [expandedRows, setExpandedRows] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
+  const [showAll, setShowAll] = useState(false);
+
+  const externalCount = externalUsers?.members.length ?? 0;
+  const hasExternal = externalCount > 0;
+
+  const teamsWithSpeakers = teams.filter((team) => team.members.length > 0);
+
+  if (teamsWithSpeakers.length === 0 && !hasExternal) {
+    return (
+      <Card>
+        <div css={emptyStateStyles}>
+          <Headline3 noMargin>Speakers</Headline3>
+          {onAddSpeaker ? (
+            <>
+              <Paragraph noMargin accent="lead">
+                {editorEmptyMessage(hasFinished)}
+              </Paragraph>
+              <Button primary small noMargin onClick={onAddSpeaker}>
+                {plusIcon} Add Speakers
+              </Button>
+            </>
+          ) : (
+            <Paragraph noMargin accent="lead">
+              No speakers have been added for this event yet.
+            </Paragraph>
+          )}
+        </div>
+      </Card>
+    );
+  }
+
+  const toggleRow = (key: string) =>
+    setExpandedRows((current) => {
+      const next = new Set(current);
+      if (next.has(key)) {
+        next.delete(key);
+      } else {
+        next.add(key);
+      }
+      return next;
+    });
+
+  const teamMemberCount = teamsWithSpeakers.reduce(
+    (total, team) => total + team.members.length,
+    0,
+  );
+  const teamsShared = teamsWithSpeakers.filter(
+    (team) => team.sharedPreliminaryFindings,
+  ).length;
+  const totalSpeakers = teamMemberCount + externalCount;
+  const teamsTotal = teamsWithSpeakers.length;
+  const findingsPercentage =
+    teamsTotal > 0 ? Math.round((teamsShared / teamsTotal) * 100) : 0;
+
+  const totalRows = teamsTotal + (hasExternal ? 1 : 0);
+  const showFooter = !showAll && totalRows > defaultVisibleTeams;
+  const visibleTeams = showAll
+    ? teamsWithSpeakers
+    : teamsWithSpeakers.slice(0, defaultVisibleTeams - (hasExternal ? 1 : 0));
+  const showExternalRow = hasExternal && (showAll || !showFooter);
+
+  const lastRowPadding = (isLastTeam: boolean): string | number | undefined => {
+    if (showFooter && isLastTeam) return rem(32);
+    if (isLastTeam && !showExternalRow) return 0;
+    return undefined;
+  };
+
+  return (
+    <Card padding={false}>
+      <div css={[contentStyles, showFooter && contentWithFooterStyles]}>
+        <div css={headerStyles}>
+          <Headline3 noMargin>Speakers</Headline3>
+          <div css={actionsStyles}>
+            {onExport && (
+              <Button
+                small
+                noMargin
+                aria-label="Download speakers"
+                onClick={onExport}
+                overrideStyles={iconButtonStyles}
+              >
+                {ExportIcon}
+              </Button>
+            )}
+            {onEdit && (
+              <Button
+                small
+                noMargin
+                aria-label="Edit speakers"
+                onClick={onEdit}
+                overrideStyles={editIconButtonStyles}
+              >
+                <PencilIcon color={neutral1000.rgb} />
+              </Button>
+            )}
+          </div>
+        </div>
+
+        <div css={metricsStyles}>
+          <SpeakerCountMetric
+            label="Speakers"
+            value={totalSpeakers}
+            caption={`${teamMemberCount} from teams • ${externalCount} non-CRN`}
+          />
+          <FindingsMetric
+            label="Preliminary findings"
+            value={findingsPercentage}
+            caption={`${teamsShared} of ${teamsTotal} teams`}
+          />
+        </div>
+
+        <div css={tableWrapperStyles}>
+          <table css={speakerTableStyles}>
+            <colgroup>
+              <col />
+              <col css={findingsColStyles} />
+              <col css={chevronColStyles} />
+            </colgroup>
+            <thead>
+              <tr>
+                <th css={headerCellStyles} scope="col">
+                  Speakers
+                </th>
+                <th css={headerCellStyles} scope="col">
+                  <span css={fullFindingsLabel}>Preliminary Findings</span>
+                  <span css={shortFindingsLabel}>P. Findings</span>
+                </th>
+                <th css={headerCellStyles} />
+              </tr>
+            </thead>
+
+            {visibleTeams.map((team, index) => {
+              const bottomOverride = lastRowPadding(
+                index === visibleTeams.length - 1,
+              );
+              return (
+                <SpeakerRow
+                  key={team.teamId}
+                  label={team.teamName}
+                  sharedPreliminaryFindings={team.sharedPreliminaryFindings}
+                  expanded={expandedRows.has(team.teamId)}
+                  onToggle={() => toggleRow(team.teamId)}
+                  collapsedBottomPadding={bottomOverride}
+                  info={
+                    <>
+                      {teamIcon(team.teamType)}
+                      <Link
+                        href={
+                          network({}).teams({}).team({ teamId: team.teamId }).$
+                        }
+                      >
+                        {team.teamName}
+                      </Link>
+                      {team.isTeamInactive && <InactiveBadgeIcon />}
+                      <span css={leadTextStyles}>({team.members.length})</span>
+                    </>
+                  }
+                >
+                  <ul
+                    css={[
+                      membersListStyles,
+                      bottomOverride !== undefined && {
+                        paddingBottom: bottomOverride,
+                      },
+                    ]}
+                  >
+                    {team.members.map((member) => (
+                      <li key={member.id} css={memberRowStyles}>
+                        <span css={memberMainStyles}>
+                          <span css={memberAvatarStyles}>
+                            <Avatar
+                              firstName={member.firstName}
+                              lastName={member.lastName}
+                              imageUrl={member.avatarUrl}
+                            />
+                          </span>
+                          <Link
+                            href={
+                              network({}).users({}).user({ userId: member.id })
+                                .$
+                            }
+                          >
+                            {member.displayName}
+                          </Link>
+                          {member.isAlumni && (
+                            <span css={alumniStyles}>{alumniBadgeIcon}</span>
+                          )}
+                        </span>
+                        <Pill accent="gray" noMargin>
+                          {member.role}
+                        </Pill>
+                      </li>
+                    ))}
+                  </ul>
+                </SpeakerRow>
+              );
+            })}
+
+            {showExternalRow && externalUsers && (
+              <SpeakerRow
+                label="External Users"
+                sharedPreliminaryFindings={
+                  externalUsers.sharedPreliminaryFindings
+                }
+                expanded={expandedRows.has('external')}
+                onToggle={() => toggleRow('external')}
+                collapsedBottomPadding={0}
+                info={
+                  <>
+                    <span css={leadTextStyles}>External Users</span>
+                    <span css={leadTextStyles}>({externalCount})</span>
+                  </>
+                }
+              >
+                <ul css={[membersListStyles, { paddingBottom: 0 }]}>
+                  {externalUsers.members.map((member, index) => (
+                    <li key={`external-${index}`} css={memberRowStyles}>
+                      <span css={leadTextStyles}>{member.name}</span>
+                      <Pill accent="gray" noMargin>
+                        Guest
+                      </Pill>
+                    </li>
+                  ))}
+                </ul>
+              </SpeakerRow>
+            )}
+          </table>
+        </div>
+      </div>
+
+      {showFooter && (
+        <div css={viewMoreStyles}>
+          <Button linkStyle onClick={() => setShowAll(true)}>
+            View More Speakers
+          </Button>
+        </div>
+      )}
+    </Card>
+  );
+};
+
+export default EventSpeakers;

--- a/packages/react-components/src/organisms/EventSpeakers.tsx
+++ b/packages/react-components/src/organisms/EventSpeakers.tsx
@@ -79,6 +79,8 @@ const shortFindingsLabel = css({
 
 const teamCellStyles = css({ paddingRight: rem(24) });
 
+const horizontalScrollGutter = css({ paddingBottom: rem(8) });
+
 // Keep team rows on one line so a long name scrolls the table rather than
 // wrapping the name or shrinking the icons.
 const teamInfoNoWrapStyles = css({
@@ -450,7 +452,13 @@ const EventSpeakers: React.FC<EventSpeakersProps> = ({
           )}
         </div>
 
-        <div css={tableWrapperStyles} ref={tableRef}>
+        <div
+          css={[
+            tableWrapperStyles,
+            findingsOverflowing && horizontalScrollGutter,
+          ]}
+          ref={tableRef}
+        >
           <table css={speakerTableStyles}>
             <colgroup>
               <col />

--- a/packages/react-components/src/organisms/EventSpeakers.tsx
+++ b/packages/react-components/src/organisms/EventSpeakers.tsx
@@ -1,6 +1,6 @@
 import { network } from '@asap-hub/routing';
 import { css } from '@emotion/react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import {
   Avatar,
@@ -64,24 +64,26 @@ const speakerTableStyles = css({
   borderCollapse: 'collapse',
 });
 
-const findingsCenterMobileStyles = css({
-  [mobileQuery]: {
-    'th:nth-of-type(2), tbody td:nth-of-type(2)': {
-      textAlign: 'center',
-    },
-  },
-});
-
-const findingsColStyles = css({ width: '33%' });
+// width:1% shrinks the column to its header so the tick sits under the label.
+const findingsColStyles = css({ width: '1%' });
+const findingsHeaderCellStyles = css({ whiteSpace: 'nowrap' });
 const chevronColStyles = css({ width: rem(40) });
 
-const fullFindingsLabel = css({
-  [mobileQuery]: { display: 'none' },
-});
-
+// The compact "P. Findings" is only used on mobile while the table fits;
+// horizontal overflow forces the full label at any width (handled in JS).
+const fullFindingsLabel = css({ [mobileQuery]: { display: 'none' } });
 const shortFindingsLabel = css({
   display: 'none',
   [mobileQuery]: { display: 'inline' },
+});
+
+const teamCellStyles = css({ paddingRight: rem(24) });
+
+// Keep team rows on one line so a long name scrolls the table rather than
+// wrapping the name or shrinking the icons.
+const teamInfoNoWrapStyles = css({
+  whiteSpace: 'nowrap',
+  '> svg': { flexShrink: 0 },
 });
 
 const teamGroupStyles = css({
@@ -177,7 +179,7 @@ const FindingsMetric: React.FC<{
   <MetricCard>
     <div css={metricProgressRowStyles}>
       <span css={metricWheelStyles}>
-        <ProgressWheel percentage={value} />
+        <ProgressWheel percentage={value} label={label} />
       </span>
       <div>
         <p css={metricLabelStyles}>{label}</p>
@@ -186,7 +188,7 @@ const FindingsMetric: React.FC<{
       </div>
     </div>
     <div css={metricBarStyles}>
-      <ProgressBar percentage={value} />
+      <ProgressBar percentage={value} label={label} />
     </div>
   </MetricCard>
 );
@@ -268,8 +270,8 @@ const SpeakerRow: React.FC<{
   return (
     <tbody css={teamGroupStyles}>
       <tr>
-        <td css={[cellStyles, collapsedBottom]}>
-          <span css={teamInfoStyles}>{info}</span>
+        <td css={[cellStyles, teamCellStyles, collapsedBottom]}>
+          <span css={[teamInfoStyles, teamInfoNoWrapStyles]}>{info}</span>
         </td>
         {showFindings && (
           <td css={[statusCellStyles, collapsedBottom]}>
@@ -299,6 +301,25 @@ const SpeakerRow: React.FC<{
   );
 };
 
+// Reports whether an element's content overflows it horizontally, tracking
+// layout and content changes via ResizeObserver.
+const useHorizontalOverflow = () => {
+  const [element, setElement] = useState<HTMLElement | null>(null);
+  const [overflowing, setOverflowing] = useState(false);
+  useEffect(() => {
+    if (!element) {
+      return undefined;
+    }
+    const measure = () =>
+      setOverflowing(element.scrollWidth > element.clientWidth);
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [element]);
+  return [setElement, overflowing] as const;
+};
+
 const editorEmptyMessage = (hasFinished: boolean): string =>
   hasFinished
     ? 'Add the people who presented at this event, then mark who shared preliminary findings.'
@@ -316,8 +337,8 @@ const EventSpeakers: React.FC<EventSpeakersProps> = ({
     () => new Set(),
   );
   const [showAll, setShowAll] = useState(false);
+  const [tableRef, findingsOverflowing] = useHorizontalOverflow();
 
-  // Preliminary findings are only shared once the event has taken place.
   const showFindings = hasFinished;
 
   const externalCount = externalUsers?.members.length ?? 0;
@@ -373,21 +394,19 @@ const EventSpeakers: React.FC<EventSpeakersProps> = ({
     teamsTotal > 0 ? Math.round((teamsShared / teamsTotal) * 100) : 0;
 
   const totalRows = teamsTotal + (hasExternal ? 1 : 0);
-  const showFooter = !showAll && totalRows > defaultVisibleTeams;
+  const hasMoreRows = totalRows > defaultVisibleTeams;
   const visibleTeams = showAll
     ? teamsWithSpeakers
     : teamsWithSpeakers.slice(0, defaultVisibleTeams - (hasExternal ? 1 : 0));
-  const showExternalRow = hasExternal && (showAll || !showFooter);
+  const showExternalRow = hasExternal && (showAll || !hasMoreRows);
 
-  const lastRowPadding = (isLastTeam: boolean): string | number | undefined => {
-    if (showFooter && isLastTeam) return rem(32);
-    if (isLastTeam && !showExternalRow) return 0;
-    return undefined;
-  };
+  const lastRowBottomPadding = hasMoreRows ? rem(32) : 0;
+  const lastRowPadding = (isLastTeam: boolean): string | number | undefined =>
+    isLastTeam && !showExternalRow ? lastRowBottomPadding : undefined;
 
   return (
     <Card padding={false}>
-      <div css={[contentStyles, showFooter && contentWithFooterStyles]}>
+      <div css={[contentStyles, hasMoreRows && contentWithFooterStyles]}>
         <div css={headerStyles}>
           <Headline3 noMargin>Speakers</Headline3>
           <div css={actionsStyles}>
@@ -431,13 +450,8 @@ const EventSpeakers: React.FC<EventSpeakersProps> = ({
           )}
         </div>
 
-        <div css={tableWrapperStyles}>
-          <table
-            css={[
-              speakerTableStyles,
-              showFindings && findingsCenterMobileStyles,
-            ]}
-          >
+        <div css={tableWrapperStyles} ref={tableRef}>
+          <table css={speakerTableStyles}>
             <colgroup>
               <col />
               {showFindings && <col css={findingsColStyles} />}
@@ -449,9 +463,20 @@ const EventSpeakers: React.FC<EventSpeakersProps> = ({
                   <th css={headerCellStyles} scope="col">
                     Speakers
                   </th>
-                  <th css={headerCellStyles} scope="col">
-                    <span css={fullFindingsLabel}>Preliminary Findings</span>
-                    <span css={shortFindingsLabel}>P. Findings</span>
+                  <th
+                    css={[headerCellStyles, findingsHeaderCellStyles]}
+                    scope="col"
+                  >
+                    {findingsOverflowing ? (
+                      'Preliminary Findings'
+                    ) : (
+                      <>
+                        <span css={fullFindingsLabel}>
+                          Preliminary Findings
+                        </span>
+                        <span css={shortFindingsLabel}>P. Findings</span>
+                      </>
+                    )}
                   </th>
                   <th css={headerCellStyles} />
                 </tr>
@@ -535,7 +560,7 @@ const EventSpeakers: React.FC<EventSpeakersProps> = ({
                 showFindings={showFindings}
                 expanded={expandedRows.has('external')}
                 onToggle={() => toggleRow('external')}
-                collapsedBottomPadding={0}
+                collapsedBottomPadding={lastRowBottomPadding}
                 info={
                   <>
                     <span css={leadTextStyles}>External Users</span>
@@ -543,7 +568,12 @@ const EventSpeakers: React.FC<EventSpeakersProps> = ({
                   </>
                 }
               >
-                <ul css={[membersListStyles, { paddingBottom: 0 }]}>
+                <ul
+                  css={[
+                    membersListStyles,
+                    { paddingBottom: lastRowBottomPadding },
+                  ]}
+                >
                   {externalUsers.members.map((member, index) => (
                     <li key={`external-${index}`} css={memberRowStyles}>
                       <span css={leadTextStyles}>{member.name}</span>
@@ -559,10 +589,10 @@ const EventSpeakers: React.FC<EventSpeakersProps> = ({
         </div>
       </div>
 
-      {showFooter && (
+      {hasMoreRows && (
         <div css={viewMoreStyles}>
-          <Button linkStyle onClick={() => setShowAll(true)}>
-            View More Speakers
+          <Button linkStyle onClick={() => setShowAll((current) => !current)}>
+            {showAll ? 'View Less Speakers' : 'View More Speakers'}
           </Button>
         </div>
       )}

--- a/packages/react-components/src/organisms/EventSpeakers.tsx
+++ b/packages/react-components/src/organisms/EventSpeakers.tsx
@@ -48,11 +48,13 @@ import {
   emptyStateStyles,
   headerCellStyles,
   headerStyles,
+  horizontalScrollGutter,
   iconButtonStyles,
   metricsStyles,
   statusCellStyles,
   statusIconStyles,
   tableWrapperStyles,
+  teamInfoNoWrapStyles,
   teamInfoStyles,
   viewMoreStyles,
 } from './shared-event-card-styles';
@@ -78,15 +80,6 @@ const shortFindingsLabel = css({
 });
 
 const teamCellStyles = css({ paddingRight: rem(24) });
-
-const horizontalScrollGutter = css({ paddingBottom: rem(8) });
-
-// Keep team rows on one line so a long name scrolls the table rather than
-// wrapping the name or shrinking the icons.
-const teamInfoNoWrapStyles = css({
-  whiteSpace: 'nowrap',
-  '> svg': { flexShrink: 0 },
-});
 
 const teamGroupStyles = css({
   borderBottom: `1px solid ${steel.rgb}`,

--- a/packages/react-components/src/organisms/PreliminaryFindingsChart.tsx
+++ b/packages/react-components/src/organisms/PreliminaryFindingsChart.tsx
@@ -1,0 +1,102 @@
+/** @jsxImportSource @emotion/react */
+import { fern, info500, iris, steel } from '../colors';
+import { rem } from '../pixels';
+import { clampPercentage } from '../utils';
+
+const findingsRampStops = `${iris.hex} 30.25%, ${info500.hex} 51.91%, #1491B2 66.74%, #299C86 79.82%, ${fern.hex} 90.01%`;
+
+const findingsGradient = `linear-gradient(90deg, ${findingsRampStops})`;
+
+const WHEEL_SIZE = 74;
+const WHEEL_STROKE = 9;
+
+// Green sits near 100% then blends back to purple at the seam so the ring loops.
+const findingsConicRamp = `conic-gradient(from 0deg, ${findingsRampStops}, ${iris.hex} 100%)`;
+
+const wheelRingMask = `radial-gradient(farthest-side, transparent calc(100% - ${rem(
+  WHEEL_STROKE,
+)}), #000 calc(100% - ${rem(WHEEL_STROKE)}))`;
+
+const WHEEL_MID_RADIUS = (WHEEL_SIZE - WHEEL_STROKE) / 2;
+
+// The same conic clipped to a dot at a ring fraction, so the cap colour matches.
+const capStyles = (fraction: number) => {
+  const angle = fraction * 2 * Math.PI;
+  const x = WHEEL_SIZE / 2 + WHEEL_MID_RADIUS * Math.sin(angle);
+  const y = WHEEL_SIZE / 2 - WHEEL_MID_RADIUS * Math.cos(angle);
+  return {
+    position: 'absolute' as const,
+    inset: 0,
+    background: findingsConicRamp,
+    clipPath: `circle(${rem(WHEEL_STROKE / 2)} at ${rem(x)} ${rem(y)})`,
+  };
+};
+
+export const ProgressWheel: React.FC<{ percentage: number }> = ({
+  percentage,
+}) => {
+  const value = clampPercentage(percentage);
+  return (
+    <div
+      role="progressbar"
+      aria-valuenow={value}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      css={{
+        position: 'relative',
+        width: rem(WHEEL_SIZE),
+        height: rem(WHEEL_SIZE),
+      }}
+    >
+      <div
+        css={{
+          position: 'absolute',
+          inset: 0,
+          borderRadius: '50%',
+          background: `conic-gradient(from 0deg, transparent 0 ${value}%, ${steel.rgb} ${value}% 100%), ${findingsConicRamp}`,
+          WebkitMaskImage: wheelRingMask,
+          maskImage: wheelRingMask,
+        }}
+      />
+      {value > 0 && (
+        <>
+          <div css={capStyles(0)} />
+          <div css={capStyles(value / 100)} />
+        </>
+      )}
+    </div>
+  );
+};
+
+export const ProgressBar: React.FC<{ percentage: number }> = ({
+  percentage,
+}) => {
+  const value = clampPercentage(percentage);
+  return (
+    <div
+      css={{
+        width: '100%',
+        height: rem(8),
+        borderRadius: rem(4),
+        backgroundColor: steel.rgb,
+        overflow: 'hidden',
+      }}
+      role="progressbar"
+      aria-valuenow={value}
+      aria-valuemin={0}
+      aria-valuemax={100}
+    >
+      <div
+        css={{
+          height: '100%',
+          borderRadius: rem(4),
+          background: findingsGradient,
+          // Reveal only the 0→value slice so the tip colour tracks the value.
+          backgroundSize: `${value > 0 ? 10000 / value : 100}% 100%`,
+          backgroundRepeat: 'no-repeat',
+        }}
+        style={{ width: `${value}%` }}
+      />
+    </div>
+  );
+};

--- a/packages/react-components/src/organisms/PreliminaryFindingsChart.tsx
+++ b/packages/react-components/src/organisms/PreliminaryFindingsChart.tsx
@@ -9,13 +9,17 @@ const findingsGradient = `linear-gradient(90deg, ${findingsRampStops})`;
 
 const WHEEL_SIZE = 74;
 const WHEEL_STROKE = 9;
+// Sub-pixel offset between paired colour stops so hard gradient edges get a
+// tiny blur band and antialias instead of showing a jagged spoke/ring.
+// https://codepen.io/mandymichael/pen/oNNdKzW
+const EDGE_BLUR = 0.6;
 
 // Green sits near 100% then blends back to purple at the seam so the ring loops.
 const findingsConicRamp = `conic-gradient(from 0deg, ${findingsRampStops}, ${iris.hex} 100%)`;
 
 const wheelRingMask = `radial-gradient(farthest-side, transparent calc(100% - ${rem(
   WHEEL_STROKE,
-)}), #000 calc(100% - ${rem(WHEEL_STROKE)}))`;
+)}), #000 calc(100% - ${rem(WHEEL_STROKE)} + ${EDGE_BLUR}px))`;
 
 const WHEEL_MID_RADIUS = (WHEEL_SIZE - WHEEL_STROKE) / 2;
 
@@ -53,7 +57,9 @@ export const ProgressWheel: React.FC<{ percentage: number }> = ({
           position: 'absolute',
           inset: 0,
           borderRadius: '50%',
-          background: `conic-gradient(from 0deg, transparent 0 ${value}%, ${steel.rgb} ${value}% 100%), ${findingsConicRamp}`,
+          background: `conic-gradient(from 0deg, transparent 0 ${value}%, ${steel.rgb} ${
+            value + EDGE_BLUR
+          }% 100%), ${findingsConicRamp}`,
           WebkitMaskImage: wheelRingMask,
           maskImage: wheelRingMask,
         }}

--- a/packages/react-components/src/organisms/PreliminaryFindingsChart.tsx
+++ b/packages/react-components/src/organisms/PreliminaryFindingsChart.tsx
@@ -57,9 +57,9 @@ export const ProgressWheel: React.FC<{ percentage: number }> = ({
           position: 'absolute',
           inset: 0,
           borderRadius: '50%',
-          background: `conic-gradient(from 0deg, transparent 0 ${value}%, ${steel.rgb} ${
-            value + EDGE_BLUR
-          }% 100%), ${findingsConicRamp}`,
+          background: `conic-gradient(from 0deg, transparent 0 ${value}%, ${
+            steel.rgb
+          } ${value + EDGE_BLUR}% 100%), ${findingsConicRamp}`,
           WebkitMaskImage: wheelRingMask,
           maskImage: wheelRingMask,
         }}

--- a/packages/react-components/src/organisms/PreliminaryFindingsChart.tsx
+++ b/packages/react-components/src/organisms/PreliminaryFindingsChart.tsx
@@ -36,13 +36,15 @@ const capStyles = (fraction: number) => {
   };
 };
 
-export const ProgressWheel: React.FC<{ percentage: number }> = ({
-  percentage,
-}) => {
+export const ProgressWheel: React.FC<{
+  percentage: number;
+  label?: string;
+}> = ({ percentage, label }) => {
   const value = clampPercentage(percentage);
   return (
     <div
       role="progressbar"
+      aria-label={label}
       aria-valuenow={value}
       aria-valuemin={0}
       aria-valuemax={100}
@@ -57,9 +59,10 @@ export const ProgressWheel: React.FC<{ percentage: number }> = ({
           position: 'absolute',
           inset: 0,
           borderRadius: '50%',
+          // At 0% the blur band is dropped so the ramp seam can't peek through.
           background: `conic-gradient(from 0deg, transparent 0 ${value}%, ${
             steel.rgb
-          } ${value + EDGE_BLUR}% 100%), ${findingsConicRamp}`,
+          } ${value > 0 ? value + EDGE_BLUR : 0}% 100%), ${findingsConicRamp}`,
           WebkitMaskImage: wheelRingMask,
           maskImage: wheelRingMask,
         }}
@@ -74,8 +77,9 @@ export const ProgressWheel: React.FC<{ percentage: number }> = ({
   );
 };
 
-export const ProgressBar: React.FC<{ percentage: number }> = ({
+export const ProgressBar: React.FC<{ percentage: number; label?: string }> = ({
   percentage,
+  label,
 }) => {
   const value = clampPercentage(percentage);
   return (
@@ -88,6 +92,7 @@ export const ProgressBar: React.FC<{ percentage: number }> = ({
         overflow: 'hidden',
       }}
       role="progressbar"
+      aria-label={label}
       aria-valuenow={value}
       aria-valuemin={0}
       aria-valuemax={100}

--- a/packages/react-components/src/organisms/__tests__/EventSpeakers.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/EventSpeakers.test.tsx
@@ -1,0 +1,267 @@
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { StaticRouter } from 'react-router';
+
+import EventSpeakers, {
+  EventSpeakerTeamRow,
+  EventSpeakerExternalRow,
+} from '../EventSpeakers';
+
+const makeMembers = (teamIndex: number, count: number) =>
+  Array.from({ length: count }, (_, index) => ({
+    id: `user-${teamIndex}-${index}`,
+    firstName: 'John',
+    lastName: 'Doe',
+    displayName: `John Doe ${teamIndex}-${index}`,
+    role: 'Data Manager',
+    isAlumni: index === 0,
+  }));
+
+const teams: EventSpeakerTeamRow[] = [
+  {
+    teamId: 'team-0',
+    teamName: 'Team Alpha',
+    teamType: 'discovery',
+    sharedPreliminaryFindings: true,
+    isTeamInactive: true,
+    members: makeMembers(0, 2),
+  },
+  {
+    teamId: 'team-1',
+    teamName: 'Team Beta',
+    teamType: 'resource',
+    sharedPreliminaryFindings: false,
+    members: makeMembers(1, 1),
+  },
+];
+
+const externalUsers: EventSpeakerExternalRow = {
+  sharedPreliminaryFindings: false,
+  members: [{ name: 'External user 1' }],
+};
+
+const renderCard = (
+  props: Partial<React.ComponentProps<typeof EventSpeakers>> = {},
+) =>
+  render(
+    <StaticRouter location="/">
+      <EventSpeakers teams={teams} externalUsers={externalUsers} {...props} />
+    </StaticRouter>,
+  );
+
+describe('EventSpeakers', () => {
+  describe('empty state', () => {
+    it('Should show the read-only message for a non-editor', () => {
+      const { getByText } = renderCard({ teams: [], externalUsers: undefined });
+      expect(
+        getByText('No speakers have been added for this event yet.'),
+      ).toBeVisible();
+    });
+
+    it('Should prompt an editor to add speakers for an upcoming event', () => {
+      const { getByText, getByRole } = renderCard({
+        teams: [],
+        externalUsers: undefined,
+        hasFinished: false,
+        onAddSpeaker: jest.fn(),
+      });
+      expect(
+        getByText(/Marking who shared preliminary findings becomes available/i),
+      ).toBeVisible();
+      expect(getByRole('button', { name: /add speakers/i })).toBeVisible();
+    });
+
+    it('Should prompt an editor to add presenters for a past event', () => {
+      const { getByText } = renderCard({
+        teams: [],
+        externalUsers: undefined,
+        hasFinished: true,
+        onAddSpeaker: jest.fn(),
+      });
+      expect(
+        getByText(/Add the people who presented at this event/i),
+      ).toBeVisible();
+    });
+
+    it('Should fire onAddSpeaker from the empty-state button', async () => {
+      const onAddSpeaker = jest.fn();
+      const { getByRole } = renderCard({
+        teams: [],
+        externalUsers: undefined,
+        onAddSpeaker,
+      });
+      await userEvent.click(getByRole('button', { name: /add speakers/i }));
+      expect(onAddSpeaker).toHaveBeenCalled();
+    });
+  });
+
+  describe('metrics', () => {
+    it('Should derive the speaker and preliminary-findings metrics', () => {
+      const { getByText } = renderCard();
+      // 2 + 1 team members + 1 external = 4 total, 3 from teams, 1 non-CRN
+      expect(getByText('4')).toBeVisible();
+      expect(getByText('3 from teams • 1 non-CRN')).toBeVisible();
+      // 1 of 2 teams shared findings = 50%
+      expect(getByText('50%')).toBeVisible();
+      expect(getByText('1 of 2 teams')).toBeVisible();
+    });
+  });
+
+  describe('team rows', () => {
+    it('Should render team links, counts, inactive badge and findings status', () => {
+      const { getByRole, getByText, getByLabelText, getAllByLabelText } =
+        renderCard();
+      expect(getByRole('link', { name: 'Team Alpha' })).toHaveAttribute(
+        'href',
+        expect.stringContaining('team-0'),
+      );
+      expect(getByText('(2)')).toBeVisible();
+      expect(getByText('Inactive Team')).toBeInTheDocument();
+      expect(getByLabelText('Shared preliminary findings')).toBeInTheDocument();
+      // Team Beta + External Users both show the cross.
+      expect(getAllByLabelText('No preliminary findings')).toHaveLength(2);
+    });
+
+    it('Should expand a team to reveal its members with roles', async () => {
+      const { getByRole, queryByRole, getAllByText } = renderCard();
+      expect(
+        queryByRole('link', { name: 'John Doe 0-0' }),
+      ).not.toBeInTheDocument();
+      await userEvent.click(getByRole('button', { name: 'Expand Team Alpha' }));
+      expect(getByRole('link', { name: 'John Doe 0-0' })).toHaveAttribute(
+        'href',
+        expect.stringContaining('user-0-0'),
+      );
+      expect(getAllByText('Data Manager')[0]).toBeVisible();
+    });
+
+    it('Should collapse an expanded team', async () => {
+      const { getByRole, queryByRole } = renderCard();
+      await userEvent.click(getByRole('button', { name: 'Expand Team Alpha' }));
+      expect(getByRole('link', { name: 'John Doe 0-0' })).toBeInTheDocument();
+      await userEvent.click(
+        getByRole('button', { name: 'Collapse Team Alpha' }),
+      );
+      expect(
+        queryByRole('link', { name: 'John Doe 0-0' }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('teams without speakers', () => {
+    it('Should hide teams that have no speakers and exclude them from the findings count', () => {
+      const { queryByRole, getByText } = renderCard({
+        teams: [
+          ...teams,
+          {
+            teamId: 'team-empty',
+            teamName: 'Empty Team',
+            sharedPreliminaryFindings: true,
+            members: [],
+          },
+        ],
+        externalUsers: undefined,
+      });
+      expect(
+        queryByRole('link', { name: 'Empty Team' }),
+      ).not.toBeInTheDocument();
+      // Only Team Alpha + Team Beta count; Team Alpha shared → 1 of 2.
+      expect(getByText('1 of 2 teams')).toBeVisible();
+    });
+  });
+
+  describe('external-only event', () => {
+    it('Should render with zero-team findings when there are only external users', () => {
+      const { getByText } = renderCard({ teams: [] });
+      expect(getByText('0%')).toBeVisible();
+      expect(getByText('0 of 0 teams')).toBeVisible();
+      expect(getByText('External Users')).toBeVisible();
+    });
+  });
+
+  describe('external users row', () => {
+    it('Should render and expand the external users row', async () => {
+      const { getByRole, getByText, queryByText } = renderCard();
+      expect(getByText('External Users')).toBeVisible();
+      expect(queryByText('External user 1')).not.toBeInTheDocument();
+      await userEvent.click(
+        getByRole('button', { name: 'Expand External Users' }),
+      );
+      expect(getByText('External user 1')).toBeVisible();
+      expect(getByText('Guest')).toBeVisible();
+    });
+  });
+
+  describe('admin actions', () => {
+    it('Should render and fire the edit and export buttons when provided', async () => {
+      const onEdit = jest.fn();
+      const onExport = jest.fn();
+      const { getByRole } = renderCard({ onEdit, onExport });
+      await userEvent.click(getByRole('button', { name: 'Edit speakers' }));
+      await userEvent.click(getByRole('button', { name: 'Download speakers' }));
+      expect(onEdit).toHaveBeenCalled();
+      expect(onExport).toHaveBeenCalled();
+    });
+
+    it('Should not render admin buttons for a read-only viewer', () => {
+      const { queryByRole } = renderCard();
+      expect(
+        queryByRole('button', { name: 'Edit speakers' }),
+      ).not.toBeInTheDocument();
+      expect(
+        queryByRole('button', { name: 'Download speakers' }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('overflow', () => {
+    const manyTeams: EventSpeakerTeamRow[] = Array.from(
+      { length: 14 },
+      (_, index) => ({
+        teamId: `team-${index}`,
+        teamName: `Team ${index + 1}`,
+        sharedPreliminaryFindings: true,
+        members: makeMembers(index, 1),
+      }),
+    );
+
+    it('Should not render the footer with 10 or fewer rows', () => {
+      const { queryByRole } = renderCard({
+        teams: manyTeams.slice(0, 10),
+        externalUsers: undefined,
+      });
+      expect(
+        queryByRole('button', { name: /view more speakers/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('Should reveal the remaining rows on View More', async () => {
+      const { getByRole, queryByRole } = renderCard({
+        teams: manyTeams,
+        externalUsers: undefined,
+      });
+      expect(
+        queryByRole('button', { name: 'Expand Team 14' }),
+      ).not.toBeInTheDocument();
+      await userEvent.click(
+        getByRole('button', { name: /view more speakers/i }),
+      );
+      expect(
+        getByRole('button', { name: 'Expand Team 14' }),
+      ).toBeInTheDocument();
+      expect(
+        queryByRole('button', { name: /view more speakers/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('Should still expand the last visible team above the footer', async () => {
+      const { getByRole, getByText } = renderCard({
+        teams: manyTeams,
+        externalUsers: undefined,
+      });
+      // Team 10 is the last visible row while the footer is shown.
+      await userEvent.click(getByRole('button', { name: 'Expand Team 10' }));
+      expect(getByText('John Doe 9-0')).toBeVisible();
+    });
+  });
+});

--- a/packages/react-components/src/organisms/__tests__/EventSpeakers.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/EventSpeakers.test.tsx
@@ -45,7 +45,12 @@ const renderCard = (
 ) =>
   render(
     <StaticRouter location="/">
-      <EventSpeakers teams={teams} externalUsers={externalUsers} {...props} />
+      <EventSpeakers
+        teams={teams}
+        externalUsers={externalUsers}
+        hasFinished
+        {...props}
+      />
     </StaticRouter>,
   );
 
@@ -104,6 +109,39 @@ describe('EventSpeakers', () => {
       // 1 of 2 teams shared findings = 50%
       expect(getByText('50%')).toBeVisible();
       expect(getByText('1 of 2 teams')).toBeVisible();
+    });
+  });
+
+  describe('upcoming event', () => {
+    it('Should hide preliminary findings before the event has taken place', () => {
+      const { getByText, queryByText, queryByLabelText } = renderCard({
+        hasFinished: false,
+      });
+      // Speaker count stays; the findings metric, header and ticks disappear.
+      expect(getByText('4')).toBeVisible();
+      expect(queryByText('Preliminary findings')).not.toBeInTheDocument();
+      expect(queryByText('50%')).not.toBeInTheDocument();
+      expect(
+        queryByLabelText('Shared preliminary findings'),
+      ).not.toBeInTheDocument();
+      expect(
+        queryByLabelText('No preliminary findings'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('Should still expand a team to reveal members when findings are hidden', async () => {
+      const { getByRole, getByText } = renderCard({ hasFinished: false });
+      await userEvent.click(getByRole('button', { name: 'Expand Team Alpha' }));
+      expect(getByText('John Doe 0-0')).toBeVisible();
+    });
+
+    it('Should default to hiding findings when hasFinished is not provided', () => {
+      const { queryByText } = render(
+        <StaticRouter location="/">
+          <EventSpeakers teams={teams} externalUsers={externalUsers} />
+        </StaticRouter>,
+      );
+      expect(queryByText('Preliminary findings')).not.toBeInTheDocument();
     });
   });
 

--- a/packages/react-components/src/organisms/__tests__/EventSpeakers.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/EventSpeakers.test.tsx
@@ -41,7 +41,7 @@ const teams: EventSpeakerTeamRow[] = [
   {
     teamId: 'team-0',
     teamName: 'Team Alpha',
-    teamType: 'discovery',
+    teamType: 'Discovery Team',
     sharedPreliminaryFindings: true,
     isTeamInactive: true,
     members: makeMembers(0, 2),
@@ -49,7 +49,7 @@ const teams: EventSpeakerTeamRow[] = [
   {
     teamId: 'team-1',
     teamName: 'Team Beta',
-    teamType: 'resource',
+    teamType: 'Resource Team',
     sharedPreliminaryFindings: false,
     members: makeMembers(1, 1),
   },

--- a/packages/react-components/src/organisms/__tests__/EventSpeakers.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/EventSpeakers.test.tsx
@@ -7,6 +7,26 @@ import EventSpeakers, {
   EventSpeakerExternalRow,
 } from '../EventSpeakers';
 
+// jsdom has no ResizeObserver and does no layout.
+globalThis.ResizeObserver = jest.fn(() => ({
+  observe: jest.fn(),
+  unobserve: jest.fn(),
+  disconnect: jest.fn(),
+})) as unknown as typeof ResizeObserver;
+
+const mockTableOverflow = (scrollWidth: number, clientWidth: number) => {
+  Object.defineProperty(Element.prototype, 'scrollWidth', {
+    configurable: true,
+    get: () => scrollWidth,
+  });
+  Object.defineProperty(Element.prototype, 'clientWidth', {
+    configurable: true,
+    get: () => clientWidth,
+  });
+};
+
+afterEach(() => mockTableOverflow(0, 0));
+
 const makeMembers = (teamIndex: number, count: number) =>
   Array.from({ length: count }, (_, index) => ({
     id: `user-${teamIndex}-${index}`,
@@ -109,6 +129,29 @@ describe('EventSpeakers', () => {
       // 1 of 2 teams shared findings = 50%
       expect(getByText('50%')).toBeVisible();
       expect(getByText('1 of 2 teams')).toBeVisible();
+    });
+
+    it('Should give the findings progress indicators an accessible name', () => {
+      const { container } = renderCard();
+      const progressbars = container.querySelectorAll('[role="progressbar"]');
+      expect(progressbars.length).toBeGreaterThan(0);
+      progressbars.forEach((bar) =>
+        expect(bar).toHaveAttribute('aria-label', 'Preliminary findings'),
+      );
+    });
+  });
+
+  describe('findings column label', () => {
+    it('Should render the compact "P. Findings" label when the table fits', () => {
+      const { getByText } = renderCard();
+      expect(getByText('P. Findings')).toBeInTheDocument();
+    });
+
+    it('Should drop the compact label and only show "Preliminary Findings" when the table overflows', () => {
+      mockTableOverflow(400, 100);
+      const { getByText, queryByText } = renderCard();
+      expect(getByText('Preliminary Findings')).toBeInTheDocument();
+      expect(queryByText('P. Findings')).not.toBeInTheDocument();
     });
   });
 
@@ -290,6 +333,25 @@ describe('EventSpeakers', () => {
       expect(
         queryByRole('button', { name: /view more speakers/i }),
       ).not.toBeInTheDocument();
+    });
+
+    it('Should collapse the extra rows again on View Less', async () => {
+      const { getByRole, queryByRole } = renderCard({
+        teams: manyTeams,
+        externalUsers: undefined,
+      });
+      await userEvent.click(
+        getByRole('button', { name: /view more speakers/i }),
+      );
+      await userEvent.click(
+        getByRole('button', { name: /view less speakers/i }),
+      );
+      expect(
+        queryByRole('button', { name: 'Expand Team 14' }),
+      ).not.toBeInTheDocument();
+      expect(
+        getByRole('button', { name: /view more speakers/i }),
+      ).toBeInTheDocument();
     });
 
     it('Should still expand the last visible team above the footer', async () => {

--- a/packages/react-components/src/organisms/index.ts
+++ b/packages/react-components/src/organisms/index.ts
@@ -34,6 +34,13 @@ export { default as EventCard } from './EventCard';
 export { default as EventConversation } from './EventConversation';
 export { default as EventMaterials } from './EventMaterials';
 export { default as EventSearch } from './EventSearch';
+export { default as EventSpeakers } from './EventSpeakers';
+export type {
+  EventSpeakerTeamRow,
+  EventSpeakerExternalRow,
+  EventSpeakerExternalMember,
+  EventSpeakerMember,
+} from './EventSpeakers';
 export { default as ExportAnalyticsModal } from './ExportAnalyticsModal';
 export { default as Filter } from './Filter';
 export { default as Form } from './Form';

--- a/packages/react-components/src/organisms/shared-event-card-styles.ts
+++ b/packages/react-components/src/organisms/shared-event-card-styles.ts
@@ -1,0 +1,111 @@
+import { css } from '@emotion/react';
+
+import { charcoal, steel, tin } from '../colors';
+import { mobileScreen, rem, tabletScreen } from '../pixels';
+
+export const contentStyles = css({
+  padding: `${rem(32)} ${rem(24)}`,
+});
+
+export const contentWithFooterStyles = css({
+  paddingBottom: 0,
+});
+
+export const headerStyles = css({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: rem(15),
+});
+
+export const actionsStyles = css({
+  display: 'flex',
+  gap: rem(12),
+});
+
+export const iconButtonStyles = css({
+  flexGrow: 0,
+  width: rem(40),
+  height: rem(40),
+  alignItems: 'center',
+  borderColor: tin.rgb,
+  ':hover, :focus': {
+    borderColor: tin.rgb,
+  },
+  [`@media (max-width: ${mobileScreen.max}px)`]: {
+    minWidth: rem(40),
+  },
+});
+
+export const editIconButtonStyles = css([
+  iconButtonStyles,
+  {
+    '> svg': {
+      width: rem(24),
+      height: rem(24),
+      padding: 0,
+    },
+  },
+]);
+
+export const metricsStyles = css({
+  display: 'grid',
+  gridTemplateColumns: '1fr',
+  gap: rem(24),
+  marginTop: rem(24),
+  [`@media (min-width: ${tabletScreen.min}px)`]: {
+    gridTemplateColumns: '1fr 1fr',
+  },
+});
+
+export const viewMoreStyles = css({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  height: rem(56),
+  borderTop: `1px solid ${steel.rgb}`,
+});
+
+export const emptyStateStyles = css({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'flex-start',
+  gap: rem(24),
+});
+
+export const statusIconStyles = css({
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: rem(24),
+  height: rem(24),
+  verticalAlign: 'middle',
+});
+
+export const teamInfoStyles = css({
+  display: 'flex',
+  alignItems: 'center',
+  gap: rem(8),
+  minWidth: 0,
+});
+
+export const tableWrapperStyles = css({
+  marginTop: rem(40),
+  overflowX: 'auto',
+});
+
+export const headerCellStyles = css({
+  textAlign: 'left',
+  color: charcoal.rgb,
+  fontSize: rem(17),
+  fontWeight: 'bold',
+  lineHeight: rem(24),
+  letterSpacing: rem(0.1),
+});
+
+export const cellStyles = css({
+  padding: `${rem(16)} 0`,
+  verticalAlign: 'middle',
+});
+
+export const statusCellStyles = css([cellStyles, { lineHeight: 0 }]);

--- a/packages/react-components/src/organisms/shared-event-card-styles.ts
+++ b/packages/react-components/src/organisms/shared-event-card-styles.ts
@@ -33,6 +33,9 @@ export const iconButtonStyles = css({
     borderColor: tin.rgb,
   },
   [`@media (max-width: ${mobileScreen.max}px)`]: {
+    // Button re-asserts flexGrow:1 at this breakpoint; re-declare it so the
+    // fixed 40px icon button doesn't stretch.
+    flexGrow: 0,
     minWidth: rem(40),
   },
 });
@@ -88,6 +91,16 @@ export const teamInfoStyles = css({
   gap: rem(8),
   minWidth: 0,
 });
+
+// Keep a team row on one line so a long name scrolls the table rather than
+// wrapping the name or shrinking the icons.
+export const teamInfoNoWrapStyles = css({
+  whiteSpace: 'nowrap',
+  '> svg': { flexShrink: 0 },
+});
+
+// Breathing room below the table for the horizontal scrollbar when it appears.
+export const horizontalScrollGutter = css({ paddingBottom: rem(8) });
 
 export const tableWrapperStyles = css({
   marginTop: rem(40),

--- a/packages/react-components/src/organisms/shared-event-card.tsx
+++ b/packages/react-components/src/organisms/shared-event-card.tsx
@@ -1,0 +1,16 @@
+import { DiscoveryTeamIcon, ResourceTeamIcon, TeamIcon } from '../icons';
+
+export const defaultVisibleTeams = 10;
+
+export type EventTeamType = 'discovery' | 'resource';
+
+export const teamIcon = (teamType?: EventTeamType) => {
+  switch (teamType) {
+    case 'discovery':
+      return <DiscoveryTeamIcon />;
+    case 'resource':
+      return <ResourceTeamIcon />;
+    default:
+      return <TeamIcon />;
+  }
+};

--- a/packages/react-components/src/organisms/shared-event-card.tsx
+++ b/packages/react-components/src/organisms/shared-event-card.tsx
@@ -1,14 +1,16 @@
+import { TeamType } from '@asap-hub/model';
+
 import { DiscoveryTeamIcon, ResourceTeamIcon, TeamIcon } from '../icons';
 
 export const defaultVisibleTeams = 10;
 
-export type EventTeamType = 'discovery' | 'resource';
+export type EventTeamType = TeamType;
 
 export const teamIcon = (teamType?: EventTeamType) => {
   switch (teamType) {
-    case 'discovery':
+    case 'Discovery Team':
       return <DiscoveryTeamIcon />;
-    case 'resource':
+    case 'Resource Team':
       return <ResourceTeamIcon />;
     default:
       return <TeamIcon />;


### PR DESCRIPTION
ref: https://asaphub.atlassian.net/browse/ASAP-1569

Stacked on top of #5104. I'll merge that one Monday, but this is ready for review.

This PR does two things:

1. Adds the EventSpeakers component — the speakers card for the redesigned CRN event detail page (header + metrics + per-team accordion table + External Users row + role/past-aware empty states).
2. Extracts the chrome shared with Attendance (#5104) into reusable modules, so both cards stay in sync instead of drifting:
  - shared-event-card-styles.ts — card/header/table-cell styling
  - shared-event-card.tsx — teamIcon, EventTeamType, defaultVisibleTeams
  - shared-metric-card-styles.ts — metric shell styling
  - Attendance (#5104) was migrated onto these in the same PR.
  
Design decision — preliminary-findings chart as a conic gradient

The designer's spec for the "Preliminary findings" wheel/bar is a multi-stop brand gradient (purple → blue → teal → green) that fills along the arc, not a solid colour.

You can test on storybook under Events > Speakers > Playground
