### PR TITLE
[ASAP-1592] - Add Edit Speakers modal

### DIFF
--- a/apps/storybook/src/EditEventSpeakersModal.stories.tsx
+++ b/apps/storybook/src/EditEventSpeakersModal.stories.tsx
@@ -1,0 +1,105 @@
+import { EditEventSpeakersModal } from '@asap-hub/react-components';
+import type { SpeakerGroup } from '@asap-hub/react-components';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta<typeof EditEventSpeakersModal> = {
+  title: 'Organisms / Events / Edit Speakers Modal',
+  component: EditEventSpeakersModal,
+};
+
+type Story = StoryObj<typeof EditEventSpeakersModal>;
+
+// Search returns a mix of: a user with a single team (added directly), a user
+// with multiple teams (shows the "pick a team" pending card), and — for any
+// unmatched text — a creatable "External User" option. Type any letter in the
+// search field to see them.
+const searchResults = [
+  {
+    value: 'user-jordan',
+    label: 'Jordan Lee',
+    user: {
+      userId: 'user-jordan',
+      displayName: 'Jordan Lee',
+      teamOptions: [
+        { teamId: 'team-3', teamName: 'Chen', role: 'Data Manager' },
+      ],
+    },
+  },
+  {
+    value: 'user-alex',
+    label: 'Alex Kim',
+    user: {
+      userId: 'user-alex',
+      displayName: 'Alex Kim',
+      teamOptions: [
+        { teamId: 'team-1', teamName: 'Aguzzi', role: 'Project Manager' },
+        { teamId: 'team-3', teamName: 'Chen', role: 'Trainee' },
+      ],
+    },
+  },
+];
+
+const loadSearchOptions = async (inputValue: string) =>
+  searchResults.filter((option) =>
+    option.label.toLowerCase().includes(inputValue.toLowerCase()),
+  );
+
+const populatedGroups: SpeakerGroup[] = [
+  {
+    id: 'team-1',
+    variant: 'team',
+    teamName: 'Aguzzi',
+    teamType: 'Discovery Team',
+    isTeamInactive: true,
+    preliminaryFindingsShared: true,
+    users: [
+      {
+        id: 'user-1',
+        displayName: 'Jane Doe',
+        roles: ['Lead PI'],
+        isAlumni: true,
+      },
+      { id: 'user-2', displayName: 'John Smith', roles: ['Data Manager'] },
+    ],
+  },
+  {
+    id: 'team-2',
+    variant: 'team',
+    teamName: 'Herzog',
+    teamType: 'Resource Team',
+    preliminaryFindingsShared: true,
+    users: [
+      {
+        id: 'user-3',
+        displayName: 'Priya Patel',
+        roles: ['Project Manager', 'Data Manager'],
+      },
+    ],
+  },
+  {
+    id: 'external',
+    variant: 'external',
+    preliminaryFindingsShared: false,
+    users: [{ id: 'ext-1', displayName: 'Sam Rivera' }],
+  },
+];
+
+export const AddSpeakers: Story = {
+  args: {
+    groups: [],
+    loadSearchOptions,
+    onSave: () => undefined,
+    onDismiss: () => undefined,
+  },
+};
+
+export const EditSpeakers: Story = {
+  args: {
+    groups: populatedGroups,
+    loadSearchOptions,
+    onSave: () => undefined,
+    onDismiss: () => undefined,
+  },
+};
+
+export default meta;

--- a/apps/storybook/src/EventSpeakers.stories.tsx
+++ b/apps/storybook/src/EventSpeakers.stories.tsx
@@ -1,14 +1,20 @@
 import {
+  EditEventSpeakersModal,
   EventSpeakers,
-  EventSpeakerTeamRow,
-  EventSpeakerExternalRow,
+} from '@asap-hub/react-components';
+import type {
+  SpeakerGroup,
+  SpeakerSearchOption,
 } from '@asap-hub/react-components';
 import { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
 import { StaticRouter } from 'react-router';
 
 import { CenterDecorator } from './layout';
 
 const noop = () => undefined;
+
+type SpeakerTeamGroup = Extract<SpeakerGroup, { variant: 'team' }>;
 
 const roles = ['Data Manager', 'Multiple roles', 'Lead PI', 'Project Manager'];
 
@@ -17,9 +23,10 @@ const buildTeams = (
   membersPerTeam: number,
   teamsSharingFindings: number,
   hasInactiveTeam: boolean,
-): EventSpeakerTeamRow[] =>
+): SpeakerTeamGroup[] =>
   Array.from({ length: numberOfTeams }, (_, teamIndex) => ({
-    teamId: `team-${teamIndex}`,
+    id: `team-${teamIndex}`,
+    variant: 'team',
     teamName: `Team ${teamIndex + 1}`,
     teamType:
       teamIndex % 2 === 0
@@ -27,26 +34,27 @@ const buildTeams = (
         : ('Resource Team' as const),
     isTeamInactive: hasInactiveTeam && teamIndex === 2,
     // The first N teams share findings — drives the preliminary-findings %.
-    sharedPreliminaryFindings: teamIndex < teamsSharingFindings,
-    members: Array.from({ length: membersPerTeam }, (_m, memberIndex) => ({
+    preliminaryFindingsShared: teamIndex < teamsSharingFindings,
+    users: Array.from({ length: membersPerTeam }, (_m, memberIndex) => ({
       id: `user-${teamIndex}-${memberIndex}`,
-      firstName: 'John',
-      lastName: 'Doe',
       displayName: `John Doe ${teamIndex + 1}.${memberIndex + 1}`,
-      role: roles[memberIndex % roles.length] as string,
+      roles: [roles[memberIndex % roles.length] as string],
       isAlumni: memberIndex === 1,
     })),
   }));
 
-const buildExternalUsers = (
+const buildExternalGroup = (
   numberOfExternalUsers: number,
   externalSharedFindings: boolean,
-): EventSpeakerExternalRow | undefined =>
+): SpeakerGroup | undefined =>
   numberOfExternalUsers > 0
     ? {
-        sharedPreliminaryFindings: externalSharedFindings,
-        members: Array.from({ length: numberOfExternalUsers }, (_, index) => ({
-          name: `External user ${index + 1}`,
+        id: 'external',
+        variant: 'external',
+        preliminaryFindingsShared: externalSharedFindings,
+        users: Array.from({ length: numberOfExternalUsers }, (_, index) => ({
+          id: `ext-${index}`,
+          displayName: `External user ${index + 1}`,
         })),
       }
     : undefined;
@@ -126,13 +134,13 @@ const meta: Meta<ControlArgs> = {
     if (longTeamNameExample && teams[0]) {
       teams[0] = { ...teams[0], teamName: 'Sundaravadivelu' };
     }
+    const externalGroup = buildExternalGroup(
+      numberOfExternalUsers,
+      externalSharedFindings,
+    );
     return (
       <EventSpeakers
-        teams={teams}
-        externalUsers={buildExternalUsers(
-          numberOfExternalUsers,
-          externalSharedFindings,
-        )}
+        groups={externalGroup ? [...teams, externalGroup] : teams}
         hasFinished={hasFinished}
         onEdit={isEditor ? noop : undefined}
         onExport={isEditor ? noop : undefined}
@@ -203,4 +211,101 @@ export const EmptyEditorPast: Story = {
 
 export const EmptyReadOnly: Story = {
   args: { ...EmptyEditorUpcoming.args, isEditor: false },
+};
+
+// End-to-end wiring: the card and the edit modal share one SpeakerGroup[] —
+// open the pencil, add/remove speakers or toggle findings, and Save to see the
+// card refresh. onSave writes the modal's result straight back, no adapter.
+const editAndSaveInitial: SpeakerGroup[] = [
+  {
+    id: 'team-1',
+    variant: 'team',
+    teamName: 'Aguzzi',
+    teamType: 'Discovery Team',
+    preliminaryFindingsShared: true,
+    users: [
+      { id: 'user-1', displayName: 'Jane Doe', roles: ['Lead PI'] },
+      { id: 'user-2', displayName: 'John Smith', roles: ['Data Manager'] },
+    ],
+  },
+  {
+    id: 'team-2',
+    variant: 'team',
+    teamName: 'Herzog',
+    teamType: 'Resource Team',
+    preliminaryFindingsShared: false,
+    users: [
+      {
+        id: 'user-3',
+        displayName: 'Priya Patel',
+        roles: ['Project Manager', 'Data Manager'],
+      },
+    ],
+  },
+  {
+    id: 'external',
+    variant: 'external',
+    preliminaryFindingsShared: false,
+    users: [{ id: 'ext-1', displayName: 'Sam Rivera' }],
+  },
+];
+
+const editAndSaveSearchResults: SpeakerSearchOption[] = [
+  {
+    value: 'user-jordan',
+    label: 'Jordan Lee',
+    user: {
+      userId: 'user-jordan',
+      displayName: 'Jordan Lee',
+      teamOptions: [
+        { teamId: 'team-3', teamName: 'Chen', role: 'Data Manager' },
+      ],
+    },
+  },
+  {
+    value: 'user-alex',
+    label: 'Alex Kim',
+    user: {
+      userId: 'user-alex',
+      displayName: 'Alex Kim',
+      teamOptions: [
+        { teamId: 'team-1', teamName: 'Aguzzi', role: 'Project Manager' },
+        { teamId: 'team-3', teamName: 'Chen', role: 'Trainee' },
+      ],
+    },
+  },
+];
+
+const loadEditAndSaveSearchOptions = async (inputValue: string) =>
+  editAndSaveSearchResults.filter((option) =>
+    option.label.toLowerCase().includes(inputValue.toLowerCase()),
+  );
+
+export const EditAndSave: Story = {
+  render: () => {
+    const [groups, setGroups] = useState<SpeakerGroup[]>(editAndSaveInitial);
+    const [isEditing, setIsEditing] = useState(false);
+
+    return (
+      <>
+        <EventSpeakers
+          groups={groups}
+          hasFinished
+          onExport={noop}
+          onEdit={() => setIsEditing(true)}
+        />
+        {isEditing && (
+          <EditEventSpeakersModal
+            groups={groups}
+            loadSearchOptions={loadEditAndSaveSearchOptions}
+            onSave={(updated) => {
+              setGroups(updated);
+              setIsEditing(false);
+            }}
+            onDismiss={() => setIsEditing(false)}
+          />
+        )}
+      </>
+    );
+  },
 };

--- a/packages/react-components/src/atoms/PillSelector.tsx
+++ b/packages/react-components/src/atoms/PillSelector.tsx
@@ -1,14 +1,26 @@
-import { css } from '@emotion/react';
+import { css, SerializedStyles } from '@emotion/react';
 import { colors } from '..';
 import { lead, paper, steel, tin } from '../colors';
 import { borderWidth } from '../form';
-import { rem } from '../pixels';
+import { mobileScreen, rem } from '../pixels';
 
 const containerStyles = css({
   padding: rem(6),
   display: 'flex',
   flexWrap: 'wrap',
   gap: rem(8),
+});
+
+// Opt-in: pills span the full row (stacking one per line) instead of
+// sizing to their own text, and the group's own padding drops (at every
+// breakpoint) so it aligns flush with the parent's content width exactly.
+const fullWidthOnMobileContainerStyles = css({
+  padding: 0,
+  [`@media (max-width: ${mobileScreen.max}px)`]: { gap: rem(16) },
+});
+
+const fullWidthOnMobilePillStyles = css({
+  [`@media (max-width: ${mobileScreen.max}px)`]: { width: '100%' },
 });
 
 const disabledStyles = css({
@@ -23,6 +35,7 @@ const pillStyles = (selected: boolean, error: boolean) =>
     display: 'flex',
     justifyContent: 'center',
     alignItems: 'center',
+    gap: rem(8),
 
     borderStyle: 'solid',
     borderWidth: `${borderWidth}px`,
@@ -32,6 +45,11 @@ const pillStyles = (selected: boolean, error: boolean) =>
     userSelect: 'none',
     backgroundColor: selected ? colors.info100.rgba : paper.rgb,
     color: selected ? colors.info500.rgba : lead.rgba,
+    '> svg': {
+      width: rem(24),
+      height: rem(24),
+      flexShrink: 0,
+    },
   });
 
 const hoverStyles = css({
@@ -45,6 +63,7 @@ const hoverStyles = css({
 type PillOption<V extends string> = {
   value: V;
   label: string;
+  icon?: React.ReactNode;
 };
 
 type PillSelectorProps<V extends string> = {
@@ -53,6 +72,8 @@ type PillSelectorProps<V extends string> = {
   onChange: (value: V[]) => void;
   enabled?: boolean;
   error?: boolean;
+  fullWidthOnMobile?: boolean;
+  overrideStyles?: SerializedStyles;
 };
 
 const PillSelector = <V extends string>({
@@ -61,6 +82,8 @@ const PillSelector = <V extends string>({
   onChange,
   enabled = true,
   error = false,
+  fullWidthOnMobile = false,
+  overrideStyles,
 }: PillSelectorProps<V>) => {
   const toggle = (val: V) => {
     if (!enabled) return;
@@ -72,7 +95,12 @@ const PillSelector = <V extends string>({
   };
 
   return (
-    <div css={containerStyles}>
+    <div
+      css={[
+        containerStyles,
+        fullWidthOnMobile && fullWidthOnMobileContainerStyles,
+      ]}
+    >
       {options.map((option) => {
         const selected = value.includes(option.value);
 
@@ -82,10 +110,13 @@ const PillSelector = <V extends string>({
             css={[
               pillStyles(selected, error),
               ...(enabled ? [hoverStyles] : [disabledStyles]),
+              fullWidthOnMobile && fullWidthOnMobilePillStyles,
+              overrideStyles,
             ]}
             type="button"
             onClick={() => toggle(option.value)}
           >
+            {option.icon}
             {option.label}
           </button>
         );

--- a/packages/react-components/src/atoms/SpeakerRoleBadge.tsx
+++ b/packages/react-components/src/atoms/SpeakerRoleBadge.tsx
@@ -1,0 +1,23 @@
+import Pill from './Pill';
+
+type SpeakerRoleBadgeProps = {
+  readonly roles: string[];
+};
+
+const displayRole = ([role, ...rest]: string[]): string => {
+  if (role === undefined) {
+    return 'No role';
+  }
+  if (rest.length > 0) {
+    return 'Multiple roles';
+  }
+  return role;
+};
+
+const SpeakerRoleBadge: React.FC<SpeakerRoleBadgeProps> = ({ roles }) => (
+  <Pill accent="gray" noMargin>
+    {displayRole(roles)}
+  </Pill>
+);
+
+export default SpeakerRoleBadge;

--- a/packages/react-components/src/atoms/__tests__/SpeakerRoleBadge.test.tsx
+++ b/packages/react-components/src/atoms/__tests__/SpeakerRoleBadge.test.tsx
@@ -1,0 +1,20 @@
+import { render } from '@testing-library/react';
+
+import SpeakerRoleBadge from '../SpeakerRoleBadge';
+
+it('renders the single role when exactly one role is given', () => {
+  const { getByText } = render(<SpeakerRoleBadge roles={['Lead PI']} />);
+  expect(getByText('Lead PI')).toBeVisible();
+});
+
+it('renders "Multiple roles" when two or more roles are given', () => {
+  const { getByText } = render(
+    <SpeakerRoleBadge roles={['Project Manager', 'Data Manager']} />,
+  );
+  expect(getByText('Multiple roles')).toBeVisible();
+});
+
+it('renders "No role" when no roles are given', () => {
+  const { getByText } = render(<SpeakerRoleBadge roles={[]} />);
+  expect(getByText('No role')).toBeVisible();
+});

--- a/packages/react-components/src/atoms/index.ts
+++ b/packages/react-components/src/atoms/index.ts
@@ -33,6 +33,7 @@ export { default as Paragraph } from './Paragraph';
 export { default as Pill } from './Pill';
 export { default as PillSelector } from './PillSelector';
 export { default as RadioButton } from './RadioButton';
+export { default as SpeakerRoleBadge } from './SpeakerRoleBadge';
 export { default as Spinner } from './Spinner';
 export { default as Subtitle } from './Subtitle';
 export { default as Switch } from './Switch';

--- a/packages/react-components/src/index.ts
+++ b/packages/react-components/src/index.ts
@@ -166,6 +166,7 @@ export {
   DeliverablesCard,
   DiscussionModal,
   EditEventAttendanceModal,
+  EditEventSpeakersModal,
   EditModal,
   EmailPasswordSignin,
   EventAbout,
@@ -402,13 +403,14 @@ export type {
   UploadListSuggestion,
   UploadListUnmatchedTeam,
   UploadListSourceFile,
+  SpeakerGroup,
+  SpeakerGroupExternalUser,
+  SpeakerGroupUser,
+  SpeakerSearchOption,
+  SpeakerTeamOption,
   UserCollaborationMetric,
   TeamCollaborationMetric,
   ResearchOutputConfirmModalType,
-  EventSpeakerTeamRow,
-  EventSpeakerExternalRow,
-  EventSpeakerExternalMember,
-  EventSpeakerMember,
 } from './organisms';
 export type { ResearchOutputOption } from './utils';
 export type {

--- a/packages/react-components/src/molecules/CollaboratingMembers.tsx
+++ b/packages/react-components/src/molecules/CollaboratingMembers.tsx
@@ -12,6 +12,7 @@ import {
   chevronDownIcon,
 } from '../icons';
 import { rem } from '../pixels';
+import { splitDisplayName } from '../utils/user';
 import CollaboratingList, {
   nonMobileQuery,
   ARTICLES_BEFORE_SCROLL,
@@ -140,11 +141,6 @@ const articleTitleGroupStyles = css({
   },
 });
 
-const memberNameParts = (displayName: string) => {
-  const [firstName, ...rest] = displayName.split(' ');
-  return { firstName, lastName: rest.join(' ') };
-};
-
 const MemberTeamInfo = ({ member }: { member: CollaboratingMember }) => {
   if (member.teams.length === 0) {
     return null;
@@ -184,7 +180,7 @@ const CollaboratingMemberRow: React.FC<{ member: CollaboratingMember }> = ({
 }) => {
   const [expanded, setExpanded] = useState(false);
   const articleCount = member.articles.length;
-  const { firstName, lastName } = memberNameParts(member.displayName);
+  const { firstName, lastName } = splitDisplayName(member.displayName);
 
   const toggle = () => setExpanded((v) => !v);
 

--- a/packages/react-components/src/molecules/ConfirmableModalFooter.tsx
+++ b/packages/react-components/src/molecules/ConfirmableModalFooter.tsx
@@ -1,4 +1,4 @@
-import { css, SerializedStyles } from '@emotion/react';
+import { css } from '@emotion/react';
 
 import { Button } from '../atoms';
 import { neutral1000 } from '../colors';
@@ -10,7 +10,7 @@ const footerStyles = (isConfirming: boolean) =>
     alignItems: 'center',
     justifyContent: isConfirming ? 'space-between' : 'flex-end',
     gap: rem(24),
-    padding: `${rem(48)} ${rem(24)} ${rem(24)}`,
+    padding: `${rem(48)} ${rem(24)} ${rem(32)}`,
     [`@media (max-width: ${mobileScreen.max}px)`]: {
       flexDirection: 'column',
       alignItems: 'stretch',
@@ -58,7 +58,6 @@ type ConfirmableModalFooterProps = {
   onConfirm: () => void;
   confirmEnabled?: boolean;
   confirmLoading?: boolean;
-  overrideStyles?: SerializedStyles;
 };
 
 const ConfirmableModalFooter: React.FC<ConfirmableModalFooterProps> = ({
@@ -72,9 +71,8 @@ const ConfirmableModalFooter: React.FC<ConfirmableModalFooterProps> = ({
   onConfirm,
   confirmEnabled = true,
   confirmLoading = false,
-  overrideStyles,
 }) => (
-  <footer css={[footerStyles(isConfirming), overrideStyles]}>
+  <footer css={footerStyles(isConfirming)}>
     {isConfirming && <span css={warningStyles}>{confirmationMessage}</span>}
     <div css={actionsStyles}>
       {isConfirming ? (

--- a/packages/react-components/src/molecules/PendingSpeakerCard.tsx
+++ b/packages/react-components/src/molecules/PendingSpeakerCard.tsx
@@ -1,0 +1,200 @@
+import { network } from '@asap-hub/routing';
+import { css } from '@emotion/react';
+
+import { Avatar, Button, Link, Paragraph, PillSelector } from '../atoms';
+import { fern, neutral1000, warning100, warning900 } from '../colors';
+import { binIcon, plusIcon, WarningIcon } from '../icons';
+import { deleteButtonStyles } from '../organisms/EditEventAttendanceModal';
+import { mobileScreen, rem } from '../pixels';
+import { splitDisplayName } from '../utils/user';
+import { avatar24Styles } from './SpeakerUserRow';
+
+const hideOnMobileStyles = css({
+  [`@media (max-width: ${mobileScreen.max}px)`]: { display: 'none' },
+});
+
+const hideOnDesktopStyles = css({
+  [`@media (min-width: ${mobileScreen.max + 1}px)`]: { display: 'none' },
+});
+
+// Sits as the table's first row, so its own bottom spacing — not a top margin
+// — separates it from the row that follows. Desktop: [icon] [content column],
+// icon top-aligned 16px left of the content. Mobile: the desktop icon hides
+// and the mobile-only icon inside pendingHeaderStyles takes over.
+const cardStyles = css({
+  display: 'flex',
+  alignItems: 'flex-start',
+  gap: rem(16),
+  marginBottom: rem(16),
+  padding: rem(16),
+  border: `1px solid ${warning900.rgb}`,
+  borderRadius: rem(8),
+  backgroundColor: warning100.rgb,
+});
+
+const iconDesktopStyles = css([hideOnMobileStyles, { flexShrink: 0 }]);
+
+const contentStyles = css({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: rem(12),
+  flexGrow: 1,
+  minWidth: 0,
+});
+
+// Desktop: one row (avatar, name, dismiss — dismiss pushed flush right via its
+// own marginLeft: auto; the warning icon lives outside this row). Mobile: wraps
+// into two lines — icon + dismiss on top, avatar + name below — matching Figma.
+// `order`/`flexBasis` reflow visually without changing DOM order (kept stable
+// for a11y).
+const headerStyles = css({
+  display: 'flex',
+  alignItems: 'center',
+  gap: rem(8),
+  [`@media (max-width: ${mobileScreen.max}px)`]: {
+    flexWrap: 'wrap',
+  },
+});
+
+const iconStyles = css([
+  hideOnDesktopStyles,
+  {
+    display: 'inline-flex',
+    alignItems: 'center',
+    [`@media (max-width: ${mobileScreen.max}px)`]: { order: 1 },
+  },
+]);
+
+// A dedicated, empty line-break — not `flexBasis: 100%` on the avatar or name
+// themselves, which would each claim the whole line for themselves (pushing the
+// other to a third line) instead of sharing the new line. Hidden on desktop:
+// even at zero width it's still a real flex item, so left unhidden it'd eat
+// headerStyles' gap on both sides — showing up as stray space before the avatar.
+const lineBreakStyles = css([
+  hideOnDesktopStyles,
+  {
+    [`@media (max-width: ${mobileScreen.max}px)`]: {
+      order: 3,
+      flexBasis: '100%',
+      width: 0,
+    },
+  },
+]);
+
+const avatarSlotStyles = css({
+  [`@media (max-width: ${mobileScreen.max}px)`]: { order: 4 },
+});
+
+// `order` lives on this wrapper, not on nameStyles below: Link renders an <a>,
+// so the actual flex child of headerStyles is the anchor, not the inner span —
+// order on the span would have no effect.
+const nameSlotStyles = css({
+  [`@media (max-width: ${mobileScreen.max}px)`]: { order: 5 },
+});
+
+const nameStyles = css({
+  color: fern.rgb,
+  fontSize: rem(17),
+  fontWeight: 400,
+  lineHeight: rem(24),
+});
+
+// Same 24x24 "Secondary" button as SpeakerUserRow's delete button; just add
+// layout positioning.
+const dismissStyles = css([
+  deleteButtonStyles,
+  {
+    flexGrow: 0,
+    marginLeft: 'auto',
+    [`@media (max-width: ${mobileScreen.max}px)`]: {
+      order: 2,
+    },
+  },
+]);
+
+const warningTextStyles = css({
+  color: warning900.rgb,
+  fontSize: rem(17),
+  fontWeight: 400,
+  lineHeight: rem(24),
+  [`@media (max-width: ${mobileScreen.max}px)`]: {
+    fontSize: rem(14),
+    lineHeight: rem(16),
+  },
+});
+
+const pillStyles = css({
+  fontSize: rem(17),
+  fontWeight: 400,
+  lineHeight: rem(24),
+  color: neutral1000.rgb,
+});
+
+type PendingSpeakerCardProps = {
+  readonly displayName: string;
+  readonly avatarUrl?: string;
+  readonly userId: string;
+  readonly teams: ReadonlyArray<{ teamId: string; teamName: string }>;
+  readonly onPickTeam: (teamId: string) => void;
+  readonly onDismiss: () => void;
+};
+
+const PendingSpeakerCard: React.FC<PendingSpeakerCardProps> = ({
+  displayName,
+  avatarUrl,
+  userId,
+  teams,
+  onPickTeam,
+  onDismiss,
+}) => (
+  <div css={cardStyles} role="status">
+    <span css={iconDesktopStyles}>
+      <WarningIcon />
+    </span>
+    <div css={contentStyles}>
+      <div css={headerStyles}>
+        <span css={iconStyles}>
+          <WarningIcon />
+        </span>
+        <span css={lineBreakStyles} aria-hidden="true" />
+        <span css={avatarSlotStyles}>
+          <Avatar
+            {...splitDisplayName(displayName)}
+            imageUrl={avatarUrl}
+            overrideStyles={avatar24Styles}
+          />
+        </span>
+        <span css={nameSlotStyles}>
+          <Link href={network({}).users({}).user({ userId }).$}>
+            <span css={nameStyles}>{displayName}</span>
+          </Link>
+        </span>
+        <Button
+          noMargin
+          small
+          aria-label={`Remove ${displayName}`}
+          onClick={onDismiss}
+          overrideStyles={dismissStyles}
+        >
+          {binIcon}
+        </Button>
+      </div>
+      <Paragraph noMargin styles={warningTextStyles}>
+        Pick a team to finish adding them.
+      </Paragraph>
+      <PillSelector<string>
+        fullWidthOnMobile
+        overrideStyles={pillStyles}
+        options={teams.map((team) => ({
+          value: team.teamId,
+          label: team.teamName,
+          icon: plusIcon,
+        }))}
+        value={[]}
+        onChange={(values) => values.forEach(onPickTeam)}
+      />
+    </div>
+  </div>
+);
+
+export default PendingSpeakerCard;

--- a/packages/react-components/src/molecules/SpeakerTeamRow.tsx
+++ b/packages/react-components/src/molecules/SpeakerTeamRow.tsx
@@ -1,0 +1,201 @@
+import { network } from '@asap-hub/routing';
+import { css } from '@emotion/react';
+
+import { Link, Switch } from '../atoms';
+import { lead, steel } from '../colors';
+import { chevronDownIcon, chevronUpIcon, InactiveBadgeIcon } from '../icons';
+import { EventTeamType, teamIcon } from '../organisms/shared-event-card';
+import { chevronButtonStyles } from '../organisms/shared-event-card-styles';
+import {
+  mobileScreen,
+  rem,
+  tabletScreen,
+  vminLinearCalcClamped,
+} from '../pixels';
+import SpeakerUserRow from './SpeakerUserRow';
+
+const wrapperStyles = css({
+  display: 'flex',
+  flexDirection: 'column',
+  paddingTop: rem(16),
+  paddingBottom: rem(16),
+  borderBottom: `1px solid ${steel.rgb}`,
+  '&:first-of-type': {
+    paddingTop: 0,
+  },
+  '&:last-of-type': {
+    paddingBottom: 0,
+    borderBottom: 'none',
+  },
+});
+
+// [name+counter] and [switch+chevron], per Figma's auto-layout. `gap` is a
+// floor — space-between still pushes the switch/chevron group flush right
+// whenever there's room.
+const headerStyles = css({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: rem(24),
+});
+
+// No `overflow`/`minWidth: 0` — team names never truncate. A name wider than
+// the card just scrolls (overflowX: auto on groupsCardStyles), matching
+// EditEventAttendanceModal. Spacing between icon/name/badge/count comes from
+// `gap`, not a literal space character — a flex container drops anonymous
+// all-whitespace text nodes (see EventSpeakers.tsx's teamInfoStyles, the
+// same fix applied there).
+const labelStyles = css({
+  display: 'flex',
+  alignItems: 'center',
+  flexShrink: 0,
+  gap: rem(8),
+  fontSize: rem(17),
+  [`@media (max-width: ${mobileScreen.max}px)`]: {
+    // Figma's "Caption/C1" mobile type scale for the team name + counter.
+    fontSize: rem(14),
+    lineHeight: rem(16),
+    '> svg': { display: 'none' },
+  },
+  '> svg': {
+    width: rem(24),
+    height: rem(24),
+    flexShrink: 0,
+  },
+});
+
+const leadTextStyles = css({ color: lead.rgb, fontWeight: 400 });
+
+const teamNameStyles = css({ whiteSpace: 'nowrap', fontWeight: 400 });
+
+const externalLabelStyles = css([leadTextStyles, { whiteSpace: 'nowrap' }]);
+
+const inactiveBadgeStyles = css({
+  display: 'inline-flex',
+  alignItems: 'center',
+});
+
+const countStyles = css([leadTextStyles, { flexShrink: 0 }]);
+
+// Scales with the viewport instead of jumping at a breakpoint, bottoming
+// out at 12px (Figma's own spacing annotation for this gap).
+const actionsGap = vminLinearCalcClamped(
+  mobileScreen,
+  12,
+  tabletScreen,
+  24,
+  'px',
+);
+
+const actionsStyles = css({
+  display: 'flex',
+  alignItems: 'center',
+  flexShrink: 0,
+  gap: actionsGap,
+});
+
+const nestedListStyles = css({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: rem(16),
+  marginTop: rem(16),
+  paddingBottom: rem(12),
+  paddingLeft: rem(32),
+  [`@media (max-width: ${mobileScreen.max}px)`]: {
+    gap: rem(24),
+    paddingLeft: rem(12),
+  },
+});
+
+export type SpeakerTeamRowUser = {
+  readonly id: string;
+  readonly displayName: string;
+  readonly avatarUrl?: string;
+  readonly roles: string[];
+  readonly isAlumni?: boolean;
+};
+
+type SpeakerTeamRowProps = {
+  readonly variant?: 'team' | 'external';
+  readonly teamId?: string;
+  readonly teamType?: EventTeamType;
+  readonly isTeamInactive?: boolean;
+  readonly label: string;
+  readonly users: ReadonlyArray<SpeakerTeamRowUser>;
+  readonly preliminaryFindingsShared: boolean;
+  readonly expanded: boolean;
+  readonly onToggleExpanded: () => void;
+  readonly onToggleShared: () => void;
+  readonly onRemoveUser: (userId: string) => void;
+};
+
+const SpeakerTeamRow: React.FC<SpeakerTeamRowProps> = ({
+  variant = 'team',
+  teamId,
+  teamType,
+  isTeamInactive,
+  label,
+  users,
+  preliminaryFindingsShared,
+  expanded,
+  onToggleExpanded,
+  onToggleShared,
+  onRemoveUser,
+}) => (
+  <div css={wrapperStyles} role="listitem">
+    <div css={headerStyles}>
+      <span css={labelStyles}>
+        {variant === 'team' && teamIcon(teamType)}
+        {variant === 'team' && teamId ? (
+          <Link href={network({}).teams({}).team({ teamId }).$}>
+            <span css={teamNameStyles}>{label}</span>
+          </Link>
+        ) : (
+          <span css={variant === 'team' ? teamNameStyles : externalLabelStyles}>
+            {label}
+          </span>
+        )}
+        {variant === 'team' && isTeamInactive && (
+          <span css={inactiveBadgeStyles}>
+            <InactiveBadgeIcon />
+          </span>
+        )}
+        <span css={countStyles}>({users.length})</span>
+      </span>
+      <span css={actionsStyles}>
+        <Switch
+          checked={preliminaryFindingsShared}
+          uncheckedColor="error"
+          ariaLabel={`${label} preliminary findings shared`}
+          onClick={onToggleShared}
+        />
+        <button
+          type="button"
+          aria-label={expanded ? `Collapse ${label}` : `Expand ${label}`}
+          aria-expanded={expanded}
+          onClick={onToggleExpanded}
+          css={chevronButtonStyles}
+        >
+          {expanded ? chevronUpIcon : chevronDownIcon}
+        </button>
+      </span>
+    </div>
+    {expanded && (
+      <div css={nestedListStyles} role="list">
+        {users.map((user) => (
+          <SpeakerUserRow
+            key={user.id}
+            displayName={user.displayName}
+            avatarUrl={user.avatarUrl}
+            roles={variant === 'team' ? user.roles : undefined}
+            userId={variant === 'team' ? user.id : undefined}
+            isAlumni={variant === 'team' ? user.isAlumni : undefined}
+            onRemove={() => onRemoveUser(user.id)}
+          />
+        ))}
+      </div>
+    )}
+  </div>
+);
+
+export default SpeakerTeamRow;

--- a/packages/react-components/src/molecules/SpeakerUserRow.tsx
+++ b/packages/react-components/src/molecules/SpeakerUserRow.tsx
@@ -1,0 +1,135 @@
+import { network } from '@asap-hub/routing';
+import { css } from '@emotion/react';
+
+import { Avatar, Button, Link, SpeakerRoleBadge } from '../atoms';
+import { lead } from '../colors';
+import { alumniBadgeIcon, binIcon } from '../icons';
+import { deleteButtonStyles } from '../organisms/EditEventAttendanceModal';
+import { mobileScreen, rem } from '../pixels';
+import { splitDisplayName } from '../utils/user';
+
+export const flexRowGap8Styles = css({
+  display: 'flex',
+  alignItems: 'center',
+  gap: rem(8),
+});
+
+// [user info block, flex-grow] + [optional delete button]. When a delete
+// button is present it bottom-aligns on mobile against the (now two-line)
+// user info block, per Figma; read-only rows (no delete) keep the default
+// top alignment.
+const rowStyles = css(flexRowGap8Styles);
+
+const rowWithRemoveStyles = css([
+  flexRowGap8Styles,
+  {
+    [`@media (max-width: ${mobileScreen.max}px)`]: {
+      alignItems: 'flex-end',
+    },
+  },
+]);
+
+// Desktop: a plain row, so topRowStyles + the role badge sit inline. Mobile:
+// stacks into two lines — avatar+name on top, role badge below — matching
+// Figma's "User Name" column layout.
+const userInfoStyles = css([
+  flexRowGap8Styles,
+  {
+    flexGrow: 1,
+    minWidth: 0,
+    [`@media (max-width: ${mobileScreen.max}px)`]: {
+      flexDirection: 'column',
+      alignItems: 'flex-start',
+    },
+  },
+]);
+
+const topRowStyles = flexRowGap8Styles;
+
+export const avatar24Styles = css({
+  margin: 0,
+  flexShrink: 0,
+  width: rem(24),
+  height: rem(24),
+});
+
+// No truncation, matching the team name policy — a name wider than the card
+// just scrolls (overflowX: auto on groupsCardStyles). Color comes from
+// Link's default (fern) for team members.
+const nameStyles = css({
+  display: 'block',
+  whiteSpace: 'nowrap',
+  [`@media (max-width: ${mobileScreen.max}px)`]: {
+    // Figma's "Caption/C1" mobile type scale, matching the team name.
+    fontSize: rem(14),
+    lineHeight: rem(16),
+    fontWeight: 400,
+  },
+});
+
+export const externalNameStyles = css([nameStyles, { color: lead.rgb }]);
+
+const alumniStyles = css({
+  display: 'inline-flex',
+  alignItems: 'center',
+});
+
+// deleteButtonStyles only resets Button's base flexGrow:1 inside the mobile
+// query; in this flex row (userInfo grows) the button would otherwise stretch
+// on desktop, so pin flexGrow:0 at every width.
+const removeButtonStyles = css([deleteButtonStyles, { flexGrow: 0 }]);
+
+type SpeakerUserRowProps = {
+  readonly displayName: string;
+  readonly avatarUrl?: string;
+  readonly roles?: string[];
+  readonly userId?: string;
+  readonly isAlumni?: boolean;
+  readonly onRemove?: () => void;
+};
+
+const SpeakerUserRow: React.FC<SpeakerUserRowProps> = ({
+  displayName,
+  avatarUrl,
+  roles,
+  userId,
+  isAlumni,
+  onRemove,
+}) => {
+  const { firstName, lastName } = splitDisplayName(displayName);
+  return (
+    <div css={onRemove ? rowWithRemoveStyles : rowStyles} role="listitem">
+      <div css={userInfoStyles}>
+        <span css={topRowStyles}>
+          <Avatar
+            firstName={firstName}
+            lastName={lastName}
+            imageUrl={avatarUrl}
+            overrideStyles={avatar24Styles}
+          />
+          {userId ? (
+            <Link href={network({}).users({}).user({ userId }).$}>
+              <span css={nameStyles}>{displayName}</span>
+            </Link>
+          ) : (
+            <span css={externalNameStyles}>{displayName}</span>
+          )}
+          {isAlumni && <span css={alumniStyles}>{alumniBadgeIcon}</span>}
+        </span>
+        {roles && <SpeakerRoleBadge roles={roles} />}
+      </div>
+      {onRemove && (
+        <Button
+          noMargin
+          aria-label={`Remove ${displayName}`}
+          onClick={onRemove}
+          overrideStyles={removeButtonStyles}
+        >
+          {binIcon}
+        </Button>
+      )}
+    </div>
+  );
+};
+
+export default SpeakerUserRow;

--- a/packages/react-components/src/molecules/__tests__/SpeakerTeamRow.test.tsx
+++ b/packages/react-components/src/molecules/__tests__/SpeakerTeamRow.test.tsx
@@ -1,0 +1,126 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import SpeakerTeamRow from '../SpeakerTeamRow';
+
+const users = [
+  { id: 'u1', displayName: 'Jane Doe', roles: ['Lead PI'] },
+  {
+    id: 'u2',
+    displayName: 'John Smith',
+    roles: ['Project Manager', 'Data Manager'],
+  },
+];
+
+const defaultProps = {
+  label: 'Team Alpha',
+  users,
+  preliminaryFindingsShared: false,
+  expanded: false,
+  onToggleExpanded: jest.fn(),
+  onToggleShared: jest.fn(),
+  onRemoveUser: jest.fn(),
+};
+
+it('renders the team name, member count, and current switch state', () => {
+  render(<SpeakerTeamRow {...defaultProps} />);
+  expect(screen.getByText('Team Alpha')).toBeVisible();
+  expect(screen.getByText('(2)')).toBeVisible();
+  expect(
+    screen.getByRole('checkbox', {
+      name: 'Team Alpha preliminary findings shared',
+    }),
+  ).not.toBeChecked();
+});
+
+it('does not render the nested user list at all when collapsed', () => {
+  render(<SpeakerTeamRow {...defaultProps} expanded={false} />);
+  expect(screen.queryByText('Jane Doe')).not.toBeInTheDocument();
+});
+
+it('renders the nested user list, including role badges, when expanded', () => {
+  render(<SpeakerTeamRow {...defaultProps} expanded />);
+  expect(screen.getByText('Jane Doe')).toBeVisible();
+  expect(screen.getByText('Lead PI')).toBeVisible();
+  expect(screen.getByText('Multiple roles')).toBeVisible();
+});
+
+it('calls onToggleExpanded when the chevron is clicked', () => {
+  const onToggleExpanded = jest.fn();
+  render(
+    <SpeakerTeamRow {...defaultProps} onToggleExpanded={onToggleExpanded} />,
+  );
+  fireEvent.click(screen.getByRole('button', { name: 'Expand Team Alpha' }));
+  expect(onToggleExpanded).toHaveBeenCalled();
+});
+
+it('reflects the expanded state on the chevron via aria-expanded', () => {
+  const { rerender } = render(
+    <SpeakerTeamRow {...defaultProps} expanded={false} />,
+  );
+  expect(
+    screen.getByRole('button', { name: 'Expand Team Alpha' }),
+  ).toHaveAttribute('aria-expanded', 'false');
+  rerender(<SpeakerTeamRow {...defaultProps} expanded />);
+  expect(
+    screen.getByRole('button', { name: 'Collapse Team Alpha' }),
+  ).toHaveAttribute('aria-expanded', 'true');
+});
+
+it('calls onRemoveUser with the user id, not the group id, when a nested delete button is clicked', () => {
+  const onRemoveUser = jest.fn();
+  render(
+    <SpeakerTeamRow {...defaultProps} expanded onRemoveUser={onRemoveUser} />,
+  );
+  fireEvent.click(screen.getByRole('button', { name: 'Remove Jane Doe' }));
+  expect(onRemoveUser).toHaveBeenCalledWith('u1');
+});
+
+it('renders an inactive badge next to the team name when isTeamInactive is true', () => {
+  render(<SpeakerTeamRow {...defaultProps} isTeamInactive />);
+  expect(screen.getByTitle('Inactive Team')).toBeInTheDocument();
+});
+
+it('does not render an inactive badge when isTeamInactive is false or omitted', () => {
+  render(<SpeakerTeamRow {...defaultProps} />);
+  expect(screen.queryByTitle('Inactive Team')).not.toBeInTheDocument();
+});
+
+it('renders each team member as a link to their profile and shows an alumni badge when applicable', () => {
+  render(
+    <SpeakerTeamRow
+      {...defaultProps}
+      expanded
+      users={[
+        {
+          id: 'u1',
+          displayName: 'Jane Doe',
+          roles: ['Lead PI'],
+          isAlumni: true,
+        },
+      ]}
+    />,
+  );
+  expect(screen.getByRole('link', { name: 'Jane Doe' })).toHaveAttribute(
+    'href',
+    expect.stringContaining('u1'),
+  );
+  expect(screen.getByTitle('Alumni Member')).toBeInTheDocument();
+});
+
+it('renders the external variant without a team icon and without role badges on nested rows', () => {
+  render(
+    <SpeakerTeamRow
+      {...defaultProps}
+      variant="external"
+      label="External Users"
+      expanded
+    />,
+  );
+  expect(screen.getByText('External Users')).toBeVisible();
+  expect(screen.getByText('Jane Doe')).toBeVisible();
+  expect(
+    screen.queryByRole('link', { name: 'Jane Doe' }),
+  ).not.toBeInTheDocument();
+  expect(screen.queryByText('Lead PI')).not.toBeInTheDocument();
+  expect(screen.queryByText('Multiple roles')).not.toBeInTheDocument();
+});

--- a/packages/react-components/src/molecules/index.ts
+++ b/packages/react-components/src/molecules/index.ts
@@ -77,6 +77,8 @@ export { default as ReminderItem } from './ReminderItem';
 export { default as RolesList } from './RolesList';
 export { default as SearchField } from './SearchField';
 export { default as SocialIcons } from './SocialIcons';
+export { default as SpeakerTeamRow } from './SpeakerTeamRow';
+export { default as SpeakerUserRow } from './SpeakerUserRow';
 export { default as StatusBadge } from './StatusBadge';
 export { default as StatusButton } from './StatusButton';
 export { default as TabbedCard } from './TabbedCard';

--- a/packages/react-components/src/organisms/EditEventAttendanceModal.tsx
+++ b/packages/react-components/src/organisms/EditEventAttendanceModal.tsx
@@ -359,7 +359,7 @@ const attendanceSwitchStyles = css({
   paddingRight: rem(24),
 });
 
-const deleteButtonStyles = css({
+export const deleteButtonStyles = css({
   flexShrink: 0,
   display: 'inline-flex',
   alignItems: 'center',

--- a/packages/react-components/src/organisms/EditEventSpeakersModal.tsx
+++ b/packages/react-components/src/organisms/EditEventSpeakersModal.tsx
@@ -59,7 +59,6 @@ type EditEventSpeakersModalProps = {
   ) => Promise<SpeakerSearchOption[]>;
   readonly onSave: (groups: SpeakerGroup[]) => void | Promise<void>;
   readonly onDismiss: () => void;
-  readonly disableAdding?: boolean;
 };
 
 const modalStyles = css({ width: '100%' });
@@ -280,7 +279,6 @@ const EditEventSpeakersModal: React.FC<EditEventSpeakersModalProps> = ({
   loadSearchOptions,
   onSave,
   onDismiss,
-  disableAdding = false,
 }) => {
   const [speakerGroups, setSpeakerGroups] = useState<SpeakerGroup[]>(() => [
     ...groups,
@@ -495,72 +493,70 @@ const EditEventSpeakersModal: React.FC<EditEventSpeakersModalProps> = ({
       </header>
 
       <div css={bodyStyles}>
-        {!disableAdding && (
-          <div css={searchSpacingStyles}>
-            <MultiSelect<SpeakerSearchOption, false>
-              isMulti={false}
-              values={null}
-              noMargin
-              creatable
-              defaultOptions={false}
-              leftIndicator={searchIcon}
-              loadOptions={loadSearchOptions}
-              onChange={handleSelectSearchOption}
-              noOptionsMessage={({ inputValue }) =>
-                `Sorry, no matches for ${inputValue}.`
-              }
-              components={{
-                Placeholder: (placeholderProps) => (
-                  <components.Placeholder {...placeholderProps}>
-                    <span css={[placeholderStyles, hideOnMobileStyles]}>
-                      Search for a person to add…
-                    </span>
-                    <span css={[placeholderStyles, hideOnDesktopStyles]}>
-                      Search for a person…
-                    </span>
-                  </components.Placeholder>
-                ),
-                Menu: (menuProps) =>
-                  menuProps.selectProps.inputValue ? (
-                    <components.Menu {...menuProps} />
-                  ) : null,
-                Option: (optionProps) => {
-                  const option = optionProps.data;
-                  return (
-                    <components.Option {...optionProps}>
-                      <span css={searchOptionStyles}>
+        <div css={searchSpacingStyles}>
+          <MultiSelect<SpeakerSearchOption, false>
+            isMulti={false}
+            values={null}
+            noMargin
+            creatable
+            defaultOptions={false}
+            leftIndicator={searchIcon}
+            loadOptions={loadSearchOptions}
+            onChange={handleSelectSearchOption}
+            noOptionsMessage={({ inputValue }) =>
+              `Sorry, no matches for ${inputValue}.`
+            }
+            components={{
+              Placeholder: (placeholderProps) => (
+                <components.Placeholder {...placeholderProps}>
+                  <span css={[placeholderStyles, hideOnMobileStyles]}>
+                    Search for a person to add…
+                  </span>
+                  <span css={[placeholderStyles, hideOnDesktopStyles]}>
+                    Search for a person…
+                  </span>
+                </components.Placeholder>
+              ),
+              Menu: (menuProps) =>
+                menuProps.selectProps.inputValue ? (
+                  <components.Menu {...menuProps} />
+                ) : null,
+              Option: (optionProps) => {
+                const option = optionProps.data;
+                return (
+                  <components.Option {...optionProps}>
+                    <span css={searchOptionStyles}>
+                      {option.user ? (
+                        <Avatar
+                          {...splitDisplayName(option.user.displayName)}
+                          imageUrl={option.user.avatarUrl}
+                          overrideStyles={avatar24Styles}
+                        />
+                      ) : (
+                        plusIcon
+                      )}
+                      <span
+                        css={
+                          option.user
+                            ? searchUserNameStyles
+                            : searchExternalTextStyles
+                        }
+                      >
                         {option.user ? (
-                          <Avatar
-                            {...splitDisplayName(option.user.displayName)}
-                            imageUrl={option.user.avatarUrl}
-                            overrideStyles={avatar24Styles}
-                          />
+                          option.user.displayName
                         ) : (
-                          plusIcon
+                          <>
+                            <strong>{optionProps.children}</strong> (Non CRN)
+                          </>
                         )}
-                        <span
-                          css={
-                            option.user
-                              ? searchUserNameStyles
-                              : searchExternalTextStyles
-                          }
-                        >
-                          {option.user ? (
-                            option.user.displayName
-                          ) : (
-                            <>
-                              <strong>{optionProps.children}</strong> (Non CRN)
-                            </>
-                          )}
-                        </span>
                       </span>
-                    </components.Option>
-                  );
-                },
-              }}
-            />
-          </div>
-        )}
+                    </span>
+                  </components.Option>
+                );
+              },
+            }}
+          />
+        </div>
 
         <section css={speakersSectionStyles}>
           <div css={speakersHeaderStyles}>

--- a/packages/react-components/src/organisms/EditEventSpeakersModal.tsx
+++ b/packages/react-components/src/organisms/EditEventSpeakersModal.tsx
@@ -20,7 +20,7 @@ import {
   tin,
 } from '../colors';
 import { crossIcon, plusIcon, searchIcon } from '../icons';
-import { Modal } from '../molecules';
+import { ConfirmableModalFooter, Modal } from '../molecules';
 import PendingSpeakerCard from '../molecules/PendingSpeakerCard';
 import SpeakerTeamRow from '../molecules/SpeakerTeamRow';
 import { avatar24Styles, flexRowGap8Styles } from '../molecules/SpeakerUserRow';
@@ -230,40 +230,6 @@ const emptyStateStyles = css([
 ]);
 
 const emptyStateTitleStyles = css({ fontWeight: 700 });
-
-const footerStyles = (isConfirmingCancel: boolean) =>
-  css({
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: isConfirmingCancel ? 'space-between' : 'flex-end',
-    gap: rem(24),
-    padding: `${rem(48)} ${rem(24)} ${rem(32)}`,
-    [`@media (max-width: ${mobileScreen.max}px)`]: {
-      flexDirection: 'column',
-      alignItems: 'stretch',
-      paddingTop: rem(56),
-    },
-  });
-
-const footerActionsStyles = css({
-  display: 'flex',
-  gap: rem(24),
-  flexShrink: 0,
-  [`@media (max-width: ${mobileScreen.max}px)`]: {
-    flexDirection: 'column-reverse',
-  },
-});
-
-const footerButtonStyles = css({
-  width: 'fit-content',
-  flexShrink: 0,
-  [`@media (max-width: ${mobileScreen.max}px)`]: { width: '100%' },
-});
-
-const discardWarningStyles = css({
-  fontWeight: 'bold',
-  color: neutral1000.rgb,
-});
 
 const findUserGroup = (
   groups: SpeakerGroup[],
@@ -653,60 +619,20 @@ const EditEventSpeakersModal: React.FC<EditEventSpeakersModalProps> = ({
         </section>
       </div>
 
-      <footer css={footerStyles(isCancelling)}>
-        {isCancelling && (
-          <span css={discardWarningStyles}>
-            You&apos;ll lose all unsaved changes if you cancel now.
-          </span>
-        )}
-        <div css={footerActionsStyles}>
-          {isCancelling ? (
-            <>
-              <div css={footerButtonStyles}>
-                <Button
-                  fullWidth
-                  noMargin
-                  onClick={() => setIsCancelling(false)}
-                >
-                  Keep Editing
-                </Button>
-              </div>
-              <div css={footerButtonStyles}>
-                <Button warning fullWidth noMargin onClick={onDismiss}>
-                  Discard changes
-                </Button>
-              </div>
-            </>
-          ) : (
-            <>
-              <div css={footerButtonStyles}>
-                <Button
-                  fullWidth
-                  noMargin
-                  enabled={!isSaving}
-                  onClick={handleCancel}
-                >
-                  Cancel
-                </Button>
-              </div>
-              <div css={footerButtonStyles}>
-                <Button
-                  primary
-                  fullWidth
-                  noMargin
-                  enabled={saveEnabled}
-                  loading={isSaving}
-                  onClick={() => {
-                    void handleSave();
-                  }}
-                >
-                  Save
-                </Button>
-              </div>
-            </>
-          )}
-        </div>
-      </footer>
+      <ConfirmableModalFooter
+        isConfirming={isCancelling}
+        confirmationMessage="You'll lose all unsaved changes if you cancel now."
+        onKeepEditing={() => setIsCancelling(false)}
+        onDiscard={onDismiss}
+        onCancel={handleCancel}
+        cancelEnabled={!isSaving}
+        confirmLabel="Save"
+        onConfirm={() => {
+          void handleSave();
+        }}
+        confirmEnabled={saveEnabled}
+        confirmLoading={isSaving}
+      />
     </Modal>
   );
 };

--- a/packages/react-components/src/organisms/EditEventSpeakersModal.tsx
+++ b/packages/react-components/src/organisms/EditEventSpeakersModal.tsx
@@ -1,0 +1,718 @@
+import { css } from '@emotion/react';
+import { useState } from 'react';
+import { components } from 'react-select';
+
+import {
+  Avatar,
+  Button,
+  Headline2,
+  MultiSelect,
+  MultiSelectOptionsType,
+  Paragraph,
+} from '../atoms';
+import {
+  charcoal,
+  lead,
+  neutral1000,
+  pearl,
+  pine,
+  steel,
+  tin,
+} from '../colors';
+import { crossIcon, plusIcon, searchIcon } from '../icons';
+import { Modal } from '../molecules';
+import PendingSpeakerCard from '../molecules/PendingSpeakerCard';
+import SpeakerTeamRow from '../molecules/SpeakerTeamRow';
+import { avatar24Styles, flexRowGap8Styles } from '../molecules/SpeakerUserRow';
+import { mobileScreen, rem } from '../pixels';
+import { splitDisplayName } from '../utils/user';
+import { EventTeamType } from './shared-event-card';
+import { iconButtonStyles } from './shared-event-card-styles';
+import {
+  SpeakerGroup,
+  SpeakerGroupExternalUser,
+  SpeakerGroupUser,
+} from './speaker-group';
+
+export type SpeakerTeamOption = {
+  readonly teamId: string;
+  readonly teamName: string;
+  readonly teamType?: EventTeamType;
+  readonly isTeamInactive?: boolean;
+  readonly role: string;
+};
+
+export type SpeakerSearchOption = MultiSelectOptionsType & {
+  readonly user?: {
+    readonly userId: string;
+    readonly displayName: string;
+    readonly avatarUrl?: string;
+    readonly isAlumni?: boolean;
+    readonly teamOptions: ReadonlyArray<SpeakerTeamOption>;
+  };
+};
+
+type EditEventSpeakersModalProps = {
+  readonly groups?: SpeakerGroup[];
+  readonly loadSearchOptions: (
+    inputValue: string,
+  ) => Promise<SpeakerSearchOption[]>;
+  readonly onSave: (groups: SpeakerGroup[]) => void | Promise<void>;
+  readonly onDismiss: () => void;
+  readonly disableAdding?: boolean;
+};
+
+const modalStyles = css({ width: '100%' });
+
+const headerStyles = css({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: rem(15),
+  padding: `${rem(32)} ${rem(24)} 0`,
+});
+
+const titleStyles = css({
+  fontSize: rem(26),
+  fontWeight: 700,
+  lineHeight: rem(32),
+  color: neutral1000.rgb,
+});
+
+const bodyStyles = css({
+  display: 'flex',
+  flexDirection: 'column',
+  padding: `0 ${rem(24)}`,
+});
+
+const searchSpacingStyles = css({ marginTop: rem(32) });
+
+const hideOnMobileStyles = css({
+  [`@media (max-width: ${mobileScreen.max}px)`]: { display: 'none' },
+});
+
+const hideOnDesktopStyles = css({
+  [`@media (min-width: ${mobileScreen.max + 1}px)`]: { display: 'none' },
+});
+
+const placeholderStyles = css({ color: tin.rgb });
+
+const searchOptionStyles = css([
+  flexRowGap8Styles,
+  { '> svg': { width: rem(24), height: rem(24), flexShrink: 0 } },
+]);
+
+const searchUserNameStyles = css({
+  color: pine.rgb,
+  fontSize: rem(17),
+  fontWeight: 400,
+  lineHeight: rem(24),
+});
+
+const searchExternalTextStyles = css({
+  color: lead.rgb,
+  fontSize: rem(17),
+  fontWeight: 400,
+  lineHeight: rem(24),
+});
+
+const speakersSectionStyles = css({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: rem(16),
+  marginTop: rem(48),
+  [`@media (max-width: ${mobileScreen.max}px)`]: { gap: rem(24) },
+});
+
+const speakersHeaderStyles = css({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  flexWrap: 'wrap',
+  gap: rem(12),
+  [`@media (max-width: ${mobileScreen.max}px)`]: {
+    flexDirection: 'column',
+    alignItems: 'stretch',
+    gap: rem(24),
+  },
+});
+
+const sectionTitleStyles = css({
+  margin: 0,
+  fontSize: rem(17),
+  fontWeight: 700,
+  lineHeight: rem(24),
+  color: neutral1000.rgb,
+});
+
+// Wraps the "Speakers" heading and the stat span — always stacked on
+// mobile (not just when it doesn't fit), matching
+// EditEventAttendanceModal's attendeesStatsStyles.
+const statsHeaderStyles = css({
+  display: 'flex',
+  alignItems: 'center',
+  flexWrap: 'wrap',
+  [`@media (max-width: ${mobileScreen.max}px)`]: {
+    flexDirection: 'column',
+    alignItems: 'flex-start',
+    gap: rem(4),
+  },
+});
+
+const statsGroupStyles = css({
+  display: 'flex',
+  alignItems: 'center',
+  flexWrap: 'wrap',
+});
+
+const statStyles = css({
+  fontSize: rem(17),
+  fontWeight: 400,
+  color: lead.rgb,
+});
+
+const separatorStyles = css({
+  fontSize: rem(17),
+  fontWeight: 400,
+  color: lead.rgb,
+  padding: `0 ${rem(8)}`,
+});
+
+const markAllSharedButtonStyles = css({
+  flexGrow: 0,
+  [`@media (max-width: ${mobileScreen.max}px)`]: {
+    flexGrow: 1,
+    minWidth: '100%',
+  },
+});
+
+const cardSurfaceStyles = css({
+  border: `1px solid ${steel.rgb}`,
+  borderRadius: rem(8),
+  backgroundColor: pearl.rgb,
+});
+
+const groupsCardStyles = css([
+  cardSurfaceStyles,
+  { padding: rem(24), overflowX: 'auto' },
+]);
+
+// "Team" and "Preliminary Findings", mirroring SpeakerTeamRow's row layout
+// below it. `gap` is a floor — space-between still pushes them apart when
+// there's room.
+const groupsTableHeaderStyles = css({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: rem(24),
+  fontSize: rem(17),
+  fontWeight: 'bold',
+  lineHeight: rem(24),
+  letterSpacing: rem(0.1),
+  color: charcoal.rgb,
+  paddingBottom: rem(16),
+});
+
+const groupsRowsStyles = css({
+  display: 'flex',
+  flexDirection: 'column',
+});
+
+const emptyStateStyles = css([
+  cardSurfaceStyles,
+  {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    gap: rem(8),
+    textAlign: 'center',
+    padding: rem(24),
+  },
+]);
+
+const emptyStateTitleStyles = css({ fontWeight: 700 });
+
+const footerStyles = (isConfirmingCancel: boolean) =>
+  css({
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: isConfirmingCancel ? 'space-between' : 'flex-end',
+    gap: rem(24),
+    padding: `${rem(48)} ${rem(24)} ${rem(32)}`,
+    [`@media (max-width: ${mobileScreen.max}px)`]: {
+      flexDirection: 'column',
+      alignItems: 'stretch',
+      paddingTop: rem(56),
+    },
+  });
+
+const footerActionsStyles = css({
+  display: 'flex',
+  gap: rem(24),
+  flexShrink: 0,
+  [`@media (max-width: ${mobileScreen.max}px)`]: {
+    flexDirection: 'column-reverse',
+  },
+});
+
+const footerButtonStyles = css({
+  width: 'fit-content',
+  flexShrink: 0,
+  [`@media (max-width: ${mobileScreen.max}px)`]: { width: '100%' },
+});
+
+const discardWarningStyles = css({
+  fontWeight: 'bold',
+  color: neutral1000.rgb,
+});
+
+const findUserGroup = (
+  groups: SpeakerGroup[],
+  teamId: string,
+): Extract<SpeakerGroup, { variant: 'team' }> | undefined =>
+  groups.find(
+    (group): group is Extract<SpeakerGroup, { variant: 'team' }> =>
+      group.variant === 'team' && group.id === teamId,
+  );
+
+const EditEventSpeakersModal: React.FC<EditEventSpeakersModalProps> = ({
+  groups = [],
+  loadSearchOptions,
+  onSave,
+  onDismiss,
+  disableAdding = false,
+}) => {
+  const [speakerGroups, setSpeakerGroups] = useState<SpeakerGroup[]>(() => [
+    ...groups,
+  ]);
+  const [expandedIds, setExpandedIds] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
+  const [pendingSpeaker, setPendingSpeaker] = useState<
+    SpeakerSearchOption['user'] | null
+  >(null);
+  const [isSaving, setIsSaving] = useState(false);
+  const [isCancelling, setIsCancelling] = useState(false);
+
+  const isEditMode = speakerGroups.some((group) => group.users.length > 0);
+  const title = isEditMode ? 'Edit Speakers' : 'Add Speakers';
+  // A group with no members left (every speaker removed) is dropped from the
+  // visible table, but kept in speakerGroups so onSave still reports it.
+  const visibleGroups = speakerGroups.filter((group) => group.users.length > 0);
+  const teamCount = visibleGroups.filter(
+    (group) => group.variant === 'team',
+  ).length;
+  const userCount = speakerGroups.reduce(
+    (total, group) => total + group.users.length,
+    0,
+  );
+  const saveEnabled = !isSaving && isEditMode;
+
+  const withExternalGroupLast = (nextGroups: SpeakerGroup[]) => [
+    ...nextGroups.filter((group) => group.variant !== 'external'),
+    ...nextGroups.filter((group) => group.variant === 'external'),
+  ];
+
+  const addUserToTeam = (
+    user: NonNullable<SpeakerSearchOption['user']>,
+    team: SpeakerTeamOption,
+  ) => {
+    const newUser: SpeakerGroupUser = {
+      id: user.userId,
+      displayName: user.displayName,
+      avatarUrl: user.avatarUrl,
+      isAlumni: user.isAlumni,
+      roles: [team.role],
+    };
+    setSpeakerGroups((current) => {
+      const existingGroup = findUserGroup(current, team.teamId);
+      if (!existingGroup) {
+        const newGroup: SpeakerGroup = {
+          id: team.teamId,
+          variant: 'team',
+          teamName: team.teamName,
+          teamType: team.teamType,
+          isTeamInactive: team.isTeamInactive,
+          preliminaryFindingsShared: false,
+          users: [newUser],
+        };
+        return withExternalGroupLast([...current, newGroup]);
+      }
+      if (existingGroup.users.some((row) => row.id === user.userId)) {
+        return current;
+      }
+      const updatedGroup: SpeakerGroup = {
+        ...existingGroup,
+        users: [...existingGroup.users, newUser],
+      };
+      return current.map((group) =>
+        group.id === existingGroup.id ? updatedGroup : group,
+      );
+    });
+    setExpandedIds((current) => new Set(current).add(team.teamId));
+  };
+
+  const addExternalUser = (name: string) => {
+    setSpeakerGroups((current) => {
+      const externalGroup = current.find(
+        (group): group is Extract<SpeakerGroup, { variant: 'external' }> =>
+          group.variant === 'external',
+      );
+      const totalUsers = current.reduce(
+        (total, group) => total + group.users.length,
+        0,
+      );
+      const newUser: SpeakerGroupExternalUser = {
+        id: `external-${totalUsers}-${name}`,
+        displayName: name,
+      };
+      if (!externalGroup) {
+        return [
+          ...current,
+          {
+            id: 'external',
+            variant: 'external',
+            preliminaryFindingsShared: false,
+            users: [newUser],
+          },
+        ];
+      }
+      return current.map((group) =>
+        group.variant === 'external'
+          ? { ...group, users: [...group.users, newUser] }
+          : group,
+      );
+    });
+    setExpandedIds((current) => new Set(current).add('external'));
+  };
+
+  const handleSelectSearchOption = (option: SpeakerSearchOption) => {
+    if (!option.user) {
+      addExternalUser(option.label);
+      return;
+    }
+    const [onlyTeam] = option.user.teamOptions;
+    if (option.user.teamOptions.length === 1 && onlyTeam) {
+      addUserToTeam(option.user, onlyTeam);
+    } else {
+      setPendingSpeaker(option.user);
+    }
+  };
+
+  const resolvePendingSpeaker = (
+    speaker: NonNullable<SpeakerSearchOption['user']>,
+    teamId: string,
+  ) => {
+    speaker.teamOptions
+      .filter((option) => option.teamId === teamId)
+      .forEach((team) => addUserToTeam(speaker, team));
+    setPendingSpeaker(null);
+  };
+
+  const toggleShared = (groupId: string) =>
+    setSpeakerGroups((current) =>
+      current.map((group) =>
+        group.id === groupId
+          ? {
+              ...group,
+              preliminaryFindingsShared: !group.preliminaryFindingsShared,
+            }
+          : group,
+      ),
+    );
+
+  const markAllShared = () =>
+    setSpeakerGroups((current) =>
+      current.map((group) => ({ ...group, preliminaryFindingsShared: true })),
+    );
+
+  const toggleExpanded = (groupId: string) =>
+    setExpandedIds((current) => {
+      const next = new Set(current);
+      if (next.has(groupId)) {
+        next.delete(groupId);
+      } else {
+        next.add(groupId);
+      }
+      return next;
+    });
+
+  const removeUser = (groupId: string, userId: string) =>
+    setSpeakerGroups((current) =>
+      current.map((group) => {
+        if (group.id !== groupId) {
+          return group;
+        }
+        // Duplicated on purpose: with a union return type, TS only narrows
+        // `users`'s element type per-branch when the discriminant check
+        // (variant === 'team') is explicit on both sides of the spread —
+        // collapsing this into one unconditional branch fails to typecheck.
+        return group.variant === 'team'
+          ? {
+              ...group,
+              users: group.users.filter((user) => user.id !== userId),
+            }
+          : {
+              ...group,
+              users: group.users.filter((user) => user.id !== userId),
+            };
+      }),
+    );
+
+  const handleSave = async () => {
+    setIsSaving(true);
+    try {
+      await onSave(speakerGroups);
+    } catch {
+      // The caller surfaces the error; the modal only needs to unlock so the
+      // user can retry or cancel instead of staying stuck on "saving".
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleCancel = () => {
+    const isDirty = JSON.stringify(speakerGroups) !== JSON.stringify(groups);
+    return isDirty ? setIsCancelling(true) : onDismiss();
+  };
+
+  return (
+    <Modal padding={false} overrideModalStyles={modalStyles}>
+      <header css={headerStyles}>
+        <Headline2 noMargin overrideStyles={titleStyles}>
+          {title}
+        </Headline2>
+        <Button
+          small
+          noMargin
+          aria-label="Close"
+          enabled={!isSaving}
+          onClick={handleCancel}
+          overrideStyles={iconButtonStyles}
+        >
+          {crossIcon}
+        </Button>
+      </header>
+
+      <div css={bodyStyles}>
+        {!disableAdding && (
+          <div css={searchSpacingStyles}>
+            <MultiSelect<SpeakerSearchOption, false>
+              isMulti={false}
+              values={null}
+              noMargin
+              creatable
+              defaultOptions={false}
+              leftIndicator={searchIcon}
+              loadOptions={loadSearchOptions}
+              onChange={handleSelectSearchOption}
+              noOptionsMessage={({ inputValue }) =>
+                `Sorry, no matches for ${inputValue}.`
+              }
+              components={{
+                Placeholder: (placeholderProps) => (
+                  <components.Placeholder {...placeholderProps}>
+                    <span css={[placeholderStyles, hideOnMobileStyles]}>
+                      Search for a person to add…
+                    </span>
+                    <span css={[placeholderStyles, hideOnDesktopStyles]}>
+                      Search for a person…
+                    </span>
+                  </components.Placeholder>
+                ),
+                Menu: (menuProps) =>
+                  menuProps.selectProps.inputValue ? (
+                    <components.Menu {...menuProps} />
+                  ) : null,
+                Option: (optionProps) => {
+                  const option = optionProps.data;
+                  return (
+                    <components.Option {...optionProps}>
+                      <span css={searchOptionStyles}>
+                        {option.user ? (
+                          <Avatar
+                            {...splitDisplayName(option.user.displayName)}
+                            imageUrl={option.user.avatarUrl}
+                            overrideStyles={avatar24Styles}
+                          />
+                        ) : (
+                          plusIcon
+                        )}
+                        <span
+                          css={
+                            option.user
+                              ? searchUserNameStyles
+                              : searchExternalTextStyles
+                          }
+                        >
+                          {option.user ? (
+                            option.user.displayName
+                          ) : (
+                            <>
+                              <strong>{optionProps.children}</strong> (Non CRN)
+                            </>
+                          )}
+                        </span>
+                      </span>
+                    </components.Option>
+                  );
+                },
+              }}
+            />
+          </div>
+        )}
+
+        <section css={speakersSectionStyles}>
+          <div css={speakersHeaderStyles}>
+            <div css={statsHeaderStyles}>
+              <h3 css={sectionTitleStyles}>Speakers</h3>
+              {visibleGroups.length > 0 && (
+                <span css={statsGroupStyles}>
+                  <span css={[separatorStyles, hideOnMobileStyles]}>•</span>
+                  <span css={statStyles}>{teamCount} Teams</span>
+                  <span css={separatorStyles}>•</span>
+                  <span css={statStyles}>{userCount} Users</span>
+                </span>
+              )}
+            </div>
+            {visibleGroups.length > 0 && (
+              <Button
+                small
+                noMargin
+                overrideStyles={markAllSharedButtonStyles}
+                onClick={markAllShared}
+              >
+                Mark All Shared
+              </Button>
+            )}
+          </div>
+
+          {visibleGroups.length === 0 && !pendingSpeaker ? (
+            <div css={emptyStateStyles} role="status">
+              <Paragraph noMargin accent="lead" styles={emptyStateTitleStyles}>
+                Add speakers to this event
+              </Paragraph>
+              <Paragraph noMargin accent="lead">
+                Search for a person to add them to this event.
+              </Paragraph>
+            </div>
+          ) : (
+            <div css={groupsCardStyles}>
+              <div css={groupsTableHeaderStyles}>
+                <span>Team</span>
+                <span>
+                  <span css={hideOnMobileStyles}>Preliminary Findings</span>
+                  <span css={hideOnDesktopStyles}>P. Findings</span>
+                </span>
+              </div>
+              <div css={groupsRowsStyles} role="list">
+                {pendingSpeaker && (
+                  <PendingSpeakerCard
+                    displayName={pendingSpeaker.displayName}
+                    avatarUrl={pendingSpeaker.avatarUrl}
+                    userId={pendingSpeaker.userId}
+                    teams={pendingSpeaker.teamOptions}
+                    onPickTeam={(teamId) =>
+                      resolvePendingSpeaker(pendingSpeaker, teamId)
+                    }
+                    onDismiss={() => setPendingSpeaker(null)}
+                  />
+                )}
+                {visibleGroups.map((group) => (
+                  <SpeakerTeamRow
+                    key={group.id}
+                    variant={group.variant}
+                    teamId={group.variant === 'team' ? group.id : undefined}
+                    teamType={
+                      group.variant === 'team' ? group.teamType : undefined
+                    }
+                    isTeamInactive={
+                      group.variant === 'team'
+                        ? group.isTeamInactive
+                        : undefined
+                    }
+                    label={
+                      group.variant === 'team'
+                        ? group.teamName
+                        : 'External Users'
+                    }
+                    users={group.users.map((user) => ({
+                      id: user.id,
+                      displayName: user.displayName,
+                      avatarUrl:
+                        'avatarUrl' in user ? user.avatarUrl : undefined,
+                      roles: 'roles' in user ? user.roles : [],
+                      isAlumni: 'isAlumni' in user ? user.isAlumni : undefined,
+                    }))}
+                    preliminaryFindingsShared={group.preliminaryFindingsShared}
+                    expanded={expandedIds.has(group.id)}
+                    onToggleExpanded={() => toggleExpanded(group.id)}
+                    onToggleShared={() => toggleShared(group.id)}
+                    onRemoveUser={(userId) => removeUser(group.id, userId)}
+                  />
+                ))}
+              </div>
+            </div>
+          )}
+        </section>
+      </div>
+
+      <footer css={footerStyles(isCancelling)}>
+        {isCancelling && (
+          <span css={discardWarningStyles}>
+            You&apos;ll lose all unsaved changes if you cancel now.
+          </span>
+        )}
+        <div css={footerActionsStyles}>
+          {isCancelling ? (
+            <>
+              <div css={footerButtonStyles}>
+                <Button
+                  fullWidth
+                  noMargin
+                  onClick={() => setIsCancelling(false)}
+                >
+                  Keep Editing
+                </Button>
+              </div>
+              <div css={footerButtonStyles}>
+                <Button warning fullWidth noMargin onClick={onDismiss}>
+                  Discard changes
+                </Button>
+              </div>
+            </>
+          ) : (
+            <>
+              <div css={footerButtonStyles}>
+                <Button
+                  fullWidth
+                  noMargin
+                  enabled={!isSaving}
+                  onClick={handleCancel}
+                >
+                  Cancel
+                </Button>
+              </div>
+              <div css={footerButtonStyles}>
+                <Button
+                  primary
+                  fullWidth
+                  noMargin
+                  enabled={saveEnabled}
+                  loading={isSaving}
+                  onClick={() => {
+                    void handleSave();
+                  }}
+                >
+                  Save
+                </Button>
+              </div>
+            </>
+          )}
+        </div>
+      </footer>
+    </Modal>
+  );
+};
+
+export default EditEventSpeakersModal;

--- a/packages/react-components/src/organisms/EventSpeakers.tsx
+++ b/packages/react-components/src/organisms/EventSpeakers.tsx
@@ -3,7 +3,6 @@ import { css } from '@emotion/react';
 import { useEffect, useState } from 'react';
 
 import {
-  Avatar,
   Button,
   Card,
   GradientProgressBar,
@@ -15,7 +14,6 @@ import {
 } from '../atoms';
 import { lead, neutral1000, steel } from '../colors';
 import {
-  alumniBadgeIcon,
   chevronDownIcon,
   chevronUpIcon,
   ExportIcon,
@@ -33,16 +31,16 @@ import {
   metricValueStyles,
   metricWheelStyles,
 } from '../molecules/shared-metric-card-styles';
+import SpeakerUserRow, {
+  externalNameStyles,
+} from '../molecules/SpeakerUserRow';
 import { rem, tabletScreen } from '../pixels';
 
-import {
-  defaultVisibleTeams,
-  EventTeamType,
-  teamIcon,
-} from './shared-event-card';
+import { defaultVisibleTeams, teamIcon } from './shared-event-card';
 import {
   actionsStyles,
   cellStyles,
+  chevronButtonStyles,
   contentStyles,
   contentWithFooterStyles,
   editIconButtonStyles,
@@ -59,6 +57,10 @@ import {
   teamInfoStyles,
   viewMoreStyles,
 } from './shared-event-card-styles';
+import { SpeakerGroup } from './speaker-group';
+
+type SpeakerTeamGroup = Extract<SpeakerGroup, { variant: 'team' }>;
+type SpeakerExternalGroup = Extract<SpeakerGroup, { variant: 'external' }>;
 
 const mobileQuery = `@media (max-width: ${tabletScreen.min}px)`;
 
@@ -101,16 +103,6 @@ const leadTextStyles = css({
   color: lead.rgb,
 });
 
-const chevronButtonStyles = css({
-  display: 'inline-flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  padding: 0,
-  border: 'none',
-  background: 'none',
-  cursor: 'pointer',
-});
-
 const membersListStyles = css({
   listStyle: 'none',
   margin: 0,
@@ -132,23 +124,6 @@ const memberRowStyles = css({
     flexDirection: 'column',
     alignItems: 'flex-start',
   },
-});
-
-const memberMainStyles = css({
-  display: 'flex',
-  alignItems: 'center',
-  gap: rem(8),
-});
-
-const memberAvatarStyles = css({
-  width: rem(24),
-  height: rem(24),
-  flexShrink: 0,
-});
-
-const alumniStyles = css({
-  display: 'inline-flex',
-  alignItems: 'center',
 });
 
 const MetricCard: React.FC<{ children: React.ReactNode }> = ({ children }) => (
@@ -189,39 +164,10 @@ const FindingsMetric: React.FC<{
   </MetricCard>
 );
 
-export type EventSpeakerMember = {
-  id: string;
-  displayName: string;
-  firstName?: string;
-  lastName?: string;
-  avatarUrl?: string;
-  role: string;
-  isAlumni?: boolean;
-};
-
-export type EventSpeakerTeamType = EventTeamType;
-
-export type EventSpeakerTeamRow = {
-  teamId: string;
-  teamName: string;
-  teamType?: EventSpeakerTeamType;
-  isTeamInactive?: boolean;
-  sharedPreliminaryFindings: boolean;
-  members: EventSpeakerMember[];
-};
-
-export type EventSpeakerExternalMember = {
-  name: string;
-};
-
-export type EventSpeakerExternalRow = {
-  sharedPreliminaryFindings: boolean;
-  members: EventSpeakerExternalMember[];
-};
-
 type EventSpeakersProps = {
-  teams: EventSpeakerTeamRow[];
-  externalUsers?: EventSpeakerExternalRow;
+  // Shared with EditEventSpeakersModal: the same SpeakerGroup[] can feed both
+  // this card and the modal, and the modal's onSave writes straight back.
+  groups?: SpeakerGroup[];
   hasFinished?: boolean;
   onExport?: () => void;
   onEdit?: () => void;
@@ -297,8 +243,6 @@ const SpeakerRow: React.FC<{
   );
 };
 
-// Reports whether an element's content overflows it horizontally, tracking
-// layout and content changes via ResizeObserver.
 const useHorizontalOverflow = () => {
   const [element, setElement] = useState<HTMLElement | null>(null);
   const [overflowing, setOverflowing] = useState(false);
@@ -322,8 +266,7 @@ const editorEmptyMessage = (hasFinished: boolean): string =>
     : 'Add the speakers for this event. Marking who shared preliminary findings becomes available after the event.';
 
 const EventSpeakers: React.FC<EventSpeakersProps> = ({
-  teams,
-  externalUsers,
+  groups = [],
   hasFinished = false,
   onExport,
   onEdit,
@@ -337,12 +280,19 @@ const EventSpeakers: React.FC<EventSpeakersProps> = ({
 
   const showFindings = hasFinished;
 
-  const externalCount = externalUsers?.members.length ?? 0;
+  const teamGroups = groups.filter(
+    (group): group is SpeakerTeamGroup =>
+      group.variant === 'team' && group.users.length > 0,
+  );
+  const externalGroup = groups.find(
+    (group): group is SpeakerExternalGroup =>
+      group.variant === 'external' && group.users.length > 0,
+  );
+
+  const externalCount = externalGroup?.users.length ?? 0;
   const hasExternal = externalCount > 0;
 
-  const teamsWithSpeakers = teams.filter((team) => team.members.length > 0);
-
-  if (teamsWithSpeakers.length === 0 && !hasExternal) {
+  if (teamGroups.length === 0 && !hasExternal) {
     return (
       <Card>
         <div css={emptyStateStyles}>
@@ -377,23 +327,23 @@ const EventSpeakers: React.FC<EventSpeakersProps> = ({
       return next;
     });
 
-  const teamMemberCount = teamsWithSpeakers.reduce(
-    (total, team) => total + team.members.length,
+  const teamMemberCount = teamGroups.reduce(
+    (total, group) => total + group.users.length,
     0,
   );
-  const teamsShared = teamsWithSpeakers.filter(
-    (team) => team.sharedPreliminaryFindings,
+  const teamsShared = teamGroups.filter(
+    (group) => group.preliminaryFindingsShared,
   ).length;
   const totalSpeakers = teamMemberCount + externalCount;
-  const teamsTotal = teamsWithSpeakers.length;
+  const teamsTotal = teamGroups.length;
   const findingsPercentage =
     teamsTotal > 0 ? Math.round((teamsShared / teamsTotal) * 100) : 0;
 
   const totalRows = teamsTotal + (hasExternal ? 1 : 0);
   const hasMoreRows = totalRows > defaultVisibleTeams;
   const visibleTeams = showAll
-    ? teamsWithSpeakers
-    : teamsWithSpeakers.slice(0, defaultVisibleTeams - (hasExternal ? 1 : 0));
+    ? teamGroups
+    : teamGroups.slice(0, defaultVisibleTeams - (hasExternal ? 1 : 0));
   const showExternalRow = hasExternal && (showAll || !hasMoreRows);
 
   const lastRowBottomPadding = hasMoreRows ? rem(32) : 0;
@@ -485,35 +435,36 @@ const EventSpeakers: React.FC<EventSpeakersProps> = ({
               </thead>
             )}
 
-            {visibleTeams.map((team, index) => {
+            {visibleTeams.map((group, index) => {
               const bottomOverride = lastRowPadding(
                 index === visibleTeams.length - 1,
               );
               return (
                 <SpeakerRow
-                  key={team.teamId}
-                  label={team.teamName}
-                  sharedPreliminaryFindings={team.sharedPreliminaryFindings}
+                  key={group.id}
+                  label={group.teamName}
+                  sharedPreliminaryFindings={group.preliminaryFindingsShared}
                   showFindings={showFindings}
-                  expanded={expandedRows.has(team.teamId)}
-                  onToggle={() => toggleRow(team.teamId)}
+                  expanded={expandedRows.has(group.id)}
+                  onToggle={() => toggleRow(group.id)}
                   collapsedBottomPadding={bottomOverride}
                   info={
                     <>
-                      {teamIcon(team.teamType)}
+                      {teamIcon(group.teamType)}
                       <Link
                         href={
-                          network({}).teams({}).team({ teamId: team.teamId }).$
+                          network({}).teams({}).team({ teamId: group.id }).$
                         }
                       >
-                        {team.teamName}
+                        {group.teamName}
                       </Link>
-                      {team.isTeamInactive && <InactiveBadgeIcon />}
-                      <span css={leadTextStyles}>({team.members.length})</span>
+                      {group.isTeamInactive && <InactiveBadgeIcon />}
+                      <span css={leadTextStyles}>({group.users.length})</span>
                     </>
                   }
                 >
-                  <ul
+                  <div
+                    role="list"
                     css={[
                       membersListStyles,
                       bottomOverride !== undefined && {
@@ -521,43 +472,26 @@ const EventSpeakers: React.FC<EventSpeakersProps> = ({
                       },
                     ]}
                   >
-                    {team.members.map((member) => (
-                      <li key={member.id} css={memberRowStyles}>
-                        <span css={memberMainStyles}>
-                          <span css={memberAvatarStyles}>
-                            <Avatar
-                              firstName={member.firstName}
-                              lastName={member.lastName}
-                              imageUrl={member.avatarUrl}
-                            />
-                          </span>
-                          <Link
-                            href={
-                              network({}).users({}).user({ userId: member.id })
-                                .$
-                            }
-                          >
-                            {member.displayName}
-                          </Link>
-                          {member.isAlumni && (
-                            <span css={alumniStyles}>{alumniBadgeIcon}</span>
-                          )}
-                        </span>
-                        <Pill accent="gray" noMargin>
-                          {member.role}
-                        </Pill>
-                      </li>
+                    {group.users.map((member) => (
+                      <SpeakerUserRow
+                        key={member.id}
+                        displayName={member.displayName}
+                        avatarUrl={member.avatarUrl}
+                        userId={member.id}
+                        roles={member.roles}
+                        isAlumni={member.isAlumni}
+                      />
                     ))}
-                  </ul>
+                  </div>
                 </SpeakerRow>
               );
             })}
 
-            {showExternalRow && externalUsers && (
+            {showExternalRow && externalGroup && (
               <SpeakerRow
                 label="External Users"
                 sharedPreliminaryFindings={
-                  externalUsers.sharedPreliminaryFindings
+                  externalGroup.preliminaryFindingsShared
                 }
                 showFindings={showFindings}
                 expanded={expandedRows.has('external')}
@@ -576,9 +510,9 @@ const EventSpeakers: React.FC<EventSpeakersProps> = ({
                     { paddingBottom: lastRowBottomPadding },
                   ]}
                 >
-                  {externalUsers.members.map((member, index) => (
-                    <li key={`external-${index}`} css={memberRowStyles}>
-                      <span css={leadTextStyles}>{member.name}</span>
+                  {externalGroup.users.map((member) => (
+                    <li key={member.id} css={memberRowStyles}>
+                      <span css={externalNameStyles}>{member.displayName}</span>
                       <Pill accent="gray" noMargin>
                         Guest
                       </Pill>

--- a/packages/react-components/src/organisms/UploadListModal.tsx
+++ b/packages/react-components/src/organisms/UploadListModal.tsx
@@ -348,10 +348,6 @@ const unmatchedHelpStyles = css({
   lineHeight: rem(24),
 });
 
-const footerOverrideStyles = css({
-  paddingBottom: rem(32),
-});
-
 const getAllowedExtensions = (accept: string): string[] =>
   accept
     .split(',')
@@ -759,7 +755,6 @@ const UploadListModal: React.FC<UploadListModalProps> = ({
         }}
         confirmEnabled={addEnabled}
         confirmLoading={isSaving}
-        overrideStyles={footerOverrideStyles}
       />
     </Modal>
   );

--- a/packages/react-components/src/organisms/__tests__/EditEventSpeakersModal.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/EditEventSpeakersModal.test.tsx
@@ -1,0 +1,581 @@
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ComponentProps } from 'react';
+
+import EditEventSpeakersModal, {
+  SpeakerSearchOption,
+} from '../EditEventSpeakersModal';
+import { SpeakerGroup } from '../speaker-group';
+
+const groups: SpeakerGroup[] = [
+  {
+    id: 'team-1',
+    variant: 'team',
+    teamName: 'Team Alpha',
+    preliminaryFindingsShared: true,
+    users: [{ id: 'user-1', displayName: 'Jane Doe', roles: ['Lead PI'] }],
+  },
+];
+
+const singleTeamOption: SpeakerSearchOption = {
+  value: 'user-2',
+  label: 'John Smith',
+  user: {
+    userId: 'user-2',
+    displayName: 'John Smith',
+    teamOptions: [
+      { teamId: 'team-2', teamName: 'Team Beta', role: 'Data Manager' },
+    ],
+  },
+};
+
+const multiTeamOption: SpeakerSearchOption = {
+  value: 'user-3',
+  label: 'Alex Kim',
+  user: {
+    userId: 'user-3',
+    displayName: 'Alex Kim',
+    teamOptions: [
+      { teamId: 'team-1', teamName: 'Team Alpha', role: 'Project Manager' },
+      { teamId: 'team-3', teamName: 'Team Gamma', role: 'Trainee' },
+    ],
+  },
+};
+
+const loadSearchOptions = jest.fn(async () => [
+  singleTeamOption,
+  multiTeamOption,
+]);
+const onSave = jest.fn();
+const onDismiss = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  loadSearchOptions.mockImplementation(async () => [
+    singleTeamOption,
+    multiTeamOption,
+  ]);
+});
+
+const renderModal = (
+  overrides: Partial<ComponentProps<typeof EditEventSpeakersModal>> = {},
+) =>
+  render(
+    <EditEventSpeakersModal
+      loadSearchOptions={loadSearchOptions}
+      onSave={onSave}
+      onDismiss={onDismiss}
+      groups={groups}
+      {...overrides}
+    />,
+  );
+
+describe('EditEventSpeakersModal', () => {
+  it('Should render the "Add Speakers" title and empty state with no speakers', () => {
+    renderModal({ groups: [] });
+
+    expect(
+      screen.getByRole('heading', { name: 'Add Speakers' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Add speakers to this event')).toBeInTheDocument();
+    expect(
+      screen.getByText('Search for a person to add them to this event.'),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Mark All Shared' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('Should disable Save until at least one speaker has been added', async () => {
+    renderModal({ groups: [] });
+
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+
+    await userEvent.type(screen.getByRole('combobox'), 'John');
+    await userEvent.click(await screen.findByText('John Smith'));
+
+    expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled();
+  });
+
+  it('Should render the "Edit Speakers" title and stats when speakers exist', () => {
+    renderModal();
+
+    expect(
+      screen.getByRole('heading', { name: 'Edit Speakers' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('1 Teams')).toBeInTheDocument();
+    expect(screen.getByText('1 Users')).toBeInTheDocument();
+  });
+
+  it('Should add a searched CRN user with exactly one team directly, without a pending card', async () => {
+    renderModal();
+
+    await userEvent.type(screen.getByRole('combobox'), 'John');
+    await userEvent.click(await screen.findByText('John Smith'));
+
+    // Newly added teams auto-expand, so the row is already showing its member.
+    expect(
+      await screen.findByRole('button', { name: 'Collapse Team Beta' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('John Smith')).toBeInTheDocument();
+    expect(
+      screen.queryByText('Pick a team to finish adding them.'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('Should show a pending team-assignment card for a user with multiple teams, and resolve it on pill click', async () => {
+    renderModal();
+
+    await userEvent.type(screen.getByRole('combobox'), 'Alex');
+    await userEvent.click(await screen.findByText('Alex Kim'));
+
+    expect(
+      screen.getByText('Pick a team to finish adding them.'),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Alex Kim' })).toHaveAttribute(
+      'href',
+      expect.stringContaining('user-3'),
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: /Team Gamma/ }));
+
+    expect(
+      screen.queryByText('Pick a team to finish adding them.'),
+    ).not.toBeInTheDocument();
+    // Resolving into a team auto-expands it.
+    expect(
+      screen.getByRole('button', { name: 'Collapse Team Gamma' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Alex Kim')).toBeInTheDocument();
+  });
+
+  it('Should add a creatable external name directly into the External Users group with no team-assignment step', async () => {
+    renderModal();
+
+    await userEvent.type(screen.getByRole('combobox'), 'Guest Speaker');
+    await userEvent.click(await screen.findByText('Guest Speaker'));
+
+    expect(
+      screen.queryByText('Pick a team to finish adding them.'),
+    ).not.toBeInTheDocument();
+    // Newly added groups auto-expand, so the new external user is already visible.
+    expect(
+      screen.getByRole('button', { name: 'Collapse External Users' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Guest Speaker')).toBeInTheDocument();
+  });
+
+  it('Should toggle a group’s Preliminary Findings switch independently of other groups', async () => {
+    renderModal({
+      groups: [
+        ...groups,
+        {
+          id: 'team-2',
+          variant: 'team',
+          teamName: 'Team Beta',
+          preliminaryFindingsShared: false,
+          users: [{ id: 'user-2', displayName: 'John Smith', roles: [] }],
+        },
+      ],
+    });
+
+    const alphaSwitch = screen.getByRole('checkbox', {
+      name: 'Team Alpha preliminary findings shared',
+    });
+    const betaSwitch = screen.getByRole('checkbox', {
+      name: 'Team Beta preliminary findings shared',
+    });
+    expect(alphaSwitch).toBeChecked();
+    expect(betaSwitch).not.toBeChecked();
+
+    await userEvent.click(betaSwitch);
+
+    expect(betaSwitch).toBeChecked();
+    expect(alphaSwitch).toBeChecked();
+  });
+
+  it('Should mark every group as shared', async () => {
+    renderModal({
+      groups: [
+        ...groups,
+        {
+          id: 'team-2',
+          variant: 'team',
+          teamName: 'Team Beta',
+          preliminaryFindingsShared: false,
+          users: [{ id: 'user-2', displayName: 'John Smith', roles: [] }],
+        },
+      ],
+    });
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Mark All Shared' }),
+    );
+
+    expect(
+      screen.getByRole('checkbox', {
+        name: 'Team Beta preliminary findings shared',
+      }),
+    ).toBeChecked();
+  });
+
+  it('Should remove the team row entirely once its last member is removed', async () => {
+    renderModal();
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Expand Team Alpha' }),
+    );
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Remove Jane Doe' }),
+    );
+
+    expect(screen.queryByText('Jane Doe')).not.toBeInTheDocument();
+    expect(screen.queryByText('Team Alpha')).not.toBeInTheDocument();
+    expect(screen.getByText('Add speakers to this event')).toBeInTheDocument();
+  });
+
+  it('Should never render a team with zero members, even when passed in via groups', () => {
+    renderModal({
+      groups: [
+        ...groups,
+        {
+          id: 'team-2',
+          variant: 'team',
+          teamName: 'Team Beta',
+          preliminaryFindingsShared: false,
+          users: [],
+        },
+      ],
+    });
+
+    expect(screen.getByText('Team Alpha')).toBeInTheDocument();
+    expect(screen.queryByText('Team Beta')).not.toBeInTheDocument();
+    expect(screen.getByText('1 Teams')).toBeInTheDocument();
+  });
+
+  it('Should remove a user from one group without affecting another team or the External Users group', async () => {
+    renderModal({
+      groups: [
+        ...groups,
+        {
+          id: 'team-2',
+          variant: 'team',
+          teamName: 'Team Beta',
+          preliminaryFindingsShared: false,
+          users: [{ id: 'user-2', displayName: 'John Smith', roles: [] }],
+        },
+        {
+          id: 'external',
+          variant: 'external',
+          preliminaryFindingsShared: false,
+          users: [{ id: 'ext-1', displayName: 'Guest One' }],
+        },
+      ],
+    });
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Expand External Users' }),
+    );
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Remove Guest One' }),
+    );
+
+    expect(screen.queryByText('Guest One')).not.toBeInTheDocument();
+    expect(screen.getByText('2 Users')).toBeInTheDocument();
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Expand Team Beta' }),
+    );
+    expect(screen.getByText('John Smith')).toBeInTheDocument();
+  });
+
+  it('Should not duplicate a speaker who is searched and selected twice for the same team', async () => {
+    renderModal({ groups: [] });
+
+    await userEvent.type(screen.getByRole('combobox'), 'John');
+    await userEvent.click(await screen.findByText('John Smith'));
+    // Collapse the row so the roster's "John Smith" doesn't collide with the
+    // dropdown option of the same name on the second search.
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Collapse Team Beta' }),
+    );
+    await userEvent.type(screen.getByRole('combobox'), 'John');
+    await userEvent.click(await screen.findByText('John Smith'));
+
+    // Re-adding the same speaker auto-(re)expands their team.
+    expect(
+      screen.getByRole('button', { name: 'Collapse Team Beta' }),
+    ).toBeInTheDocument();
+    const nestedLists = screen.getAllByRole('list');
+    const nestedUserList = nestedLists[nestedLists.length - 1];
+    if (!nestedUserList) {
+      throw new Error('Expected a nested user list to be rendered');
+    }
+    expect(within(nestedUserList).getAllByRole('listitem')).toHaveLength(1);
+    expect(screen.getByText('1 Users')).toBeInTheDocument();
+  });
+
+  it('Should collapse an already-expanded team when the chevron is clicked again', async () => {
+    renderModal();
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Expand Team Alpha' }),
+    );
+    expect(screen.getByText('Jane Doe')).toBeInTheDocument();
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Collapse Team Alpha' }),
+    );
+    expect(screen.queryByText('Jane Doe')).not.toBeInTheDocument();
+  });
+
+  it('Should add a second user to an already-existing team group, keeping both members and leaving other groups untouched', async () => {
+    renderModal({
+      groups: [
+        ...groups,
+        {
+          id: 'team-2',
+          variant: 'team',
+          teamName: 'Team Beta',
+          preliminaryFindingsShared: false,
+          users: [{ id: 'user-2', displayName: 'John Smith', roles: [] }],
+        },
+      ],
+    });
+
+    loadSearchOptions.mockImplementationOnce(async () => [
+      {
+        value: 'user-4',
+        label: 'Casey Fox',
+        user: {
+          userId: 'user-4',
+          displayName: 'Casey Fox',
+          teamOptions: [
+            { teamId: 'team-1', teamName: 'Team Alpha', role: 'Trainee' },
+          ],
+        },
+      },
+    ]);
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Expand Team Alpha' }),
+    );
+    await userEvent.type(screen.getByRole('combobox'), 'Casey');
+    await userEvent.click(await screen.findByText('Casey Fox'));
+
+    expect(screen.getByText('Jane Doe')).toBeInTheDocument();
+    expect(screen.getByText('Casey Fox')).toBeInTheDocument();
+    // Team Beta (the untouched other group) still contributes its member.
+    expect(screen.getByText('3 Users')).toBeInTheDocument();
+  });
+
+  it('Should add a second external user into the existing External Users group', async () => {
+    renderModal({
+      groups: [
+        ...groups,
+        {
+          id: 'external',
+          variant: 'external',
+          preliminaryFindingsShared: false,
+          users: [{ id: 'ext-1', displayName: 'Guest One' }],
+        },
+      ],
+    });
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Expand External Users' }),
+    );
+    await userEvent.type(screen.getByRole('combobox'), 'Guest Two');
+    await userEvent.click(await screen.findByText('Guest Two'));
+
+    expect(screen.getByText('Guest One')).toBeInTheDocument();
+    expect(screen.getByText('Guest Two')).toBeInTheDocument();
+  });
+
+  it('Should insert a newly added team before an existing External Users group', async () => {
+    renderModal({
+      groups: [
+        {
+          id: 'external',
+          variant: 'external',
+          preliminaryFindingsShared: false,
+          users: [{ id: 'ext-1', displayName: 'Guest One' }],
+        },
+      ],
+    });
+
+    await userEvent.type(screen.getByRole('combobox'), 'John');
+    await userEvent.click(await screen.findByText('John Smith'));
+
+    const headings = screen
+      .getAllByRole('button')
+      .map((button) => button.getAttribute('aria-label') ?? '')
+      .filter(
+        (label) =>
+          label.includes('Team Beta') || label.includes('External Users'),
+      );
+    expect(headings[0]).toContain('Team Beta');
+    expect(headings[1]).toContain('External Users');
+  });
+
+  it('Should dismiss the pending speaker card without adding them anywhere', async () => {
+    renderModal();
+
+    await userEvent.type(screen.getByRole('combobox'), 'Alex');
+    await userEvent.click(await screen.findByText('Alex Kim'));
+    expect(
+      screen.getByText('Pick a team to finish adding them.'),
+    ).toBeInTheDocument();
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Remove Alex Kim' }),
+    );
+
+    expect(
+      screen.queryByText('Pick a team to finish adding them.'),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText('Alex Kim')).not.toBeInTheDocument();
+  });
+
+  it('Should expand two different teams independently', async () => {
+    renderModal({
+      groups: [
+        ...groups,
+        {
+          id: 'team-2',
+          variant: 'team',
+          teamName: 'Team Beta',
+          preliminaryFindingsShared: false,
+          users: [{ id: 'user-2', displayName: 'John Smith', roles: [] }],
+        },
+      ],
+    });
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Expand Team Alpha' }),
+    );
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Expand Team Beta' }),
+    );
+
+    expect(screen.getByText('Jane Doe')).toBeInTheDocument();
+    expect(screen.getByText('John Smith')).toBeInTheDocument();
+  });
+
+  it('Should hide the search input but keep other controls interactive when disableAdding is set (Past events)', async () => {
+    renderModal({ disableAdding: true });
+
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Mark All Shared' }),
+    ).toBeEnabled();
+
+    await userEvent.click(
+      screen.getByRole('checkbox', {
+        name: 'Team Alpha preliminary findings shared',
+      }),
+    );
+    expect(
+      screen.getByRole('checkbox', {
+        name: 'Team Alpha preliminary findings shared',
+      }),
+    ).not.toBeChecked();
+  });
+
+  it('Should close immediately on cancel when nothing has changed', async () => {
+    renderModal();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+    expect(
+      screen.queryByRole('button', { name: 'Discard changes' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('Should confirm before discarding and call onDismiss on "Discard changes"', async () => {
+    renderModal();
+
+    await userEvent.click(
+      screen.getByRole('checkbox', {
+        name: 'Team Alpha preliminary findings shared',
+      }),
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(
+      screen.getByText("You'll lose all unsaved changes if you cancel now."),
+    ).toBeInTheDocument();
+    expect(onDismiss).not.toHaveBeenCalled();
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Discard changes' }),
+    );
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('Should return to editing when "Keep Editing" is clicked', async () => {
+    renderModal();
+
+    await userEvent.click(
+      screen.getByRole('checkbox', {
+        name: 'Team Alpha preliminary findings shared',
+      }),
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Keep Editing' }));
+
+    expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Discard changes' }),
+    ).not.toBeInTheDocument();
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it('Should call onSave with the current groups', async () => {
+    renderModal();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(onSave).toHaveBeenCalledWith(groups));
+  });
+
+  it('Should stay usable when saving fails', async () => {
+    renderModal({ onSave: jest.fn().mockRejectedValue(new Error('nope')) });
+
+    await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled(),
+    );
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeEnabled();
+  });
+
+  it('Should render both the full and shortened search placeholders (one shown per breakpoint via CSS)', () => {
+    renderModal();
+
+    expect(screen.getByText('Search for a person to add…')).toBeInTheDocument();
+    expect(screen.getByText('Search for a person…')).toBeInTheDocument();
+  });
+
+  it('Should render both the full and shortened "Preliminary Findings" table header labels (one shown per breakpoint via CSS)', () => {
+    renderModal();
+
+    expect(screen.getByText('Preliminary Findings')).toBeInTheDocument();
+    expect(screen.getByText('P. Findings')).toBeInTheDocument();
+  });
+
+  it('Should default to an empty list when groups are omitted', () => {
+    render(
+      <EditEventSpeakersModal
+        loadSearchOptions={loadSearchOptions}
+        onSave={onSave}
+        onDismiss={onDismiss}
+      />,
+    );
+
+    expect(
+      screen.getByRole('heading', { name: 'Add Speakers' }),
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/react-components/src/organisms/__tests__/EditEventSpeakersModal.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/EditEventSpeakersModal.test.tsx
@@ -462,26 +462,6 @@ describe('EditEventSpeakersModal', () => {
     expect(screen.getByText('John Smith')).toBeInTheDocument();
   });
 
-  it('Should hide the search input but keep other controls interactive when disableAdding is set (Past events)', async () => {
-    renderModal({ disableAdding: true });
-
-    expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
-    expect(
-      screen.getByRole('button', { name: 'Mark All Shared' }),
-    ).toBeEnabled();
-
-    await userEvent.click(
-      screen.getByRole('checkbox', {
-        name: 'Team Alpha preliminary findings shared',
-      }),
-    );
-    expect(
-      screen.getByRole('checkbox', {
-        name: 'Team Alpha preliminary findings shared',
-      }),
-    ).not.toBeChecked();
-  });
-
   it('Should close immediately on cancel when nothing has changed', async () => {
     renderModal();
 

--- a/packages/react-components/src/organisms/__tests__/EventSpeakers.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/EventSpeakers.test.tsx
@@ -2,10 +2,8 @@ import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { StaticRouter } from 'react-router';
 
-import EventSpeakers, {
-  EventSpeakerTeamRow,
-  EventSpeakerExternalRow,
-} from '../EventSpeakers';
+import EventSpeakers from '../EventSpeakers';
+import { SpeakerGroup, SpeakerGroupUser } from '../speaker-group';
 
 // jsdom has no ResizeObserver and does no layout.
 globalThis.ResizeObserver = jest.fn(() => ({
@@ -27,57 +25,67 @@ const mockTableOverflow = (scrollWidth: number, clientWidth: number) => {
 
 afterEach(() => mockTableOverflow(0, 0));
 
-const makeMembers = (teamIndex: number, count: number) =>
+const makeUsers = (teamIndex: number, count: number): SpeakerGroupUser[] =>
   Array.from({ length: count }, (_, index) => ({
     id: `user-${teamIndex}-${index}`,
-    firstName: 'John',
-    lastName: 'Doe',
     displayName: `John Doe ${teamIndex}-${index}`,
-    role: 'Data Manager',
+    roles: ['Data Manager'],
     isAlumni: index === 0,
   }));
 
-const teams: EventSpeakerTeamRow[] = [
+const teamGroups: SpeakerGroup[] = [
   {
-    teamId: 'team-0',
+    id: 'team-0',
+    variant: 'team',
     teamName: 'Team Alpha',
     teamType: 'Discovery Team',
-    sharedPreliminaryFindings: true,
+    preliminaryFindingsShared: true,
     isTeamInactive: true,
-    members: makeMembers(0, 2),
+    users: makeUsers(0, 2),
   },
   {
-    teamId: 'team-1',
+    id: 'team-1',
+    variant: 'team',
     teamName: 'Team Beta',
     teamType: 'Resource Team',
-    sharedPreliminaryFindings: false,
-    members: makeMembers(1, 1),
+    preliminaryFindingsShared: false,
+    users: makeUsers(1, 1),
   },
 ];
 
-const externalUsers: EventSpeakerExternalRow = {
-  sharedPreliminaryFindings: false,
-  members: [{ name: 'External user 1' }],
+const externalGroup: SpeakerGroup = {
+  id: 'external',
+  variant: 'external',
+  preliminaryFindingsShared: false,
+  users: [{ id: 'ext-1', displayName: 'External user 1' }],
 };
+
+const groups: SpeakerGroup[] = [...teamGroups, externalGroup];
 
 const renderCard = (
   props: Partial<React.ComponentProps<typeof EventSpeakers>> = {},
 ) =>
   render(
     <StaticRouter location="/">
-      <EventSpeakers
-        teams={teams}
-        externalUsers={externalUsers}
-        hasFinished
-        {...props}
-      />
+      <EventSpeakers groups={groups} hasFinished {...props} />
     </StaticRouter>,
   );
 
 describe('EventSpeakers', () => {
   describe('empty state', () => {
     it('Should show the read-only message for a non-editor', () => {
-      const { getByText } = renderCard({ teams: [], externalUsers: undefined });
+      const { getByText } = renderCard({ groups: [] });
+      expect(
+        getByText('No speakers have been added for this event yet.'),
+      ).toBeVisible();
+    });
+
+    it('Should default to the empty state when groups are omitted', () => {
+      const { getByText } = render(
+        <StaticRouter location="/">
+          <EventSpeakers />
+        </StaticRouter>,
+      );
       expect(
         getByText('No speakers have been added for this event yet.'),
       ).toBeVisible();
@@ -85,8 +93,7 @@ describe('EventSpeakers', () => {
 
     it('Should prompt an editor to add speakers for an upcoming event', () => {
       const { getByText, getByRole } = renderCard({
-        teams: [],
-        externalUsers: undefined,
+        groups: [],
         hasFinished: false,
         onAddSpeaker: jest.fn(),
       });
@@ -98,8 +105,7 @@ describe('EventSpeakers', () => {
 
     it('Should prompt an editor to add presenters for a past event', () => {
       const { getByText } = renderCard({
-        teams: [],
-        externalUsers: undefined,
+        groups: [],
         hasFinished: true,
         onAddSpeaker: jest.fn(),
       });
@@ -111,8 +117,7 @@ describe('EventSpeakers', () => {
     it('Should fire onAddSpeaker from the empty-state button', async () => {
       const onAddSpeaker = jest.fn();
       const { getByRole } = renderCard({
-        teams: [],
-        externalUsers: undefined,
+        groups: [],
         onAddSpeaker,
       });
       await userEvent.click(getByRole('button', { name: /add speakers/i }));
@@ -181,7 +186,7 @@ describe('EventSpeakers', () => {
     it('Should default to hiding findings when hasFinished is not provided', () => {
       const { queryByText } = render(
         <StaticRouter location="/">
-          <EventSpeakers teams={teams} externalUsers={externalUsers} />
+          <EventSpeakers groups={groups} />
         </StaticRouter>,
       );
       expect(queryByText('Preliminary findings')).not.toBeInTheDocument();
@@ -232,16 +237,16 @@ describe('EventSpeakers', () => {
   describe('teams without speakers', () => {
     it('Should hide teams that have no speakers and exclude them from the findings count', () => {
       const { queryByRole, getByText } = renderCard({
-        teams: [
-          ...teams,
+        groups: [
+          ...teamGroups,
           {
-            teamId: 'team-empty',
+            id: 'team-empty',
+            variant: 'team',
             teamName: 'Empty Team',
-            sharedPreliminaryFindings: true,
-            members: [],
+            preliminaryFindingsShared: true,
+            users: [],
           },
         ],
-        externalUsers: undefined,
       });
       expect(
         queryByRole('link', { name: 'Empty Team' }),
@@ -253,7 +258,7 @@ describe('EventSpeakers', () => {
 
   describe('external-only event', () => {
     it('Should render with zero-team findings when there are only external users', () => {
-      const { getByText } = renderCard({ teams: [] });
+      const { getByText } = renderCard({ groups: [externalGroup] });
       expect(getByText('0%')).toBeVisible();
       expect(getByText('0 of 0 teams')).toBeVisible();
       expect(getByText('External Users')).toBeVisible();
@@ -296,20 +301,20 @@ describe('EventSpeakers', () => {
   });
 
   describe('overflow', () => {
-    const manyTeams: EventSpeakerTeamRow[] = Array.from(
+    const manyTeamGroups: SpeakerGroup[] = Array.from(
       { length: 14 },
       (_, index) => ({
-        teamId: `team-${index}`,
+        id: `team-${index}`,
+        variant: 'team',
         teamName: `Team ${index + 1}`,
-        sharedPreliminaryFindings: true,
-        members: makeMembers(index, 1),
+        preliminaryFindingsShared: true,
+        users: makeUsers(index, 1),
       }),
     );
 
     it('Should not render the footer with 10 or fewer rows', () => {
       const { queryByRole } = renderCard({
-        teams: manyTeams.slice(0, 10),
-        externalUsers: undefined,
+        groups: manyTeamGroups.slice(0, 10),
       });
       expect(
         queryByRole('button', { name: /view more speakers/i }),
@@ -318,8 +323,7 @@ describe('EventSpeakers', () => {
 
     it('Should reveal the remaining rows on View More', async () => {
       const { getByRole, queryByRole } = renderCard({
-        teams: manyTeams,
-        externalUsers: undefined,
+        groups: manyTeamGroups,
       });
       expect(
         queryByRole('button', { name: 'Expand Team 14' }),
@@ -337,8 +341,7 @@ describe('EventSpeakers', () => {
 
     it('Should collapse the extra rows again on View Less', async () => {
       const { getByRole, queryByRole } = renderCard({
-        teams: manyTeams,
-        externalUsers: undefined,
+        groups: manyTeamGroups,
       });
       await userEvent.click(
         getByRole('button', { name: /view more speakers/i }),
@@ -356,8 +359,7 @@ describe('EventSpeakers', () => {
 
     it('Should still expand the last visible team above the footer', async () => {
       const { getByRole, getByText } = renderCard({
-        teams: manyTeams,
-        externalUsers: undefined,
+        groups: manyTeamGroups,
       });
       // Team 10 is the last visible row while the footer is shown.
       await userEvent.click(getByRole('button', { name: 'Expand Team 10' }));

--- a/packages/react-components/src/organisms/index.ts
+++ b/packages/react-components/src/organisms/index.ts
@@ -25,6 +25,16 @@ export { default as EntityCard } from './EntityCard';
 export { default as EventAbout } from './EventAbout';
 export { default as EditEventAttendanceModal } from './EditEventAttendanceModal';
 export type { AttendanceSearchOption } from './EditEventAttendanceModal';
+export { default as EditEventSpeakersModal } from './EditEventSpeakersModal';
+export type {
+  SpeakerSearchOption,
+  SpeakerTeamOption,
+} from './EditEventSpeakersModal';
+export type {
+  SpeakerGroup,
+  SpeakerGroupExternalUser,
+  SpeakerGroupUser,
+} from './speaker-group';
 export { default as EventAttendance } from './EventAttendance';
 export type {
   EventAttendanceTeam,
@@ -43,12 +53,6 @@ export { default as EventConversation } from './EventConversation';
 export { default as EventMaterials } from './EventMaterials';
 export { default as EventSearch } from './EventSearch';
 export { default as EventSpeakers } from './EventSpeakers';
-export type {
-  EventSpeakerTeamRow,
-  EventSpeakerExternalRow,
-  EventSpeakerExternalMember,
-  EventSpeakerMember,
-} from './EventSpeakers';
 export { default as ExportAnalyticsModal } from './ExportAnalyticsModal';
 export { default as Filter } from './Filter';
 export { default as Form } from './Form';

--- a/packages/react-components/src/organisms/shared-event-card-styles.ts
+++ b/packages/react-components/src/organisms/shared-event-card-styles.ts
@@ -122,3 +122,15 @@ export const cellStyles = css({
 });
 
 export const statusCellStyles = css([cellStyles, { lineHeight: 0 }]);
+
+// The accordion expand/collapse toggle, shared by the speaker table rows and
+// the edit-modal team rows.
+export const chevronButtonStyles = css({
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  padding: 0,
+  border: 'none',
+  background: 'none',
+  cursor: 'pointer',
+});

--- a/packages/react-components/src/organisms/speaker-group.ts
+++ b/packages/react-components/src/organisms/speaker-group.ts
@@ -1,0 +1,35 @@
+import { EventTeamType } from './shared-event-card';
+
+// Shared speaker data shape consumed by both the read-only EventSpeakers card
+// and the editable EditEventSpeakersModal, so a single state can flow into
+// both and the modal's onSave can write straight back — no adapter needed.
+
+export type SpeakerGroupUser = {
+  readonly id: string;
+  readonly displayName: string;
+  readonly avatarUrl?: string;
+  readonly roles: string[];
+  readonly isAlumni?: boolean;
+};
+
+export type SpeakerGroupExternalUser = {
+  readonly id: string;
+  readonly displayName: string;
+};
+
+export type SpeakerGroup =
+  | {
+      readonly id: string;
+      readonly variant: 'team';
+      readonly teamName: string;
+      readonly teamType?: EventTeamType;
+      readonly isTeamInactive?: boolean;
+      readonly preliminaryFindingsShared: boolean;
+      readonly users: SpeakerGroupUser[];
+    }
+  | {
+      readonly id: 'external';
+      readonly variant: 'external';
+      readonly preliminaryFindingsShared: boolean;
+      readonly users: SpeakerGroupExternalUser[];
+    };

--- a/packages/react-components/src/utils/user.ts
+++ b/packages/react-components/src/utils/user.ts
@@ -1,3 +1,8 @@
+export const splitDisplayName = (displayName: string) => {
+  const [firstName, ...rest] = displayName.split(' ');
+  return { firstName, lastName: rest.join(' ') };
+};
+
 export const formatUserLocation = (
   city?: string,
   stateOrProvince?: string,


### PR DESCRIPTION
ref: https://asaphub.atlassian.net/browse/ASAP-1592

Stacked on top of #5115 (Event Speakers card)

How to test (Storybook)

- **Organisms / Events / Speakers → Edit and Save**: end-to-end: open the pencil, add/remove speakers or toggle findings, Save, and watch the card refresh (no adapter between card and modal).
- **Organisms / Events / Edit Speakers Modal**: `Add Speakers` and `Edit Speakers`.
