### PR TITLE
[ASAP-1639] - Event Attendance improvements

### DIFF
--- a/apps/crn-frontend/src/events/Event.tsx
+++ b/apps/crn-frontend/src/events/Event.tsx
@@ -9,6 +9,7 @@ import {
   getIconForDocumentType,
   NotFoundPage,
   noop,
+  resolveEventThumbnail,
   SpeakerList,
   useDateHasPassed,
   considerEndedAfter,
@@ -105,6 +106,7 @@ const Event: React.FC = () => {
         <PageConstraints>
           <EventPage
             {...event}
+            thumbnail={resolveEventThumbnail(event)}
             hasFinished={hasFinished}
             tags={event.tags.map((tag) => tag.name)}
             backHref={backHref}

--- a/apps/crn-frontend/src/events/__tests__/Event.test.tsx
+++ b/apps/crn-frontend/src/events/__tests__/Event.test.tsx
@@ -98,6 +98,25 @@ it('renders the speakers list', async () => {
   expect(await findByText('Speakers')).toBeVisible();
 });
 
+it('shows the interest group thumbnail on the legacy event page', async () => {
+  const event = createEventResponse();
+  mockGetEvent.mockResolvedValue({
+    ...event,
+    id,
+    title: 'IG Thumb Event',
+    thumbnail: undefined,
+    interestGroup: {
+      ...event.interestGroup!,
+      thumbnail: 'https://example.com/ig-thumbnail.png',
+    },
+  });
+  const { findByAltText } = render(<Event />, { wrapper });
+  expect(await findByAltText('Thumbnail for "IG Thumb Event"')).toHaveAttribute(
+    'src',
+    'https://example.com/ig-thumbnail.png',
+  );
+});
+
 it('generates the back href', async () => {
   const { findByText } = render(<Event />, { wrapper });
   expect((await findByText(/back/i)).closest('a')).toHaveAttribute(

--- a/apps/crn-server/src/data-providers/contentful/event.data-provider.ts
+++ b/apps/crn-server/src/data-providers/contentful/event.data-provider.ts
@@ -517,6 +517,7 @@ export const parseGraphQLEvent = (item: EventItem): EventDataObject => {
         id: ig.sys.id,
         name: ig.name || '',
         active: !!ig.active,
+        thumbnail: ig.thumbnail?.url ?? undefined,
         tools: {
           slack: ig.slack || undefined,
           googleDrive: ig.googleDrive ?? undefined,

--- a/apps/crn-server/test/data-providers/contentful/event.data-provider.test.ts
+++ b/apps/crn-server/test/data-providers/contentful/event.data-provider.test.ts
@@ -1082,6 +1082,61 @@ describe('Events Contentful Data Provider', () => {
           },
         });
       });
+
+      it('should map the interest group thumbnail when present', async () => {
+        const contentfulGraphQLResponse = getContentfulGraphqlEvent();
+        contentfulGraphQLResponse!.calendar!.linkedFrom = {
+          interestGroupsCollection: {
+            items: [
+              {
+                sys: {
+                  id: 'ig-linked-from-calendar',
+                },
+                name: 'IG-1',
+                active: true,
+                slack: 'http://www.slack.com/ig1',
+                thumbnail: { url: 'https://example.com/ig-thumbnail.png' },
+              },
+            ],
+          },
+        };
+
+        contentfulGraphqlClientMock.request.mockResolvedValueOnce({
+          events: contentfulGraphQLResponse,
+        });
+
+        const result = await eventDataProvider.fetchById(eventId);
+
+        expect(result!.interestGroup!.thumbnail).toEqual(
+          'https://example.com/ig-thumbnail.png',
+        );
+      });
+
+      it('should leave the interest group thumbnail undefined when absent', async () => {
+        const contentfulGraphQLResponse = getContentfulGraphqlEvent();
+        contentfulGraphQLResponse!.calendar!.linkedFrom = {
+          interestGroupsCollection: {
+            items: [
+              {
+                sys: {
+                  id: 'ig-linked-from-calendar',
+                },
+                name: 'IG-1',
+                active: true,
+                slack: 'http://www.slack.com/ig1',
+              },
+            ],
+          },
+        };
+
+        contentfulGraphqlClientMock.request.mockResolvedValueOnce({
+          events: contentfulGraphQLResponse,
+        });
+
+        const result = await eventDataProvider.fetchById(eventId);
+
+        expect(result!.interestGroup!.thumbnail).toBeUndefined();
+      });
     });
   });
 

--- a/packages/contentful/src/crn/autogenerated-gql/graphql.ts
+++ b/packages/contentful/src/crn/autogenerated-gql/graphql.ts
@@ -28744,7 +28744,7 @@ export type EventsContentFragment = Pick<
               Pick<
                 InterestGroups,
                 'name' | 'active' | 'slack' | 'googleDrive'
-              > & { sys: Pick<Sys, 'id'> }
+              > & { sys: Pick<Sys, 'id'>; thumbnail?: Maybe<Pick<Asset, 'url'>> }
             >
           >;
         }>;
@@ -29200,7 +29200,7 @@ export type FetchEventByIdQuery = {
                   Pick<
                     InterestGroups,
                     'name' | 'active' | 'slack' | 'googleDrive'
-                  > & { sys: Pick<Sys, 'id'> }
+                  > & { sys: Pick<Sys, 'id'>; thumbnail?: Maybe<Pick<Asset, 'url'>> }
                 >
               >;
             }>;
@@ -29829,7 +29829,7 @@ export type FetchEventsQuery = {
                         Pick<
                           InterestGroups,
                           'name' | 'active' | 'slack' | 'googleDrive'
-                        > & { sys: Pick<Sys, 'id'> }
+                        > & { sys: Pick<Sys, 'id'>; thumbnail?: Maybe<Pick<Asset, 'url'>> }
                       >
                     >;
                   }>;
@@ -30548,7 +30548,7 @@ export type FetchEventsByUserIdQuery = {
                                       | 'active'
                                       | 'slack'
                                       | 'googleDrive'
-                                    > & { sys: Pick<Sys, 'id'> }
+                                    > & { sys: Pick<Sys, 'id'>; thumbnail?: Maybe<Pick<Asset, 'url'>> }
                                   >
                                 >;
                               }>;
@@ -31275,7 +31275,7 @@ export type FetchEventsByExternalAuthorIdQuery = {
                                       | 'active'
                                       | 'slack'
                                       | 'googleDrive'
-                                    > & { sys: Pick<Sys, 'id'> }
+                                    > & { sys: Pick<Sys, 'id'>; thumbnail?: Maybe<Pick<Asset, 'url'>> }
                                   >
                                 >;
                               }>;
@@ -32002,7 +32002,7 @@ export type FetchEventsByTeamIdQuery = {
                                       | 'active'
                                       | 'slack'
                                       | 'googleDrive'
-                                    > & { sys: Pick<Sys, 'id'> }
+                                    > & { sys: Pick<Sys, 'id'>; thumbnail?: Maybe<Pick<Asset, 'url'>> }
                                   >
                                 >;
                               }>;
@@ -42110,6 +42110,19 @@ export const EventsContentFragmentDoc = {
                                     name: {
                                       kind: 'Name',
                                       value: 'googleDrive',
+                                    },
+                                  },
+                                  {
+                                    kind: 'Field',
+                                    name: { kind: 'Name', value: 'thumbnail' },
+                                    selectionSet: {
+                                      kind: 'SelectionSet',
+                                      selections: [
+                                        {
+                                          kind: 'Field',
+                                          name: { kind: 'Name', value: 'url' },
+                                        },
+                                      ],
                                     },
                                   },
                                 ],

--- a/packages/contentful/src/crn/queries/events.queries.ts
+++ b/packages/contentful/src/crn/queries/events.queries.ts
@@ -204,6 +204,9 @@ export const eventsContentQueryFragment = gql`
             active
             slack
             googleDrive
+            thumbnail {
+              url
+            }
           }
         }
       }

--- a/packages/model/src/event.ts
+++ b/packages/model/src/event.ts
@@ -72,7 +72,7 @@ export interface EventDataObject extends BasicEvent {
   calendar: CalendarResponse;
   interestGroup?: Pick<
     InterestGroupResponse,
-    'id' | 'name' | 'active' | 'tools'
+    'id' | 'name' | 'active' | 'tools' | 'thumbnail'
   >;
   workingGroup?: Pick<WorkingGroupResponse, 'id' | 'title'>;
   speakers: EventSpeaker[];

--- a/packages/react-components/src/__tests__/event-mapper.test.ts
+++ b/packages/react-components/src/__tests__/event-mapper.test.ts
@@ -14,4 +14,51 @@ describe('eventMapper', () => {
       }).tags,
     ).toEqual(['Blood', 'Bacteria']);
   });
+
+  it('prefers the interest group thumbnail over the event thumbnail', () => {
+    const event = createEventResponse();
+    expect(
+      eventMapper({
+        ...event,
+        thumbnail: 'https://example.com/event.png',
+        interestGroup: {
+          ...event.interestGroup!,
+          thumbnail: 'https://example.com/interest-group.png',
+        },
+      }).thumbnail,
+    ).toEqual('https://example.com/interest-group.png');
+  });
+
+  it('falls back to the event thumbnail when the interest group has none', () => {
+    const event = createEventResponse();
+    expect(
+      eventMapper({
+        ...event,
+        thumbnail: 'https://example.com/event.png',
+        interestGroup: { ...event.interestGroup!, thumbnail: undefined },
+      }).thumbnail,
+    ).toEqual('https://example.com/event.png');
+  });
+
+  it('leaves the thumbnail undefined when neither has one', () => {
+    const event = createEventResponse();
+    expect(
+      eventMapper({
+        ...event,
+        thumbnail: undefined,
+        interestGroup: { ...event.interestGroup!, thumbnail: undefined },
+      }).thumbnail,
+    ).toBeUndefined();
+  });
+
+  it('falls back to the event thumbnail when there is no interest group', () => {
+    const event = createEventResponse();
+    expect(
+      eventMapper({
+        ...event,
+        thumbnail: 'https://example.com/event.png',
+        interestGroup: undefined,
+      }).thumbnail,
+    ).toEqual('https://example.com/event.png');
+  });
 });

--- a/packages/react-components/src/event-mapper.tsx
+++ b/packages/react-components/src/event-mapper.tsx
@@ -8,6 +8,7 @@ export const eventMapper = ({
   ...event
 }: EventResponse) => ({
   ...event,
+  thumbnail: interestGroup?.thumbnail ?? event.thumbnail,
   tags: event.tags.map(({ name }) => name),
   hasSpeakersToBeAnnounced: !!(
     speakers.length === 0 ||

--- a/packages/react-components/src/event-mapper.tsx
+++ b/packages/react-components/src/event-mapper.tsx
@@ -1,6 +1,14 @@
 import { EventResponse } from '@asap-hub/model';
 import { EventNumberOfSpeakers, EventOwner, EventTeams } from './molecules';
 
+// Prefer the associated Interest Group's thumbnail, fall back to the event's
+// own thumbnail. Shared by the list/detail mapper and the legacy event page.
+export const resolveEventThumbnail = ({
+  interestGroup,
+  thumbnail,
+}: Pick<EventResponse, 'interestGroup' | 'thumbnail'>): string | undefined =>
+  interestGroup?.thumbnail ?? thumbnail;
+
 export const eventMapper = ({
   speakers,
   interestGroup,
@@ -8,7 +16,10 @@ export const eventMapper = ({
   ...event
 }: EventResponse) => ({
   ...event,
-  thumbnail: interestGroup?.thumbnail ?? event.thumbnail,
+  thumbnail: resolveEventThumbnail({
+    interestGroup,
+    thumbnail: event.thumbnail,
+  }),
   tags: event.tags.map(({ name }) => name),
   hasSpeakersToBeAnnounced: !!(
     speakers.length === 0 ||

--- a/packages/react-components/src/molecules/EventAttendanceMetric.tsx
+++ b/packages/react-components/src/molecules/EventAttendanceMetric.tsx
@@ -38,16 +38,33 @@ const arrowStyles = (direction: 'up' | 'down') =>
       : { borderTop: `${rem(10)} solid ${ember.rgb}` }),
   });
 
-type BaseProps = {
+type ValueProps = {
   label: string;
   value: number;
   caption: string;
 };
 
-type EventAttendanceMetricProps = BaseProps &
-  ({ variant: 'progress' } | { variant: 'delta'; direction: 'up' | 'down' });
+type EventAttendanceMetricProps =
+  | (ValueProps & { variant: 'progress' })
+  | (ValueProps & { variant: 'delta'; direction: 'up' | 'down' | 'none' })
+  | { variant: 'empty'; label: string; message: string };
+
+const deltaSign: Record<'up' | 'down' | 'none', string> = {
+  up: '+ ',
+  down: '- ',
+  none: '',
+};
 
 const EventAttendanceMetric: React.FC<EventAttendanceMetricProps> = (props) => {
+  if (props.variant === 'empty') {
+    return (
+      <div css={metricContainerStyles}>
+        <p css={metricLabelStyles}>{props.label}</p>
+        <p css={metricLabelStyles}>{props.message}</p>
+      </div>
+    );
+  }
+
   const { label, value, caption } = props;
 
   if (props.variant === 'delta') {
@@ -55,16 +72,16 @@ const EventAttendanceMetric: React.FC<EventAttendanceMetricProps> = (props) => {
       <div css={metricContainerStyles}>
         <p css={metricLabelStyles}>{label}</p>
         <div css={deltaRowStyles}>
-          <p css={metricValueStyles}>
-            {`${props.direction === 'up' ? '+' : '-'} ${value}`}
-          </p>
-          <span
-            css={arrowContainerStyles}
-            role="img"
-            aria-label={props.direction === 'up' ? 'Increase' : 'Decrease'}
-          >
-            <span css={arrowStyles(props.direction)} />
-          </span>
+          <p css={metricValueStyles}>{`${deltaSign[props.direction]}${value}`}</p>
+          {props.direction !== 'none' && (
+            <span
+              css={arrowContainerStyles}
+              role="img"
+              aria-label={props.direction === 'up' ? 'Increase' : 'Decrease'}
+            >
+              <span css={arrowStyles(props.direction)} />
+            </span>
+          )}
         </div>
         <p css={metricLabelStyles}>{caption}</p>
       </div>

--- a/packages/react-components/src/molecules/EventAttendanceMetric.tsx
+++ b/packages/react-components/src/molecules/EventAttendanceMetric.tsx
@@ -55,10 +55,17 @@ const deltaSign: Record<'up' | 'down' | 'none', string> = {
   none: '',
 };
 
+const emptyStackStyles = css({
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'center',
+  gap: rem(24),
+});
+
 const EventAttendanceMetric: React.FC<EventAttendanceMetricProps> = (props) => {
   if (props.variant === 'empty') {
     return (
-      <div css={metricContainerStyles}>
+      <div css={[metricContainerStyles, emptyStackStyles]}>
         <p css={metricLabelStyles}>{props.label}</p>
         <p css={metricLabelStyles}>{props.message}</p>
       </div>

--- a/packages/react-components/src/molecules/EventAttendanceMetric.tsx
+++ b/packages/react-components/src/molecules/EventAttendanceMetric.tsx
@@ -68,11 +68,12 @@ const EventAttendanceMetric: React.FC<EventAttendanceMetricProps> = (props) => {
   const { label, value, caption } = props;
 
   if (props.variant === 'delta') {
+    const deltaValue = `${deltaSign[props.direction]}${value}`;
     return (
       <div css={metricContainerStyles}>
         <p css={metricLabelStyles}>{label}</p>
         <div css={deltaRowStyles}>
-          <p css={metricValueStyles}>{`${deltaSign[props.direction]}${value}`}</p>
+          <p css={metricValueStyles}>{deltaValue}</p>
           {props.direction !== 'none' && (
             <span
               css={arrowContainerStyles}

--- a/packages/react-components/src/molecules/__tests__/EventAttendanceMetric.test.tsx
+++ b/packages/react-components/src/molecules/__tests__/EventAttendanceMetric.test.tsx
@@ -47,4 +47,34 @@ describe('EventAttendanceMetric', () => {
     expect(getByText('- 5')).toBeVisible();
     expect(getByLabelText('Decrease')).toBeInTheDocument();
   });
+
+  it('renders a plain value with no sign or arrow for a none delta', () => {
+    const { getByText, queryByLabelText } = render(
+      <EventAttendanceMetric
+        variant="delta"
+        direction="none"
+        label="Since last event"
+        value={0}
+        caption="No change from 18 of 25 teams"
+      />,
+    );
+    expect(getByText('0')).toBeVisible();
+    expect(getByText('No change from 18 of 25 teams')).toBeVisible();
+    expect(queryByLabelText('Increase')).not.toBeInTheDocument();
+    expect(queryByLabelText('Decrease')).not.toBeInTheDocument();
+  });
+
+  it('renders the empty variant with its label and message and no value', () => {
+    const { getByText, queryByLabelText } = render(
+      <EventAttendanceMetric
+        variant="empty"
+        label="Since last event"
+        message="No previous event to compare to."
+      />,
+    );
+    expect(getByText('Since last event')).toBeVisible();
+    expect(getByText('No previous event to compare to.')).toBeVisible();
+    expect(queryByLabelText('Increase')).not.toBeInTheDocument();
+    expect(queryByLabelText('Decrease')).not.toBeInTheDocument();
+  });
 });

--- a/packages/react-components/src/organisms/EventAttendance.tsx
+++ b/packages/react-components/src/organisms/EventAttendance.tsx
@@ -80,15 +80,16 @@ export type EventAttendanceSinceLastEvent = {
   teamsTotal: number;
 };
 
-// Attended teams first, then active before inactive, then alphabetical by
-// name, with teamId as a stable tiebreaker so equal names order deterministically.
+// Attended teams first, then active before inactive, then by name in natural
+// order (numeric collation, so "Team 2" precedes "Team 10"), with teamId as a
+// stable tiebreaker so equal names order deterministically.
 export const compareAttendanceTeams = (
   a: EventAttendanceTeam,
   b: EventAttendanceTeam,
 ): number =>
   Number(b.attended) - Number(a.attended) ||
   Number(!!a.isTeamInactive) - Number(!!b.isTeamInactive) ||
-  a.teamName.localeCompare(b.teamName) ||
+  a.teamName.localeCompare(b.teamName, undefined, { numeric: true }) ||
   a.teamId.localeCompare(b.teamId);
 
 const useHorizontalOverflow = () => {

--- a/packages/react-components/src/organisms/EventAttendance.tsx
+++ b/packages/react-components/src/organisms/EventAttendance.tsx
@@ -80,6 +80,17 @@ export type EventAttendanceSinceLastEvent = {
   teamsTotal: number;
 };
 
+// Attended teams first, then active before inactive, then alphabetical by
+// name, with teamId as a stable tiebreaker so equal names order deterministically.
+export const compareAttendanceTeams = (
+  a: EventAttendanceTeam,
+  b: EventAttendanceTeam,
+): number =>
+  Number(b.attended) - Number(a.attended) ||
+  Number(!!a.isTeamInactive) - Number(!!b.isTeamInactive) ||
+  a.teamName.localeCompare(b.teamName) ||
+  a.teamId.localeCompare(b.teamId);
+
 const useHorizontalOverflow = () => {
   const [element, setElement] = useState<HTMLElement | null>(null);
   const [overflowing, setOverflowing] = useState(false);
@@ -119,8 +130,11 @@ const EventAttendance: React.FC<EventAttendanceProps> = ({
 }) => {
   const [expanded, setExpanded] = useState(false);
   const [tableRef, teamsOverflowing] = useHorizontalOverflow();
-  const hasMoreRows = teams.length > defaultVisibleTeams;
-  const visibleTeams = expanded ? teams : teams.slice(0, defaultVisibleTeams);
+  const sortedTeams = [...teams].sort(compareAttendanceTeams);
+  const hasMoreRows = sortedTeams.length > defaultVisibleTeams;
+  const visibleTeams = expanded
+    ? sortedTeams
+    : sortedTeams.slice(0, defaultVisibleTeams);
   const attendancePercentage =
     teamsTotal > 0 ? Math.round((teamsAttended / teamsTotal) * 100) : 0;
 
@@ -184,11 +198,25 @@ const EventAttendance: React.FC<EventAttendanceProps> = ({
         <div css={metricsStyles}>
           <EventAttendanceMetric
             variant="progress"
-            label="Attendance"
+            label="This event"
             value={attendancePercentage}
             caption={`${teamsAttended} of ${teamsTotal} teams`}
           />
-          {sinceLastEvent && (
+          {!sinceLastEvent ? (
+            <EventAttendanceMetric
+              variant="empty"
+              label="Since last event"
+              message="No previous event to compare to."
+            />
+          ) : sinceLastEvent.count === 0 ? (
+            <EventAttendanceMetric
+              variant="delta"
+              direction="none"
+              label="Since last event"
+              value={0}
+              caption={`No change from ${sinceLastEvent.teamsAttended} of ${sinceLastEvent.teamsTotal} teams`}
+            />
+          ) : (
             <EventAttendanceMetric
               variant="delta"
               direction={sinceLastEvent.count < 0 ? 'down' : 'up'}

--- a/packages/react-components/src/organisms/__tests__/EventAttendance.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/EventAttendance.test.tsx
@@ -79,6 +79,21 @@ describe('compareAttendanceTeams', () => {
     expect(compareAttendanceTeams(a, b)).toBeLessThan(0);
     expect(compareAttendanceTeams(b, a)).toBeGreaterThan(0);
   });
+
+  it('orders numeric-suffixed names naturally (Team 2 before Team 10)', () => {
+    const two: EventAttendanceTeam = {
+      teamId: 't-2',
+      teamName: 'Team 2',
+      attended: true,
+    };
+    const ten: EventAttendanceTeam = {
+      teamId: 't-10',
+      teamName: 'Team 10',
+      attended: true,
+    };
+    expect(compareAttendanceTeams(two, ten)).toBeLessThan(0);
+    expect(compareAttendanceTeams(ten, two)).toBeGreaterThan(0);
+  });
 });
 
 describe('EventAttendance', () => {
@@ -232,13 +247,13 @@ describe('EventAttendance', () => {
     expect(queryByText('View More Attendees')).not.toBeInTheDocument();
   });
 
-  // zero-padded so alphabetical sort order matches numeric order, keeping
-  // Team 10/11/12 as the last three rows once compareAttendanceTeams runs.
+  // Natural (numeric) collation keeps Team 10/11/12 as the last three rows,
+  // so no zero-padding workaround is needed.
   const manyTeams: EventAttendanceTeam[] = Array.from(
     { length: 12 },
     (_, index) => ({
       teamId: `t${index + 1}`,
-      teamName: `Team ${String(index + 1).padStart(2, '0')}`,
+      teamName: `Team ${index + 1}`,
       attended: true,
     }),
   );

--- a/packages/react-components/src/organisms/__tests__/EventAttendance.test.tsx
+++ b/packages/react-components/src/organisms/__tests__/EventAttendance.test.tsx
@@ -3,7 +3,10 @@ import userEvent from '@testing-library/user-event';
 import { StaticRouter } from 'react-router';
 
 import { rem } from '../../pixels';
-import EventAttendance, { EventAttendanceTeam } from '../EventAttendance';
+import EventAttendance, {
+  compareAttendanceTeams,
+  EventAttendanceTeam,
+} from '../EventAttendance';
 
 globalThis.ResizeObserver = jest.fn(() => ({
   observe: jest.fn(),
@@ -61,11 +64,31 @@ const renderCard = (
     </StaticRouter>,
   );
 
+describe('compareAttendanceTeams', () => {
+  it('breaks ties on equal names with a stable teamId order', () => {
+    const a: EventAttendanceTeam = {
+      teamId: 't-a',
+      teamName: 'Same Name',
+      attended: true,
+    };
+    const b: EventAttendanceTeam = {
+      teamId: 't-b',
+      teamName: 'Same Name',
+      attended: true,
+    };
+    expect(compareAttendanceTeams(a, b)).toBeLessThan(0);
+    expect(compareAttendanceTeams(b, a)).toBeGreaterThan(0);
+  });
+});
+
 describe('EventAttendance', () => {
   it('renders the title and both metric cards', () => {
-    const { getAllByText, getByText } = renderCard();
-    // title + progress metric label both read "Attendance"
-    expect(getAllByText('Attendance').length).toBeGreaterThanOrEqual(1);
+    const { getByRole, getByText } = renderCard();
+    // card title is "Attendance"; left metric label is "This event"
+    expect(
+      getByRole('heading', { level: 3, name: 'Attendance' }),
+    ).toBeVisible();
+    expect(getByText('This event')).toBeVisible();
     expect(getByText('72%')).toBeVisible();
     expect(getByText('18 of 25 teams')).toBeVisible();
     expect(getByText('Since last event')).toBeVisible();
@@ -133,12 +156,40 @@ describe('EventAttendance', () => {
     expect(getByText('- 8')).toBeVisible();
   });
 
-  it('omits the Since last event metric when there is nothing to compare', () => {
-    const { queryByText, queryByLabelText } = renderCard({
+  it('shows the no-previous-event empty state when there is nothing to compare', () => {
+    const { getByText, queryByLabelText } = renderCard({
       sinceLastEvent: undefined,
     });
-    expect(queryByText('Since last event')).not.toBeInTheDocument();
+    expect(getByText('Since last event')).toBeVisible();
+    expect(getByText('No previous event to compare to.')).toBeVisible();
     expect(queryByLabelText('Increase')).not.toBeInTheDocument();
+    expect(queryByLabelText('Decrease')).not.toBeInTheDocument();
+  });
+
+  it('shows the no-change empty state when the delta is zero', () => {
+    const { getByText, queryByLabelText } = renderCard({
+      sinceLastEvent: { count: 0, teamsAttended: 18, teamsTotal: 25 },
+    });
+    expect(getByText('No change from 18 of 25 teams')).toBeVisible();
+    expect(queryByLabelText('Increase')).not.toBeInTheDocument();
+    expect(queryByLabelText('Decrease')).not.toBeInTheDocument();
+  });
+
+  it('orders teams: attended first, then active before inactive, then alphabetical', () => {
+    const orderingTeams: EventAttendanceTeam[] = [
+      { teamId: 'a', teamName: 'Zeta', attended: false },
+      { teamId: 'b', teamName: 'Alpha', attended: true, isTeamInactive: true },
+      { teamId: 'c', teamName: 'Beta', attended: true },
+      { teamId: 'd', teamName: 'Gamma', attended: true },
+      { teamId: 'e', teamName: 'Delta', attended: false, isTeamInactive: true },
+    ];
+    const { getAllByRole } = renderCard({
+      teams: orderingTeams,
+      teamsAttended: 3,
+      teamsTotal: 5,
+    });
+    const names = getAllByRole('link').map((link) => link.textContent);
+    expect(names).toEqual(['Beta', 'Gamma', 'Alpha', 'Zeta', 'Delta']);
   });
 
   it('calls onExport and onEdit when the header buttons are clicked', async () => {
@@ -181,11 +232,13 @@ describe('EventAttendance', () => {
     expect(queryByText('View More Attendees')).not.toBeInTheDocument();
   });
 
+  // zero-padded so alphabetical sort order matches numeric order, keeping
+  // Team 10/11/12 as the last three rows once compareAttendanceTeams runs.
   const manyTeams: EventAttendanceTeam[] = Array.from(
     { length: 12 },
     (_, index) => ({
       teamId: `t${index + 1}`,
-      teamName: `Team ${index + 1}`,
+      teamName: `Team ${String(index + 1).padStart(2, '0')}`,
       attended: true,
     }),
   );


### PR DESCRIPTION
ref: https://asaphub.atlassian.net/browse/ASAP-1639

#### Changes on Event Attendance

With the left card copy updated, first event of a series of occurrence, so, no events to compare and it will show the right card of "No previous event to compare to" and with the team names sorted:

<img width="720" height="732" alt="Screenshot 2026-08-13 at 19 11 02" src="https://github.com/user-attachments/assets/3499d98d-1f6c-416a-8c42-f13c7d22b552" />

When no change in attendance from past event
<img width="1092" height="354" alt="Screenshot 2026-08-13 at 19 19 56" src="https://github.com/user-attachments/assets/f7d2b029-41a8-4b18-adf6-1996d375adf8" />



#### Interest Groups and Event Thumbnail
_(not gated by NEW_EVENT_PAGE feature flag)_

##### What is displayed in each case

| Interest Group thumbnail | Event thumbnail | Displayed | AC | How it resolves |
|---|---|---|---|---|
| ✅ has | ✅ has | **IG thumbnail** | AC03 | `IG.thumbnail ?? event` → IG wins |
| ✅ has | ❌ none | **IG thumbnail** | AC03 | `IG.thumbnail ?? undefined` → IG |
| ❌ none¹ | ✅ has | **Event thumbnail** | AC04 | `undefined ?? event` → event |
| ❌ none¹ | ❌ none | **`EventDateBlock`** (default) | AC05 | `undefined ?? undefined` → falls back to `EventDateBlock` |
| — no associated IG | ✅ has | **Event thumbnail** | AC04 | `undefined ?? event` → event |
| — no associated IG | ❌ none | **`EventDateBlock`** | AC05 | `undefined` → `EventDateBlock` |