### PR TITLE
ASAP-1613 Add disableDateMadePublic to AvailableActions

### DIFF
--- a/apps/storybook/src/ResearchOutputForm.stories.tsx
+++ b/apps/storybook/src/ResearchOutputForm.stories.tsx
@@ -19,6 +19,7 @@ const researchOutputFormProps: ComponentProps<typeof ResearchOutputForm> = {
   flowId: 'team-create-manual',
   availableActions: {
     disableImpactAndCategory: false,
+    disableDateMadePublic: false,
     canSaveDraft: true,
     showImpactAndCategory: true,
     showChangelogAndVersionHistory: false,

--- a/packages/model/src/research-output.ts
+++ b/packages/model/src/research-output.ts
@@ -620,6 +620,10 @@ const isAddVersionFlow = (flow: ResearchOutputFlowDescriptor): boolean =>
 const isEditFlow = (flow: ResearchOutputFlowDescriptor): boolean =>
   flow.action === 'edit';
 
+const isImportedFromManuscript = (
+  flow: ResearchOutputFlowDescriptor,
+): boolean => flow.origin === 'manuscript';
+
 const supportsDrafts = (flow: ResearchOutputFlowDescriptor): boolean =>
   flow.origin !== 'manuscript' &&
   flow.action !== 'add-version' &&
@@ -642,6 +646,7 @@ const publishesOnSave = (flow: ResearchOutputFlowDescriptor): boolean =>
 export type ResearchOutputFlowBehavior = {
   isAddVersionFlow: boolean;
   isEditFlow: boolean;
+  isImportedFromManuscript: boolean;
   supportsDrafts: boolean;
   requiresAddVersionConfirm: boolean;
   requiresPublishConfirm: boolean;
@@ -656,6 +661,7 @@ export const getResearchOutputFlowBehavior = (
   return {
     isAddVersionFlow: isAddVersionFlow(flow),
     isEditFlow: isEditFlow(flow),
+    isImportedFromManuscript: isImportedFromManuscript(flow),
     supportsDrafts: supportsDrafts(flow),
     requiresAddVersionConfirm: requiresAddVersionConfirm(flow),
     requiresPublishConfirm: requiresPublishConfirm(flow),

--- a/packages/model/test/research-output.test.ts
+++ b/packages/model/test/research-output.test.ts
@@ -100,25 +100,26 @@ describe('convertDecisionToBoolean', () => {
 
 describe('getResearchOutputFlowBehavior', () => {
   test.each`
-    flowId                                    | isAddVersionFlow | isEditFlow | supportsDrafts | requiresAddVersionConfirm | requiresPublishConfirm | requiresSameDescriptionConfirm | publishesOnSave
-    ${'team-create-manual'}                   | ${false}         | ${false}   | ${true}        | ${false}                  | ${true}                | ${false}                       | ${true}
-    ${'team-create-imported-from-manuscript'} | ${false}         | ${false}   | ${false}       | ${false}                  | ${true}                | ${false}                       | ${true}
-    ${'team-edit-draft'}                      | ${false}         | ${true}    | ${true}        | ${false}                  | ${true}                | ${false}                       | ${true}
-    ${'team-edit-published'}                  | ${false}         | ${true}    | ${false}       | ${false}                  | ${false}               | ${false}                       | ${false}
-    ${'team-add-version'}                     | ${true}          | ${false}   | ${false}       | ${true}                   | ${false}               | ${false}                       | ${true}
-    ${'team-add-version-from-manuscript'}     | ${true}          | ${false}   | ${false}       | ${true}                   | ${false}               | ${false}                       | ${true}
-    ${'team-duplicate'}                       | ${false}         | ${false}   | ${true}        | ${false}                  | ${true}                | ${true}                        | ${true}
-    ${'working-group-create'}                 | ${false}         | ${false}   | ${true}        | ${false}                  | ${true}                | ${false}                       | ${true}
-    ${'working-group-edit-draft'}             | ${false}         | ${true}    | ${true}        | ${false}                  | ${true}                | ${false}                       | ${true}
-    ${'working-group-edit-published'}         | ${false}         | ${true}    | ${false}       | ${false}                  | ${false}               | ${false}                       | ${false}
-    ${'working-group-add-version'}            | ${true}          | ${false}   | ${false}       | ${true}                   | ${false}               | ${false}                       | ${true}
-    ${'working-group-duplicate'}              | ${false}         | ${false}   | ${true}        | ${false}                  | ${true}                | ${true}                        | ${true}
+    flowId                                    | isAddVersionFlow | isEditFlow | isImportedFromManuscript | supportsDrafts | requiresAddVersionConfirm | requiresPublishConfirm | requiresSameDescriptionConfirm | publishesOnSave
+    ${'team-create-manual'}                   | ${false}         | ${false}   | ${false}                 | ${true}        | ${false}                  | ${true}                | ${false}                       | ${true}
+    ${'team-create-imported-from-manuscript'} | ${false}         | ${false}   | ${true}                  | ${false}       | ${false}                  | ${true}                | ${false}                       | ${true}
+    ${'team-edit-draft'}                      | ${false}         | ${true}    | ${false}                 | ${true}        | ${false}                  | ${true}                | ${false}                       | ${true}
+    ${'team-edit-published'}                  | ${false}         | ${true}    | ${false}                 | ${false}       | ${false}                  | ${false}               | ${false}                       | ${false}
+    ${'team-add-version'}                     | ${true}          | ${false}   | ${false}                 | ${false}       | ${true}                   | ${false}               | ${false}                       | ${true}
+    ${'team-add-version-from-manuscript'}     | ${true}          | ${false}   | ${true}                  | ${false}       | ${true}                   | ${false}               | ${false}                       | ${true}
+    ${'team-duplicate'}                       | ${false}         | ${false}   | ${false}                 | ${true}        | ${false}                  | ${true}                | ${true}                        | ${true}
+    ${'working-group-create'}                 | ${false}         | ${false}   | ${false}                 | ${true}        | ${false}                  | ${true}                | ${false}                       | ${true}
+    ${'working-group-edit-draft'}             | ${false}         | ${true}    | ${false}                 | ${true}        | ${false}                  | ${true}                | ${false}                       | ${true}
+    ${'working-group-edit-published'}         | ${false}         | ${true}    | ${false}                 | ${false}       | ${false}                  | ${false}               | ${false}                       | ${false}
+    ${'working-group-add-version'}            | ${true}          | ${false}   | ${false}                 | ${false}       | ${true}                   | ${false}               | ${false}                       | ${true}
+    ${'working-group-duplicate'}              | ${false}         | ${false}   | ${false}                 | ${true}        | ${false}                  | ${true}                | ${true}                        | ${true}
   `(
-    '$flowId is add version flow: $isAddVersionFlow, is edit flow: $isEditFlow, supports drafts: $supportsDrafts, requires add version confirm: $requiresAddVersionConfirm, requires publish confirm: $requiresPublishConfirm, requires same description confirm: $requiresSameDescriptionConfirm, publishes on save: $publishesOnSave',
+    '$flowId is add version flow: $isAddVersionFlow, is edit flow: $isEditFlow, is imported from manuscript: $isImportedFromManuscript, supports drafts: $supportsDrafts, requires add version confirm: $requiresAddVersionConfirm, requires publish confirm: $requiresPublishConfirm, requires same description confirm: $requiresSameDescriptionConfirm, publishes on save: $publishesOnSave',
     ({
       flowId,
       isAddVersionFlow,
       isEditFlow,
+      isImportedFromManuscript,
       supportsDrafts,
       requiresAddVersionConfirm,
       requiresPublishConfirm,
@@ -128,6 +129,7 @@ describe('getResearchOutputFlowBehavior', () => {
       expect(getResearchOutputFlowBehavior(flowId)).toEqual({
         isAddVersionFlow,
         isEditFlow,
+        isImportedFromManuscript,
         supportsDrafts,
         requiresAddVersionConfirm,
         requiresPublishConfirm,

--- a/packages/react-components/src/organisms/ResearchOutputPublishingCard.tsx
+++ b/packages/react-components/src/organisms/ResearchOutputPublishingCard.tsx
@@ -11,7 +11,7 @@ import {
 } from '../molecules';
 import { noop } from '../utils';
 
-type ResearchOutputFormSharingCardProps = Pick<
+type ResearchOutputPublishingCardProps = Pick<
   ResearchOutputPostRequest,
   'sharingStatus'
 > & {
@@ -26,6 +26,7 @@ type ResearchOutputFormSharingCardProps = Pick<
   publishDate?: Date;
   isCreatingOutputRoute?: boolean;
   isImportedFromManuscript?: boolean;
+  disableDateMadePublic?: boolean;
 };
 
 export const getPublishDateValidationMessage = (e: ValidityState): string => {
@@ -38,8 +39,8 @@ export const getPublishDateValidationMessage = (e: ValidityState): string => {
   return 'Publish date cannot be greater than today';
 };
 
-const ResearchOutputFormSharingCard: React.FC<
-  ResearchOutputFormSharingCardProps
+const ResearchOutputPublishingCard: React.FC<
+  ResearchOutputPublishingCardProps
 > = ({
   researchOutputData,
   documentType,
@@ -49,6 +50,7 @@ const ResearchOutputFormSharingCard: React.FC<
   sharingStatus,
   publishDate,
   isImportedFromManuscript,
+  disableDateMadePublic,
   onChangeAsapFunded = noop,
   onChangeUsedInPublication = noop,
   onChangeSharingStatus = noop,
@@ -117,12 +119,7 @@ const ResearchOutputFormSharingCard: React.FC<
         subtitle={'(required)'}
         description={'The date this output first became publicly available.'}
         required
-        enabled={
-          !(
-            researchOutputData?.publishDate &&
-            (isImportedFromManuscript || researchOutputData?.id)
-          )
-        }
+        enabled={!disableDateMadePublic}
         onChange={onChangePublishDate}
         value={publishDate}
         max={new Date()}
@@ -132,4 +129,4 @@ const ResearchOutputFormSharingCard: React.FC<
   </FormCard>
 );
 
-export default ResearchOutputFormSharingCard;
+export default ResearchOutputPublishingCard;

--- a/packages/react-components/src/organisms/__tests__/ResearchOutputPublishingCard.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/ResearchOutputPublishingCard.test.tsx
@@ -1,4 +1,3 @@
-import { createResearchOutputResponse } from '@asap-hub/fixtures';
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { startOfTomorrow } from 'date-fns';
@@ -46,52 +45,26 @@ it('conditionally shows date published field', async () => {
   expect(screen.queryByLabelText(/date made public/i)).toBeVisible();
 });
 
-it('enables the date made public field when creating an output', () => {
-  render(<ResearchOutputPublishingCard {...props} sharingStatus={'Public'} />);
-  expect(screen.getByLabelText(/date made public/i)).toBeEnabled();
-});
-
-it('disables the date made public field when editing an output that already has a date', () => {
+it('enables the date made public field when disableDateMadePublic is false', () => {
   render(
     <ResearchOutputPublishingCard
       {...props}
       sharingStatus={'Public'}
-      researchOutputData={{
-        ...createResearchOutputResponse(),
-        publishDate: '2022-03-24',
-      }}
+      disableDateMadePublic={false}
+    />,
+  );
+  expect(screen.getByLabelText(/date made public/i)).toBeEnabled();
+});
+
+it('disables the date made public field when disableDateMadePublic is true', () => {
+  render(
+    <ResearchOutputPublishingCard
+      {...props}
+      sharingStatus={'Public'}
+      disableDateMadePublic={true}
     />,
   );
   expect(screen.getByLabelText(/date made public/i)).toBeDisabled();
-});
-
-it('enables the date made public field when editing an output without a date', () => {
-  render(
-    <ResearchOutputPublishingCard
-      {...props}
-      sharingStatus={'Public'}
-      researchOutputData={{
-        ...createResearchOutputResponse(),
-        publishDate: undefined,
-      }}
-    />,
-  );
-  expect(screen.getByLabelText(/date made public/i)).toBeEnabled();
-});
-
-it('enables the date made public field when duplicating an output that has a date', () => {
-  render(
-    <ResearchOutputPublishingCard
-      {...props}
-      sharingStatus={'Public'}
-      researchOutputData={{
-        ...createResearchOutputResponse(),
-        id: '',
-        publishDate: '2022-03-24',
-      }}
-    />,
-  );
-  expect(screen.getByLabelText(/date made public/i)).toBeEnabled();
 });
 
 it('triggers an on change for date published', async () => {
@@ -165,33 +138,6 @@ describe('getPublishDateValidationMessage returns', () => {
       getPublishDateValidationMessage({ ...e, valueMissing: true }),
     ).toEqual('Please enter the date made public.');
   });
-});
-
-it('disables the date field when imported from a manuscript with a date', () => {
-  render(
-    <ResearchOutputPublishingCard
-      {...props}
-      sharingStatus={'Public'}
-      isImportedFromManuscript
-      researchOutputData={createResearchOutputResponse()}
-    />,
-  );
-  expect(screen.getByLabelText(/date made public/i)).toBeDisabled();
-});
-
-it('enables the date field when imported from a manuscript without a date', () => {
-  render(
-    <ResearchOutputPublishingCard
-      {...props}
-      sharingStatus={'Public'}
-      isImportedFromManuscript
-      researchOutputData={{
-        ...createResearchOutputResponse(),
-        publishDate: undefined,
-      }}
-    />,
-  );
-  expect(screen.getByLabelText(/date made public/i)).toBeEnabled();
 });
 
 it('prompts for the date when editing a public output that has no date', async () => {

--- a/packages/react-components/src/templates/ResearchOutputForm.tsx
+++ b/packages/react-components/src/templates/ResearchOutputForm.tsx
@@ -583,6 +583,7 @@ const ResearchOutputForm: React.FC<ResearchOutputFormProps> = ({
                     setPublishDate(date ? new Date(date) : undefined)
                   }
                   isImportedFromManuscript={isImportedFromManuscript}
+                  disableDateMadePublic={availableActions.disableDateMadePublic}
                 />
                 <ResearchOutputExtraInformationCard
                   documentType={documentType}

--- a/packages/react-components/src/templates/__tests__/ResearchOutputForm/DateMadePublic.test.tsx
+++ b/packages/react-components/src/templates/__tests__/ResearchOutputForm/DateMadePublic.test.tsx
@@ -1,0 +1,96 @@
+import { ResearchOutputResponse } from '@asap-hub/model';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router';
+
+import ResearchOutputForm from '../../ResearchOutputForm';
+import {
+  getDefaultProps,
+  initialResearchOutputData,
+  renderPrefilledForm,
+  submitForm,
+} from '../../test-utils/research-output-form';
+import { mockActErrorsInConsole } from '../../../test-utils';
+
+describe('date made public field', () => {
+  let researchOutputFormProps: ReturnType<typeof getDefaultProps>;
+
+  beforeEach(() => {
+    jest.spyOn(console, 'error').mockImplementation();
+    researchOutputFormProps = getDefaultProps();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should disable the date made public field when available action disableDateMadePublic is true', () => {
+    const { rerender } = render(
+      <MemoryRouter>
+        <ResearchOutputForm
+          {...researchOutputFormProps}
+          researchOutputData={initialResearchOutputData}
+          availableActions={{
+            ...researchOutputFormProps.availableActions,
+            disableDateMadePublic: true,
+          }}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByLabelText(/date made public/i)).toBeDisabled();
+
+    rerender(
+      <MemoryRouter>
+        <ResearchOutputForm
+          {...researchOutputFormProps}
+          researchOutputData={initialResearchOutputData}
+          availableActions={{
+            ...researchOutputFormProps.availableActions,
+            disableDateMadePublic: false,
+          }}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByLabelText(/date made public/i)).toBeEnabled();
+  });
+});
+
+describe('submitting the date made public', () => {
+  const saveFn = jest.fn();
+  let consoleMock: ReturnType<typeof mockActErrorsInConsole>;
+
+  beforeEach(() => {
+    saveFn.mockResolvedValue({ id: '42' } as ResearchOutputResponse);
+    consoleMock = mockActErrorsInConsole();
+  });
+
+  afterEach(() => {
+    consoleMock.mockRestore();
+    jest.resetAllMocks();
+  });
+
+  it('can submit published date', async () => {
+    renderPrefilledForm({ onSave: saveFn });
+
+    const sharingStatus = screen.getByRole('group', {
+      name: /sharing status/i,
+    });
+    await userEvent.click(
+      within(sharingStatus).getByRole('radio', { name: 'Public' }),
+    );
+    fireEvent.change(screen.getByLabelText(/date made public/i), {
+      target: { value: '2022-03-24' },
+    });
+
+    await submitForm();
+
+    expect(saveFn).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        sharingStatus: 'Public',
+        publishDate: new Date('2022-03-24').toISOString(),
+      }),
+    );
+  });
+});

--- a/packages/react-components/src/templates/__tests__/ResearchOutputForm/ResearchOutputForm.4.test.tsx
+++ b/packages/react-components/src/templates/__tests__/ResearchOutputForm/ResearchOutputForm.4.test.tsx
@@ -6,13 +6,7 @@ import {
   researchTagSubtypeResponse,
 } from '@asap-hub/fixtures';
 import { researchOutputDocumentTypeToType } from '@asap-hub/model';
-import {
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-  within,
-} from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { mockActErrorsInConsole } from '../../../test-utils';
 import ResearchOutputForm from '../../ResearchOutputForm';
 import {
@@ -110,49 +104,6 @@ describe('on submit', () => {
       name: /^Subtype/i,
     });
     expect(subtype).toBeInTheDocument();
-  });
-
-  it('can submit published date', async () => {
-    const { documentType } = initialResearchOutputData;
-    render(
-      <MemoryRouter>
-        <ResearchOutputForm
-          {...defaultProps}
-          researchOutputData={initialResearchOutputData}
-          selectedTeams={[{ value: 'TEAMID', label: 'Example Team' }]}
-          documentType={documentType}
-          typeOptions={Array.from(
-            researchOutputDocumentTypeToType[documentType],
-          )}
-          onSave={saveFn}
-          onSaveDraft={saveDraftFn}
-          getLabSuggestions={getLabSuggestions}
-          getAuthorSuggestions={getAuthorSuggestions}
-          getRelatedResearchSuggestions={getRelatedResearchSuggestions}
-          getShortDescriptionFromDescription={
-            getShortDescriptionFromDescription
-          }
-          researchTags={[]}
-        />
-      </MemoryRouter>,
-    );
-
-    const sharingStatus = screen.getByRole('group', {
-      name: /sharing status/i,
-    });
-    await userEvent.click(
-      within(sharingStatus).getByRole('radio', { name: 'Public' }),
-    );
-    fireEvent.change(screen.getByLabelText(/date made public/i), {
-      target: { value: '2022-03-24' },
-    });
-    await submitForm();
-    expect(saveFn).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        sharingStatus: 'Public',
-        publishDate: new Date('2022-03-24').toISOString(),
-      }),
-    );
   });
 
   it('can submit labCatalogNumber for lab material', async () => {

--- a/packages/react-components/src/templates/test-utils/research-output-form.tsx
+++ b/packages/react-components/src/templates/test-utils/research-output-form.tsx
@@ -10,7 +10,9 @@ import {
 } from '@asap-hub/model';
 import { ComponentProps, useEffect } from 'react';
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { render } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import userEvent from '@testing-library/user-event';
 import ResearchOutputForm from '../ResearchOutputForm';
 
 export const capturedLocation: {
@@ -35,6 +37,7 @@ const LocationCapture = () => {
 
 export const defaultAvailableActions: ResearchOutputAvailableActions = {
   disableImpactAndCategory: false,
+  disableDateMadePublic: false,
   canSaveDraft: true,
   showImpactAndCategory: false,
   showChangelogAndVersionHistory: false,
@@ -151,3 +154,14 @@ export const renderPrefilledForm = (
     selectedTeams: [{ value: 'TEAMID', label: 'Example Team' }],
     ...propOverride,
   });
+
+export const submitForm = async () => {
+  await userEvent.click(screen.getByRole('button', { name: /Publish/i }));
+  await userEvent.click(
+    screen.getByRole('button', { name: /Publish Output/i }),
+  );
+  await waitFor(() => {
+    expect(screen.getByRole('button', { name: 'Publish' })).toBeEnabled();
+    expect(screen.getByRole('button', { name: /Cancel/i })).toBeEnabled();
+  });
+};

--- a/packages/react-context/src/__tests__/permissions/research-output.test.tsx
+++ b/packages/react-context/src/__tests__/permissions/research-output.test.tsx
@@ -619,6 +619,99 @@ describe('resolveResearchOutputAvailableActions', () => {
     );
   });
 
+  describe('disableDateMadePublic truth table', () => {
+    // pseudo code: disabled = hasPublishDate && (isImportedFromManuscript || hasId)
+    // note 1: the flows team-create-manual and working-group-create shouldn't
+    // have already a publish date pre-filled in real life, but they are still in
+    // this truth table so all cases are covered
+    // note 2: the flows team-duplicate and working-group-duplicate also shouldn't
+    // have ids pre-filled in real life
+
+    const withDate = '2021-01-01T00:00:00Z';
+
+    test.each`
+      flowId                                    | publishDate  | id        | expectedDisabled
+      ${'team-create-imported-from-manuscript'} | ${withDate}  | ${''}     | ${true}
+      ${'team-create-imported-from-manuscript'} | ${withDate}  | ${'ro-1'} | ${true}
+      ${'team-add-version-from-manuscript'}     | ${withDate}  | ${''}     | ${true}
+      ${'team-add-version-from-manuscript'}     | ${withDate}  | ${'ro-1'} | ${true}
+      ${'team-create-manual'}                   | ${withDate}  | ${'ro-1'} | ${true}
+      ${'team-edit-draft'}                      | ${withDate}  | ${'ro-1'} | ${true}
+      ${'team-edit-published'}                  | ${withDate}  | ${'ro-1'} | ${true}
+      ${'team-add-version'}                     | ${withDate}  | ${'ro-1'} | ${true}
+      ${'team-duplicate'}                       | ${withDate}  | ${'ro-1'} | ${true}
+      ${'working-group-create'}                 | ${withDate}  | ${'ro-1'} | ${true}
+      ${'working-group-edit-draft'}             | ${withDate}  | ${'ro-1'} | ${true}
+      ${'working-group-edit-published'}         | ${withDate}  | ${'ro-1'} | ${true}
+      ${'working-group-add-version'}            | ${withDate}  | ${'ro-1'} | ${true}
+      ${'working-group-duplicate'}              | ${withDate}  | ${'ro-1'} | ${true}
+      ${'team-create-manual'}                   | ${undefined} | ${''}     | ${false}
+      ${'team-create-manual'}                   | ${undefined} | ${'ro-1'} | ${false}
+      ${'team-create-manual'}                   | ${withDate}  | ${''}     | ${false}
+      ${'team-create-imported-from-manuscript'} | ${undefined} | ${''}     | ${false}
+      ${'team-create-imported-from-manuscript'} | ${undefined} | ${'ro-1'} | ${false}
+      ${'team-edit-draft'}                      | ${undefined} | ${''}     | ${false}
+      ${'team-edit-draft'}                      | ${undefined} | ${'ro-1'} | ${false}
+      ${'team-edit-draft'}                      | ${withDate}  | ${''}     | ${false}
+      ${'team-edit-published'}                  | ${undefined} | ${''}     | ${false}
+      ${'team-edit-published'}                  | ${undefined} | ${'ro-1'} | ${false}
+      ${'team-edit-published'}                  | ${withDate}  | ${''}     | ${false}
+      ${'team-add-version'}                     | ${undefined} | ${''}     | ${false}
+      ${'team-add-version'}                     | ${undefined} | ${'ro-1'} | ${false}
+      ${'team-add-version'}                     | ${withDate}  | ${''}     | ${false}
+      ${'team-add-version-from-manuscript'}     | ${undefined} | ${''}     | ${false}
+      ${'team-add-version-from-manuscript'}     | ${undefined} | ${'ro-1'} | ${false}
+      ${'team-duplicate'}                       | ${undefined} | ${''}     | ${false}
+      ${'team-duplicate'}                       | ${undefined} | ${'ro-1'} | ${false}
+      ${'team-duplicate'}                       | ${withDate}  | ${''}     | ${false}
+      ${'working-group-create'}                 | ${undefined} | ${''}     | ${false}
+      ${'working-group-create'}                 | ${undefined} | ${'ro-1'} | ${false}
+      ${'working-group-create'}                 | ${withDate}  | ${''}     | ${false}
+      ${'working-group-edit-draft'}             | ${undefined} | ${''}     | ${false}
+      ${'working-group-edit-draft'}             | ${undefined} | ${'ro-1'} | ${false}
+      ${'working-group-edit-draft'}             | ${withDate}  | ${''}     | ${false}
+      ${'working-group-edit-published'}         | ${undefined} | ${''}     | ${false}
+      ${'working-group-edit-published'}         | ${undefined} | ${'ro-1'} | ${false}
+      ${'working-group-edit-published'}         | ${withDate}  | ${''}     | ${false}
+      ${'working-group-add-version'}            | ${undefined} | ${''}     | ${false}
+      ${'working-group-add-version'}            | ${undefined} | ${'ro-1'} | ${false}
+      ${'working-group-add-version'}            | ${withDate}  | ${''}     | ${false}
+      ${'working-group-duplicate'}              | ${undefined} | ${''}     | ${false}
+      ${'working-group-duplicate'}              | ${undefined} | ${'ro-1'} | ${false}
+      ${'working-group-duplicate'}              | ${withDate}  | ${''}     | ${false}
+    `(
+      'disableDateMadePublic is $expectedDisabled for $flowId (publishDate: $publishDate, id: $id)',
+      ({ flowId, publishDate, id, expectedDisabled }) => {
+        expect(
+          resolveResearchOutputAvailableActions({
+            flowId,
+            permissions: { canShareResearchOutput: true },
+            documentType: 'Bioinformatics',
+            researchOutputData: { versions: [], publishDate, id },
+          }),
+        ).toEqual(
+          expect.objectContaining({
+            disableDateMadePublic: expectedDisabled,
+          }),
+        );
+      },
+    );
+
+    it('is false when researchOutputData is not provided', () => {
+      expect(
+        resolveResearchOutputAvailableActions({
+          flowId: 'team-create-imported-from-manuscript',
+          permissions: { canShareResearchOutput: true },
+          documentType: 'Bioinformatics',
+        }),
+      ).toEqual(
+        expect.objectContaining({
+          disableDateMadePublic: false,
+        }),
+      );
+    });
+  });
+
   it('resolves saveDraft action correctly', () => {
     expect(
       resolveResearchOutputAvailableActions({

--- a/packages/react-context/src/permissions/research-output.ts
+++ b/packages/react-context/src/permissions/research-output.ts
@@ -41,6 +41,7 @@ export type ResearchOutputDetailActionAvailability = {
 
 export type ResearchOutputAvailableActions = {
   disableImpactAndCategory: boolean;
+  disableDateMadePublic: boolean;
   canSaveDraft: boolean;
   showImpactAndCategory: boolean;
   showChangelogAndVersionHistory: boolean;
@@ -56,13 +57,19 @@ export const resolveResearchOutputAvailableActions = ({
   flowId: ResearchOutputFlowId;
   permissions: ResearchOutputPermissions;
   documentType: ResearchOutputDocumentType;
-  researchOutputData?: Pick<ResearchOutputResponse, 'versions'>;
+  researchOutputData?: Pick<
+    ResearchOutputResponse,
+    'versions' | 'publishDate' | 'id'
+  >;
   versions?: readonly ResearchOutputVersion[];
 }): ResearchOutputAvailableActions => {
   const behavior = getResearchOutputFlowBehavior(flowId);
 
   return {
     disableImpactAndCategory: behavior.isAddVersionFlow,
+    disableDateMadePublic:
+      !!researchOutputData?.publishDate &&
+      (behavior.isImportedFromManuscript || !!researchOutputData?.id),
     canSaveDraft:
       behavior.supportsDrafts && !!permissions.canShareResearchOutput,
     showImpactAndCategory: documentType === 'Article',


### PR DESCRIPTION
This PR moves the "date made public" enable/disable logic into resolveResearchOutputAvailableActions so it lives in one place instead of being computed inline in the sharing card. The disableDateMadePublic is true when the output already has a publish date and it's either imported from a manuscript or already has an id.

It also renames `ResearchOutputFormSharingCard` -> `ResearchOutputPublishingCard` internally.