### PR TITLE
ASAP-1609 Add showChangelogAndVersionHistory to AvailableActions

### DIFF
--- a/apps/crn-frontend/src/network/teams/TeamOutput.tsx
+++ b/apps/crn-frontend/src/network/teams/TeamOutput.tsx
@@ -191,11 +191,6 @@ const TeamOutput: React.FC<TeamOutputProps> = ({
     // import into an add-version flow.
     hasResearchOutputId: !!(updatedOutput?.id || researchOutputData?.id),
   });
-  const availableActions = resolveResearchOutputAvailableActions({
-    flowId,
-    permissions,
-    documentType,
-  });
 
   const researchSuggestions = researchTags
     .filter((tag) => tag.category === 'Keyword')
@@ -231,6 +226,13 @@ const TeamOutput: React.FC<TeamOutputProps> = ({
     ]);
   }
 
+  const availableActions = resolveResearchOutputAvailableActions({
+    flowId,
+    permissions,
+    documentType,
+    researchOutputData: updatedOutput,
+    versions,
+  });
   const [showManuscriptOutputFlow, setShowManuscriptOutputFlow] = useState(
     !isManuscriptVersion &&
       !isDuplicate &&
@@ -353,7 +355,7 @@ const TeamOutput: React.FC<TeamOutputProps> = ({
               documentType={documentType}
               workingGroupAssociation={false}
             />
-            {versionAction && versions.length > 0 && (
+            {availableActions.showChangelogAndVersionHistory && (
               <OutputVersions
                 app="crn"
                 versions={versions}
@@ -367,10 +369,6 @@ const TeamOutput: React.FC<TeamOutputProps> = ({
                 />
               )}
             <ResearchOutputForm
-              displayChangelog={Boolean(
-                versionAction === 'create' ||
-                  (updatedOutput?.versions || []).length > 0,
-              )}
               versionAction={versionAction}
               tagSuggestions={researchSuggestions}
               documentType={documentType}

--- a/apps/crn-frontend/src/network/teams/__tests__/TeamOutput.test.tsx
+++ b/apps/crn-frontend/src/network/teams/__tests__/TeamOutput.test.tsx
@@ -877,6 +877,44 @@ it('hides changelog input when editing a research output with no version history
   ).not.toBeInTheDocument();
 });
 
+it('displays the version history when editing a versioned research output', async () => {
+  await renderPage({
+    teamId: '42',
+    outputDocumentType: 'article',
+    researchOutputData: {
+      ...baseResearchOutput,
+      versions: [
+        {
+          documentType: 'Article',
+          title: 'Previous version',
+          id: '1',
+        },
+      ],
+    },
+    versionAction: 'edit',
+  });
+
+  expect(
+    screen.getByRole('heading', { name: /version history/i }),
+  ).toBeVisible();
+});
+
+it('hides the version history when editing a research output with no versions', async () => {
+  await renderPage({
+    teamId: '42',
+    outputDocumentType: 'article',
+    researchOutputData: {
+      ...baseResearchOutput,
+      versions: [],
+    },
+    versionAction: 'edit',
+  });
+
+  expect(
+    screen.queryByRole('heading', { name: /version history/i }),
+  ).not.toBeInTheDocument();
+});
+
 describe('manuscript outputs flow', () => {
   const manuscriptImportLabelText = 'Import from compliance';
 

--- a/apps/crn-frontend/src/network/working-groups/WorkingGroupOutput.tsx
+++ b/apps/crn-frontend/src/network/working-groups/WorkingGroupOutput.tsx
@@ -108,11 +108,6 @@ const WorkingGroupOutput: React.FC<WorkingGroupOutputProps> = ({
     hasResearchOutputId: !!researchOutputData?.id,
     isDuplicate,
   });
-  const availableActions = resolveResearchOutputAvailableActions({
-    flowId,
-    permissions,
-    documentType,
-  });
 
   const researchSuggestions = researchTags
     .filter((tag) => tag.category === 'Keyword')
@@ -136,6 +131,14 @@ const WorkingGroupOutput: React.FC<WorkingGroupOutputProps> = ({
     versions = researchOutputData?.versions ?? [];
   }
 
+  const availableActions = resolveResearchOutputAvailableActions({
+    flowId,
+    permissions,
+    documentType,
+    researchOutputData,
+    versions,
+  });
+
   if (workingGroup) {
     return (
       <Frame title="Share Working Group Research Output">
@@ -151,7 +154,7 @@ const WorkingGroupOutput: React.FC<WorkingGroupOutputProps> = ({
             documentType={documentType}
             workingGroupAssociation
           />
-          {versionAction && versions.length > 0 && (
+          {availableActions.showChangelogAndVersionHistory && (
             <OutputVersions
               app="crn"
               versions={versions}
@@ -159,9 +162,6 @@ const WorkingGroupOutput: React.FC<WorkingGroupOutputProps> = ({
             />
           )}
           <ResearchOutputForm
-            displayChangelog={Boolean(
-              versionAction === 'create' || versions.length > 0,
-            )}
             versionAction={versionAction}
             tagSuggestions={researchSuggestions}
             documentType={documentType}

--- a/apps/crn-frontend/src/projects/ProjectOutput.tsx
+++ b/apps/crn-frontend/src/projects/ProjectOutput.tsx
@@ -188,11 +188,6 @@ const ProjectOutput: React.FC<ProjectOutputProps> = ({
     // auto-created preprint that turns the import flow into add-version
     hasResearchOutputId: !!(updatedOutput?.id || researchOutputData?.id),
   });
-  const availableActions = resolveResearchOutputAvailableActions({
-    flowId,
-    permissions,
-    documentType,
-  });
 
   const getShortDescriptionFromDescription = useGeneratedContent();
   const researchSuggestions = researchTags
@@ -228,6 +223,14 @@ const ProjectOutput: React.FC<ProjectOutputProps> = ({
       },
     ]);
   }
+
+  const availableActions = resolveResearchOutputAvailableActions({
+    flowId,
+    permissions,
+    documentType,
+    researchOutputData: updatedOutput,
+    versions,
+  });
 
   const [showManuscriptOutputFlow, setShowManuscriptOutputFlow] = useState(
     !isManuscriptVersion &&
@@ -351,7 +354,7 @@ const ProjectOutput: React.FC<ProjectOutputProps> = ({
               documentType={documentType}
               workingGroupAssociation={false}
             />
-            {versionAction && versions.length > 0 && (
+            {availableActions.showChangelogAndVersionHistory && (
               <OutputVersions
                 app="crn"
                 versions={versions}
@@ -365,10 +368,6 @@ const ProjectOutput: React.FC<ProjectOutputProps> = ({
                 />
               )}
             <ResearchOutputForm
-              displayChangelog={Boolean(
-                versionAction === 'create' ||
-                  (updatedOutput?.versions || []).length > 0,
-              )}
               versionAction={versionAction}
               tagSuggestions={researchSuggestions}
               documentType={documentType}

--- a/apps/storybook/src/ResearchOutputForm.stories.tsx
+++ b/apps/storybook/src/ResearchOutputForm.stories.tsx
@@ -16,12 +16,12 @@ export default {
 };
 
 const researchOutputFormProps: ComponentProps<typeof ResearchOutputForm> = {
-  displayChangelog: false,
   flowId: 'team-create-manual',
   availableActions: {
     disableImpactAndCategory: false,
     canSaveDraft: true,
     showImpactAndCategory: true,
+    showChangelogAndVersionHistory: false,
   },
   permissions: {
     canEditResearchOutput: true,

--- a/packages/model/src/research-output.ts
+++ b/packages/model/src/research-output.ts
@@ -617,6 +617,9 @@ export const FLOW_DEFINITIONS = {
 const isAddVersionFlow = (flow: ResearchOutputFlowDescriptor): boolean =>
   flow.action === 'add-version';
 
+const isEditFlow = (flow: ResearchOutputFlowDescriptor): boolean =>
+  flow.action === 'edit';
+
 const supportsDrafts = (flow: ResearchOutputFlowDescriptor): boolean =>
   flow.origin !== 'manuscript' &&
   flow.action !== 'add-version' &&
@@ -638,6 +641,7 @@ const publishesOnSave = (flow: ResearchOutputFlowDescriptor): boolean =>
 
 export type ResearchOutputFlowBehavior = {
   isAddVersionFlow: boolean;
+  isEditFlow: boolean;
   supportsDrafts: boolean;
   requiresAddVersionConfirm: boolean;
   requiresPublishConfirm: boolean;
@@ -651,6 +655,7 @@ export const getResearchOutputFlowBehavior = (
   const flow = FLOW_DEFINITIONS[flowId];
   return {
     isAddVersionFlow: isAddVersionFlow(flow),
+    isEditFlow: isEditFlow(flow),
     supportsDrafts: supportsDrafts(flow),
     requiresAddVersionConfirm: requiresAddVersionConfirm(flow),
     requiresPublishConfirm: requiresPublishConfirm(flow),

--- a/packages/model/test/research-output.test.ts
+++ b/packages/model/test/research-output.test.ts
@@ -100,24 +100,25 @@ describe('convertDecisionToBoolean', () => {
 
 describe('getResearchOutputFlowBehavior', () => {
   test.each`
-    flowId                                    | isAddVersionFlow | supportsDrafts | requiresAddVersionConfirm | requiresPublishConfirm | requiresSameDescriptionConfirm | publishesOnSave
-    ${'team-create-manual'}                   | ${false}         | ${true}        | ${false}                  | ${true}                | ${false}                       | ${true}
-    ${'team-create-imported-from-manuscript'} | ${false}         | ${false}       | ${false}                  | ${true}                | ${false}                       | ${true}
-    ${'team-edit-draft'}                      | ${false}         | ${true}        | ${false}                  | ${true}                | ${false}                       | ${true}
-    ${'team-edit-published'}                  | ${false}         | ${false}       | ${false}                  | ${false}               | ${false}                       | ${false}
-    ${'team-add-version'}                     | ${true}          | ${false}       | ${true}                   | ${false}               | ${false}                       | ${true}
-    ${'team-add-version-from-manuscript'}     | ${true}          | ${false}       | ${true}                   | ${false}               | ${false}                       | ${true}
-    ${'team-duplicate'}                       | ${false}         | ${true}        | ${false}                  | ${true}                | ${true}                        | ${true}
-    ${'working-group-create'}                 | ${false}         | ${true}        | ${false}                  | ${true}                | ${false}                       | ${true}
-    ${'working-group-edit-draft'}             | ${false}         | ${true}        | ${false}                  | ${true}                | ${false}                       | ${true}
-    ${'working-group-edit-published'}         | ${false}         | ${false}       | ${false}                  | ${false}               | ${false}                       | ${false}
-    ${'working-group-add-version'}            | ${true}          | ${false}       | ${true}                   | ${false}               | ${false}                       | ${true}
-    ${'working-group-duplicate'}              | ${false}         | ${true}        | ${false}                  | ${true}                | ${true}                        | ${true}
+    flowId                                    | isAddVersionFlow | isEditFlow | supportsDrafts | requiresAddVersionConfirm | requiresPublishConfirm | requiresSameDescriptionConfirm | publishesOnSave
+    ${'team-create-manual'}                   | ${false}         | ${false}   | ${true}        | ${false}                  | ${true}                | ${false}                       | ${true}
+    ${'team-create-imported-from-manuscript'} | ${false}         | ${false}   | ${false}       | ${false}                  | ${true}                | ${false}                       | ${true}
+    ${'team-edit-draft'}                      | ${false}         | ${true}    | ${true}        | ${false}                  | ${true}                | ${false}                       | ${true}
+    ${'team-edit-published'}                  | ${false}         | ${true}    | ${false}       | ${false}                  | ${false}               | ${false}                       | ${false}
+    ${'team-add-version'}                     | ${true}          | ${false}   | ${false}       | ${true}                   | ${false}               | ${false}                       | ${true}
+    ${'team-add-version-from-manuscript'}     | ${true}          | ${false}   | ${false}       | ${true}                   | ${false}               | ${false}                       | ${true}
+    ${'team-duplicate'}                       | ${false}         | ${false}   | ${true}        | ${false}                  | ${true}                | ${true}                        | ${true}
+    ${'working-group-create'}                 | ${false}         | ${false}   | ${true}        | ${false}                  | ${true}                | ${false}                       | ${true}
+    ${'working-group-edit-draft'}             | ${false}         | ${true}    | ${true}        | ${false}                  | ${true}                | ${false}                       | ${true}
+    ${'working-group-edit-published'}         | ${false}         | ${true}    | ${false}       | ${false}                  | ${false}               | ${false}                       | ${false}
+    ${'working-group-add-version'}            | ${true}          | ${false}   | ${false}       | ${true}                   | ${false}               | ${false}                       | ${true}
+    ${'working-group-duplicate'}              | ${false}         | ${false}   | ${true}        | ${false}                  | ${true}                | ${true}                        | ${true}
   `(
-    '$flowId is add version flow: $isAddVersionFlow, supports drafts: $supportsDrafts, requires add version confirm: $requiresAddVersionConfirm, requires publish confirm: $requiresPublishConfirm, requires same description confirm: $requiresSameDescriptionConfirm, publishes on save: $publishesOnSave',
+    '$flowId is add version flow: $isAddVersionFlow, is edit flow: $isEditFlow, supports drafts: $supportsDrafts, requires add version confirm: $requiresAddVersionConfirm, requires publish confirm: $requiresPublishConfirm, requires same description confirm: $requiresSameDescriptionConfirm, publishes on save: $publishesOnSave',
     ({
       flowId,
       isAddVersionFlow,
+      isEditFlow,
       supportsDrafts,
       requiresAddVersionConfirm,
       requiresPublishConfirm,
@@ -126,6 +127,7 @@ describe('getResearchOutputFlowBehavior', () => {
     }) => {
       expect(getResearchOutputFlowBehavior(flowId)).toEqual({
         isAddVersionFlow,
+        isEditFlow,
         supportsDrafts,
         requiresAddVersionConfirm,
         requiresPublishConfirm,

--- a/packages/react-components/src/organisms/ResearchOutputFormSharingCard.tsx
+++ b/packages/react-components/src/organisms/ResearchOutputFormSharingCard.tsx
@@ -338,7 +338,7 @@ const ResearchOutputFormSharingCard: React.FC<
                 : 'You can select up to two categories only.'
             }
             title="Category"
-            description="Select up to two options that best describe the scientific category of this manuscript."
+            description="Select up to two options that best describe the scientific category of this output."
             subtitle="(required)"
             enabled={!isSaving && !disableImpactAndCategory}
             placeholder="Start typing..."
@@ -361,7 +361,7 @@ const ResearchOutputFormSharingCard: React.FC<
             getValidationMessage={() => 'Please choose an impact.'}
             title="Impact"
             subtitle="(required)"
-            description="Select the option that best describes the impact of this manuscript on the PD field."
+            description="Select the option that best describes the impact of this output on the PD field."
             options={impactOptions}
             onChange={(e) => {
               const impactOption = impactOptions.find(
@@ -407,7 +407,7 @@ const ResearchOutputFormSharingCard: React.FC<
         <LabeledTextArea
           title="Changelog"
           subtitle="(required)"
-          tip="Briefly explain what’s new or changed in this version in comparison to the prior version of the manuscript."
+          tip="Briefly explain what’s new or changed in this version in comparison to the prior version of the output."
           customValidationMessage={changelogValidationMessage}
           value={changelog ?? ''}
           onChange={(changelogNewValue) => {

--- a/packages/react-components/src/organisms/__tests__/ResearchOutputFormSharingCard.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/ResearchOutputFormSharingCard.test.tsx
@@ -281,6 +281,8 @@ describe('Changelog validation', () => {
     fireEvent.change(changelogInput, { target: { value: '  ' } });
     fireEvent.blur(changelogInput);
 
+    expect(screen.queryByText(/manuscript/i)).not.toBeInTheDocument();
+
     expect(screen.getByText('Please enter a changelog')).toBeInTheDocument();
   });
 
@@ -336,6 +338,8 @@ describe('impact and category', () => {
 
     const categoryInput = screen.getByRole('combobox', { name: /category/i });
     expect(categoryInput).toBeInTheDocument();
+
+    expect(screen.queryByText(/manuscript/i)).not.toBeInTheDocument();
 
     fireEvent.change(categoryInput, { target: { value: 'Category' } });
 

--- a/packages/react-components/src/templates/ResearchOutputForm.tsx
+++ b/packages/react-components/src/templates/ResearchOutputForm.tsx
@@ -68,7 +68,6 @@ type ResearchOutputFormProps = Pick<
     | 'getTeamSuggestions'
     | 'authorsRequired'
   > & {
-    displayChangelog: boolean;
     versionAction?: 'create' | 'edit';
     onSave: (
       output: ResearchOutputPostRequest,
@@ -114,7 +113,6 @@ const contentStyles = css({
 });
 
 const ResearchOutputForm: React.FC<ResearchOutputFormProps> = ({
-  displayChangelog,
   documentType,
   researchOutputData,
   onSave,
@@ -523,7 +521,9 @@ const ResearchOutputForm: React.FC<ResearchOutputFormProps> = ({
                   }
                   showImpactAndCategory={availableActions.showImpactAndCategory}
                   isFormSubmitted={isFormSubmitted}
-                  displayChangelog={displayChangelog}
+                  displayChangelog={
+                    availableActions.showChangelogAndVersionHistory
+                  }
                   serverValidationErrors={serverValidationErrors}
                   clearServerValidationError={clearServerValidationError}
                   isSaving={isSaving}

--- a/packages/react-components/src/templates/__tests__/ResearchOutputForm/ChangelogAndVersionHistory.test.tsx
+++ b/packages/react-components/src/templates/__tests__/ResearchOutputForm/ChangelogAndVersionHistory.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+
+import ResearchOutputForm from '../../ResearchOutputForm';
+import { getDefaultProps } from '../../test-utils/research-output-form';
+
+let researchOutputFormProps: ReturnType<typeof getDefaultProps>;
+
+beforeEach(() => {
+  jest.spyOn(console, 'error').mockImplementation();
+  researchOutputFormProps = getDefaultProps();
+});
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
+it('displays changelog when availableAction showChangelogAndVersionHistory is true', () => {
+  render(
+    <MemoryRouter>
+      <ResearchOutputForm
+        {...researchOutputFormProps}
+        availableActions={{
+          ...researchOutputFormProps.availableActions,
+          showChangelogAndVersionHistory: true,
+        }}
+      />
+    </MemoryRouter>,
+  );
+
+  expect(screen.getByRole('textbox', { name: /changelog/i })).toBeVisible();
+});
+
+it('hides changelog when availableAction showChangelogAndVersionHistory is false', () => {
+  render(
+    <MemoryRouter>
+      <ResearchOutputForm
+        {...researchOutputFormProps}
+        availableActions={{
+          ...researchOutputFormProps.availableActions,
+          showChangelogAndVersionHistory: false,
+        }}
+      />
+    </MemoryRouter>,
+  );
+
+  expect(
+    screen.queryByRole('textbox', { name: /changelog/i }),
+  ).not.toBeInTheDocument();
+});

--- a/packages/react-components/src/templates/test-utils/research-output-form.tsx
+++ b/packages/react-components/src/templates/test-utils/research-output-form.tsx
@@ -37,12 +37,12 @@ export const defaultAvailableActions: ResearchOutputAvailableActions = {
   disableImpactAndCategory: false,
   canSaveDraft: true,
   showImpactAndCategory: false,
+  showChangelogAndVersionHistory: false,
 };
 
 export const getDefaultProps = (): ComponentProps<
   typeof ResearchOutputForm
 > => ({
-  displayChangelog: false,
   onSave: jest.fn(),
   onSaveDraft: jest.fn(),
   published: false,

--- a/packages/react-context/src/__tests__/permissions/research-output.test.tsx
+++ b/packages/react-context/src/__tests__/permissions/research-output.test.tsx
@@ -1,4 +1,8 @@
-import { researchOutputDocumentTypes } from '@asap-hub/model';
+import {
+  RESEARCH_OUTPUT_FLOW_IDS,
+  researchOutputDocumentTypes,
+  ResearchOutputFlowId,
+} from '@asap-hub/model';
 import { render } from '@testing-library/react';
 
 import {
@@ -662,6 +666,54 @@ describe('resolveResearchOutputAvailableActions', () => {
             showImpactAndCategory: false,
           }),
         );
+      },
+    );
+  });
+
+  describe('showChangelogAndVersionHistory', () => {
+    const version = {
+      id: 'v1',
+      title: 'Previous',
+      documentType: 'Article' as const,
+    };
+
+    // Changelog and version history are visible only on edit/add-version flows
+    // AND when the output already has versions. This truth table locks the
+    // expected outcome for every RESEARCH_OUTPUT_FLOW_IDS when versions exist.
+    const whenVersionedExpectations = {
+      'team-create-manual': false,
+      'team-create-imported-from-manuscript': false,
+      'team-edit-draft': true,
+      'team-edit-published': true,
+      'team-add-version': true,
+      'team-add-version-from-manuscript': true,
+      'team-duplicate': false,
+      'working-group-create': false,
+      'working-group-edit-draft': true,
+      'working-group-edit-published': true,
+      'working-group-add-version': true,
+      'working-group-duplicate': false,
+    } as const satisfies Record<ResearchOutputFlowId, boolean>;
+
+    const resolve = (flowId: ResearchOutputFlowId, hasVersions: boolean) =>
+      resolveResearchOutputAvailableActions({
+        flowId,
+        permissions: { canShareResearchOutput: true },
+        documentType: 'Article',
+        versions: hasVersions ? [version] : [],
+      }).showChangelogAndVersionHistory;
+
+    it.each(Object.entries(whenVersionedExpectations))(
+      'flow %s with versions resolves to %s',
+      (flowId, expected) => {
+        expect(resolve(flowId as ResearchOutputFlowId, true)).toBe(expected);
+      },
+    );
+
+    it.each(Object.values(RESEARCH_OUTPUT_FLOW_IDS))(
+      'is false when flow is %s and there are no versions',
+      (flowId) => {
+        expect(resolve(flowId, false)).toBe(false);
       },
     );
   });

--- a/packages/react-context/src/permissions/research-output.ts
+++ b/packages/react-context/src/permissions/research-output.ts
@@ -2,6 +2,8 @@ import {
   getResearchOutputFlowBehavior,
   ResearchOutputDocumentType,
   ResearchOutputFlowId,
+  ResearchOutputResponse,
+  ResearchOutputVersion,
 } from '@asap-hub/model';
 import { createContext, useContext } from 'react';
 
@@ -41,23 +43,31 @@ export type ResearchOutputAvailableActions = {
   disableImpactAndCategory: boolean;
   canSaveDraft: boolean;
   showImpactAndCategory: boolean;
+  showChangelogAndVersionHistory: boolean;
 };
 
 export const resolveResearchOutputAvailableActions = ({
   flowId,
   permissions,
   documentType,
+  researchOutputData,
+  versions = researchOutputData?.versions ?? [],
 }: {
   flowId: ResearchOutputFlowId;
   permissions: ResearchOutputPermissions;
   documentType: ResearchOutputDocumentType;
+  researchOutputData?: Pick<ResearchOutputResponse, 'versions'>;
+  versions?: readonly ResearchOutputVersion[];
 }): ResearchOutputAvailableActions => {
   const behavior = getResearchOutputFlowBehavior(flowId);
+
   return {
     disableImpactAndCategory: behavior.isAddVersionFlow,
     canSaveDraft:
       behavior.supportsDrafts && !!permissions.canShareResearchOutput,
     showImpactAndCategory: documentType === 'Article',
+    showChangelogAndVersionHistory:
+      (behavior.isAddVersionFlow || behavior.isEditFlow) && versions.length > 0,
   };
 };
 


### PR DESCRIPTION
This PR moves the changelog and version history visibility logic into resolveResearchOutputAvailableActions so it lives in one place instead of being recalculated in each output page.

- Add `showChangelogAndVersionHistory` to ResearchOutputAvailableActions: true on edit/add-version flows when there are versions. This issue mentioned [here](https://yld.slack.com/archives/G01A6J33G8H/p1784727425124949) is fixed.
- Add `isEditFlow` to the flow behavior so the resolver can tell edit from the other flows.
- Pass researchOutputData/versions into the resolver and drop the `displayChangelog` prop from ResearchOutputForm it now reads from availableActions.
- Fix copy on the sharing card to say "output" instead of "manuscript".