### PR TITLE
ASAP-1615 Add disableNonPublicSharingStatus to AvailableActions

### DIFF
--- a/apps/storybook/src/ResearchOutputForm.stories.tsx
+++ b/apps/storybook/src/ResearchOutputForm.stories.tsx
@@ -21,6 +21,7 @@ const researchOutputFormProps: ComponentProps<typeof ResearchOutputForm> = {
     disableImpactAndCategory: false,
     disableDateMadePublic: false,
     disableUsedInPublication: false,
+    disableNonPublicSharingStatus: false,
     canSaveDraft: true,
     showImpactAndCategory: true,
     showChangelogAndVersionHistory: false,

--- a/packages/react-components/src/organisms/ResearchOutputPublishingCard.tsx
+++ b/packages/react-components/src/organisms/ResearchOutputPublishingCard.tsx
@@ -1,7 +1,6 @@
 import {
   DecisionOption,
   ResearchOutputPostRequest,
-  ResearchOutputResponse,
   ResearchOutputSharingStatus,
 } from '@asap-hub/model';
 import {
@@ -15,8 +14,6 @@ type ResearchOutputPublishingCardProps = Pick<
   ResearchOutputPostRequest,
   'sharingStatus'
 > & {
-  researchOutputData?: ResearchOutputResponse;
-  documentType?: ResearchOutputResponse['documentType'];
   onChangeAsapFunded?: (newValue: DecisionOption) => void;
   onChangeUsedInPublication?: (newValue: DecisionOption) => void;
   onChangeSharingStatus?: (newValue: ResearchOutputSharingStatus) => void;
@@ -24,9 +21,9 @@ type ResearchOutputPublishingCardProps = Pick<
   asapFunded: DecisionOption;
   usedInPublication: DecisionOption;
   publishDate?: Date;
-  isImportedFromManuscript?: boolean;
   disableDateMadePublic?: boolean;
   disableUsedInPublication?: boolean;
+  disableNonPublicSharingStatus?: boolean;
 };
 
 export const getPublishDateValidationMessage = (e: ValidityState): string => {
@@ -42,15 +39,13 @@ export const getPublishDateValidationMessage = (e: ValidityState): string => {
 const ResearchOutputPublishingCard: React.FC<
   ResearchOutputPublishingCardProps
 > = ({
-  researchOutputData,
-  documentType,
   asapFunded,
   usedInPublication,
   sharingStatus,
   publishDate,
-  isImportedFromManuscript,
   disableDateMadePublic,
   disableUsedInPublication,
+  disableNonPublicSharingStatus,
   onChangeAsapFunded = noop,
   onChangeUsedInPublication = noop,
   onChangeSharingStatus = noop,
@@ -96,10 +91,7 @@ const ResearchOutputPublishingCard: React.FC<
         {
           value: 'Network Only',
           label: 'CRN Only',
-          disabled:
-            (documentType === 'Article' &&
-              researchOutputData?.sharingStatus === undefined) ||
-            isImportedFromManuscript,
+          disabled: disableNonPublicSharingStatus,
         },
         { value: 'Public', label: 'Public' },
       ]}

--- a/packages/react-components/src/templates/ResearchOutputForm.tsx
+++ b/packages/react-components/src/templates/ResearchOutputForm.tsx
@@ -542,8 +542,6 @@ const ResearchOutputForm: React.FC<ResearchOutputFormProps> = ({
                   typeDescription="Select the type that matches your output the best."
                 />
                 <ResearchOutputPublishingCard
-                  documentType={documentType}
-                  researchOutputData={researchOutputData}
                   asapFunded={asapFunded}
                   onChangeAsapFunded={setAsapFunded}
                   usedInPublication={usedInPublication}
@@ -554,10 +552,12 @@ const ResearchOutputForm: React.FC<ResearchOutputFormProps> = ({
                   onChangePublishDate={(date) =>
                     setPublishDate(date ? new Date(date) : undefined)
                   }
-                  isImportedFromManuscript={isImportedFromManuscript}
                   disableDateMadePublic={availableActions.disableDateMadePublic}
                   disableUsedInPublication={
                     availableActions.disableUsedInPublication
+                  }
+                  disableNonPublicSharingStatus={
+                    availableActions.disableNonPublicSharingStatus
                   }
                 />
                 <ResearchOutputExtraInformationCard

--- a/packages/react-components/src/templates/__tests__/ResearchOutputForm/FundingandPublicationDetails.test.tsx
+++ b/packages/react-components/src/templates/__tests__/ResearchOutputForm/FundingandPublicationDetails.test.tsx
@@ -1,4 +1,8 @@
-import { ResearchOutputResponse } from '@asap-hub/model';
+import {
+  ResearchOutputDocumentType,
+  ResearchOutputResponse,
+} from '@asap-hub/model';
+import { resolveResearchOutputAvailableActions } from '@asap-hub/react-context';
 import { screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -65,5 +69,79 @@ describe('ResearchOutputForm publishing decisions', () => {
     expect(
       within(usedInPublication).getByRole('radio', { name: 'Not Sure' }),
     ).toBeDisabled();
+  });
+
+  it('disables the "CRN Only" sharing status option when disableNonPublicSharingStatus is true', () => {
+    renderForm({
+      availableActions: {
+        ...defaultAvailableActions,
+        disableNonPublicSharingStatus: true,
+      },
+    });
+
+    const sharingStatus = screen.getByRole('group', {
+      name: /sharing status/i,
+    });
+
+    expect(
+      within(sharingStatus).getByRole('radio', { name: /CRN Only/i }),
+    ).toBeDisabled();
+    expect(
+      within(sharingStatus).getByRole('radio', { name: /Public/i }),
+    ).toBeEnabled();
+  });
+
+  it('enables the "CRN Only" sharing status option when disableNonPublicSharingStatus is false', () => {
+    renderForm({
+      availableActions: {
+        ...defaultAvailableActions,
+        disableNonPublicSharingStatus: false,
+      },
+    });
+
+    const sharingStatus = screen.getByRole('group', {
+      name: /sharing status/i,
+    });
+
+    expect(
+      within(sharingStatus).getByRole('radio', { name: /CRN Only/i }),
+    ).toBeEnabled();
+  });
+
+  it('disables the "CRN Only" sharing status option when importing from a manuscript', () => {
+    const flowId = 'team-create-imported-from-manuscript';
+    const documentType = 'Article' as ResearchOutputDocumentType;
+    renderForm({
+      documentType,
+      flowId,
+      availableActions: resolveResearchOutputAvailableActions({
+        flowId,
+        permissions: { canShareResearchOutput: true },
+        documentType,
+      }),
+    });
+
+    const sharingStatus = screen.getByRole('group', {
+      name: /sharing status/i,
+    });
+
+    expect(
+      within(sharingStatus).getByRole('radio', { name: /CRN Only/i }),
+    ).toBeDisabled();
+    expect(
+      within(sharingStatus).getByRole('radio', { name: /Public/i }),
+    ).toBeEnabled();
+  });
+
+  it('displays the sharing status from the pre-populated research output data', () => {
+    renderPrefilledForm();
+
+    const sharingStatus = screen.getByRole('group', {
+      name: /sharing status/i,
+    });
+
+    expect(
+      within(sharingStatus).getByRole('radio', { name: /Public/i }),
+    ).toBeChecked();
   });
 });

--- a/packages/react-components/src/templates/__tests__/ResearchOutputForm/ResearchOutputForm.formButtons.test.tsx
+++ b/packages/react-components/src/templates/__tests__/ResearchOutputForm/ResearchOutputForm.formButtons.test.tsx
@@ -282,15 +282,6 @@ describe('form buttons', () => {
     });
   });
 
-  it('disables CRN Only option when importing from manuscript', async () => {
-    await setupForm({
-      isImportedFromManuscript: true,
-    });
-
-    expect(screen.getByRole('radio', { name: /CRN Only/i })).toBeDisabled();
-    expect(screen.getByRole('radio', { name: /Public/i })).toBeEnabled();
-  });
-
   it('pre-selects DOI on identifier type when importing from manuscript', async () => {
     await setupForm({ isImportedFromManuscript: true });
 

--- a/packages/react-components/src/templates/__tests__/ResearchOutputForm/ResearchOutputForm.test.tsx
+++ b/packages/react-components/src/templates/__tests__/ResearchOutputForm/ResearchOutputForm.test.tsx
@@ -115,7 +115,6 @@ it('pre populates the form with provided backend response', async () => {
   expect(screen.getByText(researchOutputData.shortDescription)).toBeVisible();
   expect(screen.getByDisplayValue(researchOutputData.title)).toBeVisible();
   expect(screen.getByText(researchOutputData.type!)).toBeVisible();
-  expect(screen.getByText(researchOutputData.sharingStatus)).toBeVisible();
   expect(
     screen.getByText(researchOutputData.authors[0]!.displayName),
   ).toBeVisible();

--- a/packages/react-components/src/templates/test-utils/research-output-form.tsx
+++ b/packages/react-components/src/templates/test-utils/research-output-form.tsx
@@ -39,6 +39,7 @@ export const defaultAvailableActions: ResearchOutputAvailableActions = {
   disableImpactAndCategory: false,
   disableDateMadePublic: false,
   disableUsedInPublication: false,
+  disableNonPublicSharingStatus: false,
   canSaveDraft: true,
   showImpactAndCategory: false,
   showChangelogAndVersionHistory: false,

--- a/packages/react-context/src/__tests__/permissions/research-output.test.tsx
+++ b/packages/react-context/src/__tests__/permissions/research-output.test.tsx
@@ -687,7 +687,12 @@ describe('resolveResearchOutputAvailableActions', () => {
             flowId,
             permissions: { canShareResearchOutput: true },
             documentType: 'Bioinformatics',
-            researchOutputData: { versions: [], publishDate, id },
+            researchOutputData: {
+              versions: [],
+              publishDate,
+              id,
+              sharingStatus: 'Public',
+            },
           }),
         ).toEqual(
           expect.objectContaining({
@@ -734,7 +739,12 @@ describe('resolveResearchOutputAvailableActions', () => {
             flowId,
             permissions: { canShareResearchOutput: true },
             documentType,
-            researchOutputData: { versions: [], id: '', usedInPublication },
+            researchOutputData: {
+              versions: [],
+              id: '',
+              usedInPublication,
+              sharingStatus: 'Public',
+            },
           }),
         ).toEqual(
           expect.objectContaining({
@@ -757,6 +767,48 @@ describe('resolveResearchOutputAvailableActions', () => {
         }),
       );
     });
+  });
+
+  describe('disableNonPublicSharingStatus truth table', () => {
+    const publicSharing = {
+      versions: [],
+      id: '',
+      sharingStatus: 'Public',
+    } as const;
+    const networkOnlySharing = {
+      versions: [],
+      id: '',
+      sharingStatus: 'Network Only',
+    } as const;
+
+    test.each`
+      flowId                                    | documentType        | researchOutputData    | expectedDisabled
+      ${'team-create-manual'}                   | ${'Article'}        | ${undefined}          | ${true}
+      ${'working-group-create'}                 | ${'Article'}        | ${undefined}          | ${true}
+      ${'team-create-imported-from-manuscript'} | ${'Article'}        | ${undefined}          | ${true}
+      ${'team-add-version-from-manuscript'}     | ${'Article'}        | ${undefined}          | ${true}
+      ${'team-create-manual'}                   | ${'Article'}        | ${networkOnlySharing} | ${false}
+      ${'team-create-manual'}                   | ${'Bioinformatics'} | ${undefined}          | ${false}
+      ${'team-edit-published'}                  | ${'Article'}        | ${publicSharing}      | ${false}
+      ${'working-group-edit-published'}         | ${'Article'}        | ${publicSharing}      | ${false}
+      ${'team-add-version'}                     | ${'Bioinformatics'} | ${publicSharing}      | ${false}
+    `(
+      'disableNonPublicSharingStatus is $expectedDisabled for $flowId (documentType: $documentType)',
+      ({ flowId, documentType, researchOutputData, expectedDisabled }) => {
+        expect(
+          resolveResearchOutputAvailableActions({
+            flowId,
+            permissions: { canShareResearchOutput: true },
+            documentType,
+            researchOutputData,
+          }),
+        ).toEqual(
+          expect.objectContaining({
+            disableNonPublicSharingStatus: expectedDisabled,
+          }),
+        );
+      },
+    );
   });
 
   it('resolves saveDraft action correctly', () => {

--- a/packages/react-context/src/permissions/research-output.ts
+++ b/packages/react-context/src/permissions/research-output.ts
@@ -43,6 +43,7 @@ export type ResearchOutputAvailableActions = {
   disableImpactAndCategory: boolean;
   disableDateMadePublic: boolean;
   disableUsedInPublication: boolean;
+  disableNonPublicSharingStatus: boolean;
   canSaveDraft: boolean;
   showImpactAndCategory: boolean;
   showChangelogAndVersionHistory: boolean;
@@ -60,7 +61,7 @@ export const resolveResearchOutputAvailableActions = ({
   documentType: ResearchOutputDocumentType;
   researchOutputData?: Pick<
     ResearchOutputResponse,
-    'versions' | 'publishDate' | 'id' | 'usedInPublication'
+    'versions' | 'publishDate' | 'id' | 'usedInPublication' | 'sharingStatus'
   >;
   versions?: readonly ResearchOutputVersion[];
 }): ResearchOutputAvailableActions => {
@@ -75,6 +76,10 @@ export const resolveResearchOutputAvailableActions = ({
       behavior.isCreateFlow &&
       documentType === 'Article' &&
       researchOutputData?.usedInPublication === undefined,
+    disableNonPublicSharingStatus:
+      (documentType === 'Article' &&
+        researchOutputData?.sharingStatus === undefined) ||
+      behavior.isImportedFromManuscript,
     canSaveDraft:
       behavior.supportsDrafts && !!permissions.canShareResearchOutput,
     showImpactAndCategory: documentType === 'Article',


### PR DESCRIPTION
This PR adds `disableNonPublicSharingStatus` to AvailableActions following https://github.com/yldio/asap-hub/pull/5130 also with the goal of centralizing the conditions that are currently spread across child components.

<img width="884" height="633" alt="Screenshot 2026-07-24 at 07 00 13" src="https://github.com/user-attachments/assets/936a4dd9-b27a-4e3f-8a1f-15335c6f304e" />



Also, some tests were moved to [‎FundingAndPublicationDetails.test.tsx‎](https://github.com/yldio/asap-hub/pull/5131/changes#diff-436430b9788dd811b4b52034ce3366e24628103c95e270cbe257ff5c4da1b522) to keep all the tests related to this section together.