### PR TITLE
ASAP-1608 Add disableImpactAndCategory to AvailableActions

### DIFF
--- a/apps/storybook/src/ResearchOutputForm.stories.tsx
+++ b/apps/storybook/src/ResearchOutputForm.stories.tsx
@@ -18,7 +18,11 @@ export default {
 const researchOutputFormProps: ComponentProps<typeof ResearchOutputForm> = {
   displayChangelog: false,
   flowId: 'team-create-manual',
-  availableActions: { canSaveDraft: true, showImpactAndCategory: true },
+  availableActions: {
+    disableImpactAndCategory: false,
+    canSaveDraft: true,
+    showImpactAndCategory: true,
+  },
   permissions: {
     canEditResearchOutput: true,
     canPublishResearchOutput: true,

--- a/packages/model/src/research-output.ts
+++ b/packages/model/src/research-output.ts
@@ -614,6 +614,9 @@ export const FLOW_DEFINITIONS = {
   },
 } as const satisfies Record<ResearchOutputFlowId, ResearchOutputFlowDescriptor>;
 
+const isAddVersionFlow = (flow: ResearchOutputFlowDescriptor): boolean =>
+  flow.action === 'add-version';
+
 const supportsDrafts = (flow: ResearchOutputFlowDescriptor): boolean =>
   flow.origin !== 'manuscript' &&
   flow.action !== 'add-version' &&
@@ -634,6 +637,7 @@ const publishesOnSave = (flow: ResearchOutputFlowDescriptor): boolean =>
   !flow.startsPublished || flow.action === 'add-version';
 
 export type ResearchOutputFlowBehavior = {
+  isAddVersionFlow: boolean;
   supportsDrafts: boolean;
   requiresAddVersionConfirm: boolean;
   requiresPublishConfirm: boolean;
@@ -646,6 +650,7 @@ export const getResearchOutputFlowBehavior = (
 ): ResearchOutputFlowBehavior => {
   const flow = FLOW_DEFINITIONS[flowId];
   return {
+    isAddVersionFlow: isAddVersionFlow(flow),
     supportsDrafts: supportsDrafts(flow),
     requiresAddVersionConfirm: requiresAddVersionConfirm(flow),
     requiresPublishConfirm: requiresPublishConfirm(flow),

--- a/packages/model/test/research-output.test.ts
+++ b/packages/model/test/research-output.test.ts
@@ -100,23 +100,24 @@ describe('convertDecisionToBoolean', () => {
 
 describe('getResearchOutputFlowBehavior', () => {
   test.each`
-    flowId                                    | supportsDrafts | requiresAddVersionConfirm | requiresPublishConfirm | requiresSameDescriptionConfirm | publishesOnSave
-    ${'team-create-manual'}                   | ${true}        | ${false}                  | ${true}                | ${false}                       | ${true}
-    ${'team-create-imported-from-manuscript'} | ${false}       | ${false}                  | ${true}                | ${false}                       | ${true}
-    ${'team-edit-draft'}                      | ${true}        | ${false}                  | ${true}                | ${false}                       | ${true}
-    ${'team-edit-published'}                  | ${false}       | ${false}                  | ${false}               | ${false}                       | ${false}
-    ${'team-add-version'}                     | ${false}       | ${true}                   | ${false}               | ${false}                       | ${true}
-    ${'team-add-version-from-manuscript'}     | ${false}       | ${true}                   | ${false}               | ${false}                       | ${true}
-    ${'team-duplicate'}                       | ${true}        | ${false}                  | ${true}                | ${true}                        | ${true}
-    ${'working-group-create'}                 | ${true}        | ${false}                  | ${true}                | ${false}                       | ${true}
-    ${'working-group-edit-draft'}             | ${true}        | ${false}                  | ${true}                | ${false}                       | ${true}
-    ${'working-group-edit-published'}         | ${false}       | ${false}                  | ${false}               | ${false}                       | ${false}
-    ${'working-group-add-version'}            | ${false}       | ${true}                   | ${false}               | ${false}                       | ${true}
-    ${'working-group-duplicate'}              | ${true}        | ${false}                  | ${true}                | ${true}                        | ${true}
+    flowId                                    | isAddVersionFlow | supportsDrafts | requiresAddVersionConfirm | requiresPublishConfirm | requiresSameDescriptionConfirm | publishesOnSave
+    ${'team-create-manual'}                   | ${false}         | ${true}        | ${false}                  | ${true}                | ${false}                       | ${true}
+    ${'team-create-imported-from-manuscript'} | ${false}         | ${false}       | ${false}                  | ${true}                | ${false}                       | ${true}
+    ${'team-edit-draft'}                      | ${false}         | ${true}        | ${false}                  | ${true}                | ${false}                       | ${true}
+    ${'team-edit-published'}                  | ${false}         | ${false}       | ${false}                  | ${false}               | ${false}                       | ${false}
+    ${'team-add-version'}                     | ${true}          | ${false}       | ${true}                   | ${false}               | ${false}                       | ${true}
+    ${'team-add-version-from-manuscript'}     | ${true}          | ${false}       | ${true}                   | ${false}               | ${false}                       | ${true}
+    ${'team-duplicate'}                       | ${false}         | ${true}        | ${false}                  | ${true}                | ${true}                        | ${true}
+    ${'working-group-create'}                 | ${false}         | ${true}        | ${false}                  | ${true}                | ${false}                       | ${true}
+    ${'working-group-edit-draft'}             | ${false}         | ${true}        | ${false}                  | ${true}                | ${false}                       | ${true}
+    ${'working-group-edit-published'}         | ${false}         | ${false}       | ${false}                  | ${false}               | ${false}                       | ${false}
+    ${'working-group-add-version'}            | ${true}          | ${false}       | ${true}                   | ${false}               | ${false}                       | ${true}
+    ${'working-group-duplicate'}              | ${false}         | ${true}        | ${false}                  | ${true}                | ${true}                        | ${true}
   `(
-    '$flowId supports drafts: $supportsDrafts, requires add version confirm: $requiresAddVersionConfirm, requires publish confirm: $requiresPublishConfirm, requires same description confirm: $requiresSameDescriptionConfirm, publishes on save: $publishesOnSave',
+    '$flowId is add version flow: $isAddVersionFlow, supports drafts: $supportsDrafts, requires add version confirm: $requiresAddVersionConfirm, requires publish confirm: $requiresPublishConfirm, requires same description confirm: $requiresSameDescriptionConfirm, publishes on save: $publishesOnSave',
     ({
       flowId,
+      isAddVersionFlow,
       supportsDrafts,
       requiresAddVersionConfirm,
       requiresPublishConfirm,
@@ -124,6 +125,7 @@ describe('getResearchOutputFlowBehavior', () => {
       publishesOnSave,
     }) => {
       expect(getResearchOutputFlowBehavior(flowId)).toEqual({
+        isAddVersionFlow,
         supportsDrafts,
         requiresAddVersionConfirm,
         requiresPublishConfirm,

--- a/packages/react-components/src/organisms/ResearchOutputFormSharingCard.tsx
+++ b/packages/react-components/src/organisms/ResearchOutputFormSharingCard.tsx
@@ -33,9 +33,11 @@ type ResearchOutputFormSharingCardProps = Pick<
   | 'changelog'
   | 'subtype'
 > &
-  Pick<ResearchOutputAvailableActions, 'showImpactAndCategory'> & {
+  Pick<
+    ResearchOutputAvailableActions,
+    'showImpactAndCategory' | 'disableImpactAndCategory'
+  > & {
     isFormSubmitted: boolean;
-    isCreatingNewVersion: boolean;
     getImpactSuggestions: (
       searchQuery: string,
     ) => Promise<{ label: string; value: string }[]>;
@@ -52,14 +54,14 @@ type ResearchOutputFormSharingCardProps = Pick<
     >;
     displayChangelog?: boolean;
     type?: ResearchOutputType | '';
-    onChangeLink?: (newValue: string) => void;
-    onChangeTitle?: (newValue: string) => void;
-    onChangeDescription?: (newValue: string) => void;
-    onChangeShortDescription?: (newValue: string) => void;
-    onChangeLayImpactStatement?: (newValue: string) => void;
-    onChangeChangelog?: (newValue: string) => void;
-    onChangeType?: (newValue: ResearchOutputType | '') => void;
-    onChangeSubtype?: (newValue: string | '') => void;
+    onChangeLink: (newValue: string) => void;
+    onChangeTitle: (newValue: string) => void;
+    onChangeDescription: (newValue: string) => void;
+    onChangeShortDescription: (newValue: string) => void;
+    onChangeLayImpactStatement: (newValue: string) => void;
+    onChangeChangelog: (newValue: string) => void;
+    onChangeType: (newValue: ResearchOutputType | '') => void;
+    onChangeSubtype: (newValue: string | '') => void;
     isSaving: boolean;
     researchTags: ResearchTagResponse[];
     serverValidationErrors?: ValidationErrorResponse['data'];
@@ -77,7 +79,7 @@ const ResearchOutputFormSharingCard: React.FC<
 > = ({
   showImpactAndCategory,
   isFormSubmitted,
-  isCreatingNewVersion,
+  disableImpactAndCategory,
   getImpactSuggestions,
   impact,
   layImpactStatement,
@@ -101,14 +103,14 @@ const ResearchOutputFormSharingCard: React.FC<
   urlRequired,
   getShortDescriptionFromDescription,
   clearServerValidationError = noop,
-  onChangeDescription = noop,
-  onChangeShortDescription = noop,
-  onChangeChangelog = noop,
-  onChangeLink = noop,
-  onChangeTitle = noop,
-  onChangeType = noop,
-  onChangeSubtype = noop,
-  onChangeLayImpactStatement = noop,
+  onChangeDescription,
+  onChangeShortDescription,
+  onChangeChangelog,
+  onChangeLink,
+  onChangeTitle,
+  onChangeType,
+  onChangeSubtype,
+  onChangeLayImpactStatement,
 }) => {
   const [urlValidationMessage, setUrlValidationMessage] = useState<string>();
   const [titleValidationMessage, setTitleValidationMessage] =
@@ -338,7 +340,7 @@ const ResearchOutputFormSharingCard: React.FC<
             title="Category"
             description="Select up to two options that best describe the scientific category of this manuscript."
             subtitle="(required)"
-            enabled={!isSaving && !isCreatingNewVersion}
+            enabled={!isSaving && !disableImpactAndCategory}
             placeholder="Start typing..."
             loadOptions={getCategorySuggestions}
             onChange={(newValues) => {
@@ -373,7 +375,7 @@ const ResearchOutputFormSharingCard: React.FC<
             onBlur={validateImpact}
             customValidationMessage={impactValidationMessage}
             value={impact?.value ?? ''}
-            enabled={!isSaving && !isCreatingNewVersion}
+            enabled={!isSaving && !disableImpactAndCategory}
             noOptionsMessage={(option) =>
               `Sorry, no impacts match ${option.inputValue}`
             }

--- a/packages/react-components/src/organisms/__tests__/ResearchOutputFormSharingCard.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/ResearchOutputFormSharingCard.test.tsx
@@ -8,9 +8,9 @@ import { mockActErrorsInConsole } from '../../test-utils';
 import ResearchOutputFormSharingCard from '../ResearchOutputFormSharingCard';
 
 const defaultProps: ComponentProps<typeof ResearchOutputFormSharingCard> = {
+  disableImpactAndCategory: false,
   showImpactAndCategory: false,
   isFormSubmitted: false,
-  isCreatingNewVersion: false,
   isSaving: false,
   link: '',
   title: '',
@@ -30,6 +30,7 @@ const defaultProps: ComponentProps<typeof ResearchOutputFormSharingCard> = {
   onChangeChangelog: jest.fn(),
   onChangeType: jest.fn(),
   onChangeSubtype: jest.fn(),
+  onChangeLayImpactStatement: jest.fn(),
   getImpactSuggestions: jest.fn().mockResolvedValue([]),
   impact: undefined,
   onChangeImpact: jest.fn(),
@@ -396,6 +397,24 @@ describe('impact and category', () => {
     expect(onChangeCategories).toHaveBeenCalled();
   });
 
+  it('shows validation message when no category is selected', async () => {
+    render(
+      <ResearchOutputFormSharingCard
+        {...defaultProps}
+        showImpactAndCategory={true}
+        categories={[]}
+      />,
+    );
+
+    const categoryInput = screen.getByRole('combobox', { name: /category/i });
+    await userEvent.click(categoryInput);
+    await userEvent.tab();
+
+    expect(
+      await screen.findByText('Please add at least one category.'),
+    ).toBeVisible();
+  });
+
   it('shows validation message when more than two categories are selected', async () => {
     const getCategorySuggestions = jest
       .fn()
@@ -454,17 +473,17 @@ describe('impact and category', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('disables impact and category fields when isCreatingNewVersion is true', () => {
+  it('disables impact and category fields when disableImpactAndCategory is true', () => {
     const loadOptions = jest.fn();
     loadOptions.mockResolvedValue([]);
 
     const { rerender } = render(
       <ResearchOutputFormSharingCard
         {...defaultProps}
+        disableImpactAndCategory={true}
         showImpactAndCategory={true}
         getImpactSuggestions={loadOptions}
         getCategorySuggestions={loadOptions}
-        isCreatingNewVersion={true}
       />,
     );
     expect(screen.getByLabelText(/impact\(required\)/i)).toBeDisabled();
@@ -473,11 +492,11 @@ describe('impact and category', () => {
     rerender(
       <ResearchOutputFormSharingCard
         {...defaultProps}
+        disableImpactAndCategory={false}
         showImpactAndCategory={true}
         getImpactSuggestions={loadOptions}
         getCategorySuggestions={loadOptions}
         isSaving={false}
-        isCreatingNewVersion={false}
       />,
     );
     expect(screen.getByLabelText(/impact\(required\)/i)).toBeEnabled();

--- a/packages/react-components/src/templates/ResearchOutputForm.tsx
+++ b/packages/react-components/src/templates/ResearchOutputForm.tsx
@@ -518,9 +518,11 @@ const ResearchOutputForm: React.FC<ResearchOutputFormProps> = ({
               )}
               <div css={contentStyles} data-flow-id={flowId}>
                 <ResearchOutputFormSharingCard
+                  disableImpactAndCategory={
+                    availableActions.disableImpactAndCategory
+                  }
                   showImpactAndCategory={availableActions.showImpactAndCategory}
                   isFormSubmitted={isFormSubmitted}
-                  isCreatingNewVersion={versionAction === 'create'}
                   displayChangelog={displayChangelog}
                   serverValidationErrors={serverValidationErrors}
                   clearServerValidationError={clearServerValidationError}

--- a/packages/react-components/src/templates/__tests__/ResearchOutputForm/ImpactAndCategory.test.tsx
+++ b/packages/react-components/src/templates/__tests__/ResearchOutputForm/ImpactAndCategory.test.tsx
@@ -82,3 +82,37 @@ it('renders category input and does not throw when getCategorySuggestions is noo
     screen.queryByText(/no category options match/i),
   ).not.toBeInTheDocument();
 });
+
+it('should disable impact and category when available action disableImpactAndCategory is true', () => {
+  const { rerender } = render(
+    <MemoryRouter>
+      <ResearchOutputForm
+        {...researchOutputFormProps}
+        availableActions={{
+          ...researchOutputFormProps.availableActions,
+          showImpactAndCategory: true,
+          disableImpactAndCategory: true,
+        }}
+      />
+    </MemoryRouter>,
+  );
+
+  expect(screen.getByLabelText(/impact\(required\)/i)).toBeDisabled();
+  expect(screen.getByLabelText(/category/i)).toBeDisabled();
+
+  rerender(
+    <MemoryRouter>
+      <ResearchOutputForm
+        {...researchOutputFormProps}
+        availableActions={{
+          ...researchOutputFormProps.availableActions,
+          showImpactAndCategory: true,
+          disableImpactAndCategory: false,
+        }}
+      />
+    </MemoryRouter>,
+  );
+
+  expect(screen.getByLabelText(/impact\(required\)/i)).toBeEnabled();
+  expect(screen.getByLabelText(/category/i)).toBeEnabled();
+});

--- a/packages/react-components/src/templates/test-utils/research-output-form.tsx
+++ b/packages/react-components/src/templates/test-utils/research-output-form.tsx
@@ -34,6 +34,7 @@ const LocationCapture = () => {
 };
 
 export const defaultAvailableActions: ResearchOutputAvailableActions = {
+  disableImpactAndCategory: false,
   canSaveDraft: true,
   showImpactAndCategory: false,
 };

--- a/packages/react-context/src/__tests__/permissions/research-output.test.tsx
+++ b/packages/react-context/src/__tests__/permissions/research-output.test.tsx
@@ -589,6 +589,32 @@ describe('getVisibleResearchOutputActions', () => {
 });
 
 describe('resolveResearchOutputAvailableActions', () => {
+  it('resolves disableImpactAndCategory action correctly', () => {
+    expect(
+      resolveResearchOutputAvailableActions({
+        flowId: 'team-create-manual',
+        permissions: { canShareResearchOutput: true },
+        documentType: 'Bioinformatics',
+      }),
+    ).toEqual(
+      expect.objectContaining({
+        disableImpactAndCategory: false,
+      }),
+    );
+
+    expect(
+      resolveResearchOutputAvailableActions({
+        flowId: 'team-add-version',
+        permissions: { canShareResearchOutput: true },
+        documentType: 'Bioinformatics',
+      }),
+    ).toEqual(
+      expect.objectContaining({
+        disableImpactAndCategory: true,
+      }),
+    );
+  });
+
   it('resolves saveDraft action correctly', () => {
     expect(
       resolveResearchOutputAvailableActions({

--- a/packages/react-context/src/permissions/research-output.ts
+++ b/packages/react-context/src/permissions/research-output.ts
@@ -38,6 +38,7 @@ export type ResearchOutputDetailActionAvailability = {
 };
 
 export type ResearchOutputAvailableActions = {
+  disableImpactAndCategory: boolean;
   canSaveDraft: boolean;
   showImpactAndCategory: boolean;
 };
@@ -51,9 +52,11 @@ export const resolveResearchOutputAvailableActions = ({
   permissions: ResearchOutputPermissions;
   documentType: ResearchOutputDocumentType;
 }): ResearchOutputAvailableActions => {
-  const { supportsDrafts } = getResearchOutputFlowBehavior(flowId);
+  const behavior = getResearchOutputFlowBehavior(flowId);
   return {
-    canSaveDraft: supportsDrafts && !!permissions.canShareResearchOutput,
+    disableImpactAndCategory: behavior.isAddVersionFlow,
+    canSaveDraft:
+      behavior.supportsDrafts && !!permissions.canShareResearchOutput,
     showImpactAndCategory: documentType === 'Article',
   };
 };


### PR DESCRIPTION
This PR adds disableImpactAndCategory to AvailableActions following #5123 also with the goal of centralizing the conditions that are currently spread across child components.

