### PR TITLE
[ASAP-1650] - fix project member links

### DIFF
--- a/apps/crn-frontend/src/projects/ResourceProjects.tsx
+++ b/apps/crn-frontend/src/projects/ResourceProjects.tsx
@@ -1,14 +1,16 @@
 import { FC, useMemo } from 'react';
 import { SearchFrame } from '@asap-hub/frontend-utils';
-import { ProjectsPage, ResourceProjectsList } from '@asap-hub/react-components';
+import {
+  withMemberHref,
+  ProjectsPage,
+  ResourceProjectsList,
+} from '@asap-hub/react-components';
 import type {
   FetchListFilter,
-  ProjectMember,
   ProjectStatus,
   ResearchThemeType,
   ResourceProject,
 } from '@asap-hub/model';
-import { network } from '@asap-hub/routing';
 import { usePagination, usePaginationParams } from '../hooks';
 import { useProjects } from './state';
 import { ProjectListOptions } from './api';
@@ -48,12 +50,6 @@ type ResourceProjectsListContentProps = {
   pageSize: number;
 };
 
-const withMemberHref = (members?: ReadonlyArray<ProjectMember>) =>
-  members?.map((member) => ({
-    ...member,
-    href: network({}).users({}).user({ userId: member.id }).$,
-  }));
-
 const ResourceProjectsListContent: FC<ResourceProjectsListContentProps> = ({
   options,
   currentPage,
@@ -68,7 +64,7 @@ const ResourceProjectsListContent: FC<ResourceProjectsListContentProps> = ({
           ? project
           : {
               ...project,
-              members: withMemberHref(project.members) ?? project.members,
+              members: project.members?.map(withMemberHref),
             },
       ),
     [projects],

--- a/apps/crn-frontend/src/projects/TraineeProjects.tsx
+++ b/apps/crn-frontend/src/projects/TraineeProjects.tsx
@@ -1,13 +1,15 @@
 import { FC, useMemo } from 'react';
 import { SearchFrame } from '@asap-hub/frontend-utils';
-import { ProjectsPage, TraineeProjectsList } from '@asap-hub/react-components';
+import {
+  withMemberHref,
+  ProjectsPage,
+  TraineeProjectsList,
+} from '@asap-hub/react-components';
 import type {
   FetchListFilter,
-  ProjectMember,
   ProjectStatus,
   TraineeProject,
 } from '@asap-hub/model';
-import { network } from '@asap-hub/routing';
 import { usePagination, usePaginationParams } from '../hooks';
 import { useProjects } from './state';
 import { ProjectListOptions } from './api';
@@ -35,11 +37,6 @@ type TraineeProjectsListContentProps = {
   currentPage: number;
   pageSize: number;
 };
-
-const withMemberHref = (member: ProjectMember) => ({
-  ...member,
-  href: network({}).users({}).user({ userId: member.id }).$,
-});
 
 const TraineeProjectsListContent: FC<TraineeProjectsListContentProps> = ({
   options,

--- a/apps/storybook/src/ProjectMembers.stories.tsx
+++ b/apps/storybook/src/ProjectMembers.stories.tsx
@@ -39,52 +39,17 @@ const mockMembers: ProjectMember[] = [
   },
 ];
 
-const membersWithSingleTeam: ProjectMember[] = mockMembers.map((m) => ({
-  ...m,
-  teams: [{ id: 'team-1', displayName: 'Alpha Team' }],
-}));
-
-const membersWithMultipleTeams: ProjectMember[] = mockMembers.map((m, idx) => ({
-  ...m,
-  teams:
-    idx === 0
-      ? [
-          { id: 'team-1', displayName: 'Alpha Team' },
-          { id: 'team-2', displayName: 'Genomics Lab' },
-          { id: 'team-3', displayName: 'Neuroscience Team' },
-          { id: 'team-4', displayName: 'PD Consortium' },
-        ]
-      : [
-          { id: 'team-1', displayName: 'Alpha Team' },
-          { id: 'team-5', displayName: 'Another Lab' },
-        ],
-}));
-
 // ProjectMembers (List) Stories
 export const ResourceNotTeamBased = () => (
-  <ProjectMembers members={mockMembers} showTeamInfo={false} />
-);
-
-export const TraineeWithTeamInfo = () => (
-  <ProjectMembers members={membersWithSingleTeam} showTeamInfo={true} />
-);
-
-export const TraineeWithTeamInfoAndBadge = () => (
-  <ProjectMembers members={membersWithMultipleTeams} showTeamInfo={true} />
+  <ProjectMembers members={mockMembers} />
 );
 
 export const SingleMember = () => (
-  <ProjectMembers
-    members={[mockMembers[0] as ProjectMember]}
-    showTeamInfo={false}
-  />
+  <ProjectMembers members={[mockMembers[0] as ProjectMember]} />
 );
 
 export const TwoMembers = () => (
-  <ProjectMembers
-    members={mockMembers.slice(0, 2) as ProjectMember[]}
-    showTeamInfo={false}
-  />
+  <ProjectMembers members={mockMembers.slice(0, 2) as ProjectMember[]} />
 );
 
 // ProjectMemberCard (Individual) Stories
@@ -98,41 +63,11 @@ const mockGroupedMember: GroupedProjectMember = {
 };
 
 export const IndividualMemberCard = () => (
-  <ProjectMemberCard member={mockGroupedMember} showTeamInfo={false} />
-);
-
-export const MemberCardWithTeam = () => (
-  <ProjectMemberCard
-    member={{
-      ...mockGroupedMember,
-      teams: [{ id: 'team-1', displayName: 'Alpha Team' }],
-    }}
-    showTeamInfo={true}
-  />
-);
-
-export const MemberCardWithTeamAndBadge = () => (
-  <ProjectMemberCard
-    member={{
-      ...mockGroupedMember,
-      teams: [
-        { id: 'team-1', displayName: 'Anderson Research Team' },
-        { id: 'team-2', displayName: 'Team 2' },
-        { id: 'team-3', displayName: 'Team 3' },
-        { id: 'team-4', displayName: 'Team 4' },
-        { id: 'team-5', displayName: 'Team 5' },
-        { id: 'team-6', displayName: 'Team 6' },
-      ],
-    }}
-    showTeamInfo={true}
-  />
+  <ProjectMemberCard member={mockGroupedMember} />
 );
 
 export const MemberCardWithoutRole = () => (
-  <ProjectMemberCard
-    member={{ ...mockGroupedMember, roles: [] }}
-    showTeamInfo={false}
-  />
+  <ProjectMemberCard member={{ ...mockGroupedMember, roles: [] }} />
 );
 
 export const MemberCardWithLongRole = () => (
@@ -140,11 +75,7 @@ export const MemberCardWithLongRole = () => (
     member={{
       ...mockGroupedMember,
       roles: ['Senior Research Scientist and Laboratory Director'],
-      teams: [
-        { id: 'team-1', displayName: 'Neuroscience Research Consortium' },
-      ],
     }}
-    showTeamInfo={true}
   />
 );
 
@@ -208,52 +139,13 @@ export const MembersWithMultipleRoles = () => (
         href: '/users/michael-johnson',
       },
     ]}
-    showTeamInfo={false}
-  />
-);
-
-export const TraineeWithMultipleRolesAndTeams = () => (
-  <ProjectMembers
-    members={[
-      {
-        id: '1',
-        displayName: 'Alex Chen',
-        firstName: 'Alex',
-        lastName: 'Chen',
-        role: 'Independent Project - Lead',
-        href: '/users/alex-chen',
-        teams: [
-          { id: 'team-1', displayName: 'Alpha Team' },
-          { id: 'team-2', displayName: 'Genomics Lab' },
-        ],
-      },
-      {
-        id: '1',
-        displayName: 'Alex Chen',
-        firstName: 'Alex',
-        lastName: 'Chen',
-        role: 'Independent Project - Mentor',
-        href: '/users/alex-chen',
-        teams: [{ id: 'team-1', displayName: 'Alpha Team' }],
-      },
-      {
-        id: '2',
-        displayName: 'Maria Garcia',
-        firstName: 'Maria',
-        lastName: 'Garcia',
-        role: 'Independent Project - Mentor',
-        href: '/users/maria-garcia',
-        teams: [{ id: 'team-1', displayName: 'Alpha Team' }],
-      },
-    ]}
-    showTeamInfo={true}
   />
 );
 
 export const RealWorldExample = () => (
   <div style={{ display: 'flex', flexDirection: 'column', gap: '48px' }}>
     <div>
-      <h3>Trainee Project Members (with team info)</h3>
+      <h3>Trainee Project Members</h3>
       <ProjectMembers
         members={[
           {
@@ -263,7 +155,6 @@ export const RealWorldExample = () => (
             lastName: 'Chen',
             role: 'Independent Project - Lead',
             href: '/users/alex-chen',
-            teams: [{ id: 'team-1', displayName: 'Alpha Team' }],
           },
           {
             id: '3',
@@ -272,10 +163,6 @@ export const RealWorldExample = () => (
             lastName: 'Garcia',
             role: 'Independent Project - Lead',
             href: '/users/maria-garcia',
-            teams: [
-              { id: 'team-1', displayName: 'Alpha Team' },
-              { id: 'team-4', displayName: 'Genomics Lab' },
-            ],
           },
           {
             id: '1',
@@ -284,14 +171,8 @@ export const RealWorldExample = () => (
             lastName: 'Martinez',
             role: 'Independent Project - Mentor',
             href: '/users/sarah-martinez',
-            teams: [
-              { id: 'team-1', displayName: 'Alpha Team' },
-              { id: 'team-2', displayName: 'Neuroscience Research' },
-              { id: 'team-3', displayName: 'PD Consortium' },
-            ],
           },
         ]}
-        showTeamInfo={true}
       />
     </div>
 
@@ -324,7 +205,6 @@ export const RealWorldExample = () => (
             href: '/users/david-kim',
           },
         ]}
-        showTeamInfo={false}
       />
     </div>
   </div>

--- a/packages/react-components/src/index.ts
+++ b/packages/react-components/src/index.ts
@@ -380,6 +380,8 @@ export {
   getIconForDocumentType,
   formatUserLocation,
   considerEndedAfter,
+  getMemberHref,
+  withMemberHref,
   Portal,
   PortalContainer,
   portalContainerId,

--- a/packages/react-components/src/molecules/ProjectMemberCard.tsx
+++ b/packages/react-components/src/molecules/ProjectMemberCard.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { Link } from '../atoms';
 import { rem } from '../pixels';
-import { fern } from '../colors';
+import { fern, lead } from '../colors';
 import { GroupedProjectMember } from '../utils';
 import RolesList from './RolesList';
 import UserAvatar from './UserAvatar';
@@ -34,6 +34,12 @@ const nameStyles = css({
   },
 });
 
+const noRoleStyles = css({
+  color: lead.rgb,
+  fontSize: rem(17),
+  fontStyle: 'italic',
+});
+
 type ProjectMemberCardProps = {
   readonly member: GroupedProjectMember;
 };
@@ -56,8 +62,10 @@ const ProjectMemberCard: React.FC<ProjectMemberCardProps> = ({ member }) => (
       <Link href={member.href}>
         <span css={nameStyles}>{member.displayName}</span>
       </Link>
-      {member.roles.length > 0 && (
+      {member.roles.length > 0 ? (
         <RolesList roles={member.roles} maxVisible={2} />
+      ) : (
+        <div css={noRoleStyles}>No role assigned</div>
       )}
     </div>
   </div>

--- a/packages/react-components/src/molecules/ProjectMemberCard.tsx
+++ b/packages/react-components/src/molecules/ProjectMemberCard.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { Link } from '../atoms';
 import { rem } from '../pixels';
-import { fern, lead } from '../colors';
+import { fern } from '../colors';
 import { GroupedProjectMember } from '../utils';
 import RolesList from './RolesList';
 import UserAvatar from './UserAvatar';

--- a/packages/react-components/src/molecules/ProjectMemberCard.tsx
+++ b/packages/react-components/src/molecules/ProjectMemberCard.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { Link, OverflowBadge } from '../atoms';
+import { Link } from '../atoms';
 import { rem } from '../pixels';
 import { fern, lead } from '../colors';
 import { GroupedProjectMember } from '../utils';
@@ -34,68 +34,33 @@ const nameStyles = css({
   },
 });
 
-const teamInfoStyles = css({
-  display: 'flex',
-  alignItems: 'center',
-  gap: rem(8),
-  fontSize: rem(17),
-  color: fern.rgb,
-});
-
-const noRoleStyles = css({
-  color: lead.rgb,
-  fontSize: rem(17),
-  fontStyle: 'italic',
-});
-
 type ProjectMemberCardProps = {
   readonly member: GroupedProjectMember;
-  /** Whether to show team information (true for trainee, false for resource not team-based) */
-  readonly showTeamInfo?: boolean;
 };
 
-const ProjectMemberCard: React.FC<ProjectMemberCardProps> = ({
-  member,
-  showTeamInfo = false,
-}) => {
-  const teams = member.teams || [];
-  const firstTeam = teams[0];
-  const additionalTeamsCount = teams.length > 1 ? teams.length - 1 : 0;
-
-  return (
-    <div css={memberCardStyles}>
-      <div css={avatarStyles}>
-        <UserAvatar
-          imageUrl={member.avatarUrl}
-          firstName={member.firstName}
-          lastName={member.lastName}
-          badgeUrl={member.latestAward?.smallIconUrl}
-          badgeAlt={member.latestAward?.name}
-          badgeSize={18}
-          avatarSize={48}
-          overrideBadgeStyles={css({ right: rem(0), bottom: rem(0) })}
-        />
-      </div>
-      <div css={memberInfoStyles}>
-        <Link href={'#'}>
-          <span css={nameStyles}>{member.displayName}</span>
-        </Link>
-        {member.roles.length > 0 ? (
-          <RolesList roles={member.roles} maxVisible={2} />
-        ) : (
-          <div css={noRoleStyles}>No role assigned</div>
-        )}
-        {showTeamInfo && firstTeam && (
-          <div css={teamInfoStyles}>
-            <Link href={'#'}>{firstTeam.displayName}</Link>
-            {additionalTeamsCount > 0 && (
-              <OverflowBadge count={additionalTeamsCount} />
-            )}
-          </div>
-        )}
-      </div>
+const ProjectMemberCard: React.FC<ProjectMemberCardProps> = ({ member }) => (
+  <div css={memberCardStyles}>
+    <div css={avatarStyles}>
+      <UserAvatar
+        imageUrl={member.avatarUrl}
+        firstName={member.firstName}
+        lastName={member.lastName}
+        badgeUrl={member.latestAward?.smallIconUrl}
+        badgeAlt={member.latestAward?.name}
+        badgeSize={18}
+        avatarSize={48}
+        overrideBadgeStyles={css({ right: rem(0), bottom: rem(0) })}
+      />
     </div>
-  );
-};
+    <div css={memberInfoStyles}>
+      <Link href={member.href}>
+        <span css={nameStyles}>{member.displayName}</span>
+      </Link>
+      {member.roles.length > 0 && (
+        <RolesList roles={member.roles} maxVisible={2} />
+      )}
+    </div>
+  </div>
+);
 
 export default ProjectMemberCard;

--- a/packages/react-components/src/molecules/ProjectMembers.tsx
+++ b/packages/react-components/src/molecules/ProjectMembers.tsx
@@ -16,14 +16,9 @@ const membersListStyles = css({
 
 type ProjectMembersProps = {
   readonly members: ReadonlyArray<ProjectMember>;
-  /** Show team info (true for trainee, false for resource not team-based) */
-  readonly showTeamInfo?: boolean;
 };
 
-const ProjectMembers: React.FC<ProjectMembersProps> = ({
-  members,
-  showTeamInfo = false,
-}) => {
+const ProjectMembers: React.FC<ProjectMembersProps> = ({ members }) => {
   const grouped = useMemo(
     () => groupProjectMembersByUserId(members),
     [members],
@@ -32,11 +27,7 @@ const ProjectMembers: React.FC<ProjectMembersProps> = ({
   return (
     <div css={membersListStyles}>
       {grouped.map((member) => (
-        <ProjectMemberCard
-          key={member.id}
-          member={member}
-          showTeamInfo={showTeamInfo}
-        />
+        <ProjectMemberCard key={member.id} member={member} />
       ))}
     </div>
   );

--- a/packages/react-components/src/molecules/__tests__/ProjectMemberCard.test.tsx
+++ b/packages/react-components/src/molecules/__tests__/ProjectMemberCard.test.tsx
@@ -17,7 +17,7 @@ describe('ProjectMemberCard', () => {
     render(<ProjectMemberCard member={mockMember} />);
     const nameLink = screen.getByRole('link', { name: mockMember.displayName });
     expect(nameLink).toBeInTheDocument();
-    expect(nameLink).toHaveAttribute('href', '#');
+    expect(nameLink).toHaveAttribute('href', mockMember.href);
   });
 
   it('renders member role', () => {
@@ -33,7 +33,7 @@ describe('ProjectMemberCard', () => {
   it('renders "No role assigned" in place of the role when roles is empty', () => {
     const memberWithoutRole = { ...mockMember, roles: [] };
     const { container } = render(
-      <ProjectMemberCard member={memberWithoutRole} showTeamInfo={false} />,
+      <ProjectMemberCard member={memberWithoutRole} />,
     );
     expect(container).toHaveTextContent(mockMember.displayName);
     expect(container).not.toHaveTextContent('Principal Investigator');
@@ -55,71 +55,13 @@ describe('ProjectMemberCard', () => {
     expect(screen.queryByText('No role assigned')).not.toBeInTheDocument();
   });
 
-  it('does not show team info when showTeamInfo is false', () => {
-    const memberWithTeam = {
-      ...mockMember,
-      teams: [{ id: 'team-1', displayName: 'Alpha Team' }],
-    };
-    render(<ProjectMemberCard member={memberWithTeam} showTeamInfo={false} />);
-    expect(screen.queryByText('Alpha Team')).not.toBeInTheDocument();
-  });
-
-  it('shows team name when showTeamInfo is true and member has teams', () => {
-    const memberWithTeam = {
-      ...mockMember,
-      teams: [{ id: 'team-1', displayName: 'Alpha Team' }],
-    };
-    render(<ProjectMemberCard member={memberWithTeam} showTeamInfo={true} />);
-    expect(screen.getByText('Alpha Team')).toBeInTheDocument();
-  });
-
-  it('shows additional teams badge when member has multiple teams', () => {
-    const memberWithMultipleTeams = {
-      ...mockMember,
-      teams: [
-        { id: 'team-1', displayName: 'Alpha Team' },
-        { id: 'team-2', displayName: 'Genomics Lab' },
-        { id: 'team-3', displayName: 'Neuroscience Team' },
-        { id: 'team-4', displayName: 'PD Consortium' },
-      ],
-    };
-    render(
-      <ProjectMemberCard
-        member={memberWithMultipleTeams}
-        showTeamInfo={true}
-      />,
-    );
-    expect(screen.getByText('Alpha Team')).toBeInTheDocument();
-    expect(screen.getByText('+3')).toBeInTheDocument();
-  });
-
-  it('does not show badge when member has only one team', () => {
-    const memberWithOneTeam = {
-      ...mockMember,
-      teams: [{ id: 'team-1', displayName: 'Alpha Team' }],
-    };
-    render(
-      <ProjectMemberCard member={memberWithOneTeam} showTeamInfo={true} />,
-    );
-    expect(screen.getByText('Alpha Team')).toBeInTheDocument();
-    expect(screen.queryByText(/\+\d+/)).not.toBeInTheDocument();
-  });
-
-  it('does not show team info when member has no teams', () => {
-    render(<ProjectMemberCard member={mockMember} showTeamInfo={true} />);
-    expect(screen.queryByText(/Lab/)).not.toBeInTheDocument();
-    expect(screen.queryByText(/\+\d+/)).not.toBeInTheDocument();
-  });
-
   it('renders avatar with empty initials when firstName and lastName are undefined', () => {
     const memberWithoutNames = {
       ...mockMember,
       firstName: undefined,
       lastName: undefined,
     };
-    render(
-      <ProjectMemberCard member={memberWithoutNames} showTeamInfo={false} />,
-    );
+    render(<ProjectMemberCard member={memberWithoutNames} />);
     expect(screen.getByText(mockMember.displayName)).toBeInTheDocument();
   });
 
@@ -128,9 +70,7 @@ describe('ProjectMemberCard', () => {
       ...mockMember,
       avatarUrl: 'https://example.com/avatar.jpg',
     };
-    render(
-      <ProjectMemberCard member={memberWithAvatar} showTeamInfo={false} />,
-    );
+    render(<ProjectMemberCard member={memberWithAvatar} />);
     // Avatar component is rendered - just verify the component doesn't crash
     expect(screen.getByText(mockMember.displayName)).toBeInTheDocument();
   });

--- a/packages/react-components/src/molecules/__tests__/ProjectMemberCard.test.tsx
+++ b/packages/react-components/src/molecules/__tests__/ProjectMemberCard.test.tsx
@@ -42,16 +42,14 @@ describe('ProjectMemberCard', () => {
 
   it('italicises "No role assigned" so it reads as missing data', () => {
     const memberWithoutRole = { ...mockMember, roles: [] };
-    render(
-      <ProjectMemberCard member={memberWithoutRole} showTeamInfo={false} />,
-    );
+    render(<ProjectMemberCard member={memberWithoutRole} />);
     expect(screen.getByText('No role assigned')).toHaveStyle(
       'font-style: italic',
     );
   });
 
   it('does not render "No role assigned" when the member has a role', () => {
-    render(<ProjectMemberCard member={mockMember} showTeamInfo={false} />);
+    render(<ProjectMemberCard member={mockMember} />);
     expect(screen.queryByText('No role assigned')).not.toBeInTheDocument();
   });
 

--- a/packages/react-components/src/molecules/__tests__/ProjectMembers.test.tsx
+++ b/packages/react-components/src/molecules/__tests__/ProjectMembers.test.tsx
@@ -49,9 +49,7 @@ describe('ProjectMembers', () => {
       ...mockMembers,
       { id: '4', displayName: 'Pat Roleless', href: '/users/pat-roleless' },
     ];
-    render(
-      <ProjectMembers members={membersWithOneRoleless} showTeamInfo={false} />,
-    );
+    render(<ProjectMembers members={membersWithOneRoleless} />);
     expect(screen.getByText('Pat Roleless')).toBeInTheDocument();
     expect(screen.getByText('No role assigned')).toBeVisible();
   });

--- a/packages/react-components/src/molecules/__tests__/ProjectMembers.test.tsx
+++ b/packages/react-components/src/molecules/__tests__/ProjectMembers.test.tsx
@@ -31,14 +31,14 @@ const mockMembers: ProjectMember[] = [
 
 describe('ProjectMembers', () => {
   it('renders all members', () => {
-    render(<ProjectMembers members={mockMembers} showTeamInfo={false} />);
+    render(<ProjectMembers members={mockMembers} />);
     expect(screen.getByText('John Doe')).toBeInTheDocument();
     expect(screen.getByText('Jane Smith')).toBeInTheDocument();
     expect(screen.getByText('Michael Johnson')).toBeInTheDocument();
   });
 
   it('renders member roles', () => {
-    render(<ProjectMembers members={mockMembers} showTeamInfo={false} />);
+    render(<ProjectMembers members={mockMembers} />);
     expect(screen.getByText('Principal Investigator')).toBeInTheDocument();
     expect(screen.getByText('Co-Investigator')).toBeInTheDocument();
     expect(screen.getByText('Research Associate')).toBeInTheDocument();
@@ -56,71 +56,23 @@ describe('ProjectMembers', () => {
     expect(screen.getByText('No role assigned')).toBeVisible();
   });
 
-  it('does not show team info when showTeamInfo is false', () => {
-    const membersWithTeams = mockMembers.map((m) => ({
-      ...m,
-      teams: [{ id: 'team-1', displayName: 'Alpha Team' }],
-    }));
-    render(<ProjectMembers members={membersWithTeams} showTeamInfo={false} />);
-    expect(screen.queryByText('Alpha Team')).not.toBeInTheDocument();
-  });
-
-  it('shows team name for members when showTeamInfo is true', () => {
-    const membersWithTeams = mockMembers.map((m) => ({
-      ...m,
-      teams: [{ id: 'team-1', displayName: 'Alpha Team' }],
-    }));
-    render(<ProjectMembers members={membersWithTeams} showTeamInfo={true} />);
-    const teamNames = screen.getAllByText('Alpha Team');
-    expect(teamNames).toHaveLength(mockMembers.length);
-  });
-
-  it('shows additional teams badge for members with multiple teams', () => {
-    const membersWithMultipleTeams = mockMembers.map((m) => ({
-      ...m,
-      teams: [
-        { id: 'team-1', displayName: 'Alpha Team' },
-        { id: 'team-2', displayName: 'Team 2' },
-        { id: 'team-3', displayName: 'Team 3' },
-      ],
-    }));
-    render(
-      <ProjectMembers members={membersWithMultipleTeams} showTeamInfo={true} />,
-    );
-    const badges = screen.getAllByText('+2');
-    expect(badges).toHaveLength(mockMembers.length);
-  });
-
   it('renders empty state with empty array', () => {
-    const { container } = render(
-      <ProjectMembers members={[]} showTeamInfo={false} />,
-    );
+    const { container } = render(<ProjectMembers members={[]} />);
     expect(container.firstChild).toBeEmptyDOMElement();
   });
 
   it('renders single member', () => {
-    render(<ProjectMembers members={[mockMembers[0]!]} showTeamInfo={false} />);
+    render(<ProjectMembers members={[mockMembers[0]!]} />);
     expect(screen.getByText('John Doe')).toBeInTheDocument();
     expect(screen.queryByText('Jane Smith')).not.toBeInTheDocument();
   });
 
   it('renders all member links correctly', () => {
-    render(<ProjectMembers members={mockMembers} showTeamInfo={false} />);
+    render(<ProjectMembers members={mockMembers} />);
     const links = screen.getAllByRole('link');
     expect(links).toHaveLength(mockMembers.length);
-    expect(links[0]).toHaveAttribute('href', '#');
-    expect(links[0]).toHaveAttribute('href', '#');
-    expect(links[0]).toHaveAttribute('href', '#');
-  });
-
-  it('uses default showTeamInfo=false when prop is not provided', () => {
-    const membersWithTeams = mockMembers.map((m) => ({
-      ...m,
-      teams: [{ id: 'team-1', displayName: 'Alpha Team' }],
-    }));
-    // Don't pass showTeamInfo prop - should default to false
-    render(<ProjectMembers members={membersWithTeams} />);
-    // Team info should not be shown when using default value
-    expect(screen.queryByText('Alpha Team')).not.toBeInTheDocument();
+    expect(links[0]).toHaveAttribute('href', mockMembers[0]!.href);
+    expect(links[1]).toHaveAttribute('href', mockMembers[1]!.href);
+    expect(links[2]).toHaveAttribute('href', mockMembers[2]!.href);
   });
 });

--- a/packages/react-components/src/molecules/__tests__/ProjectMembers.test.tsx
+++ b/packages/react-components/src/molecules/__tests__/ProjectMembers.test.tsx
@@ -9,7 +9,6 @@ const mockMembers: ProjectMember[] = [
     firstName: 'John',
     lastName: 'Doe',
     role: 'Principal Investigator',
-    href: '/users/john-doe',
   },
   {
     id: '2',
@@ -17,7 +16,6 @@ const mockMembers: ProjectMember[] = [
     firstName: 'Jane',
     lastName: 'Smith',
     role: 'Co-Investigator',
-    href: '/users/jane-smith',
   },
   {
     id: '3',
@@ -25,7 +23,6 @@ const mockMembers: ProjectMember[] = [
     firstName: 'Michael',
     lastName: 'Johnson',
     role: 'Research Associate',
-    href: '/users/michael-johnson',
   },
 ];
 
@@ -65,12 +62,12 @@ describe('ProjectMembers', () => {
     expect(screen.queryByText('Jane Smith')).not.toBeInTheDocument();
   });
 
-  it('renders all member links correctly', () => {
+  it('renders all member links pointing to their user profile', () => {
     render(<ProjectMembers members={mockMembers} />);
     const links = screen.getAllByRole('link');
     expect(links).toHaveLength(mockMembers.length);
-    expect(links[0]).toHaveAttribute('href', mockMembers[0]!.href);
-    expect(links[1]).toHaveAttribute('href', mockMembers[1]!.href);
-    expect(links[2]).toHaveAttribute('href', mockMembers[2]!.href);
+    expect(links[0]).toHaveAttribute('href', '/network/users/1');
+    expect(links[1]).toHaveAttribute('href', '/network/users/2');
+    expect(links[2]).toHaveAttribute('href', '/network/users/3');
   });
 });

--- a/packages/react-components/src/organisms/ProjectContributors.tsx
+++ b/packages/react-components/src/organisms/ProjectContributors.tsx
@@ -59,14 +59,11 @@ type ProjectContributorsProps =
       fundedTeam: FundedTeam;
       collaboratingTeams?: ReadonlyArray<CollaboratingTeam>;
       projectMembers?: never;
-      showTeamInfo?: never;
     }
   | {
       fundedTeam?: never;
       collaboratingTeams?: never;
       projectMembers: ReadonlyArray<ProjectMember>;
-      /** Show team info (true for trainee, false for resource not team-based) */
-      showTeamInfo?: boolean;
     };
 
 export const tabs = ['Funded Team', 'Collaborators'] as const;
@@ -77,7 +74,6 @@ const ProjectContributors: React.FC<ProjectContributorsProps> = ({
   fundedTeam,
   collaboratingTeams,
   projectMembers,
-  showTeamInfo = false,
 }) => {
   const [activeTab, setActiveTab] = useState<Tabs>('Funded Team');
 
@@ -90,10 +86,7 @@ const ProjectContributors: React.FC<ProjectContributorsProps> = ({
             View the people contributing to this project.
           </Paragraph>
           <div css={membersContentStyles}>
-            <ProjectMembers
-              members={projectMembers}
-              showTeamInfo={showTeamInfo}
-            />
+            <ProjectMembers members={projectMembers} />
           </div>
         </div>
       </Card>

--- a/packages/react-components/src/templates/ProjectDetailAbout.tsx
+++ b/packages/react-components/src/templates/ProjectDetailAbout.tsx
@@ -76,10 +76,7 @@ const ProjectDetailAbout: React.FC<ProjectDetailAboutProps> = (project) => {
         )}
 
       {project.projectType === 'Trainee Project' && (
-        <ProjectContributors
-          projectMembers={project.members}
-          showTeamInfo={true}
-        />
+        <ProjectContributors projectMembers={project.members} />
       )}
 
       {/* Contact CTA Card */}

--- a/packages/react-components/src/templates/ProjectDetailAbout.tsx
+++ b/packages/react-components/src/templates/ProjectDetailAbout.tsx
@@ -76,10 +76,7 @@ const ProjectDetailAbout: React.FC<ProjectDetailAboutProps> = (project) => {
         )}
 
       {project.projectType === 'Trainee Project' && (
-        <ProjectContributors
-          projectMembers={project.members}
-          collaboratingMembers={project.collaboratingMembers}
-        />
+        <ProjectContributors projectMembers={project.members} />
       )}
 
       {/* Contact CTA Card */}

--- a/packages/react-components/src/templates/ProjectDetailAbout.tsx
+++ b/packages/react-components/src/templates/ProjectDetailAbout.tsx
@@ -76,7 +76,10 @@ const ProjectDetailAbout: React.FC<ProjectDetailAboutProps> = (project) => {
         )}
 
       {project.projectType === 'Trainee Project' && (
-        <ProjectContributors projectMembers={project.members} />
+        <ProjectContributors
+          projectMembers={project.members}
+          collaboratingMembers={project.collaboratingMembers}
+        />
       )}
 
       {/* Contact CTA Card */}

--- a/packages/react-components/src/templates/ProjectDetailHeader.tsx
+++ b/packages/react-components/src/templates/ProjectDetailHeader.tsx
@@ -4,7 +4,7 @@ import {
   ProjectMember,
 } from '@asap-hub/model';
 import { useFlags } from '@asap-hub/react-context';
-import { network, projects } from '@asap-hub/routing';
+import { projects } from '@asap-hub/routing';
 import { css } from '@emotion/react';
 import { Display, Pill, Link, CopyButton, TabLink } from '../atoms';
 import { lead } from '../colors';
@@ -32,6 +32,7 @@ import {
 } from '../molecules';
 import { rem, tabletScreen } from '../pixels';
 import { getStatusPillAccent } from '../organisms/ProjectCard';
+import { withMemberHref } from '../utils';
 import PageInfoContainer from './PageInfoContainer';
 import Toast from '../organisms/Toast';
 
@@ -188,12 +189,7 @@ const ProjectDetailHeader = (project: ProjectDetailHeaderProps) => {
   });
 
   const membersWithHref =
-    'members' in project
-      ? project.members?.map((member: ProjectMember) => ({
-          ...member,
-          href: network({}).users({}).user({ userId: member.id }).$,
-        }))
-      : undefined;
+    'members' in project ? project.members?.map(withMemberHref) : undefined;
 
   return (
     <>

--- a/packages/react-components/src/utils/group.ts
+++ b/packages/react-components/src/utils/group.ts
@@ -9,6 +9,7 @@ import {
 } from '@asap-hub/model';
 
 import { splitListBy } from './common';
+import { getMemberHref } from './project';
 
 const mergeInactiveSinceDate = (
   existing: string | undefined,
@@ -174,7 +175,7 @@ export const groupProjectMembersByUserId = (
         avatarUrl: member.avatarUrl,
         email: member.email,
         alumniSinceDate: member.alumniSinceDate,
-        href: member.href,
+        href: getMemberHref(member.id),
         teams: member.teams ? [...member.teams] : undefined,
         roles: member.role ? [member.role] : [],
         latestAward: member.latestAward,

--- a/packages/react-components/src/utils/project.tsx
+++ b/packages/react-components/src/utils/project.tsx
@@ -1,10 +1,20 @@
-import { BaseProject, ProjectType } from '@asap-hub/model';
-import { projects } from '@asap-hub/routing';
+import { BaseProject, ProjectMember, ProjectType } from '@asap-hub/model';
+import { network, projects } from '@asap-hub/routing';
 import {
   DiscoveryProjectIcon,
   ResourceProjectIcon,
   TraineeProjectIcon,
 } from '../icons';
+
+export const getMemberHref = (memberId: string): string =>
+  network({}).users({}).user({ userId: memberId }).$;
+
+export const withMemberHref = (
+  member: ProjectMember,
+): ProjectMember & { href: string } => ({
+  ...member,
+  href: getMemberHref(member.id),
+});
 
 type ProjectConfigParams = {
   projectId: BaseProject['id'];


### PR DESCRIPTION
ref: https://asaphub.atlassian.net/browse/ASAP-1650

- I've removed the `showTeamInfo` prop in `ProjectMemberCard` as well. We don't pass the project member's teams from the backend and the current designs only show the roles