### PR TITLE
Hotfix: production deploy of the serverless split (ASAP-1591) failed on two Lambda names exceeding AWS's 64-character limit

### DIFF
--- a/apps/crn-server/serverless/functions-async.ts
+++ b/apps/crn-server/serverless/functions-async.ts
@@ -111,6 +111,9 @@ export const asyncFunctions: AWS['functions'] = {
   },
   updateContentfulWorkingGroupDeliverables: {
     handler: './src/handlers/working-group/update-deliverables-handler.handler',
+    // Shortened: the default name would exceed Lambda's 64-char limit on the
+    // production stage.
+    name: '${self:service}-${self:provider.stage}-updateWorkingGroupDeliverables',
     events: contentfulEventBridge(['WorkingGroupsPublished']),
     environment: {
       SENTRY_DSN: sentryDsnHandlers,

--- a/apps/crn-server/serverless/functions-indexers.ts
+++ b/apps/crn-server/serverless/functions-indexers.ts
@@ -15,10 +15,17 @@ const algoliaIndexEnvironment = {
   SENTRY_DSN: sentryDsnHandlers,
 };
 
-const algoliaIndexer = (handler: string, detailTypes: WebhookDetailType[]) => ({
+// `name` is only passed when the generated name would exceed Lambda's
+// 64-character limit on the production stage.
+const algoliaIndexer = (
+  handler: string,
+  detailTypes: WebhookDetailType[],
+  name?: string,
+) => ({
   handler,
   events: contentfulEventBridge(detailTypes),
   environment: algoliaIndexEnvironment,
+  ...(name ? { name: `\${self:service}-\${self:provider.stage}-${name}` } : {}),
 });
 
 const opensearchIndexerEnvironment = {
@@ -128,6 +135,7 @@ export const indexerFunctions: AWS['functions'] = {
   algoliaIndexManuscriptVersionsManuscripts: algoliaIndexer(
     './src/handlers/manuscript/algolia-index-manuscript-versions-manuscripts-handler.handler',
     ['ManuscriptsPublished', 'ManuscriptsUnpublished'],
+    'algoliaIndexManuscriptVersionsMs',
   ),
   opensearchIndexAims: {
     handler: './src/handlers/aim/opensearch-index-aim-handler.handler',


### PR DESCRIPTION
The following failure happened because the function name embeds the stage name, and "production" is a much longer word than "dev" or a PR number.

The physical Lambda name is built as <service>-<stage>-<functionKey>. AWS caps that at 64 characters. Compare the same function across stages:

```
┌────────────┬────────────────────────────────────────────────────────────────────┬────────┐
│   Stage    │                             Full name                              │ Length │
├────────────┼────────────────────────────────────────────────────────────────────┼────────┤
│ PR env     │ asap-hub-async-5109-updateContentfulWorkingGroupDeliverables       │ 60 ✅  │
├────────────┼────────────────────────────────────────────────────────────────────┼────────┤
│ dev        │ asap-hub-async-dev-updateContentfulWorkingGroupDeliverables        │ 59 ✅  │
├────────────┼────────────────────────────────────────────────────────────────────┼────────┤
│ production │ asap-hub-async-production-updateContentfulWorkingGroupDeliverables │ 66 ❌  │
└────────────┴────────────────────────────────────────────────────────────────────┴────────┘
```

production (10 chars) is 7 characters longer than dev (3) and 6 longer than 5109 (4) — exactly enough to push the two longest function names over the limit while every shorter stage squeaked under. Same story for the indexer: asap-hub-indexers-production-algoliaIndexManuscriptVersionsManuscripts is 70 chars, while the dev and PR versions fit under (or right at) 64.

That's also why it slipped through every validation round.

Production blocked flows and loss certainty

```

┌──────────────────────────────┬──────────────┬─────────────────────────────────────┬───────────────────────────────────────────────────────────────┬──────────────────┐
│             Flow             │ State right  │           Where it waits            │                        Can we lose it?                        │     Deadline     │
│                              │     now      │                                     │                                                               │                  │
├──────────────────────────────┼──────────────┼─────────────────────────────────────┼───────────────────────────────────────────────────────────────┼──────────────────┤
│ Invite emails                │ Not sent     │ invite-user-queue                   │ No — buffered                                                 │ 4 days (SQS      │
│                              │              │                                     │                                                               │ retention)       │
├──────────────────────────────┼──────────────┼─────────────────────────────────────┼───────────────────────────────────────────────────────────────┼──────────────────┤
│ Contentful publish           │ Not          │ contentful-poller-queue             │ No — buffered                                                 │ 4 days           │
│ processing                   │ processed    │                                     │                                                               │                  │
├──────────────────────────────┼──────────────┼─────────────────────────────────────┼───────────────────────────────────────────────────────────────┼──────────────────┤
│ Google Calendar event sync   │ Not          │ google-calendar-event-queue         │ No — buffered; even a missed push is recoverable via          │ 4 days           │
│                              │ processed    │                                     │ syncToken re-sync                                             │                  │
├──────────────────────────────┼──────────────┼─────────────────────────────────────┼───────────────────────────────────────────────────────────────┼──────────────────┤
│ Compliance doc sync          │ Not          │ compliance-doc-sync-queue           │ No — buffered                                                 │ 4 days           │
│                              │ processed    │                                     │                                                               │                  │
├──────────────────────────────┼──────────────┼─────────────────────────────────────┼───────────────────────────────────────────────────────────────┼──────────────────┤
│ Search indexing              │ Not updating │ Derived from Contentful — nothing   │ No source data at risk — index is rebuilt from Contentful;    │ none (staleness  │
│ (Algolia/OpenSearch)         │              │ to buffer                           │ auto full sync runs post-merge                                │ only)            │
├──────────────────────────────┼──────────────┼─────────────────────────────────────┼───────────────────────────────────────────────────────────────┼──────────────────┤
│ ActiveCampaign / ORCID syncs │ Not running  │ Periodic by design                  │ No — next runs re-sync from source                            │ none             │
├──────────────────────────────┼──────────────┼─────────────────────────────────────┼───────────────────────────────────────────────────────────────┼──────────────────┤
│ ORCID hourly cron            │ Not firing   │ n/a                                 │ No — works off a 1-month staleness threshold                  │ none             │
├──────────────────────────────┼──────────────┼─────────────────────────────────────┼───────────────────────────────────────────────────────────────┼──────────────────┤
│ Calendar renewal daily cron  │ Not firing   │ n/a                                 │ No — expired channels lapse, then next run re-subscribes and  │ cosmetic until   │
│                              │              │                                     │ forces a full re-sync that recovers everything                │ fixed            │
└──────────────────────────────┴──────────────┴─────────────────────────────────────┴───────────────────────────────────────────────────────────────┴──────────────────┘
```

<img width="1880" height="868" alt="image" src="https://github.com/user-attachments/assets/384467f8-e242-44a1-9233-fa740ff6caf4" />
<img width="1888" height="845" alt="image" src="https://github.com/user-attachments/assets/c1bd0440-30ec-42fc-9411-e3f9b1469d9a" />
