### PR TITLE
fix: unable to publish crn-report

### DIFF
--- a/packages/react-components/src/templates/ResearchOutputForm.tsx
+++ b/packages/react-components/src/templates/ResearchOutputForm.tsx
@@ -279,7 +279,7 @@ const ResearchOutputForm: React.FC<ResearchOutputFormProps> = ({
       shortDescription: values.shortDescription,
       changelog: values.changelog,
       title: values.title,
-      type: values.type || '',
+      type: values.type,
       authors: values.authors,
       labs: values.labs,
       teams: values.teams,

--- a/packages/react-components/src/templates/__tests__/ResearchOutputForm/TypeField.test.tsx
+++ b/packages/react-components/src/templates/__tests__/ResearchOutputForm/TypeField.test.tsx
@@ -1,0 +1,50 @@
+import { ResearchOutputResponse } from '@asap-hub/model';
+import { screen } from '@testing-library/react';
+
+import {
+  initialResearchOutputData,
+  renderPrefilledForm,
+  submitForm,
+} from '../../test-utils/research-output-form';
+import { mockActErrorsInConsole } from '../../../test-utils';
+
+describe('ResearchOutputForm type field', () => {
+  const saveFn = jest.fn();
+  let consoleMock: ReturnType<typeof mockActErrorsInConsole>;
+
+  beforeEach(() => {
+    saveFn.mockResolvedValue({ id: '42' } as ResearchOutputResponse);
+    consoleMock = mockActErrorsInConsole();
+  });
+
+  afterEach(() => {
+    consoleMock.mockRestore();
+    jest.resetAllMocks();
+  });
+
+  // A CRN Report has no selectable types, so the type field is never rendered
+  // and its form value stays untouched. The payload must send `undefined`, not
+  // an empty string, so the backend does not persist a blank type.
+  it('submits type as undefined for a Report with no type options', async () => {
+    renderPrefilledForm({
+      onSave: saveFn,
+      documentType: 'Report',
+      typeOptions: [],
+      researchOutputData: {
+        ...initialResearchOutputData,
+        documentType: 'Report',
+        type: undefined,
+        subtype: undefined,
+      },
+    });
+
+    expect(
+      screen.queryByRole('combobox', { name: /Select the type/i }),
+    ).not.toBeInTheDocument();
+
+    await submitForm();
+
+    expect(saveFn).toHaveBeenCalledTimes(1);
+    expect(saveFn.mock.calls[0][0].type).toBeUndefined();
+  });
+});


### PR DESCRIPTION
We were getting error 400 when trying to save/publish a CRN Report Output since d3c6191d1fc16f2f9cdce30bdde1b3a83312d84c because the `type` field in the payload we were sending to the backend was not `undefined` anymore, it was an empty string that don't belong to the allowed enums. So it was giving a validation error.
 
<img width="500" src="https://github.com/user-attachments/assets/7c6908b9-d9e2-4a21-863b-c963c6dca3f1" />
<img width="500" src="https://github.com/user-attachments/assets/101f9fd8-8cb8-41cb-bce0-9912386d299b" />
